### PR TITLE
Filters v2: (Allocation) in-Go representation + basic Matches() implementation

### DIFF
--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -4,37 +4,37 @@ import "github.com/kubecost/cost-model/pkg/log"
 
 // FilterField is an enum that represents Allocation-specific fields that can be
 // filtered on (namespace, label, etc.)
-type FilterField int
+type FilterField string
 
 // If you add a FilterField, MAKE SURE TO UPDATE ALL FILTER IMPLEMENTATIONS! Go
 // does not enforce exhaustive pattern matching on "enum" types.
 const (
-	FilterClusterID FilterField = iota
-	FilterNode
-	FilterNamespace
-	FilterControllerKind
-	FilterControllerName
-	FilterPod
-	FilterContainer
+	FilterClusterID      FilterField = "clusterid"
+	FilterNode                       = "node"
+	FilterNamespace                  = "namespace"
+	FilterControllerKind             = "controllerkind"
+	FilterControllerName             = "controllername"
+	FilterPod                        = "pod"
+	FilterContainer                  = "container"
 
 	// Filtering based on label aliases (team, department, etc.) should be a
 	// responsibility of the query handler. By the time it reaches this
 	// structured representation, we shouldn't have to be aware of what is
 	// aliased to what.
 
-	FilterLabel
-	FilterAnnotation
+	FilterLabel      = "label"
+	FilterAnnotation = "annotation"
 )
 
 // FilterOp is an enum that represents operations that can be performed
 // when filtering (equality, inequality, etc.)
-type FilterOp int
+type FilterOp string
 
 // If you add a FilterOp, MAKE SURE TO UPDATE ALL FILTER IMPLEMENTATIONS! Go
 // does not enforce exhaustive pattern matching on "enum" types.
 const (
-	FilterEquals FilterOp = iota
-	FilterNotEquals
+	FilterEquals    FilterOp = "equals"
+	FilterNotEquals          = "notequals"
 )
 
 // AllocationFilter represents anything that can be used to filter an

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -2,8 +2,8 @@ package kubecost
 
 import "github.com/kubecost/cost-model/pkg/log"
 
-// FilterCondition is an enum that represents Allocation-specific fields
-// that can be filtered on (namespace, label, etc.)
+// FilterField is an enum that represents Allocation-specific fields that can be
+// filtered on (namespace, label, etc.)
 type FilterField int
 
 // If you add a FilterField, MAKE SURE TO UPDATE ALL FILTER IMPLEMENTATIONS! Go

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -86,7 +86,6 @@ type AllocationFilterAnd struct {
 }
 
 func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
-	// TODO: For these nil cases, what about != filters?
 	if a == nil {
 		return false
 	}
@@ -181,7 +180,6 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 func (and AllocationFilterAnd) Matches(a *Allocation) bool {
 	filters := and.Filters
 	if len(filters) == 0 {
-		// TODO: Should an empty set of ANDs be true or false?
 		return true
 	}
 

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -32,8 +32,6 @@ type FilterOp int
 // does not enforce exhaustive pattern matching on "enum" types.
 const (
 	FilterEquals FilterOp = iota
-
-	// TODO: what is the != behavior for __unallocated__?
 	FilterNotEquals
 )
 
@@ -147,9 +145,9 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 			return false
 		}
 
