### PR TITLE
Fix gpu bug

### DIFF
--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -356,13 +356,12 @@ func ComputeAssetTotals(as *AssetSet, prop AssetProperty) map[string]*AssetTotal
 			adjustedCPUCost := discountedCPUCost * adjustmentRate
 			cpuCostAdjustment := adjustedCPUCost - discountedCPUCost
 
-			discountedGPUCost := node.GPUCost * (1.0 - node.Discount)
-			adjustedGPUCost := discountedGPUCost * adjustmentRate
-			gpuCostAdjustment := discountedGPUCost - adjustedGPUCost
-
 			discountedRAMCost := node.RAMCost * (1.0 - node.Discount)
 			adjustedRAMCost := discountedRAMCost * adjustmentRate
 			ramCostAdjustment := adjustedRAMCost - discountedRAMCost
+
+			adjustedGPUCost := node.GPUCost * adjustmentRate
+			gpuCostAdjustment := adjustedGPUCost - node.GPUCost
 
 			if _, ok := arts[key]; !ok {
 				arts[key] = &AssetTotals{
@@ -395,7 +394,7 @@ func ComputeAssetTotals(as *AssetSet, prop AssetProperty) map[string]*AssetTotal
 			arts[key].RAMCostAdjustment += ramCostAdjustment
 
 			// TotalGPUCost will be discounted cost + adjustment
-			arts[key].GPUCost += discountedGPUCost
+			arts[key].GPUCost += node.GPUCost
 			arts[key].GPUCostAdjustment += gpuCostAdjustment
 		} else if lb, ok := asset.(*LoadBalancer); ok && prop == AssetClusterProp {
 			// Only record load balancers when prop is Cluster because we


### PR DESCRIPTION
## What does this PR change?
* Fixes bug in the total store that can cause large idles in nodes with GPU cost. From what I can tell it does not affect nodes without GPU. This bug is caused by a swapping of direction on a subtraction when calculating GPU adjustment. Additionally GPU does not have discount applied to it anywhere else in the cost model so I removed it here.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
