### PR TITLE
Add AllocationFilter support for services contains

### DIFF
--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -321,6 +321,66 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 
 			expected: true,
 		},
+		{
+			name: `services contains -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"serv1", "serv2"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterContains,
+				Value: "serv2",
+			},
+
+			expected: true,
+		},
+		{
+			name: `services contains -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"serv1", "serv2"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterContains,
+				Value: "serv3",
+			},
+
+			expected: false,
+		},
+		{
+			name: `services contains unallocated -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"serv1", "serv2"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterContains,
+				Value: UnallocatedSuffix,
+			},
+
+			expected: false,
+		},
+		{
+			name: `services contains unallocated -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterContains,
+				Value: UnallocatedSuffix,
+			},
+
+			expected: true,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Existing allocation filtering allows users to `filterServices=a,b,c` which
becomes a "slice contains" operation because `Properties.Services` is a
`[]string`. This commit adds `FilterServices` (Field) and `FilterContains` (Op)
to support this type of filter.

Unallocated behavior is based on existing `GetServiceFilterFunc` (in KCM).

## How was this PR tested?
New unit tests
