### PR TITLE
Add append method for AssetLabels

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -360,15 +360,17 @@ func (al AssetLabels) Merge(that AssetLabels) AssetLabels {
 
 // Append joins AssetLabels with a given map of labels
 func (al AssetLabels) Append(newLabels map[string]string, overwrite bool) {
-	if len(newLabels) > 0 {
-		for label, value := range newLabels {
-			if _, ok := al[label]; ok {
-				if overwrite {
-					al[label] = value
-				}
-			} else {
+	if len(newLabels) == 0 {
+		return
+	}
+
+	for label, value := range newLabels {
+		if _, ok := al[label]; ok {
+			if overwrite {
 				al[label] = value
 			}
+		} else {
+			al[label] = value
 		}
 	}
 }

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -358,6 +358,25 @@ func (al AssetLabels) Merge(that AssetLabels) AssetLabels {
 	return result
 }
 
+// Append joins the existing AssetLabels with a given map of labels
+func (al AssetLabels) Append(newLabels map[string]string) AssetLabels {
+	if al == nil {
+		// If the asset didn't have labels before, it will now
+		return newLabels
+	}
+
+	if len(newLabels) == 0 {
+		return al
+	}
+
+	// If a label with the given name already exists, its value will be overwritten by this input
+	for label, value := range newLabels {
+		al[label] = value
+	}
+
+	return al
+}
+
 // AssetMatchFunc is a function that can be used to match Assets by
 // returning true for any given Asset if a condition is met.
 type AssetMatchFunc func(Asset) bool

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -358,23 +358,19 @@ func (al AssetLabels) Merge(that AssetLabels) AssetLabels {
 	return result
 }
 
-// Append joins the existing AssetLabels with a given map of labels
-func (al AssetLabels) Append(newLabels map[string]string) AssetLabels {
-	if al == nil {
-		// If the asset didn't have labels before, it will now
-		return newLabels
+// Append joins AssetLabels with a given map of labels
+func (al AssetLabels) Append(newLabels map[string]string, overwrite bool) {
+	if len(newLabels) > 0 {
+		for label, value := range newLabels {
+			if _, ok := al[label]; ok {
+				if overwrite {
+					al[label] = value
+				}
+			} else {
+				al[label] = value
+			}
+		}
 	}
-
-	if len(newLabels) == 0 {
-		return al
-	}
-
-	// If a label with the given name already exists, its value will be overwritten by this input
-	for label, value := range newLabels {
-		al[label] = value
-	}
-
-	return al
 }
 
 // AssetMatchFunc is a function that can be used to match Assets by


### PR DESCRIPTION
## What does this PR change?
This PR adds an `append(labels map[string]string)` method to be used on objects of type `AssetLabels`. 

## Does this PR relate to any other PRs?
Yes, this PR must be merged before https://github.com/kubecost/kubecost-cost-model/pull/718 

## How will this PR impact users?
Not directly

## Does this PR address any GitHub or Zendesk issues?
- addresses https://github.com/kubecost/cost-analyzer-helm-chart/issues/946 

## How was this PR tested?
N/A

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
Yes
