### PR TITLE
Cherry-pick v1.91.2 changes into dev

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1606,7 +1606,7 @@ func (aws *AWS) QueryAthenaPaginated(ctx context.Context, query string, fn func(
 	// Query Athena
 	startQueryExecutionOutput, err := cli.StartQueryExecution(ctx, startQueryExecutionInput)
 	if err != nil {
-		log.Errorf(err.Error())
+		return fmt.Errorf("QueryAthenaPaginated: start query error: %s", err.Error())
 	}
 	err = waitForQueryToComplete(ctx, cli, startQueryExecutionOutput.QueryExecutionId)
 	if err != nil {
@@ -1637,11 +1637,12 @@ func waitForQueryToComplete(ctx context.Context, client *athena.Client, queryExe
 		if err != nil {
 			return err
 		}
-		if qe.QueryExecution.Status.State != "RUNNING" && qe.QueryExecution.Status.State != "QUEUED" {
-			return fmt.Errorf("no query results available for query %s", *queryExecutionID)
-		}
 		if qe.QueryExecution.Status.State == "SUCCEEDED" {
 			isQueryStillRunning = false
+			continue
+		}
+		if qe.QueryExecution.Status.State != "RUNNING" && qe.QueryExecution.Status.State != "QUEUED" {
+			return fmt.Errorf("no query results available for query %s", *queryExecutionID)
 		}
 		time.Sleep(2 * time.Second)
 	}

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1610,7 +1610,7 @@ func (aws *AWS) QueryAthenaPaginated(ctx context.Context, query string, fn func(
 	}
 	err = waitForQueryToComplete(ctx, cli, startQueryExecutionOutput.QueryExecutionId)
 	if err != nil {
-		log.Errorf("QueryAthenaPaginated: query execution error: %s", err.Error())
+		return fmt.Errorf("QueryAthenaPaginated: query execution error: %s", err.Error())
 	}
 	queryResultsInput := &athena.GetQueryResultsInput{
 		QueryExecutionId: startQueryExecutionOutput.QueryExecutionId,


### PR DESCRIPTION
## What does this PR change?
Cherry-pick commits from v1.91.2 patch releases https://github.com/kubecost/cost-model/pull/1114 and https://github.com/kubecost/cost-model/pull/1117 back into develop.


## Does this PR rely on any other PRs?
No.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Changes already released in v1.91.2.

## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Tested on AWS cluster with CUR enabled by editing image, hitting `http://localhost:9090/model/etl/asset/cloud/rebuild?commit=true`, and viewing logs + assets view for cloud assets.

## Have you made an update to documentation?
No.