### PR TITLE
Add Clone to SummaryAllocationSet

### DIFF
--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -371,6 +371,32 @@ func NewSummaryAllocationSet(as *AllocationSet, ffs, kfs []AllocationMatchFunc, 
 	return sas
 }
 
+// Clone creates a deep copy of the SummaryAllocationSet
+func (sas *SummaryAllocationSet) Clone() *SummaryAllocationSet {
+	sas.RLock()
+	defer sas.RUnlock()
+
+	externalKeys := make(map[string]bool, len(sas.externalKeys))
+	for k, v := range sas.externalKeys {
+		externalKeys[k] = v
+	}
+	idleKeys := make(map[string]bool, len(sas.idleKeys))
+	for k, v := range sas.idleKeys {
+		idleKeys[k] = v
+	}
+	summaryAllocations := make(map[string]*SummaryAllocation, len(sas.SummaryAllocations))
+	for k, v := range sas.SummaryAllocations {
+		summaryAllocations[k] = v.Clone()
+	}
+
+	return &SummaryAllocationSet{
+		externalKeys:       externalKeys,
+		idleKeys:           idleKeys,
+		SummaryAllocations: summaryAllocations,
+		Window:             sas.Window.Clone(),
+	}
+}
+
 // Add sums two SummaryAllocationSets, which Adds all SummaryAllocations in the
 // given SummaryAllocationSet to thier counterparts in the receiving set. Add
 // also expands the Window to include both constituent Windows, in the case


### PR DESCRIPTION
## What does this PR change?
* Adds `Clone()` to `SummaryAllocationSet` for supporting caching. 

## Does this PR address any GitHub or Zendesk issues?
* It is part of a fix for https://github.com/kubecost/cost-analyzer-helm-chart/issues/1391

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* Required for fixing a current feature slated for 1.93
