### PR TITLE
Make service check thread safe

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubecost/cost-model/pkg/util"
@@ -210,6 +211,39 @@ func (cp *CustomPricing) GetSharedOverheadCostPerMonth() float64 {
 
 type ServiceAccountStatus struct {
 	Checks []*ServiceAccountCheck `json:"checks"`
+}
+
+// ServiceAccountChecks is a thread safe map for holding ServiceAccountCheck objects
+type ServiceAccountChecks struct {
+	serviceAccountChecks map[string]*ServiceAccountCheck
+	lock                 *sync.RWMutex
+}
+
+// NewServiceAccountChecks initialize ServiceAccountChecks
+func NewServiceAccountChecks() *ServiceAccountChecks {
+	return &ServiceAccountChecks{
+		serviceAccountChecks: make(map[string]*ServiceAccountCheck),
+		lock: new(sync.RWMutex),
+	}
+}
+
+func (sac *ServiceAccountChecks) set(key string, check *ServiceAccountCheck) {
+	sac.lock.Lock()
+	defer sac.lock.Unlock()
+	sac.serviceAccountChecks[key] = check
+}
+
+// getStatus extracts ServiceAccountCheck objects into a slice and returns them in a ServiceAccountStatus
+func (sac *ServiceAccountChecks) getStatus() *ServiceAccountStatus {
+	sac.lock.Lock()
+	defer sac.lock.Unlock()
+	checks := []*ServiceAccountCheck{}
+	for _, v := range sac.serviceAccountChecks {
+		checks = append(checks, v)
+	}
+	return &ServiceAccountStatus{
+		Checks: checks,
+	}
 }
 
 type ServiceAccountCheck struct {
@@ -419,18 +453,20 @@ func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.
 	case "AWS":
 		klog.V(2).Info("Found ProviderID starting with \"aws\", using AWS Provider")
 		return &AWS{
-			Clientset:        cache,
-			Config:           NewProviderConfig(config, cp.configFileName),
-			clusterRegion:    cp.region,
-			clusterAccountId: cp.accountID,
+			Clientset:            cache,
+			Config:               NewProviderConfig(config, cp.configFileName),
+			clusterRegion:        cp.region,
+			clusterAccountId:     cp.accountID,
+			serviceAccountChecks: NewServiceAccountChecks(),
 		}, nil
 	case "AZURE":
 		klog.V(2).Info("Found ProviderID starting with \"azure\", using Azure Provider")
 		return &Azure{
-			Clientset:        cache,
-			Config:           NewProviderConfig(config, cp.configFileName),
-			clusterRegion:    cp.region,
-			clusterAccountId: cp.accountID,
+			Clientset:            cache,
+			Config:               NewProviderConfig(config, cp.configFileName),
+			clusterRegion:        cp.region,
+			clusterAccountId:     cp.accountID,
+			serviceAccountChecks: NewServiceAccountChecks(),
 		}, nil
 	default:
 		klog.V(2).Info("Unsupported provider, falling back to default")

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -215,28 +215,27 @@ type ServiceAccountStatus struct {
 
 // ServiceAccountChecks is a thread safe map for holding ServiceAccountCheck objects
 type ServiceAccountChecks struct {
+	sync.RWMutex
 	serviceAccountChecks map[string]*ServiceAccountCheck
-	lock                 *sync.RWMutex
 }
 
 // NewServiceAccountChecks initialize ServiceAccountChecks
 func NewServiceAccountChecks() *ServiceAccountChecks {
 	return &ServiceAccountChecks{
 		serviceAccountChecks: make(map[string]*ServiceAccountCheck),
-		lock: new(sync.RWMutex),
 	}
 }
 
 func (sac *ServiceAccountChecks) set(key string, check *ServiceAccountCheck) {
-	sac.lock.Lock()
-	defer sac.lock.Unlock()
+	sac.Lock()
+	defer sac.Unlock()
 	sac.serviceAccountChecks[key] = check
 }
 
 // getStatus extracts ServiceAccountCheck objects into a slice and returns them in a ServiceAccountStatus
 func (sac *ServiceAccountChecks) getStatus() *ServiceAccountStatus {
-	sac.lock.Lock()
-	defer sac.lock.Unlock()
+	sac.Lock()
+	defer sac.Unlock()
 	checks := []*ServiceAccountCheck{}
 	for _, v := range sac.serviceAccountChecks {
 		checks = append(checks, v)


### PR DESCRIPTION
## What does this PR change?
This PR is to address a concurrent map panic which appear to occur when two processes attempt to write to the serviceAccountChecks map of the AWS or Azure provider. To prevent this I have wrapped the map in a struct which also contains a Mutex and routed all reading and writing through methods which use the Mutex. Additionally I have added an initializer that runs in the initializers of the provider implementation, so there is no longer a need for the extra nil check initialization peppered around the code.

It is worth noting that in my testing I found that this object no longer appears to be in use. It was primarily used on the assets page to check if the OOC configuration banner needed to be displayed, however this functionality is now covered by the Cloud Status feature, and the API call to get the contents of this map is never actually made on Azure or AWS with standard cloud configuration. Rather than merging this update it may be better to remove this functionality entirely. This is the relevant function on the FE https://github.com/kubecost/cost-analyzer-frontend/blob/1fc3d2928d34ec2962f0b9c76fd82b5cb210ad5f/src/pages/Assets/index.tsx#L506


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users will no longer experience rare concurrent map write panic


## Links to Issues or ZD tickets this PR addresses or fixes

- partially addresses [ZD1445](https://kubecost.zendesk.com/agent/tickets/1445)
- 


## How was this PR tested?
Tested on Azure and AWS cluster with standard cloud configurations

## Have you made an update to documentation?

