### PR TITLE
Add athena workgroup to athena config

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -262,6 +262,7 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 			c.AthenaRegion = a.AthenaRegion
 			c.AthenaDatabase = a.AthenaDatabase
 			c.AthenaTable = a.AthenaTable
+			c.AthenaWorkgroup = a.AthenaWorkgroup
 			c.ServiceKeyName = a.ServiceKeyName
 			c.ServiceKeySecret = a.ServiceKeySecret
 			c.AthenaProjectID = a.AccountID

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -167,6 +167,7 @@ type CustomPricing struct {
 	AthenaRegion                 string `json:"athenaRegion"`
 	AthenaDatabase               string `json:"athenaDatabase"`
 	AthenaTable                  string `json:"athenaTable"`
+	AthenaWorkgroup              string `json:"athenaWorkgroup"`
 	MasterPayerARN               string `json:"masterPayerARN"`
 	BillingDataDataset           string `json:"billingDataDataset,omitempty"`
 	CustomPricesEnabled          string `json:"customPricesEnabled"`


### PR DESCRIPTION
This allows setting the workgroup if required but continues to use the
default of primary if nothing is set.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/cost-analyzer-helm-chart/pull/1386
* https://github.com/kubecost/kubecost-cost-model/pull/734

## How will this PR impact users?
* This allows setting the workgroup if required but continues to use the
default of primary if nothing is set.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/897

## How was this PR tested?
* Setting the workgroup, and setting an invalid workgroup which causes the error:

```
I0423 18:57:52.534675       1 awsprovider.go:864] Failed to lookup savings plan data: Error fetching Savings Plan Data: QueryAthenaPaginated: start query error: operation error Athena: StartQueryExecution, https response error StatusCode: 400, RequestID: xxx, InvalidRequestException: WorkGroup is not found.
``` 

## Does this PR require changes to documentation?
* Change was added to the chart


