### PR TITLE
get reconciliation map

### DIFF
--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -850,6 +850,32 @@ func TestAssetSet_InsertMatchingWindow(t *testing.T) {
 	})
 }
 
+func TestAssetSet_ReconciliationMatchMap(t *testing.T) {
+	endYesterday := time.Now().UTC().Truncate(day)
+	startYesterday := endYesterday.Add(-day)
+
+	as := GenerateMockAssetSet(startYesterday)
+	matchMap := as.ReconciliationMatchMap()
+
+	// Determine the number of assets by provider ID
+	assetCountByProviderId := make(map[string]int, len(matchMap))
+	as.Each(func(key string, a Asset) {
+		if a == nil || a.Properties() == nil || a.Properties().ProviderID == "" {
+			return
+		}
+		if _, ok := assetCountByProviderId[a.Properties().ProviderID]; !ok {
+			assetCountByProviderId[a.Properties().ProviderID] = 0
+		}
+		assetCountByProviderId[a.Properties().ProviderID] += 1
+	})
+
+	for k, count := range assetCountByProviderId {
+		if len(matchMap[k]) != count {
+			t.Errorf("AssetSet.ReconciliationMatchMap: incorrect asset count for provider id: %s", k)
+		}
+	}
+}
+
 func TestAssetSetRange_Accumulate(t *testing.T) {
 	endYesterday := time.Now().UTC().Truncate(day)
 	startYesterday := endYesterday.Add(-day)


### PR DESCRIPTION
## What does this PR change?
* Add method to AssetSet which builds a map of the assets by providerID and Category. If there are duplicated assets then us the one that has previously been reconciled or failing that use the one with a higher cost to minimize cost duplication. 

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/829

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* see https://github.com/kubecost/kubecost-cost-model/pull/829

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
