### PR TITLE
Audit and Generic Store types

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -510,7 +510,7 @@ func (a *Accesses) CostDataModelRange(w http.ResponseWriter, r *http.Request, ps
 	}
 
 	window := kubecost.NewWindow(&start, &end)
-	if window.IsOpen() || window.IsEmpty() || window.IsNegative() {
+	if window.IsOpen() || !window.HasDuration() || window.IsNegative() {
 		w.Write(WrapDataWithMessage(nil, fmt.Errorf("invalid date range: %s", window), fmt.Sprintf("invalid date range: %s", window)))
 		return
 	}

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -914,7 +914,7 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 	shouldAggregate := aggregateBy != nil
 	shouldFilter := len(options.FilterFuncs) > 0
 	shouldShare := len(options.SharedHourlyCosts) > 0 || len(options.ShareFuncs) > 0
-	if !shouldAggregate && !shouldFilter && !shouldShare {
+	if !shouldAggregate && !shouldFilter && !shouldShare && options.ShareIdle == ShareNone {
 		// There is nothing for AggregateBy to do, so simply return nil
 		return nil
 	}

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -856,6 +856,7 @@ type ClusterManagement struct {
 	labels     AssetLabels
 	properties *AssetProperties
 	window     Window
+	adjustment float64
 	Cost       float64
 }
 
@@ -902,17 +903,17 @@ func (cm *ClusterManagement) SetLabels(props AssetLabels) {
 
 // Adjustment does not apply to ClusterManagement
 func (cm *ClusterManagement) Adjustment() float64 {
-	return 0.0
+	return cm.adjustment
 }
 
 // SetAdjustment does not apply to ClusterManagement
-func (cm *ClusterManagement) SetAdjustment(float64) {
-	return
+func (cm *ClusterManagement) SetAdjustment(adj float64) {
+	cm.adjustment = adj
 }
 
 // TotalCost returns the Asset's total cost
 func (cm *ClusterManagement) TotalCost() float64 {
-	return cm.Cost
+	return cm.Cost + cm.adjustment
 }
 
 // Start returns the Asset's precise start time within the window
@@ -991,6 +992,7 @@ func (cm *ClusterManagement) add(that *ClusterManagement) {
 	cm.window = window
 	cm.SetProperties(props)
 	cm.SetLabels(labels)
+	cm.adjustment += that.adjustment
 	cm.Cost += that.Cost
 }
 
@@ -1000,6 +1002,7 @@ func (cm *ClusterManagement) Clone() Asset {
 		labels:     cm.labels.Clone(),
 		properties: cm.properties.Clone(),
 		window:     cm.window.Clone(),
+		adjustment: cm.adjustment,
 		Cost:       cm.Cost,
 	}
 }
@@ -1019,6 +1022,10 @@ func (cm *ClusterManagement) Equal(a Asset) bool {
 	}
 
 	if !cm.window.Equal(that.window) {
+		return false
+	}
+
+	if cm.adjustment != that.adjustment {
 		return false
 	}
 

--- a/pkg/kubecost/audit.go
+++ b/pkg/kubecost/audit.go
@@ -37,8 +37,8 @@ func ToAuditType(check string) AuditType {
 		return AuditAssetTotalStore
 	case string(AuditAssetAggStore):
 		return AuditAssetAggStore
-	case string(AuditClusterEquality):
-		return AuditClusterEquality
+	//case string(AuditClusterEquality):
+	//	return AuditClusterEquality
 	case string(AuditAll):
 		return AuditAll
 	default:
@@ -61,13 +61,14 @@ type AuditMissingValue struct {
 	Key         string
 }
 
-// AuditFloatResult structure for holding the results of a failed audit on a float value, Expected should be the Audit generated value
-// while actual is what is contained in the relevant store
+// AuditFloatResult structure for holding the results of a failed audit on a float value, Expected should be the value
+// calculated by the Audit func while Actual is what is contained in the relevant store.
 type AuditFloatResult struct {
 	Expected float64
 	Actual   float64
 }
 
+// Clone returns a deep copy of the caller
 func (afr *AuditFloatResult) Clone() *AuditFloatResult {
 	return &AuditFloatResult{
 		Expected: afr.Expected,
@@ -75,8 +76,8 @@ func (afr *AuditFloatResult) Clone() *AuditFloatResult {
 	}
 }
 
-// AllocationReconciliationAudit records the differences of between compute resource costs between allocations by nodes
-// and node assets keyed on node name and resource
+// AllocationReconciliationAudit records the differences of between compute resources (cpu, ram, gpu) costs between
+// allocations by nodes and node assets keyed on node name and compute resource
 type AllocationReconciliationAudit struct {
 	Status        AuditStatus
 	Description   string
@@ -85,6 +86,7 @@ type AllocationReconciliationAudit struct {
 	MissingValues []*AuditMissingValue
 }
 
+// Clone returns a deep copy of the caller
 func (ara *AllocationReconciliationAudit) Clone() *AllocationReconciliationAudit {
 	if ara == nil {
 		return nil

--- a/pkg/kubecost/audit.go
+++ b/pkg/kubecost/audit.go
@@ -1,0 +1,361 @@
+package kubecost
+
+import (
+	"golang.org/x/exp/slices"
+	"sync"
+	"time"
+)
+
+// AuditType the types of Audits, each of which should be contained in an AuditSet
+type AuditType string
+
+const (
+	AuditAllocationReconciliation AuditType = "AuditAllocationReconciliation"
+	AuditAllocationTotalStore     AuditType = "AuditAllocationTotalStore"
+	AuditAllocationAggStore       AuditType = "AuditAllocationAggStore"
+	AuditAssetReconciliation      AuditType = "AuditAssetReconciliation"
+	AuditAssetTotalStore          AuditType = "AuditAssetTotalStore"
+	AuditAssetAggStore            AuditType = "AuditAssetAggStore"
+	AuditClusterEquality          AuditType = "AuditClusterEquality"
+
+	AuditAll         AuditType = ""
+	AuditInvalidType AuditType = "InvalidType"
+)
+
+// ToAuditType converts a string to an Audit type
+func ToAuditType(check string) AuditType {
+	switch check {
+	case string(AuditAllocationReconciliation):
+		return AuditAllocationReconciliation
+	case string(AuditAllocationTotalStore):
+		return AuditAllocationTotalStore
+	case string(AuditAllocationAggStore):
+		return AuditAllocationAggStore
+	case string(AuditAssetReconciliation):
+		return AuditAssetReconciliation
+	case string(AuditAssetTotalStore):
+		return AuditAssetTotalStore
+	case string(AuditAssetAggStore):
+		return AuditAssetAggStore
+	case string(AuditClusterEquality):
+		return AuditClusterEquality
+	case string(AuditAll):
+		return AuditAll
+	default:
+		return AuditInvalidType
+	}
+}
+
+// AuditStatus are possible outcomes of an audit
+type AuditStatus string
+
+const (
+	FailedStatus  AuditStatus = "Failed"
+	WarningStatus             = "Warning"
+	PassedStatus              = "Passed"
+)
+
+// AuditMissingValue records when a value that should be present in a store or in the audit generated results are missing
+type AuditMissingValue struct {
+	Description string
+	Key         string
+}
+
+// AuditFloatResult structure for holding the results of a failed audit on a float value, Expected should be the Audit generated value
+// while actual is what is contained in the relevant store
+type AuditFloatResult struct {
+	Expected float64
+	Actual   float64
+}
+
+func (afr *AuditFloatResult) Clone() *AuditFloatResult {
+	return &AuditFloatResult{
+		Expected: afr.Expected,
+		Actual:   afr.Actual,
+	}
+}
+
+// AllocationReconciliationAudit records the differences of between compute resource costs between allocations by nodes
+// and node assets keyed on node name and resource
+type AllocationReconciliationAudit struct {
+	Status        AuditStatus
+	Description   string
+	LastRun       time.Time
+	Resources     map[string]map[string]*AuditFloatResult
+	MissingValues []*AuditMissingValue
+}
+
+func (ara *AllocationReconciliationAudit) Clone() *AllocationReconciliationAudit {
+	if ara == nil {
+		return nil
+	}
+
+	resources := make(map[string]map[string]*AuditFloatResult, len(ara.Resources))
+	for node, resourceMap := range ara.Resources {
+		copyResourceMap := make(map[string]*AuditFloatResult, len(resourceMap))
+		for resourceName, val := range resourceMap {
+			copyResourceMap[resourceName] = val.Clone()
+		}
+		resources[node] = copyResourceMap
+	}
+	return &AllocationReconciliationAudit{
+		Status:        ara.Status,
+		Description:   ara.Description,
+		LastRun:       ara.LastRun,
+		Resources:     resources,
+		MissingValues: slices.Clone(ara.MissingValues),
+	}
+}
+
+// TotalAudit records the differences between a total store and the totaled results of the store that it is based on
+// keyed by cluster and node names
+type TotalAudit struct {
+	Status         AuditStatus
+	Description    string
+	LastRun        time.Time
+	TotalByNode    map[string]*AuditFloatResult
+	TotalByCluster map[string]*AuditFloatResult
+	MissingValues  []*AuditMissingValue
+}
+
+// Clone returns a deep copy of the caller
+func (ta *TotalAudit) Clone() *TotalAudit {
+	if ta == nil {
+		return nil
+	}
+
+	tbn := make(map[string]*AuditFloatResult, len(ta.TotalByNode))
+	for k, v := range ta.TotalByNode {
+		tbn[k] = v
+	}
+	tbc := make(map[string]*AuditFloatResult, len(ta.TotalByNode))
+	for k, v := range ta.TotalByCluster {
+		tbc[k] = v
+	}
+
+	return &TotalAudit{
+		Status:         ta.Status,
+		Description:    ta.Description,
+		LastRun:        ta.LastRun,
+		TotalByNode:    tbn,
+		TotalByCluster: tbc,
+		MissingValues:  slices.Clone(ta.MissingValues),
+	}
+}
+
+// AggAudit contains the results of an Audit on an AggStore keyed on aggregation prop and Allocation key
+type AggAudit struct {
+	Status        AuditStatus
+	Description   string
+	LastRun       time.Time
+	Results       map[string]map[string]*AuditFloatResult
+	MissingValues []*AuditMissingValue
+}
+
+// Clone returns a deep copy of the caller
+func (aa *AggAudit) Clone() *AggAudit {
+	if aa == nil {
+		return nil
+	}
+	res := make(map[string]map[string]*AuditFloatResult, len(aa.Results))
+	for aggType, aggResults := range aa.Results {
+		copyAggResult := make(map[string]*AuditFloatResult, len(aggResults))
+		for aggName, auditFloatResult := range aggResults {
+			copyAggResult[aggName] = auditFloatResult
+		}
+		res[aggType] = copyAggResult
+	}
+
+	return &AggAudit{
+		Status:        aa.Status,
+		Description:   aa.Description,
+		LastRun:       aa.LastRun,
+		Results:       res,
+		MissingValues: slices.Clone(aa.MissingValues),
+	}
+}
+
+// AssetReconciliationAudit records differences in assets and the Cloud
+type AssetReconciliationAudit struct {
+	Status        AuditStatus
+	Description   string
+	LastRun       time.Time
+	Results       map[string]map[string]*AuditFloatResult
+	MissingValues []*AuditMissingValue
+}
+
+// Clone returns a deep copy of the caller
+func (ara *AssetReconciliationAudit) Clone() *AssetReconciliationAudit {
+	res := make(map[string]map[string]*AuditFloatResult, len(ara.Results))
+	for aggType, aggResults := range ara.Results {
+		copyAggResult := make(map[string]*AuditFloatResult, len(aggResults))
+		for aggName, auditFloatResult := range aggResults {
+			copyAggResult[aggName] = auditFloatResult
+		}
+		res[aggType] = copyAggResult
+	}
+
+	return &AssetReconciliationAudit{
+		Status:        ara.Status,
+		Description:   ara.Description,
+		LastRun:       ara.LastRun,
+		Results:       res,
+		MissingValues: slices.Clone(ara.MissingValues),
+	}
+}
+
+// EqualityAudit records the difference in cost between Allocations and Assets aggregated by cluster and keyed on cluster
+type EqualityAudit struct {
+	Status        AuditStatus
+	Description   string
+	LastRun       time.Time
+	Clusters      map[string]*AuditFloatResult
+	MissingValues []*AuditMissingValue
+}
+
+// Clone returns a deep copy of the caller
+func (ea *EqualityAudit) Clone() *EqualityAudit {
+	if ea == nil {
+		return nil
+	}
+	clusters := make(map[string]*AuditFloatResult, len(ea.Clusters))
+	for k, v := range ea.Clusters {
+		clusters[k] = v
+	}
+	return &EqualityAudit{
+		Status:        ea.Status,
+		Description:   ea.Description,
+		LastRun:       ea.LastRun,
+		Clusters:      clusters,
+		MissingValues: slices.Clone(ea.MissingValues),
+	}
+}
+
+// AuditCoverage tracks coverage of each audit type
+type AuditCoverage struct {
+	sync.RWMutex
+	AllocationReconciliation Window `json:"allocationReconciliation"`
+	AllocationAgg            Window `json:"allocationAgg"`
+	AllocationTotal          Window `json:"allocationTotal"`
+	AssetTotal               Window `json:"assetTotal"`
+	AssetReconciliation      Window `json:"assetReconciliation"`
+	ClusterEquality          Window `json:"clusterEquality"`
+}
+
+// NewAuditCoverage create default AuditCoverage
+func NewAuditCoverage() *AuditCoverage {
+	return &AuditCoverage{}
+}
+
+// Update expands the coverage of each Window in the coverage that the given AuditSet's Window if the corresponding Audit is not nil
+// Note: This means of determining coverage can lead to holes in the given window
+func (ac *AuditCoverage) Update(as *AuditSet) {
+	if as != nil && as.AllocationReconciliation != nil {
+		ac.AllocationReconciliation.Expand(as.Window)
+		ac.AllocationAgg.Expand(as.Window)
+		ac.AllocationTotal.Expand(as.Window)
+		ac.AssetTotal.Expand(as.Window)
+		ac.AssetReconciliation.Expand(as.Window)
+		ac.ClusterEquality.Expand(as.Window)
+	}
+
+}
+
+// AuditSet is a ETLSet which contains all kind of Audits for a given Window
+type AuditSet struct {
+	sync.RWMutex
+	AllocationReconciliation *AllocationReconciliationAudit `json:"allocationReconciliation"`
+	AllocationAgg            *AggAudit                      `json:"allocationAgg"`
+	AllocationTotal          *TotalAudit                    `json:"allocationTotal"`
+	AssetTotal               *TotalAudit                    `json:"assetTotal"`
+	AssetReconciliation      *AssetReconciliationAudit      `json:"assetReconciliation"`
+	ClusterEquality          *EqualityAudit                 `json:"clusterEquality"`
+	Window                   Window                         `json:"window"`
+}
+
+// NewAuditSet creates an empty AuditSet with the given window
+func NewAuditSet(start, end time.Time) *AuditSet {
+	return &AuditSet{
+		Window: NewWindow(&start, &end),
+	}
+}
+
+// UpdateAuditSet overwrites any audit fields in the caller with those in the given AuditSet which are not nil
+func (as *AuditSet) UpdateAuditSet(that *AuditSet) *AuditSet {
+	if as == nil {
+		return that
+	}
+
+	if that.AllocationReconciliation != nil {
+		as.AllocationReconciliation = that.AllocationReconciliation
+	}
+	if that.AllocationAgg != nil {
+		as.AllocationAgg = that.AllocationAgg
+	}
+	if that.AllocationTotal != nil {
+		as.AllocationTotal = that.AllocationTotal
+	}
+	if that.AssetTotal != nil {
+		as.AssetTotal = that.AssetTotal
+	}
+	if that.AssetReconciliation != nil {
+		as.AssetReconciliation = that.AssetReconciliation
+	}
+
+	if that.ClusterEquality != nil {
+		as.ClusterEquality = that.ClusterEquality
+	}
+
+	return as
+}
+
+// ConstructSet fulfills the ETLSet interface to provide an empty version of itself so that it can be initialized in its
+// generic form.
+func (as *AuditSet) ConstructSet() ETLSet {
+	return &AuditSet{}
+}
+
+// IsEmpty returns true if any of the audits are non-nil
+func (as *AuditSet) IsEmpty() bool {
+	return as == nil || (as.AllocationReconciliation == nil &&
+		as.AllocationAgg == nil &&
+		as.AllocationTotal == nil &&
+		as.AssetTotal == nil &&
+		as.AssetReconciliation == nil &&
+		as.ClusterEquality == nil)
+}
+
+// GetWindow returns AuditSet Window
+func (as *AuditSet) GetWindow() Window {
+	return as.Window
+}
+
+// Clone returns a deep copy of the caller
+func (as *AuditSet) Clone() *AuditSet {
+	if as == nil {
+		return nil
+	}
+
+	as.RLock()
+	defer as.RUnlock()
+
+	return &AuditSet{
+		AllocationReconciliation: as.AllocationReconciliation.Clone(),
+		AllocationAgg:            as.AllocationAgg.Clone(),
+		AllocationTotal:          as.AllocationTotal.Clone(),
+		AssetTotal:               as.AssetTotal.Clone(),
+		AssetReconciliation:      as.AssetReconciliation.Clone(),
+		ClusterEquality:          as.ClusterEquality.Clone(),
+		Window:                   as.Window.Clone(),
+	}
+}
+
+// CloneSet returns a deep copy of the caller and returns set
+func (as *AuditSet) CloneSet() ETLSet {
+	return as.Clone()
+}
+
+// AuditSetRange SetRange of AuditSets
+type AuditSetRange struct {
+	SetRange[*AuditSet]
+}

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -57,4 +57,18 @@ package kubecost
 // @bingen:generate:PVAllocation
 // @bingen:end
 
+// @bingen:set[name=Audit,version=1]
+// @bingen:generate:AllocationReconciliationAudit
+// @bingen:generate:TotalAudit
+// @bingen:generate:AggAudit
+// @bingen:generate:AuditFloatResult
+// @bingen:generate:AuditMissingValue
+// @bingen:generate:AssetReconciliationAudit
+// @bingen:generate:EqualityAudit
+// @bingen:generate:AuditType
+// @bingen:generate:AuditStatus
+// @bingen:generate[stringtable]:AuditSet
+// @bingen:generate:AuditSetRange
+// @bingen:end
+
 //go:generate bingen -package=kubecost -version=15 -buffer=github.com/kubecost/opencost/pkg/util

--- a/pkg/kubecost/etlrange.go
+++ b/pkg/kubecost/etlrange.go
@@ -1,0 +1,79 @@
+package kubecost
+
+import (
+	"fmt"
+	"github.com/kubecost/opencost/pkg/util/json"
+	"sync"
+)
+
+// SetRange is a generic implementation of the SetRanges that act as containers. It covers the basic functionality that
+// is shared by the basic types but is meant to be extended by each implementation.
+type SetRange[T ETLSet] struct {
+	lock sync.RWMutex
+	sets []T
+}
+
+// Append attaches the given ETLSet to the end of the sets slice.
+// currently does not check that the window is correct.
+func (r *SetRange[T]) Append(that T) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.sets = append(r.sets, that)
+}
+
+// Each invokes the given function for each ETLSet in the SetRange
+func (r *SetRange[T]) Each(f func(int, T)) {
+	if r == nil {
+		return
+	}
+
+	for i, set := range r.sets {
+		f(i, set)
+	}
+}
+
+// Get retrieves the given index from the sets slice
+func (r *SetRange[T]) Get(i int) (T, error) {
+	if i < 0 || i >= len(r.sets) {
+		var set T
+		return set, fmt.Errorf("range: index out of range: %d", i)
+	}
+
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.sets[i], nil
+}
+
+// Length returns the length of the sets slice
+func (r *SetRange[T]) Length() int {
+	if r == nil || r.sets == nil {
+		return 0
+	}
+
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return len(r.sets)
+}
+
+// IsEmpty returns false if SetRange contains a single ETLSet that is not empty
+func (r *SetRange[T]) IsEmpty() bool {
+	if r == nil || r.Length() == 0 {
+		return true
+	}
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	for _, set := range r.sets {
+		if !set.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+// MarshalJSON converts SetRange to JSON
+func (r *SetRange[T]) MarshalJSON() ([]byte, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return json.Marshal(r.sets)
+}

--- a/pkg/kubecost/etlrange.go
+++ b/pkg/kubecost/etlrange.go
@@ -16,6 +16,9 @@ type SetRange[T ETLSet] struct {
 // Append attaches the given ETLSet to the end of the sets slice.
 // currently does not check that the window is correct.
 func (r *SetRange[T]) Append(that T) {
+	if r == nil {
+		return
+	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	r.sets = append(r.sets, that)
@@ -34,9 +37,13 @@ func (r *SetRange[T]) Each(f func(int, T)) {
 
 // Get retrieves the given index from the sets slice
 func (r *SetRange[T]) Get(i int) (T, error) {
+	var set T
+	if r == nil {
+		return set, fmt.Errorf("SetRange: Get: is nil")
+	}
 	if i < 0 || i >= len(r.sets) {
-		var set T
-		return set, fmt.Errorf("range: index out of range: %d", i)
+
+		return set, fmt.Errorf("SetRange: Get: index out of range: %d", i)
 	}
 
 	r.lock.RLock()
@@ -73,6 +80,9 @@ func (r *SetRange[T]) IsEmpty() bool {
 
 // MarshalJSON converts SetRange to JSON
 func (r *SetRange[T]) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return nil, fmt.Errorf("SetRange: MarshalJSON: is nil")
+	}
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 	return json.Marshal(r.sets)

--- a/pkg/kubecost/etlset.go
+++ b/pkg/kubecost/etlset.go
@@ -1,0 +1,15 @@
+package kubecost
+
+import "encoding"
+
+// ETLSet is an interface which represents the basic data block of an ETL. It is keyed by its Window
+type ETLSet interface {
+	ConstructSet() ETLSet
+	CloneSet() ETLSet
+	IsEmpty() bool
+	GetWindow() Window
+
+	// Representations
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+}

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -13,12 +13,11 @@ package kubecost
 
 import (
 	"fmt"
+	util "github.com/kubecost/opencost/pkg/util"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
-
-	util "github.com/kubecost/opencost/pkg/util"
 )
 
 const (
@@ -42,6 +41,9 @@ const (
 
 	// AllocationCodecVersion is used for any resources listed in the Allocation version set
 	AllocationCodecVersion uint8 = 15
+
+	// AuditCodecVersion is used for any resources listed in the Audit version set
+	AuditCodecVersion uint8 = 1
 )
 
 //--------------------------------------------------------------------------
@@ -51,26 +53,35 @@ const (
 // Generated type map for resolving interface implementations to
 // to concrete types
 var typeMap map[string]reflect.Type = map[string]reflect.Type{
-	"Allocation":            reflect.TypeOf((*Allocation)(nil)).Elem(),
-	"AllocationProperties":  reflect.TypeOf((*AllocationProperties)(nil)).Elem(),
-	"AllocationSet":         reflect.TypeOf((*AllocationSet)(nil)).Elem(),
-	"AllocationSetRange":    reflect.TypeOf((*AllocationSetRange)(nil)).Elem(),
-	"Any":                   reflect.TypeOf((*Any)(nil)).Elem(),
-	"AssetProperties":       reflect.TypeOf((*AssetProperties)(nil)).Elem(),
-	"AssetSet":              reflect.TypeOf((*AssetSet)(nil)).Elem(),
-	"AssetSetRange":         reflect.TypeOf((*AssetSetRange)(nil)).Elem(),
-	"Breakdown":             reflect.TypeOf((*Breakdown)(nil)).Elem(),
-	"Cloud":                 reflect.TypeOf((*Cloud)(nil)).Elem(),
-	"ClusterManagement":     reflect.TypeOf((*ClusterManagement)(nil)).Elem(),
-	"Disk":                  reflect.TypeOf((*Disk)(nil)).Elem(),
-	"LoadBalancer":          reflect.TypeOf((*LoadBalancer)(nil)).Elem(),
-	"Network":               reflect.TypeOf((*Network)(nil)).Elem(),
-	"Node":                  reflect.TypeOf((*Node)(nil)).Elem(),
-	"PVAllocation":          reflect.TypeOf((*PVAllocation)(nil)).Elem(),
-	"PVKey":                 reflect.TypeOf((*PVKey)(nil)).Elem(),
-	"RawAllocationOnlyData": reflect.TypeOf((*RawAllocationOnlyData)(nil)).Elem(),
-	"SharedAsset":           reflect.TypeOf((*SharedAsset)(nil)).Elem(),
-	"Window":                reflect.TypeOf((*Window)(nil)).Elem(),
+	"AggAudit":                      reflect.TypeOf((*AggAudit)(nil)).Elem(),
+	"Allocation":                    reflect.TypeOf((*Allocation)(nil)).Elem(),
+	"AllocationProperties":          reflect.TypeOf((*AllocationProperties)(nil)).Elem(),
+	"AllocationReconciliationAudit": reflect.TypeOf((*AllocationReconciliationAudit)(nil)).Elem(),
+	"AllocationSet":                 reflect.TypeOf((*AllocationSet)(nil)).Elem(),
+	"AllocationSetRange":            reflect.TypeOf((*AllocationSetRange)(nil)).Elem(),
+	"Any":                           reflect.TypeOf((*Any)(nil)).Elem(),
+	"AssetProperties":               reflect.TypeOf((*AssetProperties)(nil)).Elem(),
+	"AssetReconciliationAudit":      reflect.TypeOf((*AssetReconciliationAudit)(nil)).Elem(),
+	"AssetSet":                      reflect.TypeOf((*AssetSet)(nil)).Elem(),
+	"AssetSetRange":                 reflect.TypeOf((*AssetSetRange)(nil)).Elem(),
+	"AuditFloatResult":              reflect.TypeOf((*AuditFloatResult)(nil)).Elem(),
+	"AuditMissingValue":             reflect.TypeOf((*AuditMissingValue)(nil)).Elem(),
+	"AuditSet":                      reflect.TypeOf((*AuditSet)(nil)).Elem(),
+	"AuditSetRange":                 reflect.TypeOf((*AuditSetRange)(nil)).Elem(),
+	"Breakdown":                     reflect.TypeOf((*Breakdown)(nil)).Elem(),
+	"Cloud":                         reflect.TypeOf((*Cloud)(nil)).Elem(),
+	"ClusterManagement":             reflect.TypeOf((*ClusterManagement)(nil)).Elem(),
+	"Disk":                          reflect.TypeOf((*Disk)(nil)).Elem(),
+	"EqualityAudit":                 reflect.TypeOf((*EqualityAudit)(nil)).Elem(),
+	"LoadBalancer":                  reflect.TypeOf((*LoadBalancer)(nil)).Elem(),
+	"Network":                       reflect.TypeOf((*Network)(nil)).Elem(),
+	"Node":                          reflect.TypeOf((*Node)(nil)).Elem(),
+	"PVAllocation":                  reflect.TypeOf((*PVAllocation)(nil)).Elem(),
+	"PVKey":                         reflect.TypeOf((*PVKey)(nil)).Elem(),
+	"RawAllocationOnlyData":         reflect.TypeOf((*RawAllocationOnlyData)(nil)).Elem(),
+	"SharedAsset":                   reflect.TypeOf((*SharedAsset)(nil)).Elem(),
+	"TotalAudit":                    reflect.TypeOf((*TotalAudit)(nil)).Elem(),
+	"Window":                        reflect.TypeOf((*Window)(nil)).Elem(),
 }
 
 //--------------------------------------------------------------------------
@@ -246,6 +257,359 @@ type BinEncoder interface {
 // BinDecoder is a decoding interface which defines a context based unmarshal contract.
 type BinDecoder interface {
 	UnmarshalBinaryWithContext(*DecodingContext) error
+}
+
+//--------------------------------------------------------------------------
+//  AggAudit
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AggAudit instance
+// into a byte array
+func (target *AggAudit) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AggAudit instance
+// into a byte array leveraging a predefined context.
+func (target *AggAudit) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	// --- [begin][write][alias](AuditStatus) ---
+	if ctx.IsStringTable() {
+		a := ctx.Table.AddOrGet(string(target.Status))
+		buff.WriteInt(a) // write table index
+	} else {
+		buff.WriteString(string(target.Status)) // write string
+	}
+	// --- [end][write][alias](AuditStatus) ---
+
+	if ctx.IsStringTable() {
+		b := ctx.Table.AddOrGet(target.Description)
+		buff.WriteInt(b) // write table index
+	} else {
+		buff.WriteString(target.Description) // write string
+	}
+	// --- [begin][write][reference](time.Time) ---
+	c, errA := target.LastRun.MarshalBinary()
+	if errA != nil {
+		return errA
+	}
+	buff.WriteInt(len(c))
+	buff.WriteBytes(c)
+	// --- [end][write][reference](time.Time) ---
+
+	if target.Results == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][map](map[string]map[string]*AuditFloatResult) ---
+		buff.WriteInt(len(target.Results)) // map length
+		for v, z := range target.Results {
+			if ctx.IsStringTable() {
+				d := ctx.Table.AddOrGet(v)
+				buff.WriteInt(d) // write table index
+			} else {
+				buff.WriteString(v) // write string
+			}
+			if z == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][map](map[string]*AuditFloatResult) ---
+				buff.WriteInt(len(z)) // map length
+				for vv, zz := range z {
+					if ctx.IsStringTable() {
+						e := ctx.Table.AddOrGet(vv)
+						buff.WriteInt(e) // write table index
+					} else {
+						buff.WriteString(vv) // write string
+					}
+					if zz == nil {
+						buff.WriteUInt8(uint8(0)) // write nil byte
+					} else {
+						buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+						// --- [begin][write][struct](AuditFloatResult) ---
+						buff.WriteInt(0) // [compatibility, unused]
+						errB := zz.MarshalBinaryWithContext(ctx)
+						if errB != nil {
+							return errB
+						}
+						// --- [end][write][struct](AuditFloatResult) ---
+
+					}
+				}
+				// --- [end][write][map](map[string]*AuditFloatResult) ---
+
+			}
+		}
+		// --- [end][write][map](map[string]map[string]*AuditFloatResult) ---
+
+	}
+	if target.MissingValues == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][slice]([]*AuditMissingValue) ---
+		buff.WriteInt(len(target.MissingValues)) // array length
+		for i := 0; i < len(target.MissingValues); i++ {
+			if target.MissingValues[i] == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditMissingValue) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errC := target.MissingValues[i].MarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				// --- [end][write][struct](AuditMissingValue) ---
+
+			}
+		}
+		// --- [end][write][slice]([]*AuditMissingValue) ---
+
+	}
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AggAudit type
+func (target *AggAudit) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AggAudit type
+func (target *AggAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AggAudit. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][alias](AuditStatus) ---
+		var a string
+		var c string
+		if ctx.IsStringTable() {
+			d := buff.ReadInt() // read string index
+			c = ctx.Table[d]
+		} else {
+			c = buff.ReadString() // read string
+		}
+		b := c
+		a = b
+
+		target.Status = AuditStatus(a)
+		// --- [end][read][alias](AuditStatus) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var f string
+		if ctx.IsStringTable() {
+			g := buff.ReadInt() // read string index
+			f = ctx.Table[g]
+		} else {
+			f = buff.ReadString() // read string
+		}
+		e := f
+		target.Description = e
+
+	} else {
+		target.Description = "" // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][reference](time.Time) ---
+		h := &time.Time{}
+		k := buff.ReadInt()    // byte array length
+		l := buff.ReadBytes(k) // byte array
+		errA := h.UnmarshalBinary(l)
+		if errA != nil {
+			return errA
+		}
+		target.LastRun = *h
+		// --- [end][read][reference](time.Time) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.Results = nil
+		} else {
+			// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
+			n := buff.ReadInt() // map len
+			m := make(map[string]map[string]*AuditFloatResult, n)
+			for i := 0; i < n; i++ {
+				var v string
+				var p string
+				if ctx.IsStringTable() {
+					q := buff.ReadInt() // read string index
+					p = ctx.Table[q]
+				} else {
+					p = buff.ReadString() // read string
+				}
+				o := p
+				v = o
+
+				var z map[string]*AuditFloatResult
+				if buff.ReadUInt8() == uint8(0) {
+					z = nil
+				} else {
+					// --- [begin][read][map](map[string]*AuditFloatResult) ---
+					s := buff.ReadInt() // map len
+					r := make(map[string]*AuditFloatResult, s)
+					for j := 0; j < s; j++ {
+						var vv string
+						var u string
+						if ctx.IsStringTable() {
+							w := buff.ReadInt() // read string index
+							u = ctx.Table[w]
+						} else {
+							u = buff.ReadString() // read string
+						}
+						t := u
+						vv = t
+
+						var zz *AuditFloatResult
+						if buff.ReadUInt8() == uint8(0) {
+							zz = nil
+						} else {
+							// --- [begin][read][struct](AuditFloatResult) ---
+							x := &AuditFloatResult{}
+							buff.ReadInt() // [compatibility, unused]
+							errB := x.UnmarshalBinaryWithContext(ctx)
+							if errB != nil {
+								return errB
+							}
+							zz = x
+							// --- [end][read][struct](AuditFloatResult) ---
+
+						}
+						r[vv] = zz
+					}
+					z = r
+					// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+				}
+				m[v] = z
+			}
+			target.Results = m
+			// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
+
+		}
+	} else {
+		target.Results = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.MissingValues = nil
+		} else {
+			// --- [begin][read][slice]([]*AuditMissingValue) ---
+			aa := buff.ReadInt() // array len
+			y := make([]*AuditMissingValue, aa)
+			for ii := 0; ii < aa; ii++ {
+				var bb *AuditMissingValue
+				if buff.ReadUInt8() == uint8(0) {
+					bb = nil
+				} else {
+					// --- [begin][read][struct](AuditMissingValue) ---
+					cc := &AuditMissingValue{}
+					buff.ReadInt() // [compatibility, unused]
+					errC := cc.UnmarshalBinaryWithContext(ctx)
+					if errC != nil {
+						return errC
+					}
+					bb = cc
+					// --- [end][read][struct](AuditMissingValue) ---
+
+				}
+				y[ii] = bb
+			}
+			target.MissingValues = y
+			// --- [end][read][slice]([]*AuditMissingValue) ---
+
+		}
+	} else {
+		target.MissingValues = nil
+
+	}
+
+	return nil
 }
 
 //--------------------------------------------------------------------------
@@ -1242,6 +1606,359 @@ func (target *AllocationProperties) UnmarshalBinaryWithContext(ctx *DecodingCont
 		// --- [end][read][alias](AllocationAnnotations) ---
 
 	} else {
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  AllocationReconciliationAudit
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AllocationReconciliationAudit instance
+// into a byte array
+func (target *AllocationReconciliationAudit) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AllocationReconciliationAudit instance
+// into a byte array leveraging a predefined context.
+func (target *AllocationReconciliationAudit) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	// --- [begin][write][alias](AuditStatus) ---
+	if ctx.IsStringTable() {
+		a := ctx.Table.AddOrGet(string(target.Status))
+		buff.WriteInt(a) // write table index
+	} else {
+		buff.WriteString(string(target.Status)) // write string
+	}
+	// --- [end][write][alias](AuditStatus) ---
+
+	if ctx.IsStringTable() {
+		b := ctx.Table.AddOrGet(target.Description)
+		buff.WriteInt(b) // write table index
+	} else {
+		buff.WriteString(target.Description) // write string
+	}
+	// --- [begin][write][reference](time.Time) ---
+	c, errA := target.LastRun.MarshalBinary()
+	if errA != nil {
+		return errA
+	}
+	buff.WriteInt(len(c))
+	buff.WriteBytes(c)
+	// --- [end][write][reference](time.Time) ---
+
+	if target.Resources == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][map](map[string]map[string]*AuditFloatResult) ---
+		buff.WriteInt(len(target.Resources)) // map length
+		for v, z := range target.Resources {
+			if ctx.IsStringTable() {
+				d := ctx.Table.AddOrGet(v)
+				buff.WriteInt(d) // write table index
+			} else {
+				buff.WriteString(v) // write string
+			}
+			if z == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][map](map[string]*AuditFloatResult) ---
+				buff.WriteInt(len(z)) // map length
+				for vv, zz := range z {
+					if ctx.IsStringTable() {
+						e := ctx.Table.AddOrGet(vv)
+						buff.WriteInt(e) // write table index
+					} else {
+						buff.WriteString(vv) // write string
+					}
+					if zz == nil {
+						buff.WriteUInt8(uint8(0)) // write nil byte
+					} else {
+						buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+						// --- [begin][write][struct](AuditFloatResult) ---
+						buff.WriteInt(0) // [compatibility, unused]
+						errB := zz.MarshalBinaryWithContext(ctx)
+						if errB != nil {
+							return errB
+						}
+						// --- [end][write][struct](AuditFloatResult) ---
+
+					}
+				}
+				// --- [end][write][map](map[string]*AuditFloatResult) ---
+
+			}
+		}
+		// --- [end][write][map](map[string]map[string]*AuditFloatResult) ---
+
+	}
+	if target.MissingValues == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][slice]([]*AuditMissingValue) ---
+		buff.WriteInt(len(target.MissingValues)) // array length
+		for i := 0; i < len(target.MissingValues); i++ {
+			if target.MissingValues[i] == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditMissingValue) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errC := target.MissingValues[i].MarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				// --- [end][write][struct](AuditMissingValue) ---
+
+			}
+		}
+		// --- [end][write][slice]([]*AuditMissingValue) ---
+
+	}
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AllocationReconciliationAudit type
+func (target *AllocationReconciliationAudit) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AllocationReconciliationAudit type
+func (target *AllocationReconciliationAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AllocationReconciliationAudit. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][alias](AuditStatus) ---
+		var a string
+		var c string
+		if ctx.IsStringTable() {
+			d := buff.ReadInt() // read string index
+			c = ctx.Table[d]
+		} else {
+			c = buff.ReadString() // read string
+		}
+		b := c
+		a = b
+
+		target.Status = AuditStatus(a)
+		// --- [end][read][alias](AuditStatus) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var f string
+		if ctx.IsStringTable() {
+			g := buff.ReadInt() // read string index
+			f = ctx.Table[g]
+		} else {
+			f = buff.ReadString() // read string
+		}
+		e := f
+		target.Description = e
+
+	} else {
+		target.Description = "" // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][reference](time.Time) ---
+		h := &time.Time{}
+		k := buff.ReadInt()    // byte array length
+		l := buff.ReadBytes(k) // byte array
+		errA := h.UnmarshalBinary(l)
+		if errA != nil {
+			return errA
+		}
+		target.LastRun = *h
+		// --- [end][read][reference](time.Time) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.Resources = nil
+		} else {
+			// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
+			n := buff.ReadInt() // map len
+			m := make(map[string]map[string]*AuditFloatResult, n)
+			for i := 0; i < n; i++ {
+				var v string
+				var p string
+				if ctx.IsStringTable() {
+					q := buff.ReadInt() // read string index
+					p = ctx.Table[q]
+				} else {
+					p = buff.ReadString() // read string
+				}
+				o := p
+				v = o
+
+				var z map[string]*AuditFloatResult
+				if buff.ReadUInt8() == uint8(0) {
+					z = nil
+				} else {
+					// --- [begin][read][map](map[string]*AuditFloatResult) ---
+					s := buff.ReadInt() // map len
+					r := make(map[string]*AuditFloatResult, s)
+					for j := 0; j < s; j++ {
+						var vv string
+						var u string
+						if ctx.IsStringTable() {
+							w := buff.ReadInt() // read string index
+							u = ctx.Table[w]
+						} else {
+							u = buff.ReadString() // read string
+						}
+						t := u
+						vv = t
+
+						var zz *AuditFloatResult
+						if buff.ReadUInt8() == uint8(0) {
+							zz = nil
+						} else {
+							// --- [begin][read][struct](AuditFloatResult) ---
+							x := &AuditFloatResult{}
+							buff.ReadInt() // [compatibility, unused]
+							errB := x.UnmarshalBinaryWithContext(ctx)
+							if errB != nil {
+								return errB
+							}
+							zz = x
+							// --- [end][read][struct](AuditFloatResult) ---
+
+						}
+						r[vv] = zz
+					}
+					z = r
+					// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+				}
+				m[v] = z
+			}
+			target.Resources = m
+			// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
+
+		}
+	} else {
+		target.Resources = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.MissingValues = nil
+		} else {
+			// --- [begin][read][slice]([]*AuditMissingValue) ---
+			aa := buff.ReadInt() // array len
+			y := make([]*AuditMissingValue, aa)
+			for ii := 0; ii < aa; ii++ {
+				var bb *AuditMissingValue
+				if buff.ReadUInt8() == uint8(0) {
+					bb = nil
+				} else {
+					// --- [begin][read][struct](AuditMissingValue) ---
+					cc := &AuditMissingValue{}
+					buff.ReadInt() // [compatibility, unused]
+					errC := cc.UnmarshalBinaryWithContext(ctx)
+					if errC != nil {
+						return errC
+					}
+					bb = cc
+					// --- [end][read][struct](AuditMissingValue) ---
+
+				}
+				y[ii] = bb
+			}
+			target.MissingValues = y
+			// --- [end][read][slice]([]*AuditMissingValue) ---
+
+		}
+	} else {
+		target.MissingValues = nil
+
 	}
 
 	return nil
