### PR TITLE
Use Query offset in raw query, fix file name of local cluster

### DIFF
--- a/pkg/costmodel/clusters/clustermap.go
+++ b/pkg/costmodel/clusters/clustermap.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 	"fmt"
+	"github.com/kubecost/opencost/pkg/env"
 	"strings"
 	"sync"
 	"time"
@@ -19,6 +20,10 @@ const (
 	LoadRetries    int           = 6
 	LoadRetryDelay time.Duration = 10 * time.Second
 )
+
+// prometheus query offset to apply to each non-range query
+// package scope to prevent calling duration parse each use
+var promQueryOffset = env.GetPrometheusQueryOffset()
 
 // ClusterInfo holds attributes of Cluster from metrics pulled from Prometheus
 type ClusterInfo struct {
@@ -138,7 +143,8 @@ func (pcm *PrometheusClusterMap) loadClusters() (map[string]*ClusterInfo, error)
 	// Execute Query
 	tryQuery := func() (interface{}, error) {
 		ctx := prom.NewNamedContext(pcm.client, prom.ClusterMapContextName)
-		r, _, e := ctx.QuerySync(clusterInfoQuery(offset))
+		resCh := ctx.QueryAtTime(clusterInfoQuery(offset), time.Now().Add(-promQueryOffset))
+		r, e := resCh.Await()
 		return r, e
 	}
 

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1600,7 +1600,7 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 	// ClusterInfo Provider to provide the cluster map with local and remote cluster data
 	var clusterInfoProvider clusters.ClusterInfoProvider
 	if env.IsClusterInfoFileEnabled() {
-		clusterInfoFile := confManager.ConfigFileAt(path.Join(configPrefix, " cluster-info.json"))
+		clusterInfoFile := confManager.ConfigFileAt(path.Join(configPrefix, "cluster-info.json"))
 		clusterInfoProvider = NewConfiguredClusterInfoProvider(clusterInfoFile)
 	} else {
 		clusterInfoProvider = NewLocalClusterInfoProvider(kubeClientset, cloudProvider)

--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -189,18 +189,11 @@ func (ctx *Context) RawQuery(query string, t time.Time) ([]byte, error) {
 	q := u.Query()
 	q.Set("query", query)
 
-	if !t.IsZero() {
-		q.Set("time", strconv.FormatInt(t.Unix(), 10))
-	} else {
-		// for non-range queries, we set the timestamp for the query to time-offset
-		// this is a special use case that's typically only used when our primary
-		// prom db has delayed insertion (thanos, cortex, etc...)
-		if promQueryOffset != 0 && ctx.name != AllocationContextName {
-			q.Set("time", time.Now().Add(-promQueryOffset).UTC().Format(time.RFC3339))
-		} else {
-			q.Set("time", time.Now().UTC().Format(time.RFC3339))
-		}
+	if t.IsZero() {
+		t = time.Now()
 	}
+	
+	q.Set("time", strconv.FormatInt(t.Unix(), 10))
 
 	u.RawQuery = q.Encode()
 


### PR DESCRIPTION
## What does this PR change?
* This PR re applies offset env variable to prom querys and removes a leading space which was causing local cluster infor to not load from the file it is one.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested on hosted cluster

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
