### PR TITLE
fix panic on nil storageclasses

### DIFF
--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -48,7 +48,10 @@ func GetPVInfoLocal(cache clustercache.ClusterCache, defaultClusterID string) (m
 		ns := pvc.Namespace
 		pvcName := pvc.Name
 		volumeName := pvc.Spec.VolumeName
-		pvClass := *pvc.Spec.StorageClassName
+		pvClass := ""
+		if pvc.Spec.StorageClassName != nil {
+			pvClass = *pvc.Spec.StorageClassName
+		}
 		clusterID := defaultClusterID
 		key := fmt.Sprintf("%s,%s,%s", ns, pvcName, clusterID)
 		toReturn[key] = &PersistentVolumeClaimData{


### PR DESCRIPTION
## What does this PR change?
Fix panic on nil storageclasses.


## Does this PR rely on any other PRs?
no


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
USers with nil storageclasses no longer panic


## Links to Issues or ZD tickets this PR addresses or fixes

## How was this PR tested?
I did not repro a nil storageclass but this was regression tested by building and running the app
