### PR TITLE
JSON-serialization NaN fix

### DIFF
--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -484,15 +484,15 @@ func ComputeIdleCoefficients(shareSplit, key string, cpuCost, gpuCost, ramCost f
 		return coeff, coeff, coeff
 	}
 
-	if allocationTotals[key].CPUCost > 0 {
+	if allocationTotals[key].TotalCPUCost() > 0 {
 		cpuCoeff = cpuCost / allocationTotals[key].TotalCPUCost()
 	}
 
-	if allocationTotals[key].GPUCost > 0 {
+	if allocationTotals[key].TotalGPUCost() > 0 {
 		gpuCoeff = gpuCost / allocationTotals[key].TotalGPUCost()
 	}
 
-	if allocationTotals[key].RAMCost > 0 {
+	if allocationTotals[key].TotalRAMCost() > 0 {
 		ramCoeff = ramCost / allocationTotals[key].TotalRAMCost()
 	}
 

--- a/pkg/kubecost/totals_test.go
+++ b/pkg/kubecost/totals_test.go
@@ -1,0 +1,26 @@
+package kubecost
+
+import (
+	"math"
+	"testing"
+)
+
+func TestComputeIdleCoefficients(t *testing.T) {
+	// test that passing totals where total + adjustment == 0 returns a 0 coefficient
+	at := make(map[string]*AllocationTotals)
+
+	at["item1"] = &AllocationTotals{
+		CPUCost:           1,
+		CPUCostAdjustment: -1,
+		RAMCost:           2,
+		RAMCostAdjustment: -2,
+		GPUCost:           3,
+		GPUCostAdjustment: -3,
+	}
+
+	cpu, gpu, ram := ComputeIdleCoefficients("weighted", "item1", 100, 100, 100, at)
+
+	if math.IsNaN(cpu) || math.IsNaN(gpu) || math.IsNaN(ram) || math.IsInf(cpu, 0) || math.IsInf(gpu, 0) || math.IsInf(ram, 0) {
+		t.Errorf("Idle coefficients should not be NaN or Inf")
+	}
+}


### PR DESCRIPTION
## What does this PR change?

Adds a test for TestComputeIdleCoefficients to ensure that coefficients aren't Inf when total CPU/GPU/RAM costs are zeroed out by adjustment.

Also checks .Total\*Cost() instead of .Total\* to make the test pass.


## Does this PR rely on any other PRs?

No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)

The summary allocation endpoint will no longer break when adjustments zero out total costs for CPU/GPU/RAM


## Links to Issues or ZD tickets this PR addresses or fixes

- Fixes https://kubecost.zendesk.com/agent/tickets/1566


## How was this PR tested?
A unit test is supplied in the PR. I have not 100% confirmed that this is the source of the error in the linked ticket. I think the fastest way to confirm will be to get the user a build with this fix and see whether it resolves their issue. Alternatively, we can try to deduce whether their GPU adjustment is zeroing-out their total GPU costs.

An additional PR to merge into the RC is forthcoming. Thanks to @Sean-Holcomb for looking at this with me.

## Have you made an update to documentation?
Nope.
