### PR TITLE
NewSummaryAllocation Improvements

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1691,16 +1691,10 @@ func (as *AllocationSet) Delete(name string) {
 
 // Each invokes the given function for each Allocation in the set
 func (as *AllocationSet) Each(f func(string, *Allocation)) {
-	as.RLock()
-	defer as.RUnlock()
-
 	if as == nil {
 		return
 	}
 
-	// note: if we find that f() is causing heavy contention and blocking
-	// note: writes, we can hold a read lock while we copy the allocations,
-	// note: then execute the each over the copied map
 	for k, a := range as.allocations {
 		f(k, a)
 	}

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1691,10 +1691,16 @@ func (as *AllocationSet) Delete(name string) {
 
 // Each invokes the given function for each Allocation in the set
 func (as *AllocationSet) Each(f func(string, *Allocation)) {
+	as.RLock()
+	defer as.RUnlock()
+
 	if as == nil {
 		return
 	}
 
+	// note: if we find that f() is causing heavy contention and blocking
+	// note: writes, we can hold a read lock while we copy the allocations,
+	// note: then execute the each over the copied map
 	for k, a := range as.allocations {
 		f(k, a)
 	}

--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -49,7 +49,7 @@ func NewSummaryAllocation(alloc *Allocation, reconcile, reconcileNetwork bool) *
 
 	sa := &SummaryAllocation{
 		Name:                   alloc.Name,
-		Properties:             alloc.Properties.Clone(),
+		Properties:             alloc.Properties,
 		Start:                  alloc.Start,
 		End:                    alloc.End,
 		CPUCoreRequestAverage:  alloc.CPUCoreRequestAverage,


### PR DESCRIPTION
## What does this PR change?
* `NewSummaryAllocation` should _not_ Clone `AllocationProperties`. The `*Allocation` passed should transfer ownership to the Summary. Therefore, putting responsibility on the caller to Clone() if retaining ownership is required. 
* Add proper locking around `Allocation.Each()` to ensure write modifications are not allowed during iteration. 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Should reduce the number of replications of Allocation data during runtime. 

## How was this PR tested?
* The number of callsites was limited, and could be carefully reviewed for any retained Allocation data after calling `NewSummaryAllocation`. Use a test build and heap dumps to verify specific call paths were being invoked correctly.
