### PR TITLE
Azure Gov Cloud updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.6
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/aws/aws-sdk-go v1.28.9
 	github.com/aws/aws-sdk-go-v2 v1.13.0
 	github.com/aws/aws-sdk-go-v2/config v1.13.1

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -1150,7 +1150,7 @@ func (az *Azure) ClusterInfo() (map[string]string, error) {
 	if c.ClusterName != "" {
 		m["name"] = c.ClusterName
 	}
-	m["provider"] = "azure"
+	m["provider"] = "Azure"
 	m["account"] = az.clusterAccountId
 	m["region"] = az.clusterRegion
 	m["remoteReadEnabled"] = strconv.FormatBool(remoteEnabled)

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -175,6 +175,7 @@ type CustomPricing struct {
 	AzureClientSecret            string `json:"azureClientSecret"`
 	AzureTenantID                string `json:"azureTenantID"`
 	AzureBillingRegion           string `json:"azureBillingRegion"`
+	AzureOfferDurableID          string `json:"azureOfferDurableID"`
 	CurrencyCode                 string `json:"currencyCode"`
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -16,11 +16,6 @@ const (
 	AWSAccessKeySecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	AWSClusterIDEnvVar       = "AWS_CLUSTER_ID"
 
-	AzureStorageSubscriptionIDEnvVar = "AZURE_SUBSCRIPTION_ID"
-	AzureStorageAccessKeyEnvVar      = "AZURE_STORAGE_ACCESS_KEY"
-	AzureStorageAccountNameEnvVar    = "AZURE_STORAGE_ACCOUNT"
-	AzureStorageContainerNameEnvVar  = "AZURE_STORAGE_CONTAINER"
-
 	KubecostNamespaceEnvVar        = "KUBECOST_NAMESPACE"
 	ClusterIDEnvVar                = "CLUSTER_ID"
 	ClusterProfileEnvVar           = "CLUSTER_PROFILE"


### PR DESCRIPTION
## What does this PR change?
Simplify config retrieval for KCM, configurable OfferDurableID for rate card, support gov cloud for Rate Card API and Storage API. Rate Card API now uses correct endpoints for the cloud that it is on in addition to the ability to support the configuring the Offer Durable ID via the helm chart. For the Storage API there is now an optional field in the config secret that lets you specify that the storage account is on the gov cloud which allows it to work for both single cluster and multi-cluster.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/683
- https://github.com/kubecost/cost-analyzer-helm-chart/pull/1277


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Users will now have feature parity on Azure Gov Cloud
- Users can set the Durable Offer ID that matches their subscription via the helm chart


## Links to Issues or ZD tickets this PR addresses or fixes

- [Zendesk ticket #995](https://kubecost.zendesk.com/agent/tickets/995)
- fixes https://github.com/kubecost/cost-model/issues/990


## How was this PR tested?
The features of this PR were tested on a public cloud azure cluster, a gov cloud azure cluster and a multi-cloud azure cluster.
### Gov Cloud Cluster
Storage Integration Working:
![Screen Shot 2022-02-25 at 1 48 19 PM](https://user-images.githubusercontent.com/12225425/155807772-d2ba964d-ed81-4392-83c2-7a0029a253ea.png)
Rate Card API:
![Screen Shot 2022-02-25 at 1 48 35 PM](https://user-images.githubusercontent.com/12225425/155807805-12c1dd7e-ba4b-43ae-b97a-27c1d183246d.png)

Log show that the custom OfferDurableId is being set properly
```
I0225 20:22:22.773558       1 azureprovider.go:781] Using ratecard query OfferDurableId eq 'MS-AZR-USGOV-0044P' and Currency eq 'USD' and Locale eq 'en-US' and RegionInfo eq 'US'
```

### Multi-Cloud
This screen shot show nodes from both public and gov subscriptions showing up in the multi-cloud's assets page
![Screen Shot 2022-02-25 at 1 58 07 PM](https://user-images.githubusercontent.com/12225425/155808794-22e584d0-b5ad-4f20-9e9d-7944d013398f.png)


## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/186
