### PR TITLE
Expose all klog args

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -43,8 +43,10 @@ func Execute(costModelCmd *cobra.Command) error {
 
 	// initialize klog and make cobra aware of all the go flags
 	klog.InitFlags(nil)
-	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
-	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("logtostderr"))
+
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		pflag.CommandLine.AddGoFlag(f)
+	})
 	pflag.CommandLine.Set("v", "3")
 
 	// in the event that no directive/command is passed, we want to default to using the cost-model command


### PR DESCRIPTION
## What does this PR change?
* Exposes all klog args to users

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Allows users to set any klog arg

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-model/issues/1122

## How was this PR tested?
* Tested by building the image and passing args

## Does this PR require changes to documentation?
* Yes