-		// namespace="__unallocated__" should match a.Properties.Namespace = ""
-		if valueToCompare == "" && filter.Value == UnallocatedSuffix {
-			return true
+		// namespace:"__unallocated__" should match a.Properties.Namespace = ""
+		if valueToCompare == "" {
+			return filter.Value == UnallocatedSuffix
 		}
 
 		if valueToCompare == filter.Value {
@@ -160,7 +158,10 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 			return true
 		}
 
-		// TODO: __unallocated__ behavior?
+		// namespace!:"__unallocated__" should match a.Properties.Namespace != ""
+		if filter.Value == UnallocatedSuffix {
+			return valueToCompare != ""
+		}
 
 		if valueToCompare != filter.Value {
 			return true

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -1,0 +1,163 @@
+package kubecost
+
+// FilterCondition is an enum that represents Allocation-specific fields
+// that can be filtered on (namespace, label, etc.)
+type FilterField int
+
+const (
+	FilterClusterID FilterField = iota
+	FilterNamespace
+	// ControllerKind
+	// ControllerName
+	// Pod
+	// Container
+
+	FilterLabel
+	// Annotation
+)
+
+// FilterOp is an enum that represents operations that can be performed
+// when filtering (equality, inequality, etc.)
+type FilterOp int
+
+const (
+	FilterEquals FilterOp = iota
+
+	// TODO: what is the != behavior for __unallocated__?
+	FilterNotEquals
+)
+
+// AllocationFilter is a mini-DSL for filtering Allocation data by different
+// conditions. By specifying a more strict DSL instead of using arbitrary
+// functions we gain the ability to take advantage of storage-level filtering
+// performance improvements like indexes in databases. We can create a
+// transformation from our DSL to the storage's specific query language. We
+// also gain the ability to define a more feature-rich query language for
+// users, supporting more operators and more complex logic, if desired.
+type AllocationFilter interface {
+	// Matches is the canonical in-Go function for determing if an Allocation
+	// matches a filter.
+	Matches(a *Allocation) bool
+}
+
+// AllocationFilterCondition is the lowest-level type of filter. It represents
+// the a filter operation (equality, inequality, etc.) on a field (namespace,
+// label, etc.).
+type AllocationFilterCondition struct {
+	Field FilterField
+	Op    FilterOp
+
+	// Key is for filters that require key-value pairs, like labels or
+	// annotations.
+	//
+	// A filter of 'label[app]:"foo"' has Key="app" and Value="foo"
+	Key string
+
+	// Value is for _all_ filters. A filter of 'namespace:"kubecost"' has
+	// Value="kubecost"
+	Value string
+}
+
+// AllocationFilterOr is a set of filters that should be evaluated as a logical
+// OR.
+type AllocationFilterOr struct {
+	Filters []AllocationFilter
+}
+
+// AllocationFilterOr is a set of filters that should be evaluated as a logical
+// AND.
+type AllocationFilterAnd struct {
+	Filters []AllocationFilter
+}
+
+func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
+	// TODO: For these nil cases, what about != filters?
+	if a == nil {
+		return false
+	}
+	if a.Properties == nil {
+		return false
+	}
+
+	// TODO Controller PARSING should allow controllerkind:controllername
+	// syntax, converted to:
+	// (AND (ControllerName Equals) (ControllerKind Equals))
+
+	// The Allocation's value for the field to compare
+	var valueToCompare string
+
+	// This switch maps the filter.Field to the field to be compared in
+	// a.Properties and sets valueToCompare from the value in a.Properties.
+	switch filter.Field {
+	case FilterClusterID:
+		valueToCompare = a.Properties.Cluster
+	case FilterNamespace:
+		valueToCompare = a.Properties.Namespace
+	// Comes from GetAnnotation/LabelFilterFunc in KCM
+	case FilterLabel:
+		val, ok := a.Properties.Labels[filter.Key]
+
+		// TODO: What about label != ?
+		if !ok {
+			return false
+		}
+
+		valueToCompare = val
+	default:
+		// TODO: log an error here? this should never happen
+		return false
+	}
+
+	switch filter.Op {
+	case FilterEquals:
+		if valueToCompare == "" && filter.Value == UnallocatedSuffix {
+			return true
+		}
+
+		if valueToCompare == filter.Value {
+			return true
+		}
+	case FilterNotEquals:
+		// TODO: __unallocated__ behavior?
+
+		if valueToCompare != filter.Value {
+			return true
+		}
+	default:
+		// TODO: log an error here? this should never happen
+		return false
+	}
+
+	return false
+}
+
+func (and AllocationFilterAnd) Matches(a *Allocation) bool {
+	filters := and.Filters
+	if len(filters) == 0 {
+		// TODO: Should an empty set of ANDs be true or false?
+		return true
+	}
+
+	for _, filter := range filters {
+		if !filter.Matches(a) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (or AllocationFilterOr) Matches(a *Allocation) bool {
+	filters := or.Filters
+	if len(filters) == 0 {
+		return true
+	}
+
+	for _, filter := range filters {
+		if filter.Matches(a) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -37,13 +37,18 @@ const (
 	FilterNotEquals
 )
 
-// AllocationFilter is a mini-DSL for filtering Allocation data by different
-// conditions. By specifying a more strict DSL instead of using arbitrary
-// functions we gain the ability to take advantage of storage-level filtering
-// performance improvements like indexes in databases. We can create a
-// transformation from our DSL to the storage's specific query language. We
-// also gain the ability to define a more feature-rich query language for
-// users, supporting more operators and more complex logic, if desired.
+// AllocationFilter represents anything that can be used to filter an
+// Allocation.
+//
+// Implement this interface with caution. While it is generic, it
+// is intended to be introspectable so query handlers can perform various
+// optimizations. These optimizations include:
+// - Routing a query to the most optimal cache
+// - Querying backing data stores efficiently (e.g. translation to SQL)
+//
+// Custom implementations of this interface outside of this package should not
+// expect to receive these benefits. Passing a custom implementation to a
+// handler may in errors.
 type AllocationFilter interface {
 	// Matches is the canonical in-Go function for determing if an Allocation
 	// matches a filter.
@@ -156,7 +161,8 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 			return true
 		}
 
-		// namespace!:"__unallocated__" should match a.Properties.Namespace != ""
+		// namespace!:"__unallocated__" should match
+		// a.Properties.Namespace != ""
 		if filter.Value == UnallocatedSuffix {
 			return valueToCompare != ""
 		}

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -89,10 +89,6 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 		return false
 	}
 
-	// TODO Controller PARSING should allow controllerkind:controllername
-	// syntax, converted to:
-	// (AND (ControllerName Equals) (ControllerKind Equals))
-
 	// The Allocation's value for the field to compare
 	var valueToCompare string
 

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -1,5 +1,7 @@
 package kubecost
 
+import "github.com/kubecost/cost-model/pkg/log"
+
 // FilterCondition is an enum that represents Allocation-specific fields
 // that can be filtered on (namespace, label, etc.)
 type FilterField int
@@ -135,7 +137,7 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 			valueToCompare = val
 		}
 	default:
-		// TODO: log an error here? this should never happen
+		log.Errorf("Allocation Filter: Unhandled filter field. This is a filter implementation error and requires immediate patching. Field: %d", filter.Field)
 		return false
 	}
 
@@ -167,7 +169,7 @@ func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
 			return true
 		}
 	default:
-		// TODO: log an error here? this should never happen
+		log.Errorf("Allocation Filter: Unhandled filter op. This is a filter implementation error and requires immediate patching. Op: %d", filter.Op)
 		return false
 	}
 

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -28,6 +28,21 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "Node Equals -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Node: "node123",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterNode,
+				Op:    FilterEquals,
+				Value: "node123",
+			},
+
+			expected: true,
+		},
+		{
 			name: "Namespace NotEquals -> false",
 			a: &Allocation{
 				Properties: &AllocationProperties{
@@ -43,6 +58,66 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "ControllerKind Equals -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					ControllerKind: "deployment", // We generally store controller kinds as all lowercase
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterControllerKind,
+				Op:    FilterEquals,
+				Value: "deployment",
+			},
+
+			expected: true,
+		},
+		{
+			name: "ControllerName Equals -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Controller: "kc-cost-analyzer",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterControllerName,
+				Op:    FilterEquals,
+				Value: "kc-cost-analyzer",
+			},
+
+			expected: true,
+		},
+		{
+			name: "Pod (with UID) Equals -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Pod: "pod-123 UID-ABC",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterPod,
+				Op:    FilterEquals,
+				Value: "pod-123 UID-ABC",
+			},
+
+			expected: true,
+		},
+		{
+			name: "Container Equals -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Container: "cost-model",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterContainer,
+				Op:    FilterEquals,
+				Value: "cost-model",
+			},
+
+			expected: true,
+		},
+		{
 			name: `label[app]="foo" -> true`,
 			a: &Allocation{
 				Properties: &AllocationProperties{
@@ -56,6 +131,24 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 				Op:    FilterEquals,
 				Key:   "app",
 				Value: "foo",
+			},
+
+			expected: true,
+		},
+		{
+			name: `annotation[prom_modified_name]="testing123" -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Annotations: map[string]string{
+						"prom_modified_name": "testing123",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterAnnotation,
+				Op:    FilterEquals,
+				Key:   "prom_modified_name",
+				Value: "testing123",
 			},
 
 			expected: true,

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -58,6 +58,51 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "Namespace NotEquals Unallocated -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kube-system",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterNamespace,
+				Op:    FilterNotEquals,
+				Value: UnallocatedSuffix,
+			},
+
+			expected: true,
+		},
+		{
+			name: "Namespace NotEquals Unallocated -> false",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterNamespace,
+				Op:    FilterNotEquals,
+				Value: UnallocatedSuffix,
+			},
+
+			expected: false,
+		},
+		{
+			name: "Namespace Equals Unallocated -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterNamespace,
+				Op:    FilterEquals,
+				Value: UnallocatedSuffix,
+			},
+
+			expected: true,
+		},
+		{
 			name: "ControllerKind Equals -> true",
 			a: &Allocation{
 				Properties: &AllocationProperties{

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -1,0 +1,250 @@
+package kubecost
+
+import (
+	"testing"
+)
+
+func Test_AllocationFilterCondition_Matches(t *testing.T) {
+	cases := []struct {
+		name   string
+		a      *Allocation
+		filter AllocationFilter
+
+		expected bool
+	}{
+		{
+			name: "ClusterID Equals -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "cluster-one",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterEquals,
+				Value: "cluster-one",
+			},
+
+			expected: true,
+		},
+		{
+			name: "Namespace NotEquals -> false",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kube-system",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterNamespace,
+				Op:    FilterNotEquals,
+				Value: "kube-system",
+			},
+
+			expected: false,
+		},
+		{
+			name: `label[app]="foo" -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterLabel,
+				Op:    FilterEquals,
+				Key:   "app",
+				Value: "foo",
+			},
+
+			expected: true,
+		},
+		{
+			name: `namespace unallocated -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterNamespace,
+				Op:    FilterEquals,
+				Value: UnallocatedSuffix,
+			},
+
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		result := c.filter.Matches(c.a)
+
+		if result != c.expected {
+			t.Errorf("%s: expected %t, got %t", c.name, c.expected, result)
+		}
+	}
+}
+
+func Test_AllocationFilterAnd_Matches(t *testing.T) {
+	cases := []struct {
+		name   string
+		a      *Allocation
+		filter AllocationFilter
+
+		expected bool
+	}{
+		{
+			name: `label[app]="foo" and namespace="kubecost" -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kubecost",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+			},
+			filter: AllocationFilterAnd{[]AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterEquals,
+					Key:   "app",
+					Value: "foo",
+				},
+				AllocationFilterCondition{
+					Field: FilterNamespace,
+					Op:    FilterEquals,
+					Value: "kubecost",
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: `label[app]="foo" and namespace="kubecost" -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kubecost-secondary",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+			},
+			filter: AllocationFilterAnd{[]AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterEquals,
+					Key:   "app",
+					Value: "foo",
+				},
+				AllocationFilterCondition{
+					Field: FilterNamespace,
+					Op:    FilterEquals,
+					Value: "kubecost",
+				},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		result := c.filter.Matches(c.a)
+
+		if result != c.expected {
+			t.Errorf("%s: expected %t, got %t", c.name, c.expected, result)
+		}
+	}
+}
+
+func Test_AllocationFilterOr_Matches(t *testing.T) {
+	cases := []struct {
+		name   string
+		a      *Allocation
+		filter AllocationFilter
+
+		expected bool
+	}{
+		{
+			name: `label[app]="foo" or namespace="kubecost" -> first true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				},
+			},
+			filter: AllocationFilterOr{[]AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterEquals,
+					Key:   "app",
+					Value: "foo",
+				},
+				AllocationFilterCondition{
+					Field: FilterNamespace,
+					Op:    FilterEquals,
+					Value: "kubecost",
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: `label[app]="foo" or namespace="kubecost" -> second true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kubecost",
+					Labels: map[string]string{
+						"app": "bar",
+					},
+				},
+			},
+			filter: AllocationFilterOr{[]AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterEquals,
+					Key:   "app",
+					Value: "foo",
+				},
+				AllocationFilterCondition{
+					Field: FilterNamespace,
+					Op:    FilterEquals,
+					Value: "kubecost",
+				},
+			}},
+			expected: true,
+		},
+		{
+			name: `label[app]="foo" or namespace="kubecost" -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Namespace: "kubecost-secondary",
+					Labels: map[string]string{
+						"app": "bar",
+					},
+				},
+			},
+			filter: AllocationFilterOr{[]AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterEquals,
+					Key:   "app",
+					Value: "foo",
+				},
+				AllocationFilterCondition{
+					Field: FilterNamespace,
+					Op:    FilterEquals,
+					Value: "kubecost",
+				},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		result := c.filter.Matches(c.a)
+
+		if result != c.expected {
+			t.Errorf("%s: expected %t, got %t", c.name, c.expected, result)
+		}
+	}
+}

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -136,6 +136,60 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: `label[app]="foo" -> different value -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Labels: map[string]string{
+						"app": "bar",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterLabel,
+				Op:    FilterEquals,
+				Key:   "app",
+				Value: "foo",
+			},
+
+			expected: false,
+		},
+		{
+			name: `label[app]="foo" -> label missing -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Labels: map[string]string{
+						"someotherlabel": "someothervalue",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterLabel,
+				Op:    FilterEquals,
+				Key:   "app",
+				Value: "foo",
+			},
+
+			expected: false,
+		},
+		{
+			name: `label[app]!="foo" -> label missing -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Labels: map[string]string{
+						"someotherlabel": "someothervalue",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterLabel,
+				Op:    FilterNotEquals,
+				Key:   "app",
+				Value: "foo",
+			},
+
+			expected: true,
+		},
+		{
 			name: `annotation[prom_modified_name]="testing123" -> true`,
 			a: &Allocation{
 				Properties: &AllocationProperties{
@@ -149,6 +203,60 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 				Op:    FilterEquals,
 				Key:   "prom_modified_name",
 				Value: "testing123",
+			},
+
+			expected: true,
+		},
+		{
+			name: `annotation[app]="foo" -> different value -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Annotations: map[string]string{
+						"app": "bar",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterAnnotation,
+				Op:    FilterEquals,
+				Key:   "app",
+				Value: "foo",
+			},
+
+			expected: false,
+		},
+		{
+			name: `annotation[app]="foo" -> annotation missing -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Annotations: map[string]string{
+						"someotherannotation": "someothervalue",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterAnnotation,
+				Op:    FilterEquals,
+				Key:   "app",
+				Value: "foo",
+			},
+
+			expected: false,
+		},
+		{
+			name: `annotation[app]!="foo" -> annotation missing -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Annotations: map[string]string{
+						"someotherannotation": "someothervalue",
+					},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterAnnotation,
+				Op:    FilterNotEquals,
+				Key:   "app",
+				Value: "foo",
 			},
 
 			expected: true,


