### PR TITLE
Update Azure LB pricing and comment

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -1066,22 +1066,13 @@ func (az *Azure) NetworkPricing() (*Network, error) {
 	}, nil
 }
 
+// LoadBalancerPricing on Azure, LoadBalancer services correspond to public IPs. For now the pricing of LoadBalancer
+// services will be that of a standard static public IP https://azure.microsoft.com/en-us/pricing/details/ip-addresses/.
+// Azure still has load balancers which follow the standard pricing scheme based on rules
+// https://azure.microsoft.com/en-us/pricing/details/load-balancer/, they are created on a per-cluster basis.
 func (azr *Azure) LoadBalancerPricing() (*LoadBalancer, error) {
-	fffrc := 0.025
-	afrc := 0.010
-	lbidc := 0.008
-
-	numForwardingRules := 1.0
-	dataIngressGB := 0.0
-
-	var totalCost float64
-	if numForwardingRules < 5 {
-		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
-	} else {
-		totalCost = fffrc*5 + afrc*(numForwardingRules-5) + lbidc*dataIngressGB
-	}
 	return &LoadBalancer{
-		Cost: totalCost,
+		Cost: 0.005,
 	}, nil
 }
 


### PR DESCRIPTION
## What does this PR change?
* This PR lowers pricing of Load Balancers Services on Azure. Which should actually correspond to pricing for public IP addresses https://azure.microsoft.com/en-us/pricing/details/ip-addresses/.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* Users should see more accurate pricing on Azure Loadbalancers

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/opencost/issues/1220
* Closes ZD1659

## How was this PR tested?
* This PR was tested by running it on Azure clusters and ensuring that the cost of the LBs dropped after being applied.
![Screen Shot 2022-07-08 at 1 15 14 PM](https://user-images.githubusercontent.com/12225425/178312996-1b6c876c-a31e-4c2b-8076-2baa75f73d84.png)

## Does this PR require changes to documentation?
* 


## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
