### PR TITLE
Add provider id for PV for GCP

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -1189,6 +1189,7 @@ func (gcp *GCP) getReservedInstances() ([]*GCPReservedInstance, error) {
 }
 
 type pvKey struct {
+	ProviderID             string
 	Labels                 map[string]string
 	StorageClass           string
 	StorageClassParameters map[string]string
@@ -1196,7 +1197,7 @@ type pvKey struct {
 }
 
 func (key *pvKey) ID() string {
-	return ""
+	return key.ProviderID
 }
 
 func (key *pvKey) GetStorageClass() string {
@@ -1204,7 +1205,12 @@ func (key *pvKey) GetStorageClass() string {
 }
 
 func (gcp *GCP) GetPVKey(pv *v1.PersistentVolume, parameters map[string]string, defaultRegion string) PVKey {
+	providerID := ""
+	if pv.Spec.GCEPersistentDisk != nil {
+		providerID = pv.Spec.GCEPersistentDisk.PDName
+	}
 	return &pvKey{
+		ProviderID:             providerID,
 		Labels:                 pv.Labels,
 		StorageClass:           pv.Spec.StorageClassName,
 		StorageClassParameters: parameters,

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -296,11 +296,9 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, start, end 
 		// Apply all remaining RAM to Idle
 		disk.Breakdown.Idle = 1.0 - (disk.Breakdown.System + disk.Breakdown.Other + disk.Breakdown.User)
 
-		// Set provider Id to the name for reconciliation on Azure
-		if fmt.Sprintf("%T", provider) == "*provider.Azure" {
-			if disk.ProviderID == "" {
-				disk.ProviderID = disk.Name
-			}
+		// Set provider Id to the name for reconciliation
+		if disk.ProviderID == "" {
+			disk.ProviderID = disk.Name
 		}
 	}
 


### PR DESCRIPTION
## What does this PR change?
Update to support GCP reconciliation. Adds provider Id's for GCP PVs and makes the general upgrade that all disks will have a provider id equal to their name if they do not already have one assigned. This second change will have an effect for all users that they will see disks that previously did not have a provider id as separate items at the time of the upgrade. This ID is determined at build time, so repairing or rebuilding the ETL will fix the issue.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/787

## How will this PR impact users?
* Users will have provider ids on all disks. This will cause some disks to appear as separate items at the time of upgrade. Repairing/rebuilding older days will remove this discontinuity, applying the new provider id retroactively.  
## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* see https://github.com/kubecost/kubecost-cost-model/pull/787

## Does this PR require changes to documentation?
* https://github.com/kubecost/kubecost-cost-model/pull/787

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