### PR DESCRIPTION
## What does this PR change?
Introduces a structured representation for Allocation filters in the form of the `AllocationFilter` interface and 3 structs that implement that interface: `AllocationFilterCondition`, `AllocationFilterOr`, and `AllocationFilterAnd`. It supports representing all of our current `AllocationProperties` filters, OR, AND, and Not Equals. The code has detailed comments, check it out!

This PR _does not_ introduce anything user-facing or include any changes to existing filtering logic. It is the foundation for work that will introduce those changes.

### Why?
By moving from arbitrary `FilterFunc`s (which have served us well) to a structured representation, we can do many useful things:
- Provide a more featureful query frontend for our API users
- Introspect filters (answer: "what is this trying to filter?") for query-time optimization, like pre-agg ETL
- Translate filters to a backing store-specific language (e.g. SQL) for store-level filtering+optimization

### Important notes
The representation's goal is to support arbitrarily complex boolean expressions for maximum flexibility. This lets us experiment with query "frontends" (string languages, e.g. `namespace:"kubecost" AND cluster!:"testing"`) without worrying that the representation won't be able to support a given frontend.

This representation will be the unifying point for all filter work. It will be challenging to change once it has been merged and implementations are built on top of it, so please review carefully :pray: 

Once the design has settled, we can open a mirror(ish) PR for Asset filters. @mbolt35 do you see any way to use generics to unify the Asset and Allocation filter work?

### Backing design doc

You can find the full Filters v2 design doc [here (internal only)](https://docs.google.com/document/d/1HKkp2bv3mnvfQoBZlpHjfZwQ0FzDLOHKpnwV9gQ_KgU/edit#).

## Does this PR relate to any other PRs?
N/A

## How will this PR impact users?
N/A (requires more work! see design doc!)

## Does this PR address any GitHub or Zendesk issues?
N/A

## How was this PR tested?
Unit tests in this PR

## Does this PR require changes to documentation?
N/A. This PR is purely for devs and documentation is in docstrings.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
No. This PR provides no functionality to the product. Future PRs that depend on this work may be marked as next release.