### PR TITLE
Add GPU in NodeHourlyCost formula in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ For on-prem clusters, these resource prices can be configured directly with cust
 
 Measuring the CPU/RAM/GPU cost of a deployment, service, namespace, etc is the aggregation of its individual container costs.
 
-#### How do you determine RAM/CPU costs for a node when this data isn’t provided by a cloud provider?
+#### How do you determine RAM/CPU/GPU costs for a node when this data isn’t provided by a cloud provider?
 
-When explicit RAM or CPU prices are not provided by your cloud provider, the Kubecost model falls back to the ratio of base CPU and RAM price inputs supplied. The default values for these parameters are based on the marginal resource rates of the cloud provider, but they can be customized within Kubecost.
+When explicit RAM, CPU or GPU prices are not provided by your cloud provider, the Kubecost model falls back to the ratio of base CPU, GPU and RAM price inputs supplied. The default values for these parameters are based on the marginal resource rates of the cloud provider, but they can be customized within Kubecost.
 
-These base RAM/CPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU costs is greater (or less) than the price of the node, then the ratio between the two input prices are held constant.  
+These base RAM/CPU/GPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU/GPU costs is greater (or less) than the price of the node, then the ratio between the input prices is held constant.
 
 As an example, let's imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM Gb price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU remain 3x the price of a Gb of RAM.
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ When explicit RAM or CPU prices are not provided by your cloud provider, the Kub
 
 These base RAM/CPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU costs is greater (or less) than the price of the node, then the ratio between the two input prices are held constant.  
 
-As an example, let's imagine a node with 1 CPU and 1 Gb of RAM that costs $20/mo. If your base CPU price is $30 and your RAM Gb price is $10, then these inputs will be normlized to $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a CPU remains 3x the price of a Gb of RAM. 
+As an example, let's imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM Gb price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a CPU, as well as the price of a GPU remain 3x the price of a Gb of RAM.
 
-    NodeHourlyCost = NORMALIZED_CPU_PRICE * # of CPUS + NORMALIZED_RAM_PRICE * # of RAM Gb
+    NodeHourlyCost = NORMALIZED_CPU_PRICE * # of CPUS + NORMALIZED_GPU_PRICE * # of GPUS + NORMALIZED_RAM_PRICE * # of RAM Gb
 
 #### How do you allocate a specific amount of RAM/CPU to an individual pod or container?
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ When explicit RAM or CPU prices are not provided by your cloud provider, the Kub
 
 These base RAM/CPU prices are normalized to ensure the sum of each component is equal to the total price of the node provisioned, based on billing rates from your provider. When the sum of RAM/CPU costs is greater (or less) than the price of the node, then the ratio between the two input prices are held constant.  
 
-As an example, let's imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM Gb price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a CPU, as well as the price of a GPU remain 3x the price of a Gb of RAM.
+As an example, let's imagine a node with 1 GPU, 1 CPU and 1 Gb of RAM that costs $35/mo. If your base GPU price is $30, base CPU price is $30 and RAM Gb price is $10, then these inputs will be normalized to $15 for GPU, $15 for CPU and $5 for RAM so that the sum equals the cost of the node. Note that the price of a GPU, as well as the price of a CPU remain 3x the price of a Gb of RAM.
 
-    NodeHourlyCost = NORMALIZED_CPU_PRICE * # of CPUS + NORMALIZED_GPU_PRICE * # of GPUS + NORMALIZED_RAM_PRICE * # of RAM Gb
+    NodeHourlyCost = NORMALIZED_GPU_PRICE * # of GPUS + NORMALIZED_CPU_PRICE * # of CPUS + NORMALIZED_RAM_PRICE * # of RAM Gb
 
 #### How do you allocate a specific amount of RAM/CPU to an individual pod or container?
 


### PR DESCRIPTION
## What does this PR change?
This PR adjusts the `NodeHourlyCost` formula in the README to account for GPU costs.


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It updates the `NodeHourlyCost` formula to match our present calculation.


## Links to Issues or ZD tickets this PR addresses or fixes
- fixes https://github.com/kubecost/cost-model/issues/1105


## How was this PR tested?
N/A

## Have you made an update to documentation?
This is an update to the documentation.
