### PR TITLE
Add support for translating current filters (filterNamespaces=) to the new AllocationFilter types

### DIFF
--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -382,6 +382,36 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: `services startswith -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"serv1", "serv2"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterStartsWith,
+				Value: "serv",
+			},
+
+			expected: true,
+		},
+		{
+			name: `services startswith -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"foo", "bar"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterStartsWith,
+				Value: "serv",
+			},
+
+			expected: false,
+		},
+		{
 			name: `services contains unallocated -> false`,
 			a: &Allocation{
 				Properties: &AllocationProperties{

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -382,7 +382,7 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: `services startswith -> true`,
+			name: `services containsprefix -> true`,
 			a: &Allocation{
 				Properties: &AllocationProperties{
 					Services: []string{"serv1", "serv2"},
@@ -390,14 +390,14 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			},
 			filter: AllocationFilterCondition{
 				Field: FilterServices,
-				Op:    FilterStartsWith,
+				Op:    FilterContainsPrefix,
 				Value: "serv",
 			},
 
 			expected: true,
 		},
 		{
-			name: `services startswith -> false`,
+			name: `services containsprefix -> false`,
 			a: &Allocation{
 				Properties: &AllocationProperties{
 					Services: []string{"foo", "bar"},
@@ -405,7 +405,7 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			},
 			filter: AllocationFilterCondition{
 				Field: FilterServices,
-				Op:    FilterStartsWith,
+				Op:    FilterContainsPrefix,
 				Value: "serv",
 			},
 

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -28,6 +28,36 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "ClusterID StartsWith -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "cluster-one",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterStartsWith,
+				Value: "cluster",
+			},
+
+			expected: true,
+		},
+		{
+			name: "ClusterID StartsWith -> false",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "k8s-one",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterStartsWith,
+				Value: "cluster",
+			},
+
+			expected: false,
+		},
+		{
 			name: "Node Equals -> true",
 			a: &Allocation{
 				Properties: &AllocationProperties{

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -210,13 +210,16 @@ func AllocationFilterFromParamsV1(
 	}
 	for _, filterValue := range qp.GetList("filterServices", ",") {
 		// TODO: wildcard support
-		servicesFilter.Filters = append(servicesFilter.Filters,
-			kubecost.AllocationFilterCondition{
-				Field: kubecost.FilterServices,
-				Op:    kubecost.FilterContains,
-				Value: filterValue,
-			},
-		)
+		filterValue, wildcard := parseWildcardEnd(filterValue)
+		subFilter := kubecost.AllocationFilterCondition{
+			Field: kubecost.FilterServices,
+			Op:    kubecost.FilterContains,
+			Value: filterValue,
+		}
+		if wildcard {
+			subFilter.Op = kubecost.FilterStartsWith
+		}
+		servicesFilter.Filters = append(servicesFilter.Filters, subFilter)
 	}
 	filter.Filters = append(filter.Filters, servicesFilter)
 

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -174,18 +174,19 @@ func AllocationFilterFromParamsV1(
 		filterV1DoubleValueFromList(qp.GetList("filterLabels", ","), kubecost.FilterLabel),
 	)
 
-	// TODO: filter service condition
-	// filterServices := qp.GetList("filterServices", ",")
-	// if len(filterServices) > 0 {
-	// 	subFilter := kubecost.AllocationFilterOr{
-	// 		Filters: []kubecost.AllocationFilter{},
-	// 	}
-
-	// 	for _, filter := range filterServices {
-	// 		ffs = append(ffs, GetServiceFilterFunc(filter))
-	// 	}
-	// 	filter.Filters = append(filter.Filters, subFilter)
-	// }
+	servicesFilter := kubecost.AllocationFilterOr{
+		Filters: []kubecost.AllocationFilter{},
+	}
+	for _, filterValue := range qp.GetList("filterServices", ",") {
+		servicesFilter.Filters = append(servicesFilter.Filters,
+			kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterServices,
+				Op:    kubecost.FilterContains,
+				Value: filterValue,
+			},
+		)
+	}
+	filter.Filters = append(filter.Filters, servicesFilter)
 
 	return filter
 }

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -1,0 +1,224 @@
+package filterutil
+
+import (
+	"strings"
+
+	"github.com/kubecost/cost-model/pkg/kubecost"
+	"github.com/kubecost/cost-model/pkg/log"
+	"github.com/kubecost/cost-model/pkg/prom"
+	"github.com/kubecost/cost-model/pkg/util/httputil"
+)
+
+func FiltersFromParamsV1(qp httputil.QueryParams) kubecost.AllocationFilter {
+	if qp.Get("filter", "") != "" {
+		// TODO: short-circuit to a query language parser if the filter= param is
+		// present.
+	}
+
+	// TODO: wildcard handling
+
+	filter := kubecost.AllocationFilterAnd{
+		Filters: []kubecost.AllocationFilter{},
+	}
+
+	// TODO: remove comment
+	// The following is adapted from KCM's original pkg/allocation/filters.go
+
+	// Load Label Config
+	// Pull a LabelConfig from the app configuration, or default if
+	// configuration is unavailable.
+	// labelConfig := kubecost.NewLabelConfig()
+
+	// TODO: label config from analyzer in OSS?
+	// cfg, err := config.GetAnalyzerConfig()
+	// if err != nil {
+	// 	log.Warnf("AnalyzerConfig is nil")
+	// } else {
+	// 	labelConfig = cfg.LabelConfig()
+	// }
+
+	filterClusters := qp.GetList("filterClusters", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterClusters, kubecost.FilterClusterID),
+	)
+	// TODO: OR by cluster name
+	// Cluster Map doesn't seem to have a name -> ID mapping,
+	// only an ID (from the allocation) -> name mapping
+
+	// generate a filter func for each node filter, and OR the results
+	filterNodes := qp.GetList("filterNodes", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterNodes, kubecost.FilterNode),
+	)
+
+	// generate a filter func for each namespace filter, and OR the results
+	filterNamespaces := qp.GetList("filterNamespaces", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterNamespaces, kubecost.FilterNamespace),
+	)
+
+	filterControllerKinds := qp.GetList("filterControllerKinds", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterControllerKinds, kubecost.FilterControllerKind),
+	)
+
+	filterControllers := qp.GetList("filterControllers", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterControllers, kubecost.FilterControllerName),
+	)
+	// TODO: controllerkind:controllername filter e.g. "deployment:kubecost"
+
+	filterPods := qp.GetList("filterPods", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterPods, kubecost.FilterPod),
+	)
+
+	filterContainers := qp.GetList("filterContainers", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1SingleValueFromList(filterContainers, kubecost.FilterContainer),
+	)
+
+	// TODO: label mapping special things
+	// filterDepartments := qp.GetList("filterDepartments", ",")
+	// if len(filterDepartments) > 0 {
+	// 	subFilter := kubecost.AllocationFilterOr{
+	// 		Filters: []kubecost.AllocationFilter{},
+	// 	}
+
+	// 	for _, filter := range filterDepartments {
+	// 		ffs = append(ffs, GetDepartmentFilterFunc(labelConfig, filter))
+	// 	}
+	// 	filter.Filters = append(filter.Filters, subFilter)
+	// }
+
+	// filterEnvironments := qp.GetList("filterEnvironments", ",")
+	// if len(filterEnvironments) > 0 {
+	// 	subFilter := kubecost.AllocationFilterOr{
+	// 		Filters: []kubecost.AllocationFilter{},
+	// 	}
+
+	// 	for _, filter := range filterEnvironments {
+	// 		ffs = append(ffs, GetEnvironmentFilterFunc(labelConfig, filter))
+	// 	}
+	// 	filter.Filters = append(filter.Filters, subFilter)
+	// }
+
+	// filterOwners := qp.GetList("filterOwners", ",")
+	// if len(filterOwners) > 0 {
+	// 	subFilter := kubecost.AllocationFilterOr{
+	// 		Filters: []kubecost.AllocationFilter{},
+	// 	}
+
+	// 	for _, filter := range filterOwners {
+	// 		ffs = append(ffs, GetOwnerFilterFunc(labelConfig, filter))
+	// 	}
+	// 	filter.Filters = append(filter.Filters, subFilter)
+	// }
+
+	// filterProducts := qp.GetList("filterProducts", ",")
+	// if len(filterProducts) > 0 {
+	// 	subFilter := kubecost.AllocationFilterOr{
+	// 		Filters: []kubecost.AllocationFilter{},
+	// 	}
+
+	// 	for _, filter := range filterProducts {
+	// 		ffs = append(ffs, GetProductFilterFunc(labelConfig, filter))
+	// 	}
+	// 	filter.Filters = append(filter.Filters, subFilter)
+	// }
+
+	// filterTeams := qp.GetList("filterTeams", ",")
+	// if len(filterTeams) > 0 {
+	// 	subFilter := kubecost.AllocationFilterOr{
+	// 		Filters: []kubecost.AllocationFilter{},
+	// 	}
+
+	// 	for _, filter := range filterTeams {
+	// 		ffs = append(ffs, GetTeamFilterFunc(labelConfig, filter))
+	// 	}
+	// 	filter.Filters = append(filter.Filters, subFilter)
+	// }
+
+	filterAnnotations := qp.GetList("filterAnnotations", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1DoubleValueFromList(filterAnnotations, kubecost.FilterAnnotation),
+	)
+
+	filterLabels := qp.GetList("filterLabels", ",")
+	filter.Filters = append(filter.Filters,
+		filterV1DoubleValueFromList(filterLabels, kubecost.FilterLabel),
+	)
+
+	// TODO: filter service condition
+	// filterServices := qp.GetList("filterServices", ",")
+	// if len(filterServices) > 0 {
+	// 	subFilter := kubecost.AllocationFilterOr{
+	// 		Filters: []kubecost.AllocationFilter{},
+	// 	}
+
+	// 	for _, filter := range filterServices {
+	// 		ffs = append(ffs, GetServiceFilterFunc(filter))
+	// 	}
+	// 	filter.Filters = append(filter.Filters, subFilter)
+	// }
+
+	return filter
+}
+
+// TODO: comment
+// We don't need the filter op because all filter V1 comparisons are equality
+func filterV1SingleValueFromList(rawFilterValues []string, filterField kubecost.FilterField) kubecost.AllocationFilter {
+	// The v1 query language (e.g. "filterNamespaces=XYZ,ABC") uses or within
+	// a field (e.g. namespace = XYZ OR namespace = ABC)
+	filter := kubecost.AllocationFilterOr{
+		Filters: []kubecost.AllocationFilter{},
+	}
+
+	for _, filterValue := range rawFilterValues {
+		filterValue = strings.TrimSpace(filterValue)
+
+		filter.Filters = append(filter.Filters,
+			kubecost.AllocationFilterCondition{
+				Field: filterField,
+				Op:    kubecost.FilterEquals,
+				Value: filterValue,
+			},
+		)
+	}
+
+	return filter
+}
+
+// TODO: comment
+// We don't need the filter op because all filter V1 comparisons are equality
+func filterV1DoubleValueFromList(rawFilterValuesUnsplit []string, filterField kubecost.FilterField) kubecost.AllocationFilter {
+
+	// The v1 query language (e.g. "filterLabels=app:foo,l2:bar") uses OR within
+	// a field (e.g. label[app] = foo OR label[l2] = bar)
+	filter := kubecost.AllocationFilterOr{
+		Filters: []kubecost.AllocationFilter{},
+	}
+
+	for _, unsplit := range rawFilterValuesUnsplit {
+		if unsplit != "" {
+			split := strings.Split(unsplit, ":")
+			if len(split) != 2 {
+				log.Warningf("illegal key/value filter (ignoring): %s", unsplit)
+				continue
+			}
+			key := prom.SanitizeLabelName(strings.TrimSpace(split[0]))
+			val := strings.TrimSpace(split[1])
+
+			filter.Filters = append(filter.Filters,
+				kubecost.AllocationFilterCondition{
+					Field: filterField,
+					Op:    kubecost.FilterEquals,
+					Key:   key,
+					Value: val,
+				},
+			)
+		}
+	}
+
+	return filter
+}

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -33,9 +33,6 @@ func parseWildcardEnd(rawFilterValue string) (string, bool) {
 // It takes an optional ClusterMap, which if provided enables cluster name
 // filtering. This turns all `filterClusters=foo` arguments into the equivalent
 // of `clusterID = "foo" OR clusterName = "foo"`.
-//
-// TODO: This does not yet support filters with wildcards (e.g.
-// filterNamespaces=kube*)
 func AllocationFilterFromParamsV1(
 	qp httputil.QueryParams,
 	labelConfig *kubecost.LabelConfig,

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -10,6 +10,16 @@ import (
 	"github.com/kubecost/cost-model/pkg/util/httputil"
 )
 
+// parseWildcardEnd checks if the given filter value is wildcarded, meaning
+// it ends in "*". If it does, it removes the suffix and returns the cleaned
+// string and true. Otherwise, it returns the same filter and false.
+//
+// parseWildcardEnd("kube*") = "kube", true
+// parseWildcardEnd("kube") = "kube", false
+func parseWildcardEnd(rawFilterValue string) (string, bool) {
+	return strings.TrimSuffix(rawFilterValue, "*"), strings.HasSuffix(rawFilterValue, "*")
+}
+
 // AllocationFilterFromParamsV1 takes a set of HTTP query parameters and
 // converts them to an AllocationFilter, which is a structured in-Go
 // representation of a set of filters.
@@ -69,8 +79,19 @@ func AllocationFilterFromParamsV1(
 		Filters: []kubecost.AllocationFilter{},
 	}
 	clustersOr.Filters = append(clustersOr.Filters, filterV1SingleValueFromList(filterClusters, kubecost.FilterClusterID))
-	for _, possibleClusterName := range filterClusters {
-		for _, clusterID := range clusterNameToIDs[possibleClusterName] {
+	for _, rawFilterValue := range filterClusters {
+		clusterNameFilter, wildcard := parseWildcardEnd(rawFilterValue)
+
+		clusterIDsToFilter := []string{}
+		for clusterName := range clusterNameToIDs {
+			if wildcard && strings.HasPrefix(clusterName, clusterNameFilter) {
+				clusterIDsToFilter = append(clusterIDsToFilter, clusterNameToIDs[clusterName]...)
+			} else if !wildcard && clusterName == clusterNameFilter {
+				clusterIDsToFilter = append(clusterIDsToFilter, clusterNameToIDs[clusterName]...)
+			}
+		}
+
+		for _, clusterID := range clusterIDsToFilter {
 			clustersOr.Filters = append(clustersOr.Filters,
 				kubecost.AllocationFilterCondition{
 					Field: kubecost.FilterClusterID,
@@ -105,27 +126,39 @@ func AllocationFilterFromParamsV1(
 	for _, rawFilterValue := range filterControllers {
 		split := strings.Split(rawFilterValue, ":")
 		if len(split) == 1 {
-			controllersOr.Filters = append(controllersOr.Filters,
-				kubecost.AllocationFilterCondition{
-					Field: kubecost.FilterControllerName,
-					Op:    kubecost.FilterEquals,
-					Value: split[0],
-				})
+			filterValue, wildcard := parseWildcardEnd(split[0])
+			subFilter := kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterControllerName,
+				Op:    kubecost.FilterEquals,
+				Value: filterValue,
+			}
+
+			if wildcard {
+				subFilter.Op = kubecost.FilterStartsWith
+			}
+			controllersOr.Filters = append(controllersOr.Filters, subFilter)
 		} else if len(split) == 2 {
+			kindFilterVal := split[0]
+			nameFilterVal, wildcard := parseWildcardEnd(split[1])
+
+			kindFilter := kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterControllerKind,
+				Op:    kubecost.FilterEquals,
+				Value: kindFilterVal,
+			}
+			nameFilter := kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterControllerName,
+				Op:    kubecost.FilterEquals,
+				Value: nameFilterVal,
+			}
+
+			if wildcard {
+				nameFilter.Op = kubecost.FilterStartsWith
+			}
+
 			// The controller name AND the controller kind must match
 			multiFilter := kubecost.AllocationFilterAnd{
-				Filters: []kubecost.AllocationFilter{
-					kubecost.AllocationFilterCondition{
-						Field: kubecost.FilterControllerKind,
-						Op:    kubecost.FilterEquals,
-						Value: split[0],
-					},
-					kubecost.AllocationFilterCondition{
-						Field: kubecost.FilterControllerName,
-						Op:    kubecost.FilterEquals,
-						Value: split[1],
-					},
-				},
+				Filters: []kubecost.AllocationFilter{kindFilter, nameFilter},
 			}
 			controllersOr.Filters = append(controllersOr.Filters, multiFilter)
 		} else {
@@ -176,6 +209,7 @@ func AllocationFilterFromParamsV1(
 		Filters: []kubecost.AllocationFilter{},
 	}
 	for _, filterValue := range qp.GetList("filterServices", ",") {
+		// TODO: wildcard support
 		servicesFilter.Filters = append(servicesFilter.Filters,
 			kubecost.AllocationFilterCondition{
 				Field: kubecost.FilterServices,
@@ -201,14 +235,20 @@ func filterV1SingleValueFromList(rawFilterValues []string, filterField kubecost.
 
 	for _, filterValue := range rawFilterValues {
 		filterValue = strings.TrimSpace(filterValue)
+		filterValue, wildcard := parseWildcardEnd(filterValue)
 
-		filter.Filters = append(filter.Filters,
-			kubecost.AllocationFilterCondition{
-				Field: filterField,
-				// All v1 filters are equality comparisons
-				Op:    kubecost.FilterEquals,
-				Value: filterValue,
-			})
+		subFilter := kubecost.AllocationFilterCondition{
+			Field: filterField,
+			// All v1 filters are equality comparisons
+			Op:    kubecost.FilterEquals,
+			Value: filterValue,
+		}
+
+		if wildcard {
+			subFilter.Op = kubecost.FilterStartsWith
+		}
+
+		filter.Filters = append(filter.Filters, subFilter)
 	}
 
 	return filter
@@ -224,15 +264,21 @@ func filterV1LabelMappedFromList(rawFilterValues []string, labelName string) kub
 
 	for _, filterValue := range rawFilterValues {
 		filterValue = strings.TrimSpace(filterValue)
+		filterValue, wildcard := parseWildcardEnd(filterValue)
 
-		filter.Filters = append(filter.Filters,
-			kubecost.AllocationFilterCondition{
-				Field: kubecost.FilterLabel,
-				// All v1 filters are equality comparisons
-				Op:    kubecost.FilterEquals,
-				Key:   labelName,
-				Value: filterValue,
-			})
+		subFilter := kubecost.AllocationFilterCondition{
+			Field: kubecost.FilterLabel,
+			// All v1 filters are equality comparisons
+			Op:    kubecost.FilterEquals,
+			Key:   labelName,
+			Value: filterValue,
+		}
+
+		if wildcard {
+			subFilter.Op = kubecost.FilterStartsWith
+		}
+
+		filter.Filters = append(filter.Filters, subFilter)
 	}
 
 	return filter
@@ -257,16 +303,21 @@ func filterV1DoubleValueFromList(rawFilterValuesUnsplit []string, filterField ku
 			}
 			key := prom.SanitizeLabelName(strings.TrimSpace(split[0]))
 			val := strings.TrimSpace(split[1])
+			val, wildcard := parseWildcardEnd(val)
 
-			filter.Filters = append(filter.Filters,
-				kubecost.AllocationFilterCondition{
-					Field: filterField,
-					// All v1 filters are equality comparisons
-					Op:    kubecost.FilterEquals,
-					Key:   key,
-					Value: val,
-				},
-			)
+			subFilter := kubecost.AllocationFilterCondition{
+				Field: filterField,
+				// All v1 filters are equality comparisons
+				Op:    kubecost.FilterEquals,
+				Key:   key,
+				Value: val,
+			}
+
+			if wildcard {
+				subFilter.Op = kubecost.FilterStartsWith
+			}
+
+			filter.Filters = append(filter.Filters, subFilter)
 		}
 	}
 

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -217,7 +217,7 @@ func AllocationFilterFromParamsV1(
 			Value: filterValue,
 		}
 		if wildcard {
-			subFilter.Op = kubecost.FilterStartsWith
+			subFilter.Op = kubecost.FilterContainsPrefix
 		}
 		servicesFilter.Filters = append(servicesFilter.Filters, subFilter)
 	}

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -37,36 +37,32 @@ func FiltersFromParamsV1(qp httputil.QueryParams) kubecost.AllocationFilter {
 	// 	labelConfig = cfg.LabelConfig()
 	// }
 
-	filterClusters := qp.GetList("filterClusters", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1SingleValueFromList(filterClusters, kubecost.FilterClusterID),
+		filterV1SingleValueFromList(qp.GetList("filterClusters", ","), kubecost.FilterClusterID),
 	)
 	// TODO: OR by cluster name
 	// Cluster Map doesn't seem to have a name -> ID mapping,
 	// only an ID (from the allocation) -> name mapping
 
 	// generate a filter func for each node filter, and OR the results
-	filterNodes := qp.GetList("filterNodes", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1SingleValueFromList(filterNodes, kubecost.FilterNode),
+		filterV1SingleValueFromList(qp.GetList("filterNodes", ","), kubecost.FilterNode),
 	)
 
 	// generate a filter func for each namespace filter, and OR the results
-	filterNamespaces := qp.GetList("filterNamespaces", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1SingleValueFromList(filterNamespaces, kubecost.FilterNamespace),
+		filterV1SingleValueFromList(qp.GetList("filterNamespaces", ","), kubecost.FilterNamespace),
 	)
 
-	filterControllerKinds := qp.GetList("filterControllerKinds", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1SingleValueFromList(filterControllerKinds, kubecost.FilterControllerKind),
+		filterV1SingleValueFromList(qp.GetList("filterControllerKinds", ","), kubecost.FilterControllerKind),
 	)
 
-	filterControllers := qp.GetList("filterControllers", ",")
 	// filterControllers= accepts controllerkind:controllername filters, e.g.
 	// "deployment:kubecost-cost-analyzer"
 	//
 	// Thus, we have to make a custom OR filter for this condition.
+	filterControllers := qp.GetList("filterControllers", ",")
 	controllersOr := kubecost.AllocationFilterOr{
 		Filters: []kubecost.AllocationFilter{},
 	}
@@ -102,14 +98,12 @@ func FiltersFromParamsV1(qp httputil.QueryParams) kubecost.AllocationFilter {
 	}
 	filter.Filters = append(filter.Filters, controllersOr)
 
-	filterPods := qp.GetList("filterPods", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1SingleValueFromList(filterPods, kubecost.FilterPod),
+		filterV1SingleValueFromList(qp.GetList("filterPods", ","), kubecost.FilterPod),
 	)
 
-	filterContainers := qp.GetList("filterContainers", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1SingleValueFromList(filterContainers, kubecost.FilterContainer),
+		filterV1SingleValueFromList(qp.GetList("filterContainers", ","), kubecost.FilterContainer),
 	)
 
 	// TODO: label mapping special things
@@ -173,14 +167,12 @@ func FiltersFromParamsV1(qp httputil.QueryParams) kubecost.AllocationFilter {
 	// 	filter.Filters = append(filter.Filters, subFilter)
 	// }
 
-	filterAnnotations := qp.GetList("filterAnnotations", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1DoubleValueFromList(filterAnnotations, kubecost.FilterAnnotation),
+		filterV1DoubleValueFromList(qp.GetList("filterAnnotations", ","), kubecost.FilterAnnotation),
 	)
 
-	filterLabels := qp.GetList("filterLabels", ",")
 	filter.Filters = append(filter.Filters,
-		filterV1DoubleValueFromList(filterLabels, kubecost.FilterLabel),
+		filterV1DoubleValueFromList(qp.GetList("filterLabels", ","), kubecost.FilterLabel),
 	)
 
 	// TODO: filter service condition

--- a/pkg/util/filterutil/allocationfilters_test.go
+++ b/pkg/util/filterutil/allocationfilters_test.go
@@ -1,0 +1,280 @@
+package filterutil
+
+import (
+	"testing"
+
+	"github.com/kubecost/cost-model/pkg/kubecost"
+	"github.com/kubecost/cost-model/pkg/util/mapper"
+)
+
+func allocGenerator(props kubecost.AllocationProperties) kubecost.Allocation {
+	a := kubecost.Allocation{
+		Properties: &props,
+	}
+
+	a.Name = a.Properties.String()
+	return a
+}
+
+func TestFiltersFromParamsV1(t *testing.T) {
+	// TODO: __unallocated__ case?
+	cases := []struct {
+		name           string
+		qp             map[string]string
+		shouldMatch    []kubecost.Allocation
+		shouldNotMatch []kubecost.Allocation
+	}{
+		{
+			name: "single cluster ID",
+			qp: map[string]string{
+				"filterClusters": "cluster-one",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-one",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "foo",
+				}),
+			},
+		},
+		{
+			name: "single node",
+			qp: map[string]string{
+				"filterNodes": "node-123-abc",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Node: "node-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Node: "node-456-def",
+				}),
+			},
+		},
+		{
+			name: "single namespace",
+			qp: map[string]string{
+				"filterNamespaces": "kubecost",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost2",
+				}),
+			},
+		},
+		{
+			name: "single controller kind",
+			qp: map[string]string{
+				"filterControllerKinds": "deployment",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "daemonset",
+				}),
+			},
+		},
+		{
+			name: "single controller name",
+			qp: map[string]string{
+				"filterControllers": "kubecost-cost-analyzer",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kubecost-cost-analyzer",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kube-proxy",
+				}),
+			},
+		},
+		{
+			name: "single controller kind:name combo",
+			qp: map[string]string{
+				"filterControllers": "deployment:kubecost-cost-analyzer",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+					Controller:     "kubecost-cost-analyzer",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "daemonset",
+					Controller:     "kubecost-cost-analyzer",
+				}),
+			},
+		},
+		{
+			name: "single pod",
+			qp: map[string]string{
+				"filterPods": "pod-123-abc",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Pod: "pod-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Pod: "pod-456-def",
+				}),
+			},
+		},
+		{
+			name: "single container",
+			qp: map[string]string{
+				"filterContainers": "container-123-abc",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Container: "container-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Container: "container-456-def",
+				}),
+			},
+		},
+		{
+			name: "single label",
+			qp: map[string]string{
+				"filterLabels": "app:cost-analyzer",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+		{
+			name: "single annotation",
+			qp: map[string]string{
+				"filterAnnotations": "app:cost-analyzer",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+		{
+			name: "multi: namespaces, labels",
+			qp: map[string]string{
+				"filterNamespaces": "kube-system,kubecost",
+				"filterLabels":     "app:cost-analyzer,app:kube-proxy,foo:bar",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+					Labels: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						"app": "kube-proxy",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+					Labels: map[string]string{
+						"app": "something",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Convert map[string]string representation to the mapper
+			// library type
+			qpMap := mapper.NewMap()
+			for k, v := range c.qp {
+				qpMap.Set(k, v)
+			}
+			qpMapper := mapper.NewMapper(qpMap)
+
+			filter := FiltersFromParamsV1(qpMapper)
+			for _, alloc := range c.shouldMatch {
+				if !filter.Matches(&alloc) {
+					t.Errorf("should have matched: %s", alloc.Name)
+				}
+			}
+			for _, alloc := range c.shouldNotMatch {
+				if filter.Matches(&alloc) {
+					t.Errorf("incorrectly matched: %s", alloc.Name)
+				}
+			}
+		})
+	}
+}

--- a/pkg/util/filterutil/allocationfilters_test.go
+++ b/pkg/util/filterutil/allocationfilters_test.go
@@ -155,6 +155,26 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "single department",
+			qp: map[string]string{
+				"filterDepartments": "pa-1",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"internal-product-umbrella": "pa-1",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"internal-product-umbrella": "ps-N",
+					},
+				}),
+			},
+		},
+		{
 			name: "single label",
 			qp: map[string]string{
 				"filterLabels": "app:cost-analyzer",
@@ -264,7 +284,10 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			}
 			qpMapper := mapper.NewMapper(qpMap)
 
-			filter := FiltersFromParamsV1(qpMapper)
+			labelConfig := kubecost.LabelConfig{}
+			labelConfig.DepartmentLabel = "internal-product-umbrella"
+
+			filter := FiltersFromParamsV1(qpMapper, &labelConfig)
 			for _, alloc := range c.shouldMatch {
 				if !filter.Matches(&alloc) {
 					t.Errorf("should have matched: %s", alloc.Name)

--- a/pkg/util/filterutil/allocationfilters_test.go
+++ b/pkg/util/filterutil/allocationfilters_test.go
@@ -270,6 +270,43 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "single service",
+			qp: map[string]string{
+				"filterServices": "serv1",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv1"},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv2"},
+				}),
+			},
+		},
+		{
+			name: "multi service",
+			qp: map[string]string{
+				"filterServices": "serv1,serv3",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv1"},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv2", "serv3"},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv2"},
+				}),
+			},
+		},
+		{
 			name: "multi: namespaces, labels",
 			qp: map[string]string{
 				"filterNamespaces": "kube-system,kubecost",

--- a/pkg/util/filterutil/allocationfilters_test.go
+++ b/pkg/util/filterutil/allocationfilters_test.go
@@ -70,9 +70,50 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard cluster ID",
+			qp: map[string]string{
+				"filterClusters": "cluster*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-one",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-two",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "foo",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluste",
+				}),
+			},
+		},
+		{
 			name: "single cluster name",
 			qp: map[string]string{
 				"filterClusters": "cluster ABC",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "mapped-cluster-ID-ABC",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-one",
+				}),
+			},
+		},
+		{
+			name: "wildcard cluster name",
+			qp: map[string]string{
+				"filterClusters": "cluster A*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -102,6 +143,22 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard node",
+			qp: map[string]string{
+				"filterNodes": "node-1*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Node: "node-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Node: "node-456-def",
+				}),
+			},
+		},
+		{
 			name: "single namespace",
 			qp: map[string]string{
 				"filterNamespaces": "kubecost",
@@ -118,9 +175,44 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard namespace",
+			qp: map[string]string{
+				"filterNamespaces": "kube*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kube-system",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kub",
+				}),
+			},
+		},
+		{
 			name: "single controller kind",
 			qp: map[string]string{
 				"filterControllerKinds": "deployment",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "daemonset",
+				}),
+			},
+		},
+		{
+			name: "wildcard controller kind",
+			qp: map[string]string{
+				"filterControllerKinds": "depl*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -150,6 +242,25 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard controller name",
+			qp: map[string]string{
+				"filterControllers": "kubecost-*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kubecost-cost-analyzer",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kubecost-frontend",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kube-proxy",
+				}),
+			},
+		},
+		{
 			name: "single controller kind:name combo",
 			qp: map[string]string{
 				"filterControllers": "deployment:kubecost-cost-analyzer",
@@ -168,9 +279,47 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard controller kind:name combo",
+			qp: map[string]string{
+				"filterControllers": "deployment:kubecost*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+					Controller:     "kubecost-cost-analyzer",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "daemonset",
+					Controller:     "kubecost-cost-analyzer",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+					Controller:     "kube-system",
+				}),
+			},
+		},
+		{
 			name: "single pod",
 			qp: map[string]string{
 				"filterPods": "pod-123-abc",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Pod: "pod-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Pod: "pod-456-def",
+				}),
+			},
+		},
+		{
+			name: "wildcard pod",
+			qp: map[string]string{
+				"filterPods": "pod-1*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -200,9 +349,45 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard container",
+			qp: map[string]string{
+				"filterContainers": "container-1*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Container: "container-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Container: "container-456-def",
+				}),
+			},
+		},
+		{
 			name: "single department",
 			qp: map[string]string{
 				"filterDepartments": "pa-1",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"internal-product-umbrella": "pa-1",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"internal-product-umbrella": "ps-N",
+					},
+				}),
+			},
+		},
+		{
+			name: "wildcard department",
+			qp: map[string]string{
+				"filterDepartments": "pa*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -245,9 +430,59 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard label",
+			qp: map[string]string{
+				"filterLabels": "app:cost-*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+		{
 			name: "single annotation",
 			qp: map[string]string{
 				"filterAnnotations": "app:cost-analyzer",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+		{
+			name: "wildcard annotation",
+			qp: map[string]string{
+				"filterAnnotations": "app:cost-*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -303,6 +538,26 @@ func TestFiltersFromParamsV1(t *testing.T) {
 				allocGenerator(kubecost.AllocationProperties{}),
 				allocGenerator(kubecost.AllocationProperties{
 					Services: []string{"serv2"},
+				}),
+			},
+		},
+		{
+			name: "wildcard service",
+			qp: map[string]string{
+				"filterServices": "serv*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv1"},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv2"},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"foo"},
 				}),
 			},
 		},


### PR DESCRIPTION
## What does this PR change?
Adds a new package `pkg/util/filterutil` with support for translating the current HTTP filters (e.g. `filterNamespaces=kubecost,kube-system&filterLabels=app:foo`) into the new `AllocationFilter` types introduced in https://github.com/kubecost/cost-model/pull/1172.

> I would've put this under `httputil` but that causes a circular dependency.

The filter building is roughly based on the [ETL handler filter building in KCM (closed source)](https://github.com/kubecost/kubecost-cost-model/blob/693db781bf6c80471e5c8fdda34f68172bdb3e98/pkg/etl/handlers.go#L489-L677).

- ~This code does not yet support the wildcard syntax (e.g. `filterNamespaces=kube*`). That'll be a followup PR because it involves changes to the `AllocationFilter` types and I didn't want to overload this PR. See https://github.com/kubecost/cost-model/pull/1211 which adds this logic.~ The CM#1211 logic was merged into this branch.
- This logic is not yet hooked up to the HTTP handlers in CM or KCM. That requires the above wildcard support + plumbing work to swap out filter funcs throughout core query logic.

## How was this PR tested?
Unit tests in this PR.