### PR TITLE
Add editor access item to custompricing

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -186,6 +186,7 @@ type CustomPricing struct {
 	SharedLabelValues            string `json:"sharedLabelValues"`
 	ShareTenancyCosts            string `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
 	ReadOnly                     string `json:"readOnly"`
+	EditorAccess                 string `json:"editorAccess"`
 	KubecostToken                string `json:"kubecostToken"`
 	GoogleAnalyticsTag           string `json:"googleAnalyticsTag"`
 	ExcludeProviderID            string `json:"excludeProviderID"`


### PR DESCRIPTION
## What does this PR change?
* Adds an editor access item to the CustomPricing struct, which is required for the frontend/API to have knowledge of the user's new permissions in RBAC (see attached KCCM PR for more info).

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* It shouldn't, other than a new item in the json marshal.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
