### PR TITLE
use per-provider localstorage charges

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -428,6 +428,10 @@ func (az *Azure) getAzureAuth(forceReload bool, cp *CustomPricing) (subscription
 	return "", "", "", ""
 }
 
+func (az *Azure) ETLLocalStorageQueries(clusterLabel string, durationStr string, minsPerResolution int, offsetStr string, hourlyToCumulative float64) (string, string, string, string) {
+	return "", "", "", "" // local storage is not charged on azure.
+}
+
 func (az *Azure) ConfigureAzureStorage() error {
 	accessKey, accountName, containerName := az.getAzureStorageConfig(false)
 	if accessKey != "" && accountName != "" && containerName != "" {

--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -40,6 +40,10 @@ type customProviderKey struct {
 	Labels         map[string]string
 }
 
+func (*CustomProvider) ETLLocalStorageQueries(clusterLabel string, durationStr string, minsPerResolution int, offsetStr string, hourlyToCumulative float64) (string, string, string, string) {
+	return "", "", "", ""
+}
+
 func (*CustomProvider) ClusterManagementPricing() (string, float64, error) {
 	return "", 0.0, nil
 }

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -243,6 +243,7 @@ type Provider interface {
 	PricingSourceStatus() map[string]*PricingSource
 	ClusterManagementPricing() (string, float64, error)
 	CombinedDiscountForNode(string, bool, float64, float64) float64
+	ETLLocalStorageQueries(string, string, int, string, float64) (string, string, string, string)
 }
 
 // ClusterName returns the name defined in cluster info, defaulting to the


### PR DESCRIPTION
## What does this PR change?
Azure, AWS, GCP, all use different kinds of system mounts and chargeback models to place disks and the node's root disk into the VM. This gives us the freedom to configure chargeback in a per-provider way.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Improved accuracy for non-PV storage costs

## How was this PR tested?
Deployed on Azure and made sure only PVs were counted
