### PR TITLE
Making minsPerResolution configurable in cluster.go

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -136,8 +136,12 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, start, end 
 	// minsPerResolution determines accuracy and resource use for the following
 	// queries. Smaller values (higher resolution) result in better accuracy,
 	// but more expensive queries, and vice-a-versa.
-	minsPerResolution := 1
-	resolution := time.Duration(minsPerResolution) * time.Minute
+	resolution := env.GetETLResolution()
+	//Ensuring if ETL_RESOLUTION_SECONDS is less than 60s default it to 1m
+	var minsPerResolution int
+	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) == 0 {
+		minsPerResolution = 1
+	}
 
 	// hourlyToCumulative is a scaling factor that, when multiplied by an hourly
 	// value, converts it to a cumulative value; i.e.
@@ -388,8 +392,12 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, start, end time.T
 	// minsPerResolution determines accuracy and resource use for the following
 	// queries. Smaller values (higher resolution) result in better accuracy,
 	// but more expensive queries, and vice-a-versa.
-	minsPerResolution := 1
-	resolution := time.Duration(minsPerResolution) * time.Minute
+	resolution := env.GetETLResolution()
+	//Ensuring if ETL_RESOLUTION_SECONDS is less than 60s default it to 1m
+	var minsPerResolution int
+	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) == 0 {
+		minsPerResolution = 1
+	}
 
 	requiredCtx := prom.NewNamedContext(client, prom.ClusterContextName)
 	optionalCtx := prom.NewNamedContext(client, prom.ClusterOptionalContextName)
@@ -544,7 +552,12 @@ func ClusterLoadBalancers(client prometheus.Client, start, end time.Time) (map[L
 	// minsPerResolution determines accuracy and resource use for the following
 	// queries. Smaller values (higher resolution) result in better accuracy,
 	// but more expensive queries, and vice-a-versa.
-	minsPerResolution := 1
+	resolution := env.GetETLResolution()
+	//Ensuring if ETL_RESOLUTION_SECONDS is less than 60s default it to 1m
+	var minsPerResolution int
+	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) == 0 {
+		minsPerResolution = 1
+	}
 
 	ctx := prom.NewNamedContext(client, prom.ClusterContextName)
 
@@ -670,7 +683,12 @@ func (a *Accesses) ComputeClusterCosts(client prometheus.Client, provider cloud.
 	// minsPerResolution determines accuracy and resource use for the following
 	// queries. Smaller values (higher resolution) result in better accuracy,
 	// but more expensive queries, and vice-a-versa.
-	minsPerResolution := 5
+	resolution := env.GetETLResolution()
+	//Ensuring if ETL_RESOLUTION_SECONDS is less than 60s default it to 1m
+	var minsPerResolution int
+	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) < 1 {
+		minsPerResolution = 1
+	}
 
 	// hourlyToCumulative is a scaling factor that, when multiplied by an hourly
 	// value, converts it to a cumulative value; i.e.

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -141,6 +141,7 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, start, end 
 	var minsPerResolution int
 	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) == 0 {
 		minsPerResolution = 1
+		log.DedupedWarningf(3, "ClusterDisks(): Configured ETL resolution (%d seconds) is below the 60 seconds threshold. Overriding with 1 minute.", int(resolution.Seconds()))
 	}
 
 	// hourlyToCumulative is a scaling factor that, when multiplied by an hourly
@@ -397,6 +398,7 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, start, end time.T
 	var minsPerResolution int
 	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) == 0 {
 		minsPerResolution = 1
+		log.DedupedWarningf(3, "ClusterNodes(): Configured ETL resolution (%d seconds) is below the 60 seconds threshold. Overriding with 1 minute.", int(resolution.Seconds()))
 	}
 
 	requiredCtx := prom.NewNamedContext(client, prom.ClusterContextName)
@@ -557,6 +559,7 @@ func ClusterLoadBalancers(client prometheus.Client, start, end time.Time) (map[L
 	var minsPerResolution int
 	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) == 0 {
 		minsPerResolution = 1
+		log.DedupedWarningf(3, "ClusterLoadBalancers(): Configured ETL resolution (%d seconds) is below the 60 seconds threshold. Overriding with 1 minute.", int(resolution.Seconds()))
 	}
 
 	ctx := prom.NewNamedContext(client, prom.ClusterContextName)
@@ -688,6 +691,7 @@ func (a *Accesses) ComputeClusterCosts(client prometheus.Client, provider cloud.
 	var minsPerResolution int
 	if minsPerResolution = int(resolution.Minutes()); int(resolution.Minutes()) < 1 {
 		minsPerResolution = 1
+		log.DedupedWarningf(3, "ComputeClusterCosts(): Configured ETL resolution (%d seconds) is below the 60 seconds threshold. Overriding with 1 minute.", int(resolution.Seconds()))
 	}
 
 	// hourlyToCumulative is a scaling factor that, when multiplied by an hourly


### PR DESCRIPTION
## What does this PR change?
*  Make the minsPerResolution Configurable with ETL_RESOLUTION_SECONDS env variable.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* I have tried to keep this most least breaking change, to avoid impact on user 

## Does this PR address any GitHub or Zendesk issues?
* Closes ... #1291 

## How was this PR tested?
* Yet to device a test plan tomorrow 

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* Will discuss it tomorrow. 
