### PR TITLE
Mapping for annotations

### DIFF
--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -317,7 +317,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			}
 		case agg == AllocationDepartmentProp:
 			labels := p.Labels
-			if labels == nil {
+			annotations := p.Annotations
+			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
 				labelNames := strings.Split(labelConfig.DepartmentLabel, ",")
@@ -325,6 +326,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
+					} else if annotationValue, ok := annotations[labelName]; ok {
+						names = append(names, annotationValue)
 					} else {
 						names = append(names, UnallocatedSuffix)
 					}
@@ -332,7 +335,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			}
 		case agg == AllocationEnvironmentProp:
 			labels := p.Labels
-			if labels == nil {
+			annotations := p.Annotations
+			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
 				labelNames := strings.Split(labelConfig.EnvironmentLabel, ",")
@@ -340,6 +344,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
+					} else if annotationValue, ok := annotations[labelName]; ok {
+						names = append(names, annotationValue)
 					} else {
 						names = append(names, UnallocatedSuffix)
 					}
@@ -347,7 +353,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			}
 		case agg == AllocationOwnerProp:
 			labels := p.Labels
-			if labels == nil {
+			annotations := p.Annotations
+			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
 				labelNames := strings.Split(labelConfig.OwnerLabel, ",")
@@ -355,6 +362,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
+					} else if annotationValue, ok := annotations[labelName]; ok {
+						names = append(names, annotationValue)
 					} else {
 						names = append(names, UnallocatedSuffix)
 					}
@@ -362,7 +371,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			}
 		case agg == AllocationProductProp:
 			labels := p.Labels
-			if labels == nil {
+			annotations := p.Annotations
+			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
 				labelNames := strings.Split(labelConfig.ProductLabel, ",")
@@ -370,6 +380,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
+					} else if annotationValue, ok := annotations[labelName]; ok {
+						names = append(names, annotationValue)
 					} else {
 						names = append(names, UnallocatedSuffix)
 					}
@@ -377,7 +389,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			}
 		case agg == AllocationTeamProp:
 			labels := p.Labels
