### PR TITLE
Go-JSON Replacement 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.14.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getsentry/sentry-go v0.6.1
+	github.com/goccy/go-json v0.9.4
 	github.com/google/uuid v1.3.0
-	github.com/json-iterator/go v1.1.11
 	github.com/jszwec/csvutil v1.2.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.14.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getsentry/sentry-go v0.6.1
+	github.com/goccy/go-json v0.9.4
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/google/uuid v1.3.0
-	github.com/json-iterator/go v1.1.11
 	github.com/jszwec/csvutil v1.2.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/goccy/go-json v0.9.4 h1:L8MLKG2mvVXiQu07qB6hmfqeSYQdOnqPot2GhsIwIaI=
+github.com/goccy/go-json v0.9.4/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/goccy/go-json v0.9.4 h1:L8MLKG2mvVXiQu07qB6hmfqeSYQdOnqPot2GhsIwIaI=
+github.com/goccy/go-json v0.9.4/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -1,13 +1,13 @@
 package kubecost
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/kubecost/cost-model/pkg/util"
+	"github.com/kubecost/cost-model/pkg/util/json"
 )
 
 func TestAllocation_Add(t *testing.T) {
@@ -2623,9 +2623,9 @@ func TestAllocationSetRange_Start(t *testing.T) {
 			name: "Single allocation",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
@@ -2639,12 +2639,12 @@ func TestAllocationSetRange_Start(t *testing.T) {
 			name: "Two allocations",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
-							"b": &Allocation{
+							"b": {
 								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
@@ -2658,16 +2658,16 @@ func TestAllocationSetRange_Start(t *testing.T) {
 			name: "Two AllocationSets",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"b": &Allocation{
+							"b": {
 								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
@@ -2711,9 +2711,9 @@ func TestAllocationSetRange_End(t *testing.T) {
 			name: "Single allocation",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								End: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
@@ -2727,12 +2727,12 @@ func TestAllocationSetRange_End(t *testing.T) {
 			name: "Two allocations",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								End: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
-							"b": &Allocation{
+							"b": {
 								End: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
@@ -2746,16 +2746,16 @@ func TestAllocationSetRange_End(t *testing.T) {
 			name: "Two AllocationSets",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								End: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"b": &Allocation{
+							"b": {
 								End: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
@@ -2798,9 +2798,9 @@ func TestAllocationSetRange_Minutes(t *testing.T) {
 			name: "Single allocation",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 								End:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
@@ -2815,13 +2815,13 @@ func TestAllocationSetRange_Minutes(t *testing.T) {
 			name: "Two allocations",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 								End:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
-							"b": &Allocation{
+							"b": {
 								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 								End:   time.Date(1970, 1, 3, 0, 0, 0, 0, time.UTC),
 							},
@@ -2836,17 +2836,17 @@ func TestAllocationSetRange_Minutes(t *testing.T) {
 			name: "Two AllocationSets",
 			arg: &AllocationSetRange{
 				allocations: []*AllocationSet{
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"a": &Allocation{
+							"a": {
 								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 								End:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
-					&AllocationSet{
+					{
 						allocations: map[string]*Allocation{
-							"b": &Allocation{
+							"b": {
 								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 								End:   time.Date(1970, 1, 3, 0, 0, 0, 0, time.UTC),
 							},

--- a/pkg/kubecost/asset_unmarshal.go
+++ b/pkg/kubecost/asset_unmarshal.go
@@ -6,9 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	// gojson is default golang json, required for RawMessage decoding
-	gojson "encoding/json"
-
 	"github.com/kubecost/cost-model/pkg/util/json"
 )
 
@@ -722,11 +719,11 @@ func (as *AssetSet) MarshalJSON() ([]byte, error) {
 // Unmarshals a marshaled AssetSet json into AssetSetResponse
 func (asr *AssetSetResponse) UnmarshalJSON(b []byte) error {
 
-	// gojson used here, as jsonitter UnmarshalJSON won't work with RawMessage
-	var assetMap map[string]*gojson.RawMessage
+	// json used here, as jsonitter UnmarshalJSON won't work with RawMessage
+	var assetMap map[string]*json.RawMessage
 
 	// Partial unmarshal to map of json RawMessage
-	err := gojson.Unmarshal(b, &assetMap)
+	err := json.Unmarshal(b, &assetMap)
 	if err != nil {
 		return err
 	}
@@ -739,7 +736,7 @@ func (asr *AssetSetResponse) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (asr *AssetSetResponse) RawMessageToAssetSetResponse(assetMap map[string]*gojson.RawMessage) error {
+func (asr *AssetSetResponse) RawMessageToAssetSetResponse(assetMap map[string]*json.RawMessage) error {
 
 	newAssetMap := make(map[string]Asset)
 
@@ -854,11 +851,11 @@ func (asr *AssetSetResponse) RawMessageToAssetSetResponse(assetMap map[string]*g
 
 func (asrr *AssetSetRangeResponse) UnmarshalJSON(b []byte) error {
 
-	// gojson used here, as jsonitter UnmarshalJSON won't work with RawMessage
-	var assetMapList []map[string]*gojson.RawMessage
+	// json used here, as jsonitter UnmarshalJSON won't work with RawMessage
+	var assetMapList []map[string]*json.RawMessage
 
 	// Partial unmarshal to map of json RawMessage
-	err := gojson.Unmarshal(b, &assetMapList)
+	err := json.Unmarshal(b, &assetMapList)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubecost/asset_unmarshal.go
+++ b/pkg/kubecost/asset_unmarshal.go
@@ -718,8 +718,6 @@ func (as *AssetSet) MarshalJSON() ([]byte, error) {
 
 // Unmarshals a marshaled AssetSet json into AssetSetResponse
 func (asr *AssetSetResponse) UnmarshalJSON(b []byte) error {
-
-	// json used here, as jsonitter UnmarshalJSON won't work with RawMessage
 	var assetMap map[string]*json.RawMessage
 
 	// Partial unmarshal to map of json RawMessage
@@ -850,8 +848,6 @@ func (asr *AssetSetResponse) RawMessageToAssetSetResponse(assetMap map[string]*j
 }
 
 func (asrr *AssetSetRangeResponse) UnmarshalJSON(b []byte) error {
-
-	// json used here, as jsonitter UnmarshalJSON won't work with RawMessage
 	var assetMapList []map[string]*json.RawMessage
 
 	// Partial unmarshal to map of json RawMessage

--- a/pkg/kubecost/asset_unmarshal_test.go
+++ b/pkg/kubecost/asset_unmarshal_test.go
@@ -1,7 +1,8 @@
 package kubecost
 
 import (
-	"encoding/json"
+	"github.com/kubecost/cost-model/pkg/util/json"
+
 	"testing"
 	"time"
 )

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -8,10 +8,10 @@ import (
 
 var Marshal = gojson.Marshal
 var Unmarshal = gojson.Unmarshal
-
-type Marshaler json.Marshaler
-type Unmarshaler json.Unmarshaler
-
-type RawMessage json.RawMessage
-
+var NewEncoder = json.NewEncoder
 var NewDecoder = json.NewDecoder
+
+type Marshaler = json.Marshaler
+type Unmarshaler = json.Unmarshaler
+
+type RawMessage = json.RawMessage

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -3,11 +3,11 @@ package json
 import (
 	"encoding/json"
 
-	jsoniter "github.com/json-iterator/go"
+	gojson "github.com/goccy/go-json"
 )
 
-var Marshal = jsoniter.ConfigCompatibleWithStandardLibrary.Marshal
-var Unmarshal = jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal
+var Marshal = gojson.Marshal
+var Unmarshal = gojson.Unmarshal
 
 type Marshaler json.Marshaler
 type Unmarshaler json.Unmarshaler

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -8,8 +8,9 @@ import (
 
 var Marshal = gojson.Marshal
 var Unmarshal = gojson.Unmarshal
-var NewEncoder = gojson.NewEncoder
-var NewDecoder = gojson.NewDecoder
+
+var NewEncoder = json.NewEncoder
+var NewDecoder = json.NewDecoder
 
 type Marshaler = json.Marshaler
 type Unmarshaler = json.Unmarshaler

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -8,8 +8,8 @@ import (
 
 var Marshal = gojson.Marshal
 var Unmarshal = gojson.Unmarshal
-var NewEncoder = json.NewEncoder
-var NewDecoder = json.NewDecoder
+var NewEncoder = gojson.NewEncoder
+var NewDecoder = gojson.NewDecoder
 
 type Marshaler = json.Marshaler
 type Unmarshaler = json.Unmarshaler

--- a/test/clusterinfo_test.go
+++ b/test/clusterinfo_test.go
@@ -1,10 +1,10 @@
 package test
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/kubecost/cost-model/pkg/prom"
+	"github.com/kubecost/cost-model/pkg/util/json"
 )
 
 func TestClusterInfoLabels(t *testing.T) {


### PR DESCRIPTION
## What does this PR change?
* Replaces json-iter library with go-json: https://github.com/goccy/go-json
  * The json-iter library has a show-stopping bug which will degrade performance of the go runtime almost to a full stop. See this issue for details: https://github.com/json-iterator/go/issues/603
  * go-json seems to have a more active maintainer

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Fix for requests which don't receive responses. 

## How was this PR tested?
* Using several specific benchmarks that repro'd the bug case in json-iter
* All kubecost ETL structure json encode/decode unit tests are passing. 

