### PR TITLE
Add IsEmpty() methods, fix awsProvider RIPricingError

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -327,7 +327,7 @@ func toRegionID(meterRegion string, regions map[string]string) (string, error) {
 var regionIdByDisplayName = map[string]string{
 	"US Gov AZ": "usgovarizona",
 	"US Gov TX": "usgovtexas",
-	"US Gov": "usgovvirginia",
+	"US Gov":    "usgovvirginia",
 }
 
 func checkRegionID(regionID string, regions map[string]string) bool {
@@ -462,13 +462,22 @@ func (k *azureKey) GetGPUCount() string {
 	return "0"
 }
 
-// Represents an azure storage config
+// AzureStorageConfig Represents an azure storage config
 type AzureStorageConfig struct {
 	SubscriptionId string `json:"azureSubscriptionID"`
 	AccountName    string `json:"azureStorageAccount"`
 	AccessKey      string `json:"azureStorageAccessKey"`
 	ContainerName  string `json:"azureStorageContainer"`
 	AzureCloud     string `json:"azureCloud"`
+}
+
+// IsEmpty returns true if all fields in config are empty, false if not.
+func (asc *AzureStorageConfig) IsEmpty() bool {
+	return asc.SubscriptionId == "" &&
+		asc.AccountName == "" &&
+		asc.AccessKey == "" &&
+		asc.ContainerName == "" &&
+		asc.AzureCloud == ""
 }
 
 // Represents an azure app key
@@ -530,7 +539,6 @@ func (az *Azure) GetAzureStorageConfig(forceReload bool) (*AzureStorageConfig, e
 		defaultSubscriptionID = config.AzureSubscriptionID
 	}
 
-
 	// 1. Check for secret
 	s, err := az.loadAzureStorageConfig(forceReload)
 	if err != nil {
@@ -545,7 +553,7 @@ func (az *Azure) GetAzureStorageConfig(forceReload bool) (*AzureStorageConfig, e
 		// To support already configured users, subscriptionID may not be set in secret in which case, the subscriptionID
 		// for the rate card API is used
 		if s.SubscriptionId == "" {
-			s.SubscriptionId  = defaultSubscriptionID
+			s.SubscriptionId = defaultSubscriptionID
 		}
 		return s, nil
 	}

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -161,12 +161,19 @@ func (gcp *GCP) GetConfig() (*CustomPricing, error) {
 	return c, nil
 }
 
+// BigQueryConfig contain the required config and credentials to access OOC resources for GCP
 type BigQueryConfig struct {
 	ProjectID          string            `json:"projectID"`
 	BillingDataDataset string            `json:"billingDataDataset"`
 	Key                map[string]string `json:"key"`
 }
 
+// IsEmpty returns true if all fields in config are empty, false if not.
+func (bqc *BigQueryConfig) IsEmpty() bool {
+	return bqc.ProjectID == "" &&
+		bqc.BillingDataDataset == "" &&
+		(bqc.Key == nil || len(bqc.Key) == 0)
+}
 func (gcp *GCP) GetManagementPlatform() (string, error) {
 	nodes := gcp.Clientset.GetAllNodes()
 


### PR DESCRIPTION
## What does this PR change?
This PR address issue with configuration diagnostics that have been reported. The first is the "incomplete configuration" appearing when the "missing configuration" should be present. This is coupled with confusing logs that make trouble shooting less straight forward. This is addressed by the IsEmpty() methods on the various cloud configuration that make it possible to check for empty configurations in addition to nil configurations when setting the cloud connection status. The other issue addressed here is for the RI pricing source, even if not configured, that status would come back with no error leading to a green check mark on the diagnostics page(image in testing section).


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/688
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.zendesk.com/agent/tickets/1401 (fixes misleading diagnostics)
- 


## How was this PR tested?
This PR was tested manually on an Azure and AWS cluster
### Cloud Status
Well this might not seem like a huge change the difference in these two statuses hold a significant amount of information about what is wrong with a users configuration.
Before:
![unnamed](https://user-images.githubusercontent.com/12225425/156858836-edf5a0e7-5427-42d6-b5c9-b6a151dd32ae.png)
After:
![Screen Shot 2022-03-04 at 2 25 44 PM](https://user-images.githubusercontent.com/12225425/156858860-9a069f3b-ba2f-4c66-b834-6f2fdc2df5ea.png)

### RI pricing source
Before:
![Screen Shot 2022-03-04 at 3 11 22 PM](https://user-images.githubusercontent.com/12225425/156858975-200ba76a-a14c-4064-a873-687ef4632216.png)
After:
![Screen Shot 2022-03-04 at 4 04 36 PM](https://user-images.githubusercontent.com/12225425/156858983-90029124-05b3-4082-bd7d-d7ce14eff6b7.png)
![Screen Shot 2022-03-04 at 4 08 39 PM](https://user-images.githubusercontent.com/12225425/156858947-475be5cb-2f0d-4839-8185-a04d18da3d4d.png)



## Have you made an update to documentation?

