### PR TITLE
replace method that was erroneously removed

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -2057,6 +2057,7 @@ func (aws *AWS) CombinedDiscountForNode(instanceType string, isPreemptible bool,
 	return 1.0 - ((1.0 - defaultDiscount) * (1.0 - negotiatedDiscount))
 }
 
+// Regions returns a predefined list of AWS regions
 func (aws *AWS) Regions() []string {
 	return awsRegions
 }

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -2056,3 +2056,7 @@ func (aws *AWS) ServiceAccountStatus() *ServiceAccountStatus {
 func (aws *AWS) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	return 1.0 - ((1.0 - defaultDiscount) * (1.0 - negotiatedDiscount))
 }
+
+func (aws *AWS) Regions() []string {
+	return awsRegions
+}


### PR DESCRIPTION
## What does this PR change?
This PR replaces a method which was erroneously removed from the AWSprovider during the SDK-V2 migration. It appears that this methods is only required for the RI feature which is how the change got into develop undetected.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?


## Have you made an update to documentation?

