### PR TITLE
Updated CustomerPricing to include GTag

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -188,6 +188,7 @@ type CustomPricing struct {
 	ShareTenancyCosts            string `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
 	ReadOnly                     string `json:"readOnly"`
 	KubecostToken                string `json:"kubecostToken"`
+	CustomerGoogleTag            string `json:"customerGoogleTag"`
 }
 
 // GetSharedOverheadCostPerMonth parses and returns a float64 representation


### PR DESCRIPTION
## What does this PR change?
Adds CustomerGoogleTag to CustomPricing Model

## Does this PR relate to any other PRs?
- https://github.com/kubecost/cost-analyzer-helm-chart/pull/1373
- https://github.com/kubecost/kubecost-cost-model/pull/729


## How will this PR impact users?
* This allows users to use their own Google Global Tag to track the utilization of their Kubecost frontend!

## Does this PR address any GitHub or Zendesk issues?
* https://github.com/kubecost/cost-analyzer-helm-chart/issues/1358

## How was this PR tested?
* Manually using my GKE cluster.

## Does this PR require changes to documentation?
* Yes - We'll need to add this as a capability.


## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* Next Release
