### PR TITLE
Add parameter to log init: hide log level message

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -98,7 +98,7 @@ func newCostModelCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Init logging here so cobra/viper has processed the command line args and flags
 			// otherwise only envvars are available during init
-			log.InitLogging()
+			log.InitLogging(true)
 			return costmodel.Execute(opts)
 		},
 	}
@@ -119,7 +119,7 @@ func newAgentCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Init logging here so cobra/viper has processed the command line args and flags
 			// otherwise only envvars are available during init
-			log.InitLogging()
+			log.InitLogging(true)
 			return agent.Execute(opts)
 		},
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -23,7 +23,11 @@ const (
 	flagDisableColor = "disable-log-color"
 )
 
-func InitLogging() {
+// InitLogging sets standard configuration values for logging.
+//
+// If showLogLevelSetMessage is true, will log an unleveled message
+// specifying the log level post-init.
+func InitLogging(showLogLevelSetMessage bool) {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	// Default to using pretty formatting
 	if strings.ToLower(viper.GetString(flagFormat)) != "json" {
@@ -38,7 +42,10 @@ func InitLogging() {
 		return
 	}
 	zerolog.SetGlobalLevel(level)
-	log.Log().Msgf("Log level set to %v", level)
+
+	if showLogLevelSetMessage {
+		log.Log().Msgf("Log level set to %v", level)
+	}
 
 }
 


### PR DESCRIPTION
## What does this PR change?
This is useful for package users who want to keep logs to a minimum,
like CLI tools. 

## Does this PR relate to any other PRs?
* Supersedes https://github.com/kubecost/opencost/pull/1261

## How was this PR tested?
Built with the standard Dockerfile (CM+KCM) and observed the expected log message still appears "Set log level to XYZ"