### PR TITLE
Fix panic on trying to marshal pointer to nil AllocationSetRange

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1889,6 +1889,9 @@ func (as *AllocationSet) Map() map[string]*Allocation {
 
 // MarshalJSON JSON-encodes the AllocationSet
 func (as *AllocationSet) MarshalJSON() ([]byte, error) {
+	if as == nil {
+		return json.Marshal(map[string]*Allocation{})
+	}
 	as.RLock()
 	defer as.RUnlock()
 	return json.Marshal(as.allocations)
@@ -2224,6 +2227,10 @@ func (asr *AllocationSetRange) Length() int {
 
 // MarshalJSON JSON-encodes the range
 func (asr *AllocationSetRange) MarshalJSON() ([]byte, error) {
+	if asr == nil {
+		return json.Marshal([]*AllocationSet{})
+	}
+
 	asr.RLock()
 	defer asr.RUnlock()
 	return json.Marshal(asr.allocations)

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2368,8 +2368,60 @@ func TestAllocationSetRange_InsertRange(t *testing.T) {
 // TODO niko/etl
 // func TestAllocationSetRange_Length(t *testing.T) {}
 
-// TODO niko/etl
-// func TestAllocationSetRange_MarshalJSON(t *testing.T) {}
+func TestAllocationSetRange_MarshalJSON(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		arg      *AllocationSetRange
+		expected *AllocationSetRange
+	}{
+		{
+			name: "Nil ASR",
+			arg:  nil,
+		},
+		{
+			name: "Nil AS in ASR",
+			arg:  NewAllocationSetRange(nil),
+		},
+		{
+			name: "Normal ASR",
+			arg: &AllocationSetRange{
+				allocations: []*AllocationSet{
+					{
+						allocations: map[string]*Allocation{
+							"a": {
+								Start: time.Now().UTC().Truncate(day),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		bytes, err := json.Marshal(test.arg)
+		if err != nil {
+			t.Fatalf("ASR Marshal: test %s, unexpected error: %s", test.name, err)
+		}
+
+		var testASR []*AllocationSet
+		marshaled := &testASR
+
+		err = json.Unmarshal(bytes, marshaled)
+
+		if err != nil {
+			t.Fatalf("ASR Unmarshal: test %s: unexpected error: %s", test.name, err)
+		}
+
+		if test.arg.Length() != len(testASR) {
+			t.Fatalf("ASR Unmarshal: test %s: length mutated in encoding: expected %d but got %d", test.name, test.arg.Length(), len(testASR))
+		}
+
+		// Allocations don't unmarshal back from json
+	}
+}
 
 // TODO niko/etl
 // func TestAllocationSetRange_Slice(t *testing.T) {}

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -3097,6 +3097,9 @@ func (asr *AssetSetRange) IsEmpty() bool {
 }
 
 func (asr *AssetSetRange) MarshalJSON() ([]byte, error) {
+	if asr == nil {
+		return json.Marshal([]*AssetSet{})
+	}
 	asr.RLock()
 	defer asr.RUnlock()
 	return json.Marshal(asr.assets)

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -1424,3 +1424,58 @@ func TestAssetSetRange_Minutes(t *testing.T) {
 		}
 	}
 }
+
+func TestAssetSetRange_MarshalJSON(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		arg      *AssetSetRange
+		expected *AssetSetRange
+	}{
+		{
+			name: "Nil ASR",
+			arg:  nil,
+		},
+		{
+			name: "Nil AS in ASR",
+			arg:  NewAssetSetRange(nil),
+		},
+		{
+			name: "Normal ASR",
+			arg: &AssetSetRange{
+				assets: []*AssetSet{
+					{
+						assets: map[string]Asset{
+							"a": &Any{
+								start: time.Now().UTC().Truncate(day),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		bytes, err := json.Marshal(test.arg)
+		if err != nil {
+			t.Fatalf("ASR Marshal: test %s, unexpected error: %s", test.name, err)
+		}
+
+		var testASR []*AssetSet
+		marshaled := &testASR
+
+		err = json.Unmarshal(bytes, marshaled)
+
+		if err != nil {
+			t.Fatalf("ASR Unmarshal: test %s: unexpected error: %s", test.name, err)
+		}
+
+		if test.arg.Length() != len(testASR) {
+			t.Fatalf("ASR Unmarshal: test %s: length mutated in encoding: expected %d but got %d", test.name, test.arg.Length(), len(testASR))
+		}
+
+		// asset don't unmarshal back from json
+	}
+}

--- a/pkg/kubecost/asset_unmarshal.go
+++ b/pkg/kubecost/asset_unmarshal.go
@@ -709,6 +709,9 @@ func (sa *SharedAsset) InterfaceToSharedAsset(itf interface{}) error {
 
 // MarshalJSON JSON-encodes the AssetSet
 func (as *AssetSet) MarshalJSON() ([]byte, error) {
+	if as == nil {
+		return json.Marshal(map[string]Asset{})
+	}
 	as.RLock()
 	defer as.RUnlock()
 	return json.Marshal(as.assets)

--- a/pkg/kubecost/etlrange.go
+++ b/pkg/kubecost/etlrange.go
@@ -81,7 +81,7 @@ func (r *SetRange[T]) IsEmpty() bool {
 // MarshalJSON converts SetRange to JSON
 func (r *SetRange[T]) MarshalJSON() ([]byte, error) {
 	if r == nil {
-		return nil, fmt.Errorf("SetRange: MarshalJSON: is nil")
+		return json.Marshal([]T{})
 	}
 	r.lock.RLock()
 	defer r.lock.RUnlock()


### PR DESCRIPTION
## What does this PR change?
Adds a check in MarshalJSON for AllocationSetRange that makes sure the set is not nil. If it is, it marshals an empty version of what is would marshal (e.g. AS -> empty map of strings to allocations, ASR -> empty slice of AS).

Also adds a test for marshaling AllocationSetRange.

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
Fixed a panic when querying allocations.

## Does this PR address any GitHub or Zendesk issues?

## How was this PR tested?
* Tested using written test + recreating scenario where error occurred and making sure no panic happens. 

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
Yes