### PR TITLE
Don't specify architecture in Dockerfile go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN set -e ;\
     go test ./test/*.go;\
     go test ./pkg/*;\
     cd cmd/costmodel;\
-    GOOS=linux GOARCH=amd64 \
+    GOOS=linux \
     go build -a -installsuffix cgo -o /go/bin/app
 
 FROM alpine:latest


### PR DESCRIPTION
Specifying the architecture forces the image to only support AMD64 even
if we're trying to build an ARM64 image in an ARM64 environment with
something like docker buildx. Making this change means the built binary
will support the architecture of the environment it was built in.

## How was this PR tested?

CI build on this repo.