### PR TITLE
replace warningf with dedupedwarningf in allocation.go

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -469,7 +469,7 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 					if pvcInterval, ok := pvcPodIntervalMap[pvcKey][podKey]; ok {
 						s, e = *pvcInterval.Start(), *pvcInterval.End()
 					} else {
-						log.Warningf("CostModel.ComputeAllocation: allocation %s and PVC %s have no associated active window", alloc.Name, pvc.Name)
+						log.DedupedWarningf(10, "CostModel.ComputeAllocation: allocation %s and PVC %s have no associated active window", alloc.Name, pvc.Name)
 					}
 
 					minutes := e.Sub(s).Minutes()
@@ -487,7 +487,7 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 					if coeffComponents, ok := sharedPVCCostCoefficientMap[pvcKey][podKey]; ok {
 						cost *= getCoefficientFromComponents(coeffComponents)
 					} else {
-						log.Warningf("CostModel.ComputeAllocation: allocation %s and PVC %s have relation but no coeff", alloc.Name, pvc.Name)
+						log.DedupedWarningf(10, "CostModel.ComputeAllocation: allocation %s and PVC %s have relation but no coeff", alloc.Name, pvc.Name)
 					}
 
 					// Apply the size and cost of the PV to the allocation, each
@@ -587,7 +587,7 @@ func (cm *CostModel) buildPodMap(window kubecost.Window, resolution, maxBatchSiz
 func applyPodResults(window kubecost.Window, resolution time.Duration, podMap map[podKey]*Pod, clusterStart, clusterEnd map[string]time.Time, resPods []*prom.QueryResult) {
 	for _, res := range resPods {
 		if len(res.Values) == 0 {
-			log.Warningf("CostModel.ComputeAllocation: empty minutes result")
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: empty minutes result")
 			continue
 		}
 
@@ -598,7 +598,7 @@ func applyPodResults(window kubecost.Window, resolution time.Duration, podMap ma
 
 		labels, err := res.GetStrings("namespace", "pod")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: minutes query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: minutes query result missing field: %s", err)
 			continue
 		}
 
@@ -753,7 +753,7 @@ func applyCPUCoresAllocated(podMap map[podKey]*Pod, resCPUCoresAllocated []*prom
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: CPU allocation query result missing 'node': %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU allocation query result missing 'node': %s", key)
 			continue
 		}
 		pod.Allocations[container].Properties.Node = node
@@ -797,7 +797,7 @@ func applyCPUCoresRequested(podMap map[podKey]*Pod, resCPUCoresRequested []*prom
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: CPU request query result missing 'node': %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU request query result missing 'node': %s", key)
 			continue
 		}
 		pod.Allocations[container].Properties.Node = node
@@ -902,7 +902,7 @@ func applyRAMBytesAllocated(podMap map[podKey]*Pod, resRAMBytesAllocated []*prom
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: RAM allocation query result missing 'node': %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM allocation query result missing 'node': %s", key)
 			continue
 		}
 		pod.Allocations[container].Properties.Node = node
@@ -942,7 +942,7 @@ func applyRAMBytesRequested(podMap map[podKey]*Pod, resRAMBytesRequested []*prom
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: RAM request query result missing 'node': %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM request query result missing 'node': %s", key)
 			continue
 		}
 		pod.Allocations[container].Properties.Node = node
@@ -1387,7 +1387,7 @@ func resToPodDaemonSetMap(resDaemonSetLabels []*prom.QueryResult) map[podKey]con
 
 		pod, err := res.GetString("pod")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: DaemonSetLabel result without pod: %s", controllerKey)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: DaemonSetLabel result without pod: %s", controllerKey)
 		}
 
 		podKey := newPodKey(controllerKey.Cluster, controllerKey.Namespace, pod)
@@ -1416,7 +1416,7 @@ func resToPodJobMap(resJobLabels []*prom.QueryResult) map[podKey]controllerKey {
 
 		pod, err := res.GetString("pod")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: JobLabel result without pod: %s", controllerKey)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: JobLabel result without pod: %s", controllerKey)
 		}
 
 		podKey := newPodKey(controllerKey.Cluster, controllerKey.Namespace, pod)
@@ -1458,7 +1458,7 @@ func resToPodReplicaSetMap(resPodsWithReplicaSetOwner []*prom.QueryResult, resRe
 
 		pod, err := res.GetString("pod")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: ReplicaSet result without pod: %s", controllerKey)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: ReplicaSet result without pod: %s", controllerKey)
 		}
 
 		podKey := newPodKey(controllerKey.Cluster, controllerKey.Namespace, pod)
@@ -1532,19 +1532,19 @@ func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node CPU cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node CPU cost query result missing field: %s", err)
 			continue
 		}
 
 		instanceType, err := res.GetString("instance_type")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node CPU cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node CPU cost query result missing field: %s", err)
 			continue
 		}
 
 		providerID, err := res.GetString("provider_id")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node CPU cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node CPU cost query result missing field: %s", err)
 			continue
 		}
 
@@ -1570,19 +1570,19 @@ func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRA
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node RAM cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node RAM cost query result missing field: %s", err)
 			continue
 		}
 
 		instanceType, err := res.GetString("instance_type")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node RAM cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node RAM cost query result missing field: %s", err)
 			continue
 		}
 
 		providerID, err := res.GetString("provider_id")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node RAM cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node RAM cost query result missing field: %s", err)
 			continue
 		}
 
@@ -1608,19 +1608,19 @@ func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerGPUHr
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node GPU cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node GPU cost query result missing field: %s", err)
 			continue
 		}
 
 		instanceType, err := res.GetString("instance_type")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node GPU cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node GPU cost query result missing field: %s", err)
 			continue
 		}
 
 		providerID, err := res.GetString("provider_id")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node GPU cost query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node GPU cost query result missing field: %s", err)
 			continue
 		}
 
@@ -1646,13 +1646,13 @@ func applyNodeSpot(nodeMap map[nodeKey]*NodePricing, resNodeIsSpot []*prom.Query
 
 		node, err := res.GetString("node")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: Node spot query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node spot query result missing field: %s", err)
 			continue
 		}
 
 		key := newNodeKey(cluster, node)
 		if _, ok := nodeMap[key]; !ok {
-			log.Warningf("CostModel.ComputeAllocation: Node spot  query result for missing node: %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Node spot  query result for missing node: %s", key)
 			continue
 		}
 
@@ -1700,7 +1700,7 @@ func buildPVMap(pvMap map[pvKey]*PV, resPVCostPerGiBHour []*prom.QueryResult) {
 
 		name, err := res.GetString("volumename")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: PV cost without volumename")
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: PV cost without volumename")
 			continue
 		}
 
