### PR TITLE
Add a version and commit to the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ COPY go.sum .
 # golang:latest image does not contain GCC, while the AMD64 version does.
 ARG CGO_ENABLED=0
 
+ARG version=dev
+ARG	commit=HEAD
+
 # Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download
 # COPY the source code as the last step
@@ -21,7 +24,11 @@ RUN set -e ;\
     go test ./pkg/*;\
     cd cmd/costmodel;\
     GOOS=linux \
-    go build -a -installsuffix cgo -o /go/bin/app
+    go build -a -installsuffix cgo \
+    -ldflags \
+    "-X github.com/kubecost/opencost/pkg/version.Version=${version} \
+     -X github.com/kubecost/opencost/pkg/version.GitCommit=${commit}" \
+    -o /go/bin/app
 
 FROM alpine:latest
 RUN apk add --update --no-cache ca-certificates

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubecost/opencost/pkg/metrics"
 	"github.com/kubecost/opencost/pkg/prom"
 	"github.com/kubecost/opencost/pkg/util/watcher"
+	"github.com/kubecost/opencost/pkg/version"
 
 	prometheus "github.com/prometheus/client_golang/api"
 	prometheusAPI "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -125,7 +126,7 @@ func newPrometheusClient() (prometheus.Client, error) {
 }
 
 func Execute(opts *AgentOpts) error {
-	log.Infof("Starting Kubecost Agent")
+	log.Infof("Starting Kubecost Agent version %s", version.FriendlyVersion())
 
 	configWatchers := watcher.NewConfigMapWatchers()
 

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -6,7 +6,9 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/kubecost/opencost/pkg/costmodel"
 	"github.com/kubecost/opencost/pkg/errors"
+	"github.com/kubecost/opencost/pkg/log"
 	"github.com/kubecost/opencost/pkg/metrics"
+	"github.com/kubecost/opencost/pkg/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 )
@@ -23,6 +25,7 @@ func Healthz(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 }
 
 func Execute(opts *CostModelOpts) error {
+	log.Infof("Starting cost-model version %s", version.FriendlyVersion())
 	a := costmodel.Initialize()
 
 	rootMux := http.NewServeMux()

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1350,8 +1350,6 @@ func handlePanic(p errors.Panic) bool {
 }
 
 func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses {
-	log.Infof("Starting cost-model (git commit \"%s\")", env.GetAppVersion())
-
 	configWatchers := watcher.NewConfigMapWatchers(additionalConfigWatchers...)
 
 	var err error

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,12 @@
+package version
+
+import "fmt"
+
+var (
+	Version   = "dev"
+	GitCommit = "HEAD"
+)
+
+func FriendlyVersion() string {
+	return fmt.Sprintf("%s (%s)", Version, GitCommit)
+}


### PR DESCRIPTION
## What does this PR change?
* Embed a version and git commit into the built binary. 

To see this in action
```
docker build -t cost-model --build-arg version=testing --build-arg commit=asdasd .
```

Which would give you a log like `2022-06-16T22:11:10.794033216Z INF Starting cost-model version testing (asdasd)`

## Does this PR relate to any other PRs?
* Kinda... https://github.com/kubecost/opencost/pull/1260 can use this

## How will this PR impact users?
* Exposes more info that support can use to support them

## How was this PR tested?
* Build the image and output the results of `FriendlyVersion`
