### PR TITLE
duplicate iterated item before taking address

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1442,7 +1442,8 @@ func (aws *AWS) GetAddresses() ([]byte, error) {
 	var addresses []*ec2Types.Address
 	for adds := range addressCh {
 		for _, add := range adds.Addresses {
-			addresses = append(addresses, &add)
+			a := add // duplicate to avoid pointer to iterator
+			addresses = append(addresses, &a)
 		}
 
 	}
@@ -1535,7 +1536,8 @@ func (aws *AWS) GetDisks() ([]byte, error) {
 	var volumes []*ec2Types.Volume
 	for vols := range volumeCh {
 		for _, vol := range vols.Volumes {
-			volumes = append(volumes, &vol)
+			v := vol // duplicate to avoid pointer to iterator
+			volumes = append(volumes, &v)
 		}
 	}
 


### PR DESCRIPTION
## What does this PR change?
Credit to @mbolt35 for solving this.
This PR fixes a bug with the `projectAddresses` and `projectDisks` endpoints where the results would be the correct length but each item in their respective arrays were duplicates.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users can now use these endpoints again.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
This PR was tested manually on an AWS cluster, were the endpoints are now returning unique results.

## Have you made an update to documentation?

