### PR TITLE
GCP pricing loop

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -451,6 +451,8 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]Key, pvKeys map[stri
 		t, err := dec.Token()
 		if err == io.EOF {
 			break
+		} else if err != nil {
+			return nil, "", fmt.Errorf("Error parsing GCP pricing page: %s", err)
 		}
 		if t == "skus" {
 			_, err := dec.Token() // consumes [


### PR DESCRIPTION
## What does this PR change?
* Propagates errors on reading pages of GCP pricing data.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users whose GCP pricing data fails to download and parse will get an error in the logs, rather than an unlogged error and an endlessly looping goroutine.

## Does this PR address any GitHub or Zendesk issues?
* Relates to https://github.com/kubecost/cost-model/issues/1125

## How was this PR tested?
* Building and deploying the cost analyzer image.

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* I have labeled it next release
