### PR TITLE
Remove log spam related to Allocation lb queries

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -2489,21 +2489,10 @@ type LB struct {
 
 func getLoadBalancerCosts(resLBCost, resLBActiveMins []*prom.QueryResult, resolution time.Duration) map[serviceKey]*LB {
 	lbMap := make(map[serviceKey]*LB)
-	lbHourlyCosts := make(map[serviceKey]float64)
-	for _, res := range resLBCost {
-		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), "namespace", "service_name")
-		if err != nil {
-			continue
-		}
-		lbHourlyCosts[serviceKey] = res.Values[0].Value
-	}
+
 	for _, res := range resLBActiveMins {
 		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), "namespace", "service_name")
 		if err != nil || len(res.Values) == 0 {
-			continue
-		}
-		if _, ok := lbHourlyCosts[serviceKey]; !ok {
-			log.Warnf("CostModel: failed to find hourly cost for Load Balancer: %v", serviceKey)
 			continue
 		}
 
@@ -2511,12 +2500,25 @@ func getLoadBalancerCosts(resLBCost, resLBActiveMins []*prom.QueryResult, resolu
 		// subtract resolution from start time to cover full time period
 		s = s.Add(-resolution)
 		e := time.Unix(int64(res.Values[len(res.Values)-1].Timestamp), 0)
-		hours := e.Sub(s).Hours()
 
 		lbMap[serviceKey] = &LB{
-			TotalCost: lbHourlyCosts[serviceKey] * hours,
-			Start:     s,
-			End:       e,
+			Start: s,
+			End:   e,
+		}
+	}
+
+	for _, res := range resLBCost {
+		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), "namespace", "service_name")
+		if err != nil {
+			continue
+		}
+		// Apply cost as price-per-hour * hours
+		if lb, ok := lbMap[serviceKey]; ok {
+			lbPricePerHr := res.Values[0].Value
+			hours := lb.End.Sub(lb.Start).Hours()
+			lb.TotalCost += lbPricePerHr * hours
+		} else {
+			log.DedupedWarningf(20, "CostModel: found minutes for key that does not exist: %s", serviceKey)
 		}
 	}
 	return lbMap

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1225,7 +1225,7 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 }
 
 // TODO: drop some logs
-func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costAnalyzerCloud.LoadBalancer, error) {
+func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[serviceKey]*costAnalyzerCloud.LoadBalancer, error) {
 	// for fetching prices from cloud provider
 	// cfg, err := cp.GetConfig()
 	// if err != nil {
@@ -1233,12 +1233,16 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 	// }
 
 	servicesList := cm.Cache.GetAllServices()
-	loadBalancerMap := make(map[string]*costAnalyzerCloud.LoadBalancer)
+	loadBalancerMap := make(map[serviceKey]*costAnalyzerCloud.LoadBalancer)
 
 	for _, service := range servicesList {
 		namespace := service.GetObjectMeta().GetNamespace()
 		name := service.GetObjectMeta().GetName()
-		key := namespace + "," + name // + "," + clusterID?
+		key := serviceKey{
+			Cluster:   env.GetClusterID(),
+			Namespace: namespace,
+			Service:   name,
+		}
 
 		if service.Spec.Type == "LoadBalancer" {
 			loadBalancer, err := cp.LoadBalancerPricing()

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -572,9 +572,9 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 			}
 			for lbKey, lb := range loadBalancers {
 				// TODO: parse (if necessary) and calculate cost associated with loadBalancer based on dynamic cloud prices fetched into each lb struct on GetLBCost() call
-				keyParts := getLabelStringsFromKey(lbKey)
-				namespace := keyParts[0]
-				serviceName := keyParts[1]
+
+				namespace := lbKey.Namespace
+				serviceName := lbKey.Service
 				ingressIP := ""
 				if len(lb.IngressIPAddresses) > 0 {
 					ingressIP = lb.IngressIPAddresses[0] // assumes one ingress IP per load balancer


### PR DESCRIPTION
## What does this PR change?
Fix bug causing log spam related to Load Balancer queries for Allocation calculation.
```
2022-07-05T22:43:38.206111697Z INF ETL: Allocation[1h]: AggregatedStore[XwrQQ]: run: aggregated [2022-07-05T16:00:00+0000, 2022-07-05T17:00:00+0000) from 424 to 187 in 1.486516ms
2022-07-05T22:43:38.395689478Z WRN CostModel: failed to find hourly cost for Load Balancer: aws-test-1-multi-cloud/multi-cloud-2/kubecost-frontend
2022-07-05T22:43:38.395765284Z WRN CostModel: failed to find hourly cost for Load Balancer: aws-test-1-multi-cloud-2/integration-multi-cloud/kubecost-frontend
2022-07-05T22:43:38.395780585Z WRN CostModel: failed to find hourly cost for Load Balancer: gcp-test-1-multi-cloud/multi-cloud/kubecost-frontend
```
This bug was occurring because the duration parameter on one of the load balancer prometheus queries but not the other. This caused certain hourly calculations to consistently fail on Kubecost deployments with Thanos around the data delay time period. This fix changes the processing to how it is managed with Assets to avoid this log spam. Since hourly Allocations are recalculated for the past 6h on each cycle, this issue is fixed as Thanos data fully populates.


## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested on Multi-cloud cluster to ensure spam logs were removed, and load balancers were properly pricing.

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* 