@@ -2414,6 +3131,359 @@ func (target *AssetProperties) UnmarshalBinaryWithContext(ctx *DecodingContext) 
 }
 
 //--------------------------------------------------------------------------
+//  AssetReconciliationAudit
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AssetReconciliationAudit instance
+// into a byte array
+func (target *AssetReconciliationAudit) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AssetReconciliationAudit instance
+// into a byte array leveraging a predefined context.
+func (target *AssetReconciliationAudit) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	// --- [begin][write][alias](AuditStatus) ---
+	if ctx.IsStringTable() {
+		a := ctx.Table.AddOrGet(string(target.Status))
+		buff.WriteInt(a) // write table index
+	} else {
+		buff.WriteString(string(target.Status)) // write string
+	}
+	// --- [end][write][alias](AuditStatus) ---
+
+	if ctx.IsStringTable() {
+		b := ctx.Table.AddOrGet(target.Description)
+		buff.WriteInt(b) // write table index
+	} else {
+		buff.WriteString(target.Description) // write string
+	}
+	// --- [begin][write][reference](time.Time) ---
+	c, errA := target.LastRun.MarshalBinary()
+	if errA != nil {
+		return errA
+	}
+	buff.WriteInt(len(c))
+	buff.WriteBytes(c)
+	// --- [end][write][reference](time.Time) ---
+
+	if target.Results == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][map](map[string]map[string]*AuditFloatResult) ---
+		buff.WriteInt(len(target.Results)) // map length
+		for v, z := range target.Results {
+			if ctx.IsStringTable() {
+				d := ctx.Table.AddOrGet(v)
+				buff.WriteInt(d) // write table index
+			} else {
+				buff.WriteString(v) // write string
+			}
+			if z == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][map](map[string]*AuditFloatResult) ---
+				buff.WriteInt(len(z)) // map length
+				for vv, zz := range z {
+					if ctx.IsStringTable() {
+						e := ctx.Table.AddOrGet(vv)
+						buff.WriteInt(e) // write table index
+					} else {
+						buff.WriteString(vv) // write string
+					}
+					if zz == nil {
+						buff.WriteUInt8(uint8(0)) // write nil byte
+					} else {
+						buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+						// --- [begin][write][struct](AuditFloatResult) ---
+						buff.WriteInt(0) // [compatibility, unused]
+						errB := zz.MarshalBinaryWithContext(ctx)
+						if errB != nil {
+							return errB
+						}
+						// --- [end][write][struct](AuditFloatResult) ---
+
+					}
+				}
+				// --- [end][write][map](map[string]*AuditFloatResult) ---
+
+			}
+		}
+		// --- [end][write][map](map[string]map[string]*AuditFloatResult) ---
+
+	}
+	if target.MissingValues == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][slice]([]*AuditMissingValue) ---
+		buff.WriteInt(len(target.MissingValues)) // array length
+		for i := 0; i < len(target.MissingValues); i++ {
+			if target.MissingValues[i] == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditMissingValue) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errC := target.MissingValues[i].MarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				// --- [end][write][struct](AuditMissingValue) ---
+
+			}
+		}
+		// --- [end][write][slice]([]*AuditMissingValue) ---
+
+	}
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AssetReconciliationAudit type
+func (target *AssetReconciliationAudit) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AssetReconciliationAudit type
+func (target *AssetReconciliationAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AssetReconciliationAudit. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][alias](AuditStatus) ---
+		var a string
+		var c string
+		if ctx.IsStringTable() {
+			d := buff.ReadInt() // read string index
+			c = ctx.Table[d]
+		} else {
+			c = buff.ReadString() // read string
+		}
+		b := c
+		a = b
+
+		target.Status = AuditStatus(a)
+		// --- [end][read][alias](AuditStatus) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var f string
+		if ctx.IsStringTable() {
+			g := buff.ReadInt() // read string index
+			f = ctx.Table[g]
+		} else {
+			f = buff.ReadString() // read string
+		}
+		e := f
+		target.Description = e
+
+	} else {
+		target.Description = "" // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][reference](time.Time) ---
+		h := &time.Time{}
+		k := buff.ReadInt()    // byte array length
+		l := buff.ReadBytes(k) // byte array
+		errA := h.UnmarshalBinary(l)
+		if errA != nil {
+			return errA
+		}
+		target.LastRun = *h
+		// --- [end][read][reference](time.Time) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.Results = nil
+		} else {
+			// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
+			n := buff.ReadInt() // map len
+			m := make(map[string]map[string]*AuditFloatResult, n)
+			for i := 0; i < n; i++ {
+				var v string
+				var p string
+				if ctx.IsStringTable() {
+					q := buff.ReadInt() // read string index
+					p = ctx.Table[q]
+				} else {
+					p = buff.ReadString() // read string
+				}
+				o := p
+				v = o
+
+				var z map[string]*AuditFloatResult
+				if buff.ReadUInt8() == uint8(0) {
+					z = nil
+				} else {
+					// --- [begin][read][map](map[string]*AuditFloatResult) ---
+					s := buff.ReadInt() // map len
+					r := make(map[string]*AuditFloatResult, s)
+					for j := 0; j < s; j++ {
+						var vv string
+						var u string
+						if ctx.IsStringTable() {
+							w := buff.ReadInt() // read string index
+							u = ctx.Table[w]
+						} else {
+							u = buff.ReadString() // read string
+						}
+						t := u
+						vv = t
+
+						var zz *AuditFloatResult
+						if buff.ReadUInt8() == uint8(0) {
+							zz = nil
+						} else {
+							// --- [begin][read][struct](AuditFloatResult) ---
+							x := &AuditFloatResult{}
+							buff.ReadInt() // [compatibility, unused]
+							errB := x.UnmarshalBinaryWithContext(ctx)
+							if errB != nil {
+								return errB
+							}
+							zz = x
+							// --- [end][read][struct](AuditFloatResult) ---
+
+						}
+						r[vv] = zz
+					}
+					z = r
+					// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+				}
+				m[v] = z
+			}
+			target.Results = m
+			// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
+
+		}
+	} else {
+		target.Results = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.MissingValues = nil
+		} else {
+			// --- [begin][read][slice]([]*AuditMissingValue) ---
+			aa := buff.ReadInt() // array len
+			y := make([]*AuditMissingValue, aa)
+			for ii := 0; ii < aa; ii++ {
+				var bb *AuditMissingValue
+				if buff.ReadUInt8() == uint8(0) {
+					bb = nil
+				} else {
+					// --- [begin][read][struct](AuditMissingValue) ---
+					cc := &AuditMissingValue{}
+					buff.ReadInt() // [compatibility, unused]
+					errC := cc.UnmarshalBinaryWithContext(ctx)
+					if errC != nil {
+						return errC
+					}
+					bb = cc
+					// --- [end][read][struct](AuditMissingValue) ---
+
+				}
+				y[ii] = bb
+			}
+			target.MissingValues = y
+			// --- [end][read][slice]([]*AuditMissingValue) ---
+
+		}
+	} else {
+		target.MissingValues = nil
+
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
 //  AssetSet
 //--------------------------------------------------------------------------
 
@@ -2975,6 +4045,694 @@ func (target *AssetSetRange) UnmarshalBinaryWithContext(ctx *DecodingContext) (e
 }
 
 //--------------------------------------------------------------------------
+//  AuditFloatResult
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AuditFloatResult instance
+// into a byte array
+func (target *AuditFloatResult) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AuditFloatResult instance
+// into a byte array leveraging a predefined context.
+func (target *AuditFloatResult) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	buff.WriteFloat64(target.Expected) // write float64
+	buff.WriteFloat64(target.Actual)   // write float64
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AuditFloatResult type
+func (target *AuditFloatResult) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AuditFloatResult type
+func (target *AuditFloatResult) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AuditFloatResult. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		a := buff.ReadFloat64() // read float64
+		target.Expected = a
+
+	} else {
+		target.Expected = float64(0) // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		b := buff.ReadFloat64() // read float64
+		target.Actual = b
+
+	} else {
+		target.Actual = float64(0) // default
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  AuditMissingValue
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AuditMissingValue instance
+// into a byte array
+func (target *AuditMissingValue) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AuditMissingValue instance
+// into a byte array leveraging a predefined context.
+func (target *AuditMissingValue) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	if ctx.IsStringTable() {
+		a := ctx.Table.AddOrGet(target.Description)
+		buff.WriteInt(a) // write table index
+	} else {
+		buff.WriteString(target.Description) // write string
+	}
+	if ctx.IsStringTable() {
+		b := ctx.Table.AddOrGet(target.Key)
+		buff.WriteInt(b) // write table index
+	} else {
+		buff.WriteString(target.Key) // write string
+	}
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AuditMissingValue type
+func (target *AuditMissingValue) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AuditMissingValue type
+func (target *AuditMissingValue) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AuditMissingValue. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var b string
+		if ctx.IsStringTable() {
+			c := buff.ReadInt() // read string index
+			b = ctx.Table[c]
+		} else {
+			b = buff.ReadString() // read string
+		}
+		a := b
+		target.Description = a
+
+	} else {
+		target.Description = "" // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var e string
+		if ctx.IsStringTable() {
+			f := buff.ReadInt() // read string index
+			e = ctx.Table[f]
+		} else {
+			e = buff.ReadString() // read string
+		}
+		d := e
+		target.Key = d
+
+	} else {
+		target.Key = "" // default
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  AuditSet
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AuditSet instance
+// into a byte array
+func (target *AuditSet) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  NewStringTable(),
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	sTableBytes := ctx.Table.ToBytes()
+	merged := appendBytes(sTableBytes, encBytes)
+	return merged, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AuditSet instance
+// into a byte array leveraging a predefined context.
+func (target *AuditSet) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	if target.AllocationReconciliation == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][struct](AllocationReconciliationAudit) ---
+		buff.WriteInt(0) // [compatibility, unused]
+		errA := target.AllocationReconciliation.MarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
+		}
+		// --- [end][write][struct](AllocationReconciliationAudit) ---
+
+	}
+	if target.AllocationAgg == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][struct](AggAudit) ---
+		buff.WriteInt(0) // [compatibility, unused]
+		errB := target.AllocationAgg.MarshalBinaryWithContext(ctx)
+		if errB != nil {
+			return errB
+		}
+		// --- [end][write][struct](AggAudit) ---
+
+	}
+	if target.AllocationTotal == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][struct](TotalAudit) ---
+		buff.WriteInt(0) // [compatibility, unused]
+		errC := target.AllocationTotal.MarshalBinaryWithContext(ctx)
+		if errC != nil {
+			return errC
+		}
+		// --- [end][write][struct](TotalAudit) ---
+
+	}
+	if target.AssetTotal == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][struct](TotalAudit) ---
+		buff.WriteInt(0) // [compatibility, unused]
+		errD := target.AssetTotal.MarshalBinaryWithContext(ctx)
+		if errD != nil {
+			return errD
+		}
+		// --- [end][write][struct](TotalAudit) ---
+
+	}
+	if target.AssetReconciliation == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][struct](AssetReconciliationAudit) ---
+		buff.WriteInt(0) // [compatibility, unused]
+		errE := target.AssetReconciliation.MarshalBinaryWithContext(ctx)
+		if errE != nil {
+			return errE
+		}
+		// --- [end][write][struct](AssetReconciliationAudit) ---
+
+	}
+	if target.ClusterEquality == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][struct](EqualityAudit) ---
+		buff.WriteInt(0) // [compatibility, unused]
+		errF := target.ClusterEquality.MarshalBinaryWithContext(ctx)
+		if errF != nil {
+			return errF
+		}
+		// --- [end][write][struct](EqualityAudit) ---
+
+	}
+	// --- [begin][write][struct](Window) ---
+	buff.WriteInt(0) // [compatibility, unused]
+	errG := target.Window.MarshalBinaryWithContext(ctx)
+	if errG != nil {
+		return errG
+	}
+	// --- [end][write][struct](Window) ---
+
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AuditSet type
+func (target *AuditSet) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AuditSet type
+func (target *AuditSet) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AuditSet. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.AllocationReconciliation = nil
+		} else {
+			// --- [begin][read][struct](AllocationReconciliationAudit) ---
+			a := &AllocationReconciliationAudit{}
+			buff.ReadInt() // [compatibility, unused]
+			errA := a.UnmarshalBinaryWithContext(ctx)
+			if errA != nil {
+				return errA
+			}
+			target.AllocationReconciliation = a
+			// --- [end][read][struct](AllocationReconciliationAudit) ---
+
+		}
+	} else {
+		target.AllocationReconciliation = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.AllocationAgg = nil
+		} else {
+			// --- [begin][read][struct](AggAudit) ---
+			b := &AggAudit{}
+			buff.ReadInt() // [compatibility, unused]
+			errB := b.UnmarshalBinaryWithContext(ctx)
+			if errB != nil {
+				return errB
+			}
+			target.AllocationAgg = b
+			// --- [end][read][struct](AggAudit) ---
+
+		}
+	} else {
+		target.AllocationAgg = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.AllocationTotal = nil
+		} else {
+			// --- [begin][read][struct](TotalAudit) ---
+			c := &TotalAudit{}
+			buff.ReadInt() // [compatibility, unused]
+			errC := c.UnmarshalBinaryWithContext(ctx)
+			if errC != nil {
+				return errC
+			}
+			target.AllocationTotal = c
+			// --- [end][read][struct](TotalAudit) ---
+
+		}
+	} else {
+		target.AllocationTotal = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.AssetTotal = nil
+		} else {
+			// --- [begin][read][struct](TotalAudit) ---
+			d := &TotalAudit{}
+			buff.ReadInt() // [compatibility, unused]
+			errD := d.UnmarshalBinaryWithContext(ctx)
+			if errD != nil {
+				return errD
+			}
+			target.AssetTotal = d
+			// --- [end][read][struct](TotalAudit) ---
+
+		}
+	} else {
+		target.AssetTotal = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.AssetReconciliation = nil
+		} else {
+			// --- [begin][read][struct](AssetReconciliationAudit) ---
+			e := &AssetReconciliationAudit{}
+			buff.ReadInt() // [compatibility, unused]
+			errE := e.UnmarshalBinaryWithContext(ctx)
+			if errE != nil {
+				return errE
+			}
+			target.AssetReconciliation = e
+			// --- [end][read][struct](AssetReconciliationAudit) ---
+
+		}
+	} else {
+		target.AssetReconciliation = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.ClusterEquality = nil
+		} else {
+			// --- [begin][read][struct](EqualityAudit) ---
+			f := &EqualityAudit{}
+			buff.ReadInt() // [compatibility, unused]
+			errF := f.UnmarshalBinaryWithContext(ctx)
+			if errF != nil {
+				return errF
+			}
+			target.ClusterEquality = f
+			// --- [end][read][struct](EqualityAudit) ---
+
+		}
+	} else {
+		target.ClusterEquality = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][struct](Window) ---
+		g := &Window{}
+		buff.ReadInt() // [compatibility, unused]
+		errG := g.UnmarshalBinaryWithContext(ctx)
+		if errG != nil {
+			return errG
+		}
+		target.Window = *g
+		// --- [end][read][struct](Window) ---
+
+	} else {
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  AuditSetRange
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this AuditSetRange instance
+// into a byte array
+func (target *AuditSetRange) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this AuditSetRange instance
+// into a byte array leveraging a predefined context.
+func (target *AuditSetRange) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the AuditSetRange type
+func (target *AuditSetRange) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the AuditSetRange type
+func (target *AuditSetRange) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling AuditSetRange. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
 //  Breakdown
 //--------------------------------------------------------------------------
 
@@ -3501,7 +5259,8 @@ func (target *ClusterManagement) MarshalBinaryWithContext(ctx *EncodingContext) 
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.Cost) // write float64
+	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Cost)       // write float64
 	return nil
 }
 
@@ -3639,7 +5398,15 @@ func (target *ClusterManagement) UnmarshalBinaryWithContext(ctx *DecodingContext
 
 	if uint8(0) /* field version */ <= version {
 		n := buff.ReadFloat64() // read float64
-		target.Cost = n
+		target.adjustment = n
+
+	} else {
+		target.adjustment = float64(0) // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		o := buff.ReadFloat64() // read float64
+		target.Cost = o
 
 	} else {
 		target.Cost = float64(0) // default
@@ -3987,6 +5754,316 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		}
 	} else {
 		target.Breakdown = nil
+
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  EqualityAudit
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this EqualityAudit instance
+// into a byte array
+func (target *EqualityAudit) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this EqualityAudit instance
+// into a byte array leveraging a predefined context.
+func (target *EqualityAudit) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	// --- [begin][write][alias](AuditStatus) ---
+	if ctx.IsStringTable() {
+		a := ctx.Table.AddOrGet(string(target.Status))
+		buff.WriteInt(a) // write table index
+	} else {
+		buff.WriteString(string(target.Status)) // write string
+	}
+	// --- [end][write][alias](AuditStatus) ---
+
+	if ctx.IsStringTable() {
+		b := ctx.Table.AddOrGet(target.Description)
+		buff.WriteInt(b) // write table index
+	} else {
+		buff.WriteString(target.Description) // write string
+	}
+	// --- [begin][write][reference](time.Time) ---
+	c, errA := target.LastRun.MarshalBinary()
+	if errA != nil {
+		return errA
+	}
+	buff.WriteInt(len(c))
+	buff.WriteBytes(c)
+	// --- [end][write][reference](time.Time) ---
+
+	if target.Clusters == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][map](map[string]*AuditFloatResult) ---
+		buff.WriteInt(len(target.Clusters)) // map length
+		for v, z := range target.Clusters {
+			if ctx.IsStringTable() {
+				d := ctx.Table.AddOrGet(v)
+				buff.WriteInt(d) // write table index
+			} else {
+				buff.WriteString(v) // write string
+			}
+			if z == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditFloatResult) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errB := z.MarshalBinaryWithContext(ctx)
+				if errB != nil {
+					return errB
+				}
+				// --- [end][write][struct](AuditFloatResult) ---
+
+			}
+		}
+		// --- [end][write][map](map[string]*AuditFloatResult) ---
+
+	}
+	if target.MissingValues == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][slice]([]*AuditMissingValue) ---
+		buff.WriteInt(len(target.MissingValues)) // array length
+		for i := 0; i < len(target.MissingValues); i++ {
+			if target.MissingValues[i] == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditMissingValue) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errC := target.MissingValues[i].MarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				// --- [end][write][struct](AuditMissingValue) ---
+
+			}
+		}
+		// --- [end][write][slice]([]*AuditMissingValue) ---
+
+	}
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the EqualityAudit type
+func (target *EqualityAudit) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the EqualityAudit type
+func (target *EqualityAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling EqualityAudit. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][alias](AuditStatus) ---
+		var a string
+		var c string
+		if ctx.IsStringTable() {
+			d := buff.ReadInt() // read string index
+			c = ctx.Table[d]
+		} else {
+			c = buff.ReadString() // read string
+		}
+		b := c
+		a = b
+
+		target.Status = AuditStatus(a)
+		// --- [end][read][alias](AuditStatus) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var f string
+		if ctx.IsStringTable() {
+			g := buff.ReadInt() // read string index
+			f = ctx.Table[g]
+		} else {
+			f = buff.ReadString() // read string
+		}
+		e := f
+		target.Description = e
+
+	} else {
+		target.Description = "" // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][reference](time.Time) ---
+		h := &time.Time{}
+		k := buff.ReadInt()    // byte array length
+		l := buff.ReadBytes(k) // byte array
+		errA := h.UnmarshalBinary(l)
+		if errA != nil {
+			return errA
+		}
+		target.LastRun = *h
+		// --- [end][read][reference](time.Time) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.Clusters = nil
+		} else {
+			// --- [begin][read][map](map[string]*AuditFloatResult) ---
+			n := buff.ReadInt() // map len
+			m := make(map[string]*AuditFloatResult, n)
+			for i := 0; i < n; i++ {
+				var v string
+				var p string
+				if ctx.IsStringTable() {
+					q := buff.ReadInt() // read string index
+					p = ctx.Table[q]
+				} else {
+					p = buff.ReadString() // read string
+				}
+				o := p
+				v = o
+
+				var z *AuditFloatResult
+				if buff.ReadUInt8() == uint8(0) {
+					z = nil
+				} else {
+					// --- [begin][read][struct](AuditFloatResult) ---
+					r := &AuditFloatResult{}
+					buff.ReadInt() // [compatibility, unused]
+					errB := r.UnmarshalBinaryWithContext(ctx)
+					if errB != nil {
+						return errB
+					}
+					z = r
+					// --- [end][read][struct](AuditFloatResult) ---
+
+				}
+				m[v] = z
+			}
+			target.Clusters = m
+			// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+		}
+	} else {
+		target.Clusters = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.MissingValues = nil
+		} else {
+			// --- [begin][read][slice]([]*AuditMissingValue) ---
+			t := buff.ReadInt() // array len
+			s := make([]*AuditMissingValue, t)
+			for j := 0; j < t; j++ {
+				var u *AuditMissingValue
+				if buff.ReadUInt8() == uint8(0) {
+					u = nil
+				} else {
+					// --- [begin][read][struct](AuditMissingValue) ---
+					w := &AuditMissingValue{}
+					buff.ReadInt() // [compatibility, unused]
+					errC := w.UnmarshalBinaryWithContext(ctx)
+					if errC != nil {
+						return errC
+					}
+					u = w
+					// --- [end][read][struct](AuditMissingValue) ---
+
+				}
+				s[j] = u
+			}
+			target.MissingValues = s
+			// --- [end][read][slice]([]*AuditMissingValue) ---
+
+		}
+	} else {
+		target.MissingValues = nil
 
 	}
 
@@ -5642,6 +7719,393 @@ func (target *SharedAsset) UnmarshalBinaryWithContext(ctx *DecodingContext) (err
 
 	} else {
 		target.Cost = float64(0) // default
+	}
+
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  TotalAudit
+//--------------------------------------------------------------------------
+
+// MarshalBinary serializes the internal properties of this TotalAudit instance
+// into a byte array
+func (target *TotalAudit) MarshalBinary() (data []byte, err error) {
+	ctx := &EncodingContext{
+		Buffer: util.NewBuffer(),
+		Table:  nil,
+	}
+
+	e := target.MarshalBinaryWithContext(ctx)
+	if e != nil {
+		return nil, e
+	}
+
+	encBytes := ctx.Buffer.Bytes()
+	return encBytes, nil
+}
+
+// MarshalBinaryWithContext serializes the internal properties of this TotalAudit instance
+// into a byte array leveraging a predefined context.
+func (target *TotalAudit) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	buff.WriteUInt8(AuditCodecVersion) // version
+
+	// --- [begin][write][alias](AuditStatus) ---
+	if ctx.IsStringTable() {
+		a := ctx.Table.AddOrGet(string(target.Status))
+		buff.WriteInt(a) // write table index
+	} else {
+		buff.WriteString(string(target.Status)) // write string
+	}
+	// --- [end][write][alias](AuditStatus) ---
+
+	if ctx.IsStringTable() {
+		b := ctx.Table.AddOrGet(target.Description)
+		buff.WriteInt(b) // write table index
+	} else {
+		buff.WriteString(target.Description) // write string
+	}
+	// --- [begin][write][reference](time.Time) ---
+	c, errA := target.LastRun.MarshalBinary()
+	if errA != nil {
+		return errA
+	}
+	buff.WriteInt(len(c))
+	buff.WriteBytes(c)
+	// --- [end][write][reference](time.Time) ---
+
+	if target.TotalByNode == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][map](map[string]*AuditFloatResult) ---
+		buff.WriteInt(len(target.TotalByNode)) // map length
+		for v, z := range target.TotalByNode {
+			if ctx.IsStringTable() {
+				d := ctx.Table.AddOrGet(v)
+				buff.WriteInt(d) // write table index
+			} else {
+				buff.WriteString(v) // write string
+			}
+			if z == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditFloatResult) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errB := z.MarshalBinaryWithContext(ctx)
+				if errB != nil {
+					return errB
+				}
+				// --- [end][write][struct](AuditFloatResult) ---
+
+			}
+		}
+		// --- [end][write][map](map[string]*AuditFloatResult) ---
+
+	}
+	if target.TotalByCluster == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][map](map[string]*AuditFloatResult) ---
+		buff.WriteInt(len(target.TotalByCluster)) // map length
+		for vv, zz := range target.TotalByCluster {
+			if ctx.IsStringTable() {
+				e := ctx.Table.AddOrGet(vv)
+				buff.WriteInt(e) // write table index
+			} else {
+				buff.WriteString(vv) // write string
+			}
+			if zz == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditFloatResult) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errC := zz.MarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				// --- [end][write][struct](AuditFloatResult) ---
+
+			}
+		}
+		// --- [end][write][map](map[string]*AuditFloatResult) ---
+
+	}
+	if target.MissingValues == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][slice]([]*AuditMissingValue) ---
+		buff.WriteInt(len(target.MissingValues)) // array length
+		for i := 0; i < len(target.MissingValues); i++ {
+			if target.MissingValues[i] == nil {
+				buff.WriteUInt8(uint8(0)) // write nil byte
+			} else {
+				buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+				// --- [begin][write][struct](AuditMissingValue) ---
+				buff.WriteInt(0) // [compatibility, unused]
+				errD := target.MissingValues[i].MarshalBinaryWithContext(ctx)
+				if errD != nil {
+					return errD
+				}
+				// --- [end][write][struct](AuditMissingValue) ---
+
+			}
+		}
+		// --- [end][write][slice]([]*AuditMissingValue) ---
+
+	}
+	return nil
+}
+
+// UnmarshalBinary uses the data passed byte array to set all the internal properties of
+// the TotalAudit type
+func (target *TotalAudit) UnmarshalBinary(data []byte) error {
+	var table []string
+	buff := util.NewBufferFromBytes(data)
+
+	// string table header validation
+	if isBinaryTag(data, BinaryTagStringTable) {
+		buff.ReadBytes(len(BinaryTagStringTable)) // strip tag length
+		tl := buff.ReadInt()                      // table length
+		if tl > 0 {
+			table = make([]string, tl, tl)
+			for i := 0; i < tl; i++ {
+				table[i] = buff.ReadString()
+			}
+		}
+	}
+
+	ctx := &DecodingContext{
+		Buffer: buff,
+		Table:  table,
+	}
+
+	err := target.UnmarshalBinaryWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalBinaryWithContext uses the context containing a string table and binary buffer to set all the internal properties of
+// the TotalAudit type
+func (target *TotalAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) {
+	// panics are recovered and propagated as errors
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+			} else if s, ok := r.(string); ok {
+				err = fmt.Errorf("Unexpected panic: %s", s)
+			} else {
+				err = fmt.Errorf("Unexpected panic: %+v", r)
+			}
+		}
+	}()
+
+	buff := ctx.Buffer
+	version := buff.ReadUInt8()
+
+	if version > AuditCodecVersion {
+		return fmt.Errorf("Invalid Version Unmarshaling TotalAudit. Expected %d or less, got %d", AuditCodecVersion, version)
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][alias](AuditStatus) ---
+		var a string
+		var c string
+		if ctx.IsStringTable() {
+			d := buff.ReadInt() // read string index
+			c = ctx.Table[d]
+		} else {
+			c = buff.ReadString() // read string
+		}
+		b := c
+		a = b
+
+		target.Status = AuditStatus(a)
+		// --- [end][read][alias](AuditStatus) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		var f string
+		if ctx.IsStringTable() {
+			g := buff.ReadInt() // read string index
+			f = ctx.Table[g]
+		} else {
+			f = buff.ReadString() // read string
+		}
+		e := f
+		target.Description = e
+
+	} else {
+		target.Description = "" // default
+	}
+
+	if uint8(0) /* field version */ <= version {
+		// --- [begin][read][reference](time.Time) ---
+		h := &time.Time{}
+		k := buff.ReadInt()    // byte array length
+		l := buff.ReadBytes(k) // byte array
+		errA := h.UnmarshalBinary(l)
+		if errA != nil {
+			return errA
+		}
+		target.LastRun = *h
+		// --- [end][read][reference](time.Time) ---
+
+	} else {
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.TotalByNode = nil
+		} else {
+			// --- [begin][read][map](map[string]*AuditFloatResult) ---
+			n := buff.ReadInt() // map len
+			m := make(map[string]*AuditFloatResult, n)
+			for i := 0; i < n; i++ {
+				var v string
+				var p string
+				if ctx.IsStringTable() {
+					q := buff.ReadInt() // read string index
+					p = ctx.Table[q]
+				} else {
+					p = buff.ReadString() // read string
+				}
+				o := p
+				v = o
+
+				var z *AuditFloatResult
+				if buff.ReadUInt8() == uint8(0) {
+					z = nil
+				} else {
+					// --- [begin][read][struct](AuditFloatResult) ---
+					r := &AuditFloatResult{}
+					buff.ReadInt() // [compatibility, unused]
+					errB := r.UnmarshalBinaryWithContext(ctx)
+					if errB != nil {
+						return errB
+					}
+					z = r
+					// --- [end][read][struct](AuditFloatResult) ---
+
+				}
+				m[v] = z
+			}
+			target.TotalByNode = m
+			// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+		}
+	} else {
+		target.TotalByNode = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.TotalByCluster = nil
+		} else {
+			// --- [begin][read][map](map[string]*AuditFloatResult) ---
+			t := buff.ReadInt() // map len
+			s := make(map[string]*AuditFloatResult, t)
+			for j := 0; j < t; j++ {
+				var vv string
+				var w string
+				if ctx.IsStringTable() {
+					x := buff.ReadInt() // read string index
+					w = ctx.Table[x]
+				} else {
+					w = buff.ReadString() // read string
+				}
+				u := w
+				vv = u
+
+				var zz *AuditFloatResult
+				if buff.ReadUInt8() == uint8(0) {
+					zz = nil
+				} else {
+					// --- [begin][read][struct](AuditFloatResult) ---
+					y := &AuditFloatResult{}
+					buff.ReadInt() // [compatibility, unused]
+					errC := y.UnmarshalBinaryWithContext(ctx)
+					if errC != nil {
+						return errC
+					}
+					zz = y
+					// --- [end][read][struct](AuditFloatResult) ---
+
+				}
+				s[vv] = zz
+			}
+			target.TotalByCluster = s
+			// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+		}
+	} else {
+		target.TotalByCluster = nil
+
+	}
+
+	if uint8(0) /* field version */ <= version {
+		if buff.ReadUInt8() == uint8(0) {
+			target.MissingValues = nil
+		} else {
+			// --- [begin][read][slice]([]*AuditMissingValue) ---
+			bb := buff.ReadInt() // array len
+			aa := make([]*AuditMissingValue, bb)
+			for ii := 0; ii < bb; ii++ {
+				var cc *AuditMissingValue
+				if buff.ReadUInt8() == uint8(0) {
+					cc = nil
+				} else {
+					// --- [begin][read][struct](AuditMissingValue) ---
+					dd := &AuditMissingValue{}
+					buff.ReadInt() // [compatibility, unused]
+					errD := dd.UnmarshalBinaryWithContext(ctx)
+					if errD != nil {
+						return errD
+					}
+					cc = dd
+					// --- [end][read][struct](AuditMissingValue) ---
+
+				}
+				aa[ii] = cc
+			}
+			target.MissingValues = aa
+			// --- [end][read][slice]([]*AuditMissingValue) ---
+
+		}
+	} else {
+		target.MissingValues = nil
+
 	}
 
 	return nil

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -411,7 +411,7 @@ func ComputeAssetTotals(as *AssetSet, prop AssetProperty) map[string]*AssetTotal
 
 			arts[key].Count++
 			arts[key].LoadBalancerCost += lb.Cost
