### PR TITLE
Remove ANSI colors from podLogs endpoint and update logging init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ui/.cache
 ui/dist
 ui/node_modules/
+cmd/costmodel/costmodel

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -68,9 +68,11 @@ func newRootCommand(costModelCmd *cobra.Command) *cobra.Command {
 	// Add our persistent flags, these are global and available anywhere
 	cmd.PersistentFlags().String("log-level", "info", "Set the log level")
 	cmd.PersistentFlags().String("log-format", "pretty", "Set the log format - Can be either 'JSON' or 'pretty'")
+	cmd.PersistentFlags().Bool("disable-log-color", false, "Disable coloring of log output")
 
 	viper.BindPFlag("log-level", cmd.PersistentFlags().Lookup("log-level"))
 	viper.BindPFlag("log-format", cmd.PersistentFlags().Lookup("log-format"))
+	viper.BindPFlag("disable-log-color", cmd.PersistentFlags().Lookup("disable-log-color"))
 
 	// Setup viper to read from the env, this allows reading flags from the command line or the env
 	// using the format 'LOG_LEVEL'
@@ -83,8 +85,6 @@ func newRootCommand(costModelCmd *cobra.Command) *cobra.Command {
 		newAgentCommand(),
 	)
 
-	log.InitLogging()
-
 	return cmd
 }
 
@@ -96,6 +96,9 @@ func newCostModelCommand() *cobra.Command {
 		Use:   CommandCostModel,
 		Short: "Cost-Model metric exporter and data aggregator.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Init logging here so cobra/viper has processed the command line args and flags
+			// otherwise only envvars are available during init
+			log.InitLogging()
 			return costmodel.Execute(opts)
 		},
 	}
@@ -114,6 +117,9 @@ func newAgentCommand() *cobra.Command {
 		Use:   CommandAgent,
 		Short: "Agent mode operates as a metric exporter only.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Init logging here so cobra/viper has processed the command line args and flags
+			// otherwise only envvars are available during init
+			log.InitLogging()
 			return agent.Execute(opts)
 		},
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,7 +21,8 @@ func InitLogging() {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	// Default to using pretty formatting
 	if strings.ToLower(viper.GetString("log-format")) != "json" {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano})
+		disableColor := viper.GetBool("disable-log-color")
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano, NoColor: disableColor})
 	}
 
 	level, err := zerolog.ParseLevel(viper.GetString("log-level"))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,7 +21,7 @@ func InitLogging() {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	// Default to using pretty formatting
 	if strings.ToLower(viper.GetString("log-format")) != "json" {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano, NoColor: true})
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano})
 	}
 
 	level, err := zerolog.ParseLevel(viper.GetString("log-level"))


### PR DESCRIPTION
## What does this PR change?
* Add colors back to logs and remove the ANSI colors from the podLogs endpoint. This fixes the issue when a customer creates a bug report and we process logs from kubectl directly which adds the colors. 
* Move logging init to happen after cobra has processed the flags/args
and add a new flag to disable color output of the logs


