### PR TITLE
Allow alloc/asset set clone of errors/warnings

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1668,11 +1668,30 @@ func (as *AllocationSet) Clone() *AllocationSet {
 		idleKeys[k] = v
 	}
 
+	var errors []string
+	var warnings []string
+
+	if as.Errors != nil {
+		errors = make([]string, len(as.Errors))
+		copy(errors, as.Errors)
+	} else {
+		errors = nil
+	}
+
+	if as.Warnings != nil {
+		warnings := make([]string, len(as.Warnings))
+		copy(warnings, as.Warnings)
+	} else {
+		warnings = nil
+	}
+
 	return &AllocationSet{
 		allocations:  allocs,
 		externalKeys: externalKeys,
 		idleKeys:     idleKeys,
 		Window:       as.Window.Clone(),
+		Errors:       errors,
+		Warnings:     warnings,
 	}
 }
 

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2530,10 +2530,29 @@ func (as *AssetSet) Clone() *AssetSet {
 	s := as.Start()
 	e := as.End()
 
+	var errors []string
+	var warnings []string
+
+	if as.Errors != nil {
+		errors = make([]string, len(as.Errors))
+		copy(errors, as.Errors)
+	} else {
+		errors = nil
+	}
+
+	if as.Warnings != nil {
+		warnings := make([]string, len(as.Warnings))
+		copy(warnings, as.Warnings)
+	} else {
+		warnings = nil
+	}
+
 	return &AssetSet{
 		Window:      NewWindow(&s, &e),
 		aggregateBy: aggregateBy,
 		assets:      assets,
+		Errors:      errors,
+		Warnings:    warnings,
 	}
 }
 


### PR DESCRIPTION
## What does this PR change?
Adds cloning of errors/warnings to AllocationSets and AssetSets.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
It may have slight performance ramifications, but I have discussed this w/ others and think it will be minimal.

## Does this PR address any GitHub or Zendesk issues?


## How was this PR tested?
Tested as part of the functionality of the linked issue.

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
Yes
