### PR TITLE
Fix idle filtration coefficient computation

### DIFF
--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -758,17 +758,12 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 				key = fmt.Sprintf("%s/%s", sa.Properties.Cluster, sa.Properties.Node)
 			}
 
-			if _, ok := allocTotalsAfterFilters[key]; ok {
-				allocTotalsAfterFilters[key].CPUCost += sa.CPUCost
-				allocTotalsAfterFilters[key].GPUCost += sa.GPUCost
-				allocTotalsAfterFilters[key].RAMCost += sa.RAMCost
-			} else {
-				allocTotalsAfterFilters[key] = &AllocationTotals{
-					CPUCost: sa.CPUCost,
-					GPUCost: sa.GPUCost,
-					RAMCost: sa.RAMCost,
-				}
+			if _, ok := allocTotalsAfterFilters[key]; !ok {
+				allocTotalsAfterFilters[key] = &AllocationTotals{}
 			}
+			allocTotalsAfterFilters[key].CPUCost += sa.CPUCost
+			allocTotalsAfterFilters[key].GPUCost += sa.GPUCost
+			allocTotalsAfterFilters[key].RAMCost += sa.RAMCost
 		}
 
 		// 8. Inserting the allocation with the generated key for a name
@@ -830,30 +825,30 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 			// Percentage of idle that should remain after filters are applied,
 			// which equals the proportion of filtered-to-actual cost.
 			cpuFilterCoeff := 0.0
-			if allocTotals[key].CPUCost > 0.0 {
+			if allocTotals[key].TotalCPUCost() > 0.0 {
 				filteredAlloc, ok := allocTotalsAfterFilters[key]
 				if ok {
-					cpuFilterCoeff = filteredAlloc.CPUCost / allocTotals[key].CPUCost
+					cpuFilterCoeff = filteredAlloc.TotalCPUCost() / allocTotals[key].TotalCPUCost()
 				} else {
 					cpuFilterCoeff = 0.0
 				}
 			}
 
 			gpuFilterCoeff := 0.0
-			if allocTotals[key].GPUCost > 0.0 {
+			if allocTotals[key].TotalGPUCost() > 0.0 {
 				filteredAlloc, ok := allocTotalsAfterFilters[key]
 				if ok {
-					gpuFilterCoeff = filteredAlloc.GPUCost / allocTotals[key].GPUCost
+					gpuFilterCoeff = filteredAlloc.TotalGPUCost() / allocTotals[key].TotalGPUCost()
 				} else {
 					gpuFilterCoeff = 0.0
 				}
 			}
 
 			ramFilterCoeff := 0.0
-			if allocTotals[key].RAMCost > 0.0 {
+			if allocTotals[key].TotalRAMCost() > 0.0 {
 				filteredAlloc, ok := allocTotalsAfterFilters[key]
 				if ok {
-					ramFilterCoeff = filteredAlloc.RAMCost / allocTotals[key].RAMCost
+					ramFilterCoeff = filteredAlloc.TotalRAMCost() / allocTotals[key].TotalRAMCost()
 				} else {
 					ramFilterCoeff = 0.0
 				}


### PR DESCRIPTION
## What does this PR change?
- Fixes a bug in idle filtration (i.e. when filtering, how much of a given idle allocation is included, if not 100%)

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fixes a bug in idle costs when filters are applied and there are adjustments

## Links to Issues or ZD tickets this PR addresses or fixes
- Closes https://github.com/kubecost/kubecost-cost-model/issues/663

## How was this PR tested?
- Using audit tools, and manually using user data that reproduced the issue

The correct answer for idle cost associated with `deployment-test` is `-26.7533` (`cpuCost=-23.577` and `ramCost=-3.176`), as confirmed by Allocation API and Summary Allocation API's own response with `splitIdle=true` and without filters.

### Before
```json
"__idle__": {
    "name": "__idle__",
    "start": "2022-02-09T00:00:00Z",
    "end": "2022-02-10T00:00:00Z",
    "cpuCoreRequestAverage": 0,
    "cpuCoreUsageAverage": 0,
    "cpuCost": -93.84807103335739,
    "gpuCost": 0,
    "networkCost": 0,
    "loadBalancerCost": 0,
    "pvCost": 0,
    "ramByteRequestAverage": 0,
    "ramByteUsageAverage": 0,
    "ramCost": -16.38029378010112,
    "sharedCost": 0,
    "externalCost": 0
},
"deployment-test": {
    "name": "deployment-test",
    "start": "2022-02-09T00:00:00Z",
    "end": "2022-02-10T00:00:00Z",
    "cpuCoreRequestAverage": 13.904791666666673,
    "cpuCoreUsageAverage": 2.672344861748048,
    "cpuCost": 40.13183700061102,
    "gpuCost": 0,
    "networkCost": 2.7096332821999947,
    "loadBalancerCost": 0,
    "pvCost": 12.250465777254366,
    "ramByteRequestAverage": 22957004431.999996,
    "ramByteUsageAverage": 12881078694.745825,
    "ramCost": 11.654809611216292,
    "sharedCost": 0,
    "externalCost": 0
}
```

### After
```json
"__idle__": {
    "name": "__idle__",
    "start": "2022-02-09T00:00:00Z",
    "end": "2022-02-10T00:00:00Z",
    "cpuCoreRequestAverage": 0,
    "cpuCoreUsageAverage": 0,
    "cpuCost": -23.577067180024343,
    "gpuCost": 0,
    "networkCost": 0,
    "loadBalancerCost": 0,
    "pvCost": 0,
    "ramByteRequestAverage": 0,
    "ramByteUsageAverage": 0,
    "ramCost": -3.1763204952029844,
    "sharedCost": 0,
    "externalCost": 0
},
"deployment-test": {
    "name": "deployment-test",
    "start": "2022-02-09T00:00:00Z",
    "end": "2022-02-10T00:00:00Z",
    "cpuCoreRequestAverage": 13.90479166666666,
    "cpuCoreUsageAverage": 2.672344861748044,
    "cpuCost": 40.131837000611014,
    "gpuCost": 0,
    "networkCost": 2.709633282199998,
    "loadBalancerCost": 0,
    "pvCost": 12.250465777254364,
    "ramByteRequestAverage": 22957004431.999996,
    "ramByteUsageAverage": 12881078694.745836,
    "ramCost": 11.6548096112163,
    "sharedCost": 0,
    "externalCost": 0
}
```