-			if labels == nil {
+			annotations := p.Annotations
+			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
 				labelNames := strings.Split(labelConfig.TeamLabel, ",")
@@ -385,6 +398,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
+					} else if annotationValue, ok := annotations[labelName]; ok {
+						names = append(names, annotationValue)
 					} else {
 						names = append(names, UnallocatedSuffix)
 					}

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -12,7 +12,11 @@ func TestGenerateKey(t *testing.T) {
 		allocationProps *AllocationProperties
 		expected        string
 	}{
+<<<<<<< HEAD
 		"aggregateregate by owner without owner labels": {
+=======
+		"agg by owner with labels": {
+>>>>>>> Recognizes annotations when aggregating by owner
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
 				Labels:      map[string]string{"app": "cost-analyzer"},
@@ -20,13 +24,18 @@ func TestGenerateKey(t *testing.T) {
 			},
 			expected: "test owner 123",
 		},
+<<<<<<< HEAD
 		"aggregate by owner without labels": {
+=======
+		"agg by owner without labels": {
+>>>>>>> Recognizes annotations when aggregating by owner
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
 				Annotations: map[string]string{"owner": "test owner 123"},
 			},
 			expected: "test owner 123",
 		},
+<<<<<<< HEAD
 		"aggregate by owner with owner label and annotation": {
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
@@ -75,6 +84,8 @@ func TestGenerateKey(t *testing.T) {
 			},
 			expected: "product-label/owner-label",
 		},
+=======
+>>>>>>> Recognizes annotations when aggregating by owner
 	}
 
 	for name, tc := range cases {

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -1,0 +1,92 @@
+package kubecost
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateKey(t *testing.T) {
+
+	cases := map[string]struct {
+		aggregate       []string
+		allocationProps *AllocationProperties
+		expected        string
+	}{
+		"aggregateregate by owner without owner labels": {
+			aggregate: []string{"owner"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"app": "cost-analyzer"},
+				Annotations: map[string]string{"owner": "test owner 123"},
+			},
+			expected: "test owner 123",
+		},
+		"aggregate by owner without labels": {
+			aggregate: []string{"owner"},
+			allocationProps: &AllocationProperties{
+				Annotations: map[string]string{"owner": "test owner 123"},
+			},
+			expected: "test owner 123",
+		},
+		"aggregate by owner with owner label and annotation": {
+			aggregate: []string{"owner"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"owner": "owner-label"},
+				Annotations: map[string]string{"owner": "owner-annotation"},
+			},
+			expected: "owner-label",
+		},
+		"aggregate by environment with environment label and annotation": {
+			aggregate: []string{"environment"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"env": "environment-label"},
+				Annotations: map[string]string{"env": "environment-annotation"},
+			},
+			expected: "environment-label",
+		},
+		"aggregate by department with department label and annotation": {
+			aggregate: []string{"department"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"department": "department-label"},
+				Annotations: map[string]string{"department": "department-annotation"},
+			},
+			expected: "department-label",
+		},
+		"aggregate by team with team label and annotation": {
+			aggregate: []string{"team"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"team": "team-label"},
+				Annotations: map[string]string{"team": "team-annotation"},
+			},
+			expected: "team-label",
+		},
+		"aggregate by product with product label and annotation": {
+			aggregate: []string{"product"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"app": "product-label"},
+				Annotations: map[string]string{"app": "product-annotation"},
+			},
+			expected: "product-label",
+		},
+		"aggregate by product and owner with multiple labels and annotations": {
+			aggregate: []string{"product", "owner"},
+			allocationProps: &AllocationProperties{
+				Labels:      map[string]string{"app": "product-label", "owner": "owner-label", "team": "team-label"},
+				Annotations: map[string]string{"app": "product-annotation", "owner": "owner-annotation", "team": "team-annotation"},
+			},
+			expected: "product-label/owner-label",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			lc := NewLabelConfig()
+
+			result := tc.allocationProps.GenerateKey(tc.aggregate, lc)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Fatalf("expected %+v; got %+v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -13,10 +13,14 @@ func TestGenerateKey(t *testing.T) {
 		expected        string
 	}{
 <<<<<<< HEAD
+<<<<<<< HEAD
 		"aggregateregate by owner without owner labels": {
 =======
 		"agg by owner with labels": {
 >>>>>>> Recognizes annotations when aggregating by owner
+=======
+		"aggregate by owner without owner labels": {
+>>>>>>> fixed test case wording
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
 				Labels:      map[string]string{"app": "cost-analyzer"},

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -12,15 +12,7 @@ func TestGenerateKey(t *testing.T) {
 		allocationProps *AllocationProperties
 		expected        string
 	}{
-<<<<<<< HEAD
-<<<<<<< HEAD
-		"aggregateregate by owner without owner labels": {
-=======
-		"agg by owner with labels": {
->>>>>>> Recognizes annotations when aggregating by owner
-=======
 		"aggregate by owner without owner labels": {
->>>>>>> fixed test case wording
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
 				Labels:      map[string]string{"app": "cost-analyzer"},
@@ -28,18 +20,13 @@ func TestGenerateKey(t *testing.T) {
 			},
 			expected: "test owner 123",
 		},
-<<<<<<< HEAD
 		"aggregate by owner without labels": {
-=======
-		"agg by owner without labels": {
->>>>>>> Recognizes annotations when aggregating by owner
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
 				Annotations: map[string]string{"owner": "test owner 123"},
 			},
 			expected: "test owner 123",
 		},
-<<<<<<< HEAD
 		"aggregate by owner with owner label and annotation": {
 			aggregate: []string{"owner"},
 			allocationProps: &AllocationProperties{
@@ -88,8 +75,6 @@ func TestGenerateKey(t *testing.T) {
 			},
 			expected: "product-label/owner-label",
 		},
-=======
->>>>>>> Recognizes annotations when aggregating by owner
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## What does this PR change?
* Allows users to use labels or annotations to aggregate by. Works with owner, product, environment, department, team.

## Does this PR relate to any other PRs?
* Yes, it is the continuation of https://github.com/opencost/opencost/pull/1321 

## How will this PR impact users?
* Users will no longer see "__unallocated__" when using annotations instead of labels for any of the above aggregations

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1392

## How was this PR tested?
* Unit tests and tested on a local cluster

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* No, don't have access
