### PR TITLE
Recognizes annotations when aggregating by owner

### DIFF
--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -347,7 +347,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			}
 		case agg == AllocationOwnerProp:
 			labels := p.Labels
-			if labels == nil {
+			annotations := p.Annotations
+			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
 				labelNames := strings.Split(labelConfig.OwnerLabel, ",")
@@ -355,6 +356,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
+					} else if annotationValue, ok := annotations[labelName]; ok {
+						names = append(names, annotationValue)
 					} else {
 						names = append(names, UnallocatedSuffix)
 					}

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -1,0 +1,44 @@
+package kubecost
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateKey(t *testing.T) {
+
+	cases := map[string]struct {
+		aggregate       []string
+		allocationProps *AllocationProperties
+		expected        string
+	}{
+		"agg by owner with labels": {
+			aggregate: []string{"owner"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"app": "cost-analyzer"},
+				Annotations: map[string]string{"owner": "test owner 123"},
+			},
+			expected: "test owner 123",
+		},
+		"agg by owner without labels": {
+			aggregate: []string{"owner"},
+			allocationProps: &AllocationProperties{
+				Annotations: map[string]string{"owner": "test owner 123"},
+			},
+			expected: "test owner 123",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			lc := NewLabelConfig()
+
+			result := tc.allocationProps.GenerateKey(tc.aggregate, lc)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Fatalf("expected %+v; got %+v", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* When aggregating by owner, kubecost will generate keys for annotations

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users can now see cost breakdowns when using annotations and aggregating by owner 

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1392

## How was this PR tested?
* Unit testing and manual testing on a local cluster

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Kubecost release? If not, why not?
* Yes
