### PR TITLE
use custom cloud provider + no watchers for etl readonly mode

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -423,7 +423,11 @@ func ShareTenancyCosts(p Provider) bool {
 func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.ConfigFileManager) (Provider, error) {
 	nodes := cache.GetAllNodes()
 	if len(nodes) == 0 {
-		return nil, fmt.Errorf("Could not locate any nodes for cluster.")
+		log.Infof("Could not locate any nodes for cluster.") // valid in ETL readonly mode
+		return &CustomProvider{
+			Clientset: cache,
+			Config:    NewProviderConfig(config, "default.json"),
+		}, nil
 	}
 
 	cp := getClusterProperties(nodes[0])

--- a/pkg/clustercache/clustercache.go
+++ b/pkg/clustercache/clustercache.go
@@ -134,27 +134,30 @@ func NewKubernetesClusterCache(client kubernetes.Interface) ClusterCache {
 	}
 
 	// Wait for each caching watcher to initialize
-	var wg sync.WaitGroup
-	wg.Add(16)
-
 	cancel := make(chan struct{})
-
-	go initializeCache(kcc.namespaceWatch, &wg, cancel)
-	go initializeCache(kcc.nodeWatch, &wg, cancel)
-	go initializeCache(kcc.podWatch, &wg, cancel)
-	go initializeCache(kcc.kubecostConfigMapWatch, &wg, cancel)
-	go initializeCache(kcc.serviceWatch, &wg, cancel)
-	go initializeCache(kcc.daemonsetsWatch, &wg, cancel)
-	go initializeCache(kcc.deploymentsWatch, &wg, cancel)
-	go initializeCache(kcc.statefulsetWatch, &wg, cancel)
-	go initializeCache(kcc.replicasetWatch, &wg, cancel)
-	go initializeCache(kcc.pvWatch, &wg, cancel)
-	go initializeCache(kcc.pvcWatch, &wg, cancel)
-	go initializeCache(kcc.storageClassWatch, &wg, cancel)
-	go initializeCache(kcc.jobsWatch, &wg, cancel)
-	go initializeCache(kcc.hpaWatch, &wg, cancel)
-	go initializeCache(kcc.podWatch, &wg, cancel)
-	go initializeCache(kcc.replicationControllerWatch, &wg, cancel)
+	var wg sync.WaitGroup
+	if env.GetETLReadOnlyMode() {
+		wg.Add(1)
+		go initializeCache(kcc.kubecostConfigMapWatch, &wg, cancel)
+	} else {
+		wg.Add(16)
+		go initializeCache(kcc.kubecostConfigMapWatch, &wg, cancel)
+		go initializeCache(kcc.namespaceWatch, &wg, cancel)
+		go initializeCache(kcc.nodeWatch, &wg, cancel)
+		go initializeCache(kcc.podWatch, &wg, cancel)
+		go initializeCache(kcc.serviceWatch, &wg, cancel)
+		go initializeCache(kcc.daemonsetsWatch, &wg, cancel)
+		go initializeCache(kcc.deploymentsWatch, &wg, cancel)
+		go initializeCache(kcc.statefulsetWatch, &wg, cancel)
+		go initializeCache(kcc.replicasetWatch, &wg, cancel)
+		go initializeCache(kcc.pvWatch, &wg, cancel)
+		go initializeCache(kcc.pvcWatch, &wg, cancel)
+		go initializeCache(kcc.storageClassWatch, &wg, cancel)
+		go initializeCache(kcc.jobsWatch, &wg, cancel)
+		go initializeCache(kcc.hpaWatch, &wg, cancel)
+		go initializeCache(kcc.podWatch, &wg, cancel)
+		go initializeCache(kcc.replicationControllerWatch, &wg, cancel)
+	}
 
 	wg.Wait()
 

--- a/pkg/clustercache/clustercache.go
+++ b/pkg/clustercache/clustercache.go
@@ -136,7 +136,7 @@ func NewKubernetesClusterCache(client kubernetes.Interface) ClusterCache {
 	// Wait for each caching watcher to initialize
 	cancel := make(chan struct{})
 	var wg sync.WaitGroup
-	if env.GetETLReadOnlyMode() {
+	if env.IsETLReadOnlyMode() {
 		wg.Add(1)
 		go initializeCache(kcc.kubecostConfigMapWatch, &wg, cancel)
 	} else {

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1611,7 +1611,6 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 
 	// Initialize mechanism for subscribing to settings changes
 	a.InitializeSettingsPubSub()
-
 	err = a.CloudProvider.DownloadPricingData()
 	if err != nil {
 		log.Infof("Failed to download pricing data: " + err.Error())

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -88,7 +88,7 @@ const (
 	ETLReadOnlyMode = "ETL_READ_ONLY"
 )
 
-func GetETLReadOnlyMode() bool {
+func IsETLReadOnlyMode() bool {
 	return GetBool(ETLReadOnlyMode, false)
 }
 

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -84,7 +84,13 @@ const (
 	PrometheusRetryOnRateLimitDefaultWaitEnvVar = "PROMETHEUS_RETRY_ON_RATE_LIMIT_DEFAULT_WAIT"
 
 	IngestPodUIDEnvVar = "INGEST_POD_UID"
+
+	ETLReadOnlyMode = "ETL_READ_ONLY"
 )
+
+func GetETLReadOnlyMode() bool {
+	return GetBool(ETLReadOnlyMode, false)
+}
 
 // GetKubecostConfigBucket returns a file location for a mounted bucket configuration which is used to store
 // a subset of kubecost configurations that require sharing via remote storage.


### PR DESCRIPTION
## What does this PR change?
* Allows users to deploy kubecost to clusters that do not access the k8s api. The purpose is to still monitor federated clusters that _do_ connect to the k8s API.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Support running kubecost in 

## How was this PR tested?
* Manually, ran against a federated thanos and noted that the UI/ETL still functions. 

## Does this PR require changes to documentation?
* The flag is documented. I would prefer to discourage running in this mode, so not calling it out further.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* I don't want to rush the team into getting this into the next release, but if it makes it great :)
