### PR TITLE
Add StartsWith empty string unit test to filters

### DIFF
--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -59,6 +59,36 @@ func Test_AllocationFilterCondition_Matches(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "ClusterID empty StartsWith '' -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterStartsWith,
+				Value: "",
+			},
+
+			expected: true,
+		},
+		{
+			name: "ClusterID nonempty StartsWith '' -> true",
+			a: &Allocation{
+				Properties: &AllocationProperties{
+					Cluster: "abc",
+				},
+			},
+			filter: AllocationFilterCondition{
+				Field: FilterClusterID,
+				Op:    FilterStartsWith,
+				Value: "",
+			},
+
+			expected: true,
+		},
+		{
 			name: "Node Equals -> true",
 			a: &Allocation{
 				Properties: &AllocationProperties{


### PR DESCRIPTION
## What does this PR change?
Adds unit tests for starts with empty (e.g. `filterNamespaces="*"`) behavior in AllocationFilterCondition.

## How was this PR tested?
It is a test