### PR TITLE
switch to using buffers in key() creation

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1,6 +1,7 @@
 package kubecost
 
 import (
+	"bytes"
 	"encoding"
 	"fmt"
 	"strings"
@@ -246,7 +247,7 @@ func AssetToExternalAllocation(asset Asset, aggregateBy []string, labelConfig *L
 // Valid values of `aggregateBy` elements are strings which are an `AssetProperty`, and strings prefixed
 // with `"label:"`.
 func key(a Asset, aggregateBy []string) (string, error) {
-	keys := []string{}
+	var buffer bytes.Buffer
 
 	if aggregateBy == nil {
 		aggregateBy = []string{
@@ -262,7 +263,7 @@ func key(a Asset, aggregateBy []string) (string, error) {
 		}
 	}
 
-	for _, s := range aggregateBy {
+	for i, s := range aggregateBy {
 		key := ""
 		switch true {
 		case s == string(AssetProviderProp):
@@ -300,12 +301,15 @@ func key(a Asset, aggregateBy []string) (string, error) {
 		}
 
 		if key != "" {
-			keys = append(keys, key)
+			buffer.WriteString(key)
 		} else {
-			keys = append(keys, UndefinedKey)
+			buffer.WriteString(UndefinedKey)
+		}
+		if i != (len(aggregateBy) - 1) {
+			buffer.WriteString("/")
 		}
 	}
-	return strings.Join(keys, "/"), nil
+	return buffer.String(), nil
 }
 
 func toString(a Asset) string {

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1,7 +1,6 @@
 package kubecost
 
 import (
-	"bytes"
 	"encoding"
 	"fmt"
 	"strings"
@@ -247,7 +246,7 @@ func AssetToExternalAllocation(asset Asset, aggregateBy []string, labelConfig *L
 // Valid values of `aggregateBy` elements are strings which are an `AssetProperty`, and strings prefixed
 // with `"label:"`.
 func key(a Asset, aggregateBy []string) (string, error) {
-	var buffer bytes.Buffer
+	var buffer strings.Builder
 
 	if aggregateBy == nil {
 		aggregateBy = []string{


### PR DESCRIPTION
## What does this PR change?
* Tons of churn doing allocations and growslice, join operations on arrays in key(). Just use a buffer.
![Screen Shot 2022-04-11 at 2 40 58 PM](https://user-images.githubusercontent.com/453512/162902257-94f64962-688c-4333-a7c4-a2e0f6677aee.png)

One quick questions is: should we be precomputing the buffer size to avoid any buffer growth operations? How much efficiency would that gain? @mbolt35 


## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Hopefully a performance improvement

## How was this PR tested?
* This is a pretty simple function that is string manipulation. A unit test is probably the right call but it is TODO... needs scaleteesting as well.

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* Yes...this should be released ASAP. Perhaps even pre next release as part of a set of performance improvements. 
