### PR TITLE
Assign default GKE cluster name if none set

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -296,7 +296,7 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 	})
 }
 
-// ClusterName returns the name of a GKE cluster, as provided by metadata.
+// ClusterInfo returns information on the GKE cluster, as provided by metadata.
 func (gcp *GCP) ClusterInfo() (map[string]string, error) {
 	remoteEnabled := env.IsRemoteEnabled()
 

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -318,6 +318,11 @@ func (gcp *GCP) ClusterInfo() (map[string]string, error) {
 		attribute = c.ClusterName
 	}
 
+	// Use a default name if none has been set until this point
+	if attribute == "" {
+		attribute = "GKE Cluster #1"
+	}
+
 	m := make(map[string]string)
 	m["name"] = attribute
 	m["provider"] = "GCP"


### PR DESCRIPTION
## What does this PR change?
This PR assigns a default cluster name "GKE Cluster # 1" at the moment of building the cluster metadata in the case where none had been previously set. 

## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
GKE cluster names will now have a fallback value.


## Links to Issues or ZD tickets this PR addresses or fixes
opened due to https://github.com/kubecost/cost-model/issues/1125 but will not constitute a fix for the user's issue


## How was this PR tested?
N/A


## Have you made an update to documentation?
N/A