@@ -1718,12 +1718,12 @@ func applyPVBytes(pvMap map[pvKey]*PV, resPVBytes []*prom.QueryResult) {
 	for _, res := range resPVBytes {
 		key, err := resultPVKey(res, env.GetPromClusterLabel(), "persistentvolume")
 		if err != nil {
-			log.Warningf("CostModel.ComputeAllocation: PV bytes query result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: PV bytes query result missing field: %s", err)
 			continue
 		}
 
 		if _, ok := pvMap[key]; !ok {
-			log.Warningf("CostModel.ComputeAllocation: PV bytes result for missing PV: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: PV bytes result for missing PV: %s", err)
 			continue
 		}
 
@@ -1768,7 +1768,7 @@ func buildPVCMap(window kubecost.Window, pvcMap map[pvcKey]*PVC, pvMap map[pvKey
 			}
 		}
 		if pvcStart.IsZero() || pvcEnd.IsZero() {
-			log.Warningf("CostModel.ComputeAllocation: PVC %s has no running time", pvcKey)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: PVC %s has no running time", pvcKey)
 		}
 		pvcStart = pvcStart.Add(-time.Minute)
 
@@ -1992,7 +1992,7 @@ func getLoadBalancerCosts(resLBCost, resLBActiveMins []*prom.QueryResult, resolu
 			continue
 		}
 		if _, ok := lbHourlyCosts[serviceKey]; !ok {
-			log.Warningf("CostModel: failed to find hourly cost for Load Balancer: %v", serviceKey)
+			log.DedupedWarningf(10, "CostModel: failed to find hourly cost for Load Balancer: %v", serviceKey)
 			continue
 		}
 
@@ -2063,7 +2063,7 @@ func (cm *CostModel) getNodePricing(nodeMap map[nodeKey]*NodePricing, nodeKey no
 	// node pricing with the custom values.
 	customPricingConfig, err := cm.Provider.GetConfig()
 	if err != nil {
-		log.Warningf("CostModel: failed to load custom pricing: %s", err)
+		log.DedupedWarningf(10, "CostModel: failed to load custom pricing: %s", err)
 	}
 	if cloud.CustomPricesEnabled(cm.Provider) && customPricingConfig != nil {
 		return cm.getCustomNodePricing(node.Preemptible)
@@ -2077,42 +2077,42 @@ func (cm *CostModel) getNodePricing(nodeMap map[nodeKey]*NodePricing, nodeKey no
 	// them as strings like this?
 
 	if node.CostPerCPUHr == 0 || math.IsNaN(node.CostPerCPUHr) {
-		log.Warningf("CostModel: node pricing has illegal CostPerCPUHr; replacing with custom pricing: %s", nodeKey)
+		log.DedupedWarningf(10, "CostModel: node pricing has illegal CostPerCPUHr; replacing with custom pricing: %s", nodeKey)
 		cpuCostStr := customPricingConfig.CPU
 		if node.Preemptible {
 			cpuCostStr = customPricingConfig.SpotCPU
 		}
 		costPerCPUHr, err := strconv.ParseFloat(cpuCostStr, 64)
 		if err != nil {
-			log.Warningf("CostModel: custom pricing has illegal CPU cost: %s", cpuCostStr)
+			log.DedupedWarningf(10, "CostModel: custom pricing has illegal CPU cost: %s", cpuCostStr)
 		}
 		node.CostPerCPUHr = costPerCPUHr
 		node.Source += "/customCPU"
 	}
 
 	if math.IsNaN(node.CostPerGPUHr) {
-		log.Warningf("CostModel: node pricing has illegal CostPerGPUHr; replacing with custom pricing: %s", nodeKey)
+		log.DedupedWarningf(10, "CostModel: node pricing has illegal CostPerGPUHr; replacing with custom pricing: %s", nodeKey)
 		gpuCostStr := customPricingConfig.GPU
 		if node.Preemptible {
 			gpuCostStr = customPricingConfig.SpotGPU
 		}
 		costPerGPUHr, err := strconv.ParseFloat(gpuCostStr, 64)
 		if err != nil {
-			log.Warningf("CostModel: custom pricing has illegal GPU cost: %s", gpuCostStr)
+			log.DedupedWarningf(10, "CostModel: custom pricing has illegal GPU cost: %s", gpuCostStr)
 		}
 		node.CostPerGPUHr = costPerGPUHr
 		node.Source += "/customGPU"
 	}
 
 	if node.CostPerRAMGiBHr == 0 || math.IsNaN(node.CostPerRAMGiBHr) {
-		log.Warningf("CostModel: node pricing has illegal CostPerRAMHr; replacing with custom pricing: %s", nodeKey)
+		log.DedupedWarningf(10, "CostModel: node pricing has illegal CostPerRAMHr; replacing with custom pricing: %s", nodeKey)
 		ramCostStr := customPricingConfig.RAM
 		if node.Preemptible {
 			ramCostStr = customPricingConfig.SpotRAM
 		}
 		costPerRAMHr, err := strconv.ParseFloat(ramCostStr, 64)
 		if err != nil {
-			log.Warningf("CostModel: custom pricing has illegal RAM cost: %s", ramCostStr)
+			log.DedupedWarningf(10, "CostModel: custom pricing has illegal RAM cost: %s", ramCostStr)
 		}
 		node.CostPerRAMGiBHr = costPerRAMHr
 		node.Source += "/customRAM"
@@ -2142,19 +2142,19 @@ func (cm *CostModel) getCustomNodePricing(spot bool) *NodePricing {
 
 	costPerCPUHr, err := strconv.ParseFloat(cpuCostStr, 64)
 	if err != nil {
-		log.Warningf("CostModel: custom pricing has illegal CPU cost: %s", cpuCostStr)
+		log.DedupedWarningf(10, "CostModel: custom pricing has illegal CPU cost: %s", cpuCostStr)
 	}
 	node.CostPerCPUHr = costPerCPUHr
 
 	costPerGPUHr, err := strconv.ParseFloat(gpuCostStr, 64)
 	if err != nil {
-		log.Warningf("CostModel: custom pricing has illegal GPU cost: %s", gpuCostStr)
+		log.DedupedWarningf(10, "CostModel: custom pricing has illegal GPU cost: %s", gpuCostStr)
 	}
 	node.CostPerGPUHr = costPerGPUHr
 
 	costPerRAMHr, err := strconv.ParseFloat(ramCostStr, 64)
 	if err != nil {
-		log.Warningf("CostModel: custom pricing has illegal RAM cost: %s", ramCostStr)
+		log.DedupedWarningf(10, "CostModel: custom pricing has illegal RAM cost: %s", ramCostStr)
 	}
 	node.CostPerRAMGiBHr = costPerRAMHr
 


### PR DESCRIPTION
## What does this PR change?

Replaces all occurences of Warningf log function with DedupedWarningf in allocation.go


## Does this PR rely on any other PRs?

No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Less log spam 

## How was this PR tested?

Change seems small enough to test via nightly.

## Have you made an update to documentation?

N/A
