### PR TITLE
Improve Asset querying by allowing precise times to be passed to Prometheus queries

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -1211,7 +1211,6 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 				Breakdown: &ClusterCostsBreakdown{},
 			}
 		}
-		fmt.Printf("price: %.5f & minutes: %.5f & cost: %.5f\n", cost, diskMap[key].Minutes, diskMap[key].Cost)
 		diskMap[key].Cost = cost * (diskMap[key].Bytes / 1024 / 1024 / 1024) * (diskMap[key].Minutes / 60)
 		providerID, _ := result.GetString("provider_id") // just put the providerID set up here, it's the simplest query.
 		if providerID != "" {

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -518,7 +518,7 @@ func buildActiveDataMap(resActiveMins []*prom.QueryResult, resolution time.Durat
 		}
 
 		s := time.Unix(int64(result.Values[0].Timestamp), 0)
-		e := time.Unix(int64(result.Values[len(result.Values)-1].Timestamp), 0).Add(resolution)
+		e := time.Unix(int64(result.Values[len(result.Values)-1].Timestamp), 0)
 		mins := e.Sub(s).Minutes()
 
 		// TODO niko/assets if mins >= threshold, interpolate for missing data?
@@ -705,6 +705,7 @@ func buildNodeMap(
 	preemptibleMap map[NodeIdentifier]bool,
 	labelsMap map[nodeIdentifierNoProviderID]map[string]string,
 	clusterAndNameToType map[nodeIdentifierNoProviderID]string,
+	res time.Duration,
 ) map[NodeIdentifier]*Node {
 
 	nodeMap := make(map[NodeIdentifier]*Node)
@@ -740,7 +741,7 @@ func buildNodeMap(
 		checkForKeyAndInitIfMissing(nodeMap, id, clusterAndNameToType)
 		nodeMap[id].Start = activeData.start
 		nodeMap[id].End = activeData.end
-		nodeMap[id].Minutes = activeData.minutes
+		nodeMap[id].Minutes = nodeMap[id].End.Sub(nodeMap[id].Start).Minutes()
 	}
 
 	// We now merge in data that doesn't have a provider id by looping over

--- a/pkg/costmodel/cluster_helpers_test.go
+++ b/pkg/costmodel/cluster_helpers_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubecost/cost-model/pkg/config"
-
 	"github.com/kubecost/cost-model/pkg/cloud"
+	"github.com/kubecost/cost-model/pkg/config"
 	"github.com/kubecost/cost-model/pkg/prom"
 	"github.com/kubecost/cost-model/pkg/util"
 
@@ -927,7 +926,11 @@ func TestAssetCustompricing(t *testing.T) {
 			Values: []*util.Vector{
 				&util.Vector{
 					Timestamp: 0,
-					Value:     60.0,
+					Value:     1.0,
+				},
+				&util.Vector{
+					Timestamp: 3600.0,
+					Value:     1.0,
 				},
 			},
 		},
@@ -996,10 +999,10 @@ func TestAssetCustompricing(t *testing.T) {
 			ramResult := ramMap[nodeKey]
 			gpuResult := gpuMap[nodeKey]
 
-			diskMap := map[string]*Disk{}
+			diskMap := map[DiskIdentifier]*Disk{}
 			pvCosts(diskMap, time.Hour, pvMinsPromResult, pvSizePromResult, pvCostPromResult, testProvider)
 
-			diskResult := diskMap["cluster1/pvc1"].Cost
+			diskResult := diskMap[DiskIdentifier{"cluster1", "pvc1"}].Cost
 
 			if !util.IsApproximately(cpuResult, testCase.expectedPricing["CPU"]) {
 				t.Errorf("CPU custom pricing error in %s. Got %v but expected %v", testCase.name, cpuResult, testCase.expectedPricing["CPU"])

--- a/pkg/costmodel/cluster_helpers_test.go
+++ b/pkg/costmodel/cluster_helpers_test.go
@@ -1,10 +1,11 @@
 package costmodel
 
 import (
-	"github.com/kubecost/cost-model/pkg/config"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/kubecost/cost-model/pkg/config"
 
 	"github.com/kubecost/cost-model/pkg/cloud"
 	"github.com/kubecost/cost-model/pkg/prom"
@@ -687,6 +688,7 @@ func TestBuildNodeMap(t *testing.T) {
 				testCase.preemptibleMap,
 				testCase.labelsMap,
 				testCase.clusterAndNameToType,
+				time.Minute,
 			)
 
 			if !reflect.DeepEqual(result, testCase.expected) {

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -692,8 +692,15 @@ func (a *Accesses) PrometheusQuery(w http.ResponseWriter, r *http.Request, _ htt
 		return
 	}
 
+	// TODO test to make sure "time" does not get set, if not given
+
+	var ts time.Time
+	if qp.GetInt64("time", 0) > 0 {
+		ts = time.Unix(qp.GetInt64("time", 0), 0)
+	}
+
 	ctx := prom.NewNamedContext(a.PrometheusClient, prom.FrontendContextName)
-	body, err := ctx.RawQuery(query)
+	body, err := ctx.RawQuery(query, ts)
 	if err != nil {
 		w.Write(WrapData(nil, fmt.Errorf("Error running query %s. Error: %s", query, err)))
 		return
@@ -745,8 +752,15 @@ func (a *Accesses) ThanosQuery(w http.ResponseWriter, r *http.Request, _ httprou
 		return
 	}
 
+	// TODO test to make sure "time" does not get set, if not given
+
+	var ts time.Time
+	if qp.GetInt64("time", 0) > 0 {
+		ts = time.Unix(qp.GetInt64("time", 0), 0)
+	}
+
 	ctx := prom.NewNamedContext(a.ThanosClient, prom.FrontendContextName)
-	body, err := ctx.RawQuery(query)
+	body, err := ctx.RawQuery(query, ts)
 	if err != nil {
 		w.Write(WrapData(nil, fmt.Errorf("Error running query %s. Error: %s", query, err)))
 		return

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -692,15 +692,24 @@ func (a *Accesses) PrometheusQuery(w http.ResponseWriter, r *http.Request, _ htt
 		return
 	}
 
-	// TODO test to make sure "time" does not get set, if not given
+	// Attempt to parse time as either a unix timestamp or as an RFC3339 value
+	var timeVal time.Time
+	timeStr := qp.Get("time", "")
+	if len(timeStr) > 0 {
+		if t, err := strconv.ParseInt(timeStr, 10, 64); err == nil {
+			timeVal = time.Unix(t, 0)
+		} else if t, err := time.Parse(time.RFC3339, timeStr); err == nil {
+			timeVal = t
+		}
 
-	var ts time.Time
-	if qp.GetInt64("time", 0) > 0 {
-		ts = time.Unix(qp.GetInt64("time", 0), 0)
+		// If time is given, but not parse-able, return an error
+		if timeVal.IsZero() {
+			http.Error(w, fmt.Sprintf("time must be a unix timestamp or RFC3339 value; illegal value given: %s", timeStr), http.StatusBadRequest)
+		}
 	}
 
 	ctx := prom.NewNamedContext(a.PrometheusClient, prom.FrontendContextName)
-	body, err := ctx.RawQuery(query, ts)
+	body, err := ctx.RawQuery(query, timeVal)
 	if err != nil {
 		w.Write(WrapData(nil, fmt.Errorf("Error running query %s. Error: %s", query, err)))
 		return
@@ -752,15 +761,24 @@ func (a *Accesses) ThanosQuery(w http.ResponseWriter, r *http.Request, _ httprou
 		return
 	}
 
-	// TODO test to make sure "time" does not get set, if not given
+	// Attempt to parse time as either a unix timestamp or as an RFC3339 value
+	var timeVal time.Time
+	timeStr := qp.Get("time", "")
+	if len(timeStr) > 0 {
+		if t, err := strconv.ParseInt(timeStr, 10, 64); err == nil {
+			timeVal = time.Unix(t, 0)
+		} else if t, err := time.Parse(time.RFC3339, timeStr); err == nil {
+			timeVal = t
+		}
 
-	var ts time.Time
-	if qp.GetInt64("time", 0) > 0 {
-		ts = time.Unix(qp.GetInt64("time", 0), 0)
+		// If time is given, but not parse-able, return an error
+		if timeVal.IsZero() {
+			http.Error(w, fmt.Sprintf("time must be a unix timestamp or RFC3339 value; illegal value given: %s", timeStr), http.StatusBadRequest)
+		}
 	}
 
 	ctx := prom.NewNamedContext(a.ThanosClient, prom.FrontendContextName)
-	body, err := ctx.RawQuery(query, ts)
+	body, err := ctx.RawQuery(query, timeVal)
 	if err != nil {
 		w.Write(WrapData(nil, fmt.Errorf("Error running query %s. Error: %s", query, err)))
 		return

--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -190,8 +190,6 @@ func (ctx *Context) RawQuery(query string, t time.Time) ([]byte, error) {
 	q.Set("query", query)
 
 	if !t.IsZero() {
-		// TODO remove log
-		log.Infof("[Prom] time=%s query=%s", strconv.FormatInt(t.Unix(), 10), query)
 		q.Set("time", strconv.FormatInt(t.Unix(), 10))
 	} else {
 		// for non-range queries, we set the timestamp for the query to time-offset

--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -89,7 +89,19 @@ func (ctx *Context) ErrorCollection() error {
 func (ctx *Context) Query(query string) QueryResultsChan {
 	resCh := make(QueryResultsChan)
 
-	go runQuery(query, ctx, resCh, "")
+	go runQuery(query, ctx, resCh, time.Now(), "")
+
+	return resCh
+}
+
+// QueryWithTime returns a QueryResultsChan, then runs the given query at the
+// given time (see time parameter here: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries)
+// and sends the results on the provided channel. Receiver is responsible for
+// closing the channel, preferably using the Read method.
+func (ctx *Context) QueryAtTime(query string, t time.Time) QueryResultsChan {
+	resCh := make(QueryResultsChan)
+
+	go runQuery(query, ctx, resCh, t, "")
 
 	return resCh
 }
@@ -100,7 +112,7 @@ func (ctx *Context) Query(query string) QueryResultsChan {
 func (ctx *Context) ProfileQuery(query string, profileLabel string) QueryResultsChan {
 	resCh := make(QueryResultsChan)
 
-	go runQuery(query, ctx, resCh, profileLabel)
+	go runQuery(query, ctx, resCh, time.Now(), profileLabel)
 
 	return resCh
 }
@@ -134,7 +146,7 @@ func (ctx *Context) ProfileQueryAll(queries ...string) []QueryResultsChan {
 }
 
 func (ctx *Context) QuerySync(query string) ([]*QueryResult, prometheus.Warnings, error) {
-	raw, warnings, err := ctx.query(query)
+	raw, warnings, err := ctx.query(query, time.Now())
 	if err != nil {
 		return nil, warnings, err
 	}
@@ -154,11 +166,11 @@ func (ctx *Context) QueryURL() *url.URL {
 
 // runQuery executes the prometheus query asynchronously, collects results and
 // errors, and passes them through the results channel.
-func runQuery(query string, ctx *Context, resCh QueryResultsChan, profileLabel string) {
+func runQuery(query string, ctx *Context, resCh QueryResultsChan, t time.Time, profileLabel string) {
 	defer errors.HandlePanic()
 	startQuery := time.Now()
 
-	raw, warnings, requestError := ctx.query(query)
+	raw, warnings, requestError := ctx.query(query, t)
 	results := NewQueryResults(query, raw)
 
 	// report all warnings, request, and parse errors (nils will be ignored)
@@ -172,18 +184,24 @@ func runQuery(query string, ctx *Context, resCh QueryResultsChan, profileLabel s
 }
 
 // RawQuery is a direct query to the prometheus client and returns the body of the response
-func (ctx *Context) RawQuery(query string) ([]byte, error) {
+func (ctx *Context) RawQuery(query string, t time.Time) ([]byte, error) {
 	u := ctx.Client.URL(epQuery, nil)
 	q := u.Query()
 	q.Set("query", query)
 
-	// for non-range queries, we set the timestamp for the query to time-offset
-	// this is a special use case that's typically only used when our primary
-	// prom db has delayed insertion (thanos, cortex, etc...)
-	if promQueryOffset != 0 && ctx.name != AllocationContextName {
-		q.Set("time", time.Now().Add(-promQueryOffset).UTC().Format(time.RFC3339))
+	if !t.IsZero() {
+		// TODO remove log
+		log.Infof("[Prom] time=%s query=%s", strconv.FormatInt(t.Unix(), 10), query)
+		q.Set("time", strconv.FormatInt(t.Unix(), 10))
 	} else {
-		q.Set("time", time.Now().UTC().Format(time.RFC3339))
+		// for non-range queries, we set the timestamp for the query to time-offset
+		// this is a special use case that's typically only used when our primary
+		// prom db has delayed insertion (thanos, cortex, etc...)
+		if promQueryOffset != 0 && ctx.name != AllocationContextName {
+			q.Set("time", time.Now().Add(-promQueryOffset).UTC().Format(time.RFC3339))
+		} else {
+			q.Set("time", time.Now().UTC().Format(time.RFC3339))
+		}
 	}
 
 	u.RawQuery = q.Encode()
@@ -221,8 +239,8 @@ func (ctx *Context) RawQuery(query string) ([]byte, error) {
 	return body, err
 }
 
-func (ctx *Context) query(query string) (interface{}, prometheus.Warnings, error) {
-	body, err := ctx.RawQuery(query)
+func (ctx *Context) query(query string, t time.Time) (interface{}, prometheus.Warnings, error) {
+	body, err := ctx.RawQuery(query, t)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +248,7 @@ func (ctx *Context) query(query string) (interface{}, prometheus.Warnings, error
 	var toReturn interface{}
 	err = json.Unmarshal(body, &toReturn)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unmarshal Error: %s\nQuery: %s", err, query)
+		return nil, nil, fmt.Errorf("query '%s' caused unmarshal error: %s", query, err)
 	}
 
 	warnings := warningsFrom(toReturn)
@@ -354,7 +372,7 @@ func (ctx *Context) queryRange(query string, start, end time.Time, step time.Dur
 	var toReturn interface{}
 	err = json.Unmarshal(body, &toReturn)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Unmarshal Error: %s\nQuery: %s", err, query)
+		return nil, nil, fmt.Errorf("query '%s' caused unmarshal error: %s", query, err)
 	}
 
 	warnings := warningsFrom(toReturn)


### PR DESCRIPTION
Branches off https://github.com/kubecost/cost-model/pull/1104

## What does this PR change?
- Allow passing time to Prometheus queries
- Pass time in Asset node and disk queries
- Remove 1m addition to end for nodes and disks

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- Fixes the query issues where asset (start, end) timestamps would routinely exceed the window, causing logs, and would often also be 1m short, resulting in durations of 59m instead of 1h, e.g.

## Links to Issues or ZD tickets this PR addresses or fixes
- Closes https://github.com/kubecost/cost-model/issues/1126
- Closes (or at least vastly improves) https://kubecost.zendesk.com/agent/tickets/1414

## How was this PR tested?
Manually, using logs to inspect Prometheus queries, resultant minutes running, and warning logs

Warnings like these entirely disappear
```
I0322 21:49:25.173625       1 log.go:32] [Warning] Asset ETL: node 'ip-192-168-92-251.us-east-2.compute.internal' end outside window: 2022-03-22T21:01:00 not in [2022-03-22T20:00:00, 2022-03-22T21:00:00]
I0322 21:49:25.173660       1 log.go:32] [Warning] Asset ETL: node 'ip-192-168-12-152.us-east-2.compute.internal' end outside window: 2022-03-22T21:01:00 not in [2022-03-22T20:00:00, 2022-03-22T21:00:00]
I0322 21:49:25.173672       1 log.go:32] [Warning] Asset ETL: node 'ip-192-168-3-17.us-east-2.compute.internal' end outside window: 2022-03-22T21:01:00 not in [2022-03-22T20:00:00, 2022-03-22T21:00:00]
I0322 21:49:24.964149       1 log.go:32] [Warning] Asset ETL: disk 'ip-192-168-12-152.us-east-2.compute.internal' end outside window: 2022-03-22T20:01:00 not in [2022-03-22T19:00:00, 2022-03-22T20:00:00]
I0322 21:49:24.964159       1 log.go:32] [Warning] Asset ETL: disk 'pvc-c9d62790-556d-49b8-a5c1-7fdf2ce09d72' end outside window: 2022-03-22T20:01:00 not in [2022-03-22T19:00:00, 2022-03-22T20:00:00]
I0322 21:49:24.964166       1 log.go:32] [Warning] Asset ETL: disk 'pvc-fa2baa11-f438-4795-aa32-0c3b6e11f41a' end outside window: 2022-03-22T20:01:00 not in [2022-03-22T19:00:00, 2022-03-22T20:00:00]
```

Minutes running for 1d and 1h queries now look full
```
I0323 00:23:14.617923       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:14.619729       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:14.619802       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:14.619861       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:14.623312       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.623455       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.623539       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.623607       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.623669       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.760218       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.760352       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.760435       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.760503       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:14.760572       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:15.002791       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:15.003041       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:15.003194       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:15.003295       1 log.go:47] [Info] MINUTES: 1440.000000
I0323 00:23:15.025458       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:15.025486       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:15.025505       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:15.025551       1 log.go:47] [Info] MINUTES: 60.000000
I0323 00:23:15.025618       1 log.go:47] [Info] MINUTES: 60.000000
```
