### PR TITLE
Add auto-label-new-issues workflow

### DIFF
--- a/.github/workflows/auto_label_issues.yml
+++ b/.github/workflows/auto_label_issues.yml
@@ -1,0 +1,14 @@
+name: auto-label-new-issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label new issues with 'needs-triage'
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "needs-triage"


### PR DESCRIPTION
## What does this PR change?
Adds workflow to auto-label all newly-opened issues with "needs-triage" label.

## Does this PR relate to any other PRs?
N/A

## How will this PR impact users?
N/A

## Does this PR address any GitHub or Zendesk issues?
N/A

## How was this PR tested?
N/A

## Does this PR require changes to documentation?
N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
N/A