### PR TITLE
Don't add gpu pricing when no gpu

### DIFF
--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -246,10 +246,10 @@ func buildGPUCostMap(
 		clusterAndNameToType[keyNon] = nodeType
 
 		// If gpu count is available use it to multiply gpu cost
-		if value, ok := gpuCountMap[key]; ok && value != 0 {
+		if value, ok := gpuCountMap[key]; ok {
 			gpuCostMap[key] = gpuCost * value
 		} else {
-			gpuCostMap[key] = gpuCost
+			gpuCostMap[key] = 0
 		}
 
 	}

--- a/pkg/costmodel/cluster_helpers_test.go
+++ b/pkg/costmodel/cluster_helpers_test.go
@@ -772,7 +772,7 @@ func TestBuildGPUCostMap(t *testing.T) {
 					Cluster:    "cluster1",
 					Name:       "node1",
 					ProviderID: "provider1",
-				}: 2,
+				}: 0,
 			},
 		},
 		{
@@ -799,7 +799,7 @@ func TestBuildGPUCostMap(t *testing.T) {
 					Cluster:    "cluster1",
 					Name:       "node1",
 					ProviderID: "provider1",
-				}: 2,
+				}: 0,
 			},
 		},
 		{


### PR DESCRIPTION
## What does this PR change?
* When building node pricing, no longer add GPU costs if the node does not have an associated GPU


## How will this PR impact users?
* Fix idle cost being associated with nodes that do not have a GPU when using custom pricing

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1389

## How was this PR tested?
* Running in a custom cluster before and after the change
* Running in an EKS cluster with two non-GPU nodes and a single GPU node. Tested before and after the fix to ensure idle time was not attributed to nodes without the GPU and GPU node showed idle time. 

## Does this PR require changes to documentation?
* n/a

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
