### PR TITLE
Support wildcard (filterNamespaces=kube*) queries with new AllocationFilter types

### DIFF
--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -382,6 +382,36 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: `services startswith -> true`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"serv1", "serv2"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterStartsWith,
+				Value: "serv",
+			},
+
+			expected: true,
+		},
+		{
+			name: `services startswith -> false`,
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Services: []string{"foo", "bar"},
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterServices,
+				Op:    FilterStartsWith,
+				Value: "serv",
+			},
+
+			expected: false,
+		},
+		{
 			name: `services contains unallocated -> false`,
 			a: &Allocation{
 				Properties: &AllocationProperties{

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -382,7 +382,7 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: `services startswith -> true`,
+			name: `services containsprefix -> true`,
 			a: &Allocation{
 				Properties: &AllocationProperties{
 					Services: []string{"serv1", "serv2"},
@@ -390,14 +390,14 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			},
 			filter: AllocationFilterCondition{
 				Field: FilterServices,
-				Op:    FilterStartsWith,
+				Op:    FilterContainsPrefix,
 				Value: "serv",
 			},
 
 			expected: true,
 		},
 		{
-			name: `services startswith -> false`,
+			name: `services containsprefix -> false`,
 			a: &Allocation{
 				Properties: &AllocationProperties{
 					Services: []string{"foo", "bar"},
@@ -405,7 +405,7 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			},
 			filter: AllocationFilterCondition{
 				Field: FilterServices,
-				Op:    FilterStartsWith,
+				Op:    FilterContainsPrefix,
 				Value: "serv",
 			},
 

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -28,6 +28,36 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "ClusterID StartsWith -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "cluster-one",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterStartsWith,
+				Value: "cluster",
+			},
+
+			expected: true,
+		},
+		{
+			name: "ClusterID StartsWith -> false",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "k8s-one",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterStartsWith,
+				Value: "cluster",
+			},
+
+			expected: false,
+		},
+		{
 			name: "Node Equals -> true",
 			a: &Allocation{
 				Properties: &AllocationProperties{

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -210,13 +210,16 @@ func AllocationFilterFromParamsV1(
 	}
 	for _, filterValue := range qp.GetList("filterServices", ",") {
 		// TODO: wildcard support
-		servicesFilter.Filters = append(servicesFilter.Filters,
-			kubecost.AllocationFilterCondition{
-				Field: kubecost.FilterServices,
-				Op:    kubecost.FilterContains,
-				Value: filterValue,
-			},
-		)
+		filterValue, wildcard := parseWildcardEnd(filterValue)
+		subFilter := kubecost.AllocationFilterCondition{
+			Field: kubecost.FilterServices,
+			Op:    kubecost.FilterContains,
+			Value: filterValue,
+		}
+		if wildcard {
+			subFilter.Op = kubecost.FilterStartsWith
+		}
+		servicesFilter.Filters = append(servicesFilter.Filters, subFilter)
 	}
 	filter.Filters = append(filter.Filters, servicesFilter)
 

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -10,6 +10,16 @@ import (
 	"github.com/kubecost/cost-model/pkg/util/httputil"
 )
 
+// parseWildcardEnd checks if the given filter value is wildcarded, meaning
+// it ends in "*". If it does, it removes the suffix and returns the cleaned
+// string and true. Otherwise, it returns the same filter and false.
+//
+// parseWildcardEnd("kube*") = "kube", true
+// parseWildcardEnd("kube") = "kube", false
+func parseWildcardEnd(rawFilterValue string) (string, bool) {
+	return strings.TrimSuffix(rawFilterValue, "*"), strings.HasSuffix(rawFilterValue, "*")
+}
+
 // AllocationFilterFromParamsV1 takes a set of HTTP query parameters and
 // converts them to an AllocationFilter, which is a structured in-Go
 // representation of a set of filters.
@@ -69,8 +79,19 @@ func AllocationFilterFromParamsV1(
 		Filters: []kubecost.AllocationFilter{},
 	}
 	clustersOr.Filters = append(clustersOr.Filters, filterV1SingleValueFromList(filterClusters, kubecost.FilterClusterID))
-	for _, possibleClusterName := range filterClusters {
-		for _, clusterID := range clusterNameToIDs[possibleClusterName] {
+	for _, rawFilterValue := range filterClusters {
+		clusterNameFilter, wildcard := parseWildcardEnd(rawFilterValue)
+
+		clusterIDsToFilter := []string{}
+		for clusterName := range clusterNameToIDs {
+			if wildcard && strings.HasPrefix(clusterName, clusterNameFilter) {
+				clusterIDsToFilter = append(clusterIDsToFilter, clusterNameToIDs[clusterName]...)
+			} else if !wildcard && clusterName == clusterNameFilter {
+				clusterIDsToFilter = append(clusterIDsToFilter, clusterNameToIDs[clusterName]...)
+			}
+		}
+
+		for _, clusterID := range clusterIDsToFilter {
 			clustersOr.Filters = append(clustersOr.Filters,
 				kubecost.AllocationFilterCondition{
 					Field: kubecost.FilterClusterID,
@@ -105,27 +126,39 @@ func AllocationFilterFromParamsV1(
 	for _, rawFilterValue := range filterControllers {
 		split := strings.Split(rawFilterValue, ":")
 		if len(split) == 1 {
-			controllersOr.Filters = append(controllersOr.Filters,
-				kubecost.AllocationFilterCondition{
-					Field: kubecost.FilterControllerName,
-					Op:    kubecost.FilterEquals,
-					Value: split[0],
-				})
+			filterValue, wildcard := parseWildcardEnd(split[0])
+			subFilter := kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterControllerName,
+				Op:    kubecost.FilterEquals,
+				Value: filterValue,
+			}
+
+			if wildcard {
+				subFilter.Op = kubecost.FilterStartsWith
+			}
+			controllersOr.Filters = append(controllersOr.Filters, subFilter)
 		} else if len(split) == 2 {
+			kindFilterVal := split[0]
+			nameFilterVal, wildcard := parseWildcardEnd(split[1])
+
+			kindFilter := kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterControllerKind,
+				Op:    kubecost.FilterEquals,
+				Value: kindFilterVal,
+			}
+			nameFilter := kubecost.AllocationFilterCondition{
+				Field: kubecost.FilterControllerName,
+				Op:    kubecost.FilterEquals,
+				Value: nameFilterVal,
+			}
+
+			if wildcard {
+				nameFilter.Op = kubecost.FilterStartsWith
+			}
+
 			// The controller name AND the controller kind must match
 			multiFilter := kubecost.AllocationFilterAnd{
-				Filters: []kubecost.AllocationFilter{
-					kubecost.AllocationFilterCondition{
-						Field: kubecost.FilterControllerKind,
-						Op:    kubecost.FilterEquals,
-						Value: split[0],
-					},
-					kubecost.AllocationFilterCondition{
-						Field: kubecost.FilterControllerName,
-						Op:    kubecost.FilterEquals,
-						Value: split[1],
-					},
-				},
+				Filters: []kubecost.AllocationFilter{kindFilter, nameFilter},
 			}
 			controllersOr.Filters = append(controllersOr.Filters, multiFilter)
 		} else {
@@ -176,6 +209,7 @@ func AllocationFilterFromParamsV1(
 		Filters: []kubecost.AllocationFilter{},
 	}
 	for _, filterValue := range qp.GetList("filterServices", ",") {
+		// TODO: wildcard support
 		servicesFilter.Filters = append(servicesFilter.Filters,
 			kubecost.AllocationFilterCondition{
 				Field: kubecost.FilterServices,
@@ -201,14 +235,20 @@ func filterV1SingleValueFromList(rawFilterValues []string, filterField kubecost.
 
 	for _, filterValue := range rawFilterValues {
 		filterValue = strings.TrimSpace(filterValue)
+		filterValue, wildcard := parseWildcardEnd(filterValue)
 
-		filter.Filters = append(filter.Filters,
-			kubecost.AllocationFilterCondition{
-				Field: filterField,
-				// All v1 filters are equality comparisons
-				Op:    kubecost.FilterEquals,
-				Value: filterValue,
-			})
+		subFilter := kubecost.AllocationFilterCondition{
+			Field: filterField,
+			// All v1 filters are equality comparisons
+			Op:    kubecost.FilterEquals,
+			Value: filterValue,
+		}
+
+		if wildcard {
+			subFilter.Op = kubecost.FilterStartsWith
+		}
+
+		filter.Filters = append(filter.Filters, subFilter)
 	}
 
 	return filter
@@ -224,15 +264,21 @@ func filterV1LabelMappedFromList(rawFilterValues []string, labelName string) kub
 
 	for _, filterValue := range rawFilterValues {
 		filterValue = strings.TrimSpace(filterValue)
+		filterValue, wildcard := parseWildcardEnd(filterValue)
 
-		filter.Filters = append(filter.Filters,
-			kubecost.AllocationFilterCondition{
-				Field: kubecost.FilterLabel,
-				// All v1 filters are equality comparisons
-				Op:    kubecost.FilterEquals,
-				Key:   labelName,
-				Value: filterValue,
-			})
+		subFilter := kubecost.AllocationFilterCondition{
+			Field: kubecost.FilterLabel,
+			// All v1 filters are equality comparisons
+			Op:    kubecost.FilterEquals,
+			Key:   labelName,
+			Value: filterValue,
+		}
+
+		if wildcard {
+			subFilter.Op = kubecost.FilterStartsWith
+		}
+
+		filter.Filters = append(filter.Filters, subFilter)
 	}
 
 	return filter
@@ -257,16 +303,21 @@ func filterV1DoubleValueFromList(rawFilterValuesUnsplit []string, filterField ku
 			}
 			key := prom.SanitizeLabelName(strings.TrimSpace(split[0]))
 			val := strings.TrimSpace(split[1])
+			val, wildcard := parseWildcardEnd(val)
 
-			filter.Filters = append(filter.Filters,
-				kubecost.AllocationFilterCondition{
-					Field: filterField,
-					// All v1 filters are equality comparisons
-					Op:    kubecost.FilterEquals,
-					Key:   key,
-					Value: val,
-				},
-			)
+			subFilter := kubecost.AllocationFilterCondition{
+				Field: filterField,
+				// All v1 filters are equality comparisons
+				Op:    kubecost.FilterEquals,
+				Key:   key,
+				Value: val,
+			}
+
+			if wildcard {
+				subFilter.Op = kubecost.FilterStartsWith
+			}
+
+			filter.Filters = append(filter.Filters, subFilter)
 		}
 	}
 

--- a/pkg/util/filterutil/allocationfilters.go
+++ b/pkg/util/filterutil/allocationfilters.go
@@ -217,7 +217,7 @@ func AllocationFilterFromParamsV1(
 			Value: filterValue,
 		}
 		if wildcard {
-			subFilter.Op = kubecost.FilterStartsWith
+			subFilter.Op = kubecost.FilterContainsPrefix
 		}
 		servicesFilter.Filters = append(servicesFilter.Filters, subFilter)
 	}

--- a/pkg/util/filterutil/allocationfilters_test.go
+++ b/pkg/util/filterutil/allocationfilters_test.go
@@ -70,9 +70,50 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard cluster ID",
+			qp: map[string]string{
+				"filterClusters": "cluster*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-one",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-two",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "foo",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluste",
+				}),
+			},
+		},
+		{
 			name: "single cluster name",
 			qp: map[string]string{
 				"filterClusters": "cluster ABC",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "mapped-cluster-ID-ABC",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Cluster: "cluster-one",
+				}),
+			},
+		},
+		{
+			name: "wildcard cluster name",
+			qp: map[string]string{
+				"filterClusters": "cluster A*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -102,6 +143,22 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard node",
+			qp: map[string]string{
+				"filterNodes": "node-1*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Node: "node-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Node: "node-456-def",
+				}),
+			},
+		},
+		{
 			name: "single namespace",
 			qp: map[string]string{
 				"filterNamespaces": "kubecost",
@@ -118,9 +175,44 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard namespace",
+			qp: map[string]string{
+				"filterNamespaces": "kube*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kubecost",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kube-system",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Namespace: "kub",
+				}),
+			},
+		},
+		{
 			name: "single controller kind",
 			qp: map[string]string{
 				"filterControllerKinds": "deployment",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "daemonset",
+				}),
+			},
+		},
+		{
+			name: "wildcard controller kind",
+			qp: map[string]string{
+				"filterControllerKinds": "depl*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -150,6 +242,25 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard controller name",
+			qp: map[string]string{
+				"filterControllers": "kubecost-*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kubecost-cost-analyzer",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kubecost-frontend",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Controller: "kube-proxy",
+				}),
+			},
+		},
+		{
 			name: "single controller kind:name combo",
 			qp: map[string]string{
 				"filterControllers": "deployment:kubecost-cost-analyzer",
@@ -168,9 +279,47 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard controller kind:name combo",
+			qp: map[string]string{
+				"filterControllers": "deployment:kubecost*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+					Controller:     "kubecost-cost-analyzer",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "daemonset",
+					Controller:     "kubecost-cost-analyzer",
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					ControllerKind: "deployment",
+					Controller:     "kube-system",
+				}),
+			},
+		},
+		{
 			name: "single pod",
 			qp: map[string]string{
 				"filterPods": "pod-123-abc",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Pod: "pod-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Pod: "pod-456-def",
+				}),
+			},
+		},
+		{
+			name: "wildcard pod",
+			qp: map[string]string{
+				"filterPods": "pod-1*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -200,9 +349,45 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard container",
+			qp: map[string]string{
+				"filterContainers": "container-1*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Container: "container-123-abc",
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Container: "container-456-def",
+				}),
+			},
+		},
+		{
 			name: "single department",
 			qp: map[string]string{
 				"filterDepartments": "pa-1",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"internal-product-umbrella": "pa-1",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"internal-product-umbrella": "ps-N",
+					},
+				}),
+			},
+		},
+		{
+			name: "wildcard department",
+			qp: map[string]string{
+				"filterDepartments": "pa*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -245,9 +430,59 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
+			name: "wildcard label",
+			qp: map[string]string{
+				"filterLabels": "app:cost-*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+		{
 			name: "single annotation",
 			qp: map[string]string{
 				"filterAnnotations": "app:cost-analyzer",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"app": "cost-analyzer",
+					},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"app": "foo",
+					},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				}),
+			},
+		},
+		{
+			name: "wildcard annotation",
+			qp: map[string]string{
+				"filterAnnotations": "app:cost-*",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
@@ -303,6 +538,26 @@ func TestFiltersFromParamsV1(t *testing.T) {
 				allocGenerator(kubecost.AllocationProperties{}),
 				allocGenerator(kubecost.AllocationProperties{
 					Services: []string{"serv2"},
+				}),
+			},
+		},
+		{
+			name: "wildcard service",
+			qp: map[string]string{
+				"filterServices": "serv*",
+			},
+			shouldMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv1"},
+				}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"serv2"},
+				}),
+			},
+			shouldNotMatch: []kubecost.Allocation{
+				allocGenerator(kubecost.AllocationProperties{}),
+				allocGenerator(kubecost.AllocationProperties{
+					Services: []string{"foo"},
 				}),
 			},
 		},


### PR DESCRIPTION
## What does this PR change?

:warning: This PR has a merge target of `mmd/old-filter-syntax-to-filters-v2-internal` because it is branched off of that. There is already a PR open for that branch: https://github.com/kubecost/cost-model/pull/1210 :warning: 

Adds support in the `AllocationFilter` types for wildcarded queries. Our current wildcard queries are just prefixes, so I'm calling the new FilterOp "StartsWith" (thanks for the great idea @nikovacevic!) for clarity. Because we need to support prefix matching on a slice/array (for `filterServices=`) I also added a FilterOp `ContainsPrefix` to make a clear distinction between differently-typed ops -- `ContainsPrefix` is an array op while `StartsWith` is a string op.

## Does this PR relate to any other PRs?
* This is branched off of https://github.com/kubecost/cost-model/pull/1210 which is also the merge target.

## How was this PR tested?
* Unit tests in this PR