### PR TITLE
Attribute batch/v1 CronJob controller correctly

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -44,7 +44,11 @@ const (
 )
 
 // isCron matches a CronJob name and captures the non-timestamp name
-var isCron = regexp.MustCompile(`^(.+)-\d{10}$`)
+//
+// We support either a 10 character timestamp OR an 8 character timestamp
+// because batch/v1beta1 CronJobs creates Jobs with 10 character timestamps
+// and batch/v1 CronJobs create Jobs with 8 character timestamps.
+var isCron = regexp.MustCompile(`^(.+)-(\d{10}|\d{8})$`)
 
 type CostModel struct {
 	Cache                      clustercache.ClusterCache

--- a/pkg/costmodel/costmodel_test.go
+++ b/pkg/costmodel/costmodel_test.go
@@ -1,0 +1,67 @@
+package costmodel
+
+import (
+	"testing"
+)
+
+func Test_CostData_GetController_CronJob(t *testing.T) {
+	cases := []struct {
+		name string
+		cd   CostData
+
+		expectedName          string
+		expectedKind          string
+		expectedHasController bool
+	}{
+		{
+			name: "batch/v1beta1 CronJob Job name",
+			cd: CostData{
+				// batch/v1beta1 CronJobs create Jobs with a 10 character
+				// timestamp appended to the end of the name.
+				//
+				// It looks like this:
+				// CronJob: cronjob-1
+				// Job: cronjob-1-1651057200
+				// Pod: cronjob-1-1651057200-mf5c9
+				Jobs: []string{"cronjob-1-1651057200"},
+			},
+
+			expectedName:          "cronjob-1",
+			expectedKind:          "job",
+			expectedHasController: true,
+		},
+		{
+			name: "batch/v1 CronJob Job name",
+			cd: CostData{
+				// batch/v1CronJobs create Jobs with an 8 character timestamp
+				// appended to the end of the name.
+				//
+				// It looks like this:
+				// CronJob: cj-v1
+				// Job: cj-v1-27517770
+				// Pod: cj-v1-27517770-xkrgn
+				Jobs: []string{"cj-v1-27517770"},
+			},
+
+			expectedName:          "cj-v1",
+			expectedKind:          "job",
+			expectedHasController: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			name, kind, hasController := c.cd.GetController()
+
+			if name != c.expectedName {
+				t.Errorf("Name mismatch. Expected: %s. Got: %s", c.expectedName, name)
+			}
+			if kind != c.expectedKind {
+				t.Errorf("Kind mismatch. Expected: %s. Got: %s", c.expectedKind, kind)
+			}
+			if hasController != c.expectedHasController {
+				t.Errorf("HasController mismatch. Expected: %t. Got: %t", c.expectedHasController, hasController)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?

As explained in the new comments, batch/v1beta1 CronJobs create Jobs with
a 10 character timestamp at the end. Our regex (and therefore Pod ->
Job -> CronJob controller attribution) works for this case. However,
batch/v1 CronJobs apparently create Jobs with 8 character timestamps.
This breaks our controller attribution, resulting in every Job being its
own controller.

This commit updates our regex (and adds a unit test) to support the
batch/v1 CronJob Job name format.

### Meta: this is just a stopgap

While this change fixes the immediate problem of v1 CronJob controller attribution, it doesn't address the more general case: Pods with multiple levels of ownership. Below is metadata from a live CronJob (all data from `kubectl get ... -o yaml`) which demonstrates this situation. Note how the Pod has an `ownerReference` to the Job and the Job has an `ownerReference` to the CronJob.

The costmodel's [`CostData` struct](https://github.com/kubecost/cost-model/blob/1ac8ea3a6230d71f1f8fc392ed80646f507751bd/pkg/costmodel/costmodel.go#L75-L100) only expects one level of ownership and hardcodes the type of controllers that can own a Pod: Deployments, Services, DaemonSets, StatefulSets, and Jobs (this is how we refer to CronJobs, with hacked support via the regex edited in this PR). Our limited representation prevents us from correctly attributing controllers for 3rd party deployment solutions like Argo Rollouts (https://github.com/kubecost/cost-model/issues/879) which use CRDs and custom controllers to manage K8s workloads.

The runtime complexity of discovering the true owner/controller of a Pod may be too high, but I want to mention it because this is a real problem.

#### Multi-level ownership example: CronJob
```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  creationTimestamp: "2022-04-27T13:27:23Z"
  name: cj-v1
  namespace: cj-test
  resourceVersion: "145572802"
  uid: b829078e-49c8-42ad-92a7-568cef370a41
```

```yaml          
apiVersion: batch/v1
kind: Job
metadata:
  creationTimestamp: "2022-04-27T14:25:00Z"
  labels:
    controller-uid: d1c02d48-1426-4917-8680-21f3eabb8e77
    job-name: cj-v1-27517825
  name: cj-v1-27517825
  namespace: cj-test
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: CronJob
    name: cj-v1
    uid: b829078e-49c8-42ad-92a7-568cef370a41
  resourceVersion: "145572801"
  uid: d1c02d48-1426-4917-8680-21f3eabb8e77
```

```yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2022-04-27T14:25:00Z"
  generateName: cj-v1-27517825-
  labels:
    controller-uid: d1c02d48-1426-4917-8680-21f3eabb8e77
    job-name: cj-v1-27517825
  name: cj-v1-27517825-2p7dc
  namespace: cj-test
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: cj-v1-27517825
    uid: d1c02d48-1426-4917-8680-21f3eabb8e77
  resourceVersion: "145572798"
  uid: 40f44d32-2b0d-4e42-8e8a-a7237140955b
```

## Does this PR relate to any other PRs?
N/A

## How will this PR impact users?
batch/v1 CronJob data will have the correct controller. Before this fix, the Jobs created by a batch/v1 CronJob would each belong to their own controller with the name of the Job (according to Kubecost) instead of belonging to the parent CronJob.

## Does this PR address any GitHub or Zendesk issues?
This will help some users affected by https://github.com/kubecost/kubecost-cost-model/issues/651. At least one report (https://kubecost.zendesk.com/agent/tickets/1712) of request sizing over-estimation is caused by this CronJob controller mis-attribution and should be resolved by this ticket, though an ETL rebuilt _will_ be required. There is a more fundamental problem with KCM#651 that I will address separately.

## How was this PR tested?
### Unit tests

I pulled test Job names from live clusters, one with a batch/v1 CronJob
and another with a batch/v1beta1 CronJob. GKE wouldn't let me create a
new batch/v1beta1 CronJob -- it seems to auto-upgrade. Fortunately, there
already was a batch/v1beta1 CronJob in our integration test cluster.

### Live tests

Deployed this code to a cluster with batch/v1 CronJobs. Observed that ETL data built after this change had the correct controller name (the name of the cronjob) instead of the individual job (name of the cronjob + timestamp) which it had beforehand.

After a full rebuild, this PR also corrected request sizing's savings over-estimation for those CronJobs. Again, this doesn't fully resolve the request sizing problem, just for over-estimation of batch/v1 CronJobs on freshly-built ETL data.

## Does this PR require changes to documentation?
N/A