-			arts[key].LoadBalancerCost += lb.adjustment
+			arts[key].LoadBalancerCostAdjustment += lb.adjustment
 		} else if cm, ok := asset.(*ClusterManagement); ok && prop == AssetClusterProp {
 			// Only record cluster management when prop is Cluster because we
 			// can't break down ClusterManagement by node.
@@ -426,7 +426,8 @@ func ComputeAssetTotals(as *AssetSet, prop AssetProperty) map[string]*AssetTotal
 			}
 
 			arts[key].Count++
-			arts[key].ClusterManagementCost += cm.TotalCost()
+			arts[key].ClusterManagementCost += cm.Cost
+			arts[key].ClusterManagementCostAdjustment += cm.adjustment
 		} else if disk, ok := asset.(*Disk); ok {
 			// Record disks in an intermediate structure, which will be
 			// processed after all assets have been seen.

--- a/pkg/kubecost/window.go
+++ b/pkg/kubecost/window.go
@@ -455,14 +455,22 @@ func (w Window) Hours() float64 {
 	return w.end.Sub(*w.start).Hours()
 }
 
+//IsEmpty a Window is empty if it does not have a start and an end
 func (w Window) IsEmpty() bool {
 	return w.start == nil && w.end == nil
 }
 
+//HasDuration a Window has duration if neither start and end are not nil and not equal
+func (w Window) HasDuration() bool {
+	return !w.IsOpen() && !w.end.Equal(*w.Start())
+}
+
+//IsNegative a Window is negative if start and end are not null and end is before start
 func (w Window) IsNegative() bool {
 	return !w.IsOpen() && w.end.Before(*w.Start())
 }
 
+//IsOpen a Window is open if it has a nil start or end
 func (w Window) IsOpen() bool {
 	return w.start == nil || w.end == nil
 }

--- a/pkg/kubecost/window.go
+++ b/pkg/kubecost/window.go
@@ -456,7 +456,7 @@ func (w Window) Hours() float64 {
 }
 
 func (w Window) IsEmpty() bool {
-	return !w.IsOpen() && w.end.Equal(*w.Start())
+	return w.start == nil && w.end == nil
 }
 
 func (w Window) IsNegative() bool {


### PR DESCRIPTION
## What does this PR change?
This PR implements types for Audit along with the `ETLSet` interface and the Generic `SetRange` which uses it.
The Audit types are meant to record the results of the different Audits. The general purpose is to record incorrect results along with values the are missing from one source or another. The `ETLSet` interface encompasses the functionality required by the Generic `StoreStrategy` and any Set which is modified to implement it can be moved to a generic `StoreStrategy`. `SetRange` is meant to cover the basic range functionality of managing the `ETLSets`. A `SetRange` of a specific `ETLSet` type can be inherited and then expanded to cover any specialized functionality such as `Accumulate`.

Other changes:
* Add adjustment to cluster management type
* fix issue with window.IsEmpty()
* fix issue with lb adjustment in total store

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/783

## How will this PR impact users?
* see https://github.com/kubecost/kubecost-cost-model/pull/783

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* see https://github.com/kubecost/kubecost-cost-model/pull/783

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
