### PR TITLE
Diff asset tracks cost changes

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -3,6 +3,7 @@ package kubecost
 import (
 	"encoding"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -856,8 +857,8 @@ type ClusterManagement struct {
 	labels     AssetLabels
 	properties *AssetProperties
 	window     Window
-	adjustment float64
 	Cost       float64
+	adjustment float64 // @bingen:field[version=16]
 }
 
 // NewClusterManagement creates and returns a new ClusterManagement instance
@@ -2906,14 +2907,18 @@ type Diff[T any] struct {
 // DiffAsset takes two AssetSets and returns a map of keys to Diffs by checking
 // the keys of each AssetSet. If a key is not found or is found with a different total cost,
 // a Diff is generated and added to the map.
-func DiffAsset(before, after *AssetSet) map[string]Diff[Asset] {
+func DiffAsset(before, after *AssetSet, ratioCostChange float64) (map[string]Diff[Asset], error) {
+	if ratioCostChange < 0.0 {
+		return nil, fmt.Errorf("Percent cost change cannot be less than 0")
+	}
+
 	changedItems := map[string]Diff[Asset]{}
 
 	for assetKey1, asset1 := range before.assets {
 		if asset2, ok := after.assets[assetKey1]; !ok {
 			d := Diff[Asset]{asset1, DiffRemoved}
 			changedItems[assetKey1] = d
-		} else if asset1.TotalCost() != asset2.TotalCost() {
+		} else if math.Abs(asset1.TotalCost()-asset2.TotalCost()) > ratioCostChange*asset1.TotalCost() { //check if either value exceeds the other by more than pctCostChange
 			d := Diff[Asset]{asset1, DiffChanged}
 			changedItems[assetKey1] = d
 		}
@@ -2926,7 +2931,7 @@ func DiffAsset(before, after *AssetSet) map[string]Diff[Asset] {
 		}
 	}
 
-	return changedItems
+	return changedItems, nil
 }
 
 // AssetSetRange is a thread-safe slice of AssetSets. It is meant to

--- a/pkg/kubecost/diff_test.go
+++ b/pkg/kubecost/diff_test.go
@@ -4,104 +4,122 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
 
 func TestDiff(t *testing.T) {
 
 	start := time.Now().AddDate(0, 0, -1)
-	end :=  time.Now()
+	end := time.Now()
 	window1 := NewWindow(&start, &end)
 
 	node1 := NewNode("node1", "cluster1", "123abc", start, end, window1)
+	node1.CPUCost = 10
+	node1b := node1.Clone().(*Node)
+	node1b.CPUCost = 20
+	node1Key, _ := key(node1, nil)
 	node2 := NewNode("node2", "cluster1", "123abc", start, end, window1)
+	node2Key, _ := key(node2, nil)
 	node3 := NewNode("node3", "cluster1", "123abc", start, end, window1)
+	node3Key, _ := key(node3, nil)
 	node4 := NewNode("node4", "cluster1", "123abc", start, end, window1)
+	node4Key, _ := key(node4, nil)
 	disk1 := NewDisk("disk1", "cluster1", "123abc", start, end, window1)
+	disk1Key, _ := key(disk1, nil)
 	disk2 := NewDisk("disk2", "cluster1", "123abc", start, end, window1)
+	disk2Key, _ := key(disk2, nil)
 
 	cases := map[string]struct {
 		inputAssetsBefore []Asset
 		inputAssetsAfter  []Asset
-		expected          []Diff[Asset]
+		test              []Node
+		costChange        []int
+		expected          map[string]Diff[Asset]
 	}{
-		"added node":            {
-			inputAssetsBefore: []Asset{node1, node2}, 
-			inputAssetsAfter:  []Asset{node1, node2, node3}, 
-			expected:          []Diff[Asset]{{node3, DiffAdded}},
+		"added node": {
+			inputAssetsBefore: []Asset{node1, node2},
+			inputAssetsAfter:  []Asset{node1, node2, node3},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{node3Key: {node3, DiffAdded}},
 		},
-		"multiple adds":         {
-			inputAssetsBefore: []Asset{node1, node2}, 
-			inputAssetsAfter:  []Asset{node1, node2, node3, node4}, 
-			expected:          []Diff[Asset]{{node3, DiffAdded}, {node4, DiffAdded}},
+		"multiple adds": {
+			inputAssetsBefore: []Asset{node1, node2},
+			inputAssetsAfter:  []Asset{node1, node2, node3, node4},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{node3Key: {node3, DiffAdded}, node4Key: {node4, DiffAdded}},
 		},
-		"removed node":          {
-			inputAssetsBefore: []Asset{node1, node2}, 
-			inputAssetsAfter:  []Asset{node2}, 
-			expected:          []Diff[Asset]{{node1, DiffRemoved}},
+		"removed node": {
+			inputAssetsBefore: []Asset{node1, node2},
+			inputAssetsAfter:  []Asset{node2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}},
 		},
-		"multiple removes":      {
-			inputAssetsBefore: []Asset{node1, node2, node3}, 
-			inputAssetsAfter:  []Asset{node2}, 
-			expected:          []Diff[Asset]{{node1, DiffRemoved}, {node3, DiffRemoved}},
+		"multiple removes": {
+			inputAssetsBefore: []Asset{node1, node2, node3},
+			inputAssetsAfter:  []Asset{node2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node3Key: {node3, DiffRemoved}},
 		},
-		"remove all":            {
-			inputAssetsBefore: []Asset{node1, node2}, 
-			inputAssetsAfter:  []Asset{}, 
-			expected:          []Diff[Asset]{{node1, DiffRemoved}, {node2, DiffRemoved}},
+		"remove all": {
+			inputAssetsBefore: []Asset{node1, node2},
+			inputAssetsAfter:  []Asset{},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node2Key: {node2, DiffRemoved}},
 		},
-		"add and remove":        {
-			inputAssetsBefore: []Asset{node1, node2}, 
-			inputAssetsAfter:  []Asset{node2, node3}, 
-			expected:          []Diff[Asset]{{node1, DiffRemoved}, {node3, DiffAdded}},
+		"add and remove": {
+			inputAssetsBefore: []Asset{node1, node2},
+			inputAssetsAfter:  []Asset{node2, node3},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node3Key: {node3, DiffAdded}},
 		},
-		"no change":             {
-			inputAssetsBefore: []Asset{node1, node2}, 
-			inputAssetsAfter:  []Asset{node1, node2}, 
-			expected:          []Diff[Asset]{},
+		"no change": {
+			inputAssetsBefore: []Asset{node1, node2},
+			inputAssetsAfter:  []Asset{node1, node2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{},
 		},
-		"order switch":          {
-			inputAssetsBefore: []Asset{node2, node1}, 
-			inputAssetsAfter:  []Asset{node1, node2}, 
-			expected:          []Diff[Asset]{},
+		"order switch": {
+			inputAssetsBefore: []Asset{node2, node1},
+			inputAssetsAfter:  []Asset{node1, node2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{},
 		},
-		"disk add":              {
-			inputAssetsBefore: []Asset{disk1, node1}, 
-			inputAssetsAfter:  []Asset{disk1, node1, disk2}, 
-			expected:          []Diff[Asset]{{disk2, DiffAdded}},
+		"disk add": {
+			inputAssetsBefore: []Asset{disk1, node1},
+			inputAssetsAfter:  []Asset{disk1, node1, disk2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{disk2Key: {disk2, DiffAdded}},
 		},
-		"disk and node add":     {
-			inputAssetsBefore: []Asset{disk1, node1}, 
-			inputAssetsAfter:  []Asset{disk1, node1, disk2, node2}, 
-			expected:          []Diff[Asset]{{disk2, DiffAdded}, {node2, DiffAdded}},
+		"disk and node add": {
+			inputAssetsBefore: []Asset{disk1, node1},
+			inputAssetsAfter:  []Asset{disk1, node1, disk2, node2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{disk2Key: {disk2, DiffAdded}, node2Key: {node2, DiffAdded}},
 		},
 		"disk and node removed": {
-			inputAssetsBefore: []Asset{disk1, node1, disk2, node2}, 
-			inputAssetsAfter:  []Asset{disk2, node2}, 
-			expected:          []Diff[Asset]{{disk1, DiffRemoved}, {node1, DiffRemoved}},
+			inputAssetsBefore: []Asset{disk1, node1, disk2, node2},
+			inputAssetsAfter:  []Asset{disk2, node2},
+			costChange:        []int{},
+			expected:          map[string]Diff[Asset]{disk1Key: {disk1, DiffRemoved}, node1Key: {node1, DiffRemoved}},
+		},
+		"cost change": {
+			inputAssetsBefore: []Asset{node1},
+			inputAssetsAfter:  []Asset{node1b},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffChanged}},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			as1 := NewAssetSet(start, end, tc.inputAssetsBefore...)
+
 			as2 := NewAssetSet(start, end, tc.inputAssetsAfter...)
 
 			result := DiffAsset(as1.Clone(), as2.Clone())
 
-			slices.SortFunc(result, func(a, b Diff[Asset]) bool {
-				return a.Entity.Properties().Name < b.Entity.Properties().Name
-			})
-
-			slices.SortFunc(tc.expected, func(a, b Diff[Asset]) bool {
-				return a.Entity.Properties().Name < b.Entity.Properties().Name
-			})
-	
 			if !reflect.DeepEqual(result, tc.expected) {
 				t.Fatalf("expected %+v; got %+v", tc.expected, result)
 			}
-			
+
 		})
 	}
 

--- a/pkg/kubecost/diff_test.go
+++ b/pkg/kubecost/diff_test.go
@@ -40,32 +40,32 @@ func TestDiff(t *testing.T) {
 		"added node": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node1, node2, node3},
-			expected:          map[string]Diff[Asset]{node3Key: {node3, DiffAdded}},
+			expected:          map[string]Diff[Asset]{node3Key: {nil, node3, DiffAdded}},
 		},
 		"multiple adds": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node1, node2, node3, node4},
-			expected:          map[string]Diff[Asset]{node3Key: {node3, DiffAdded}, node4Key: {node4, DiffAdded}},
+			expected:          map[string]Diff[Asset]{node3Key: {nil, node3, DiffAdded}, node4Key: {nil, node4, DiffAdded}},
 		},
 		"removed node": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node2},
-			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, nil, DiffRemoved}},
 		},
 		"multiple removes": {
 			inputAssetsBefore: []Asset{node1, node2, node3},
 			inputAssetsAfter:  []Asset{node2},
-			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node3Key: {node3, DiffRemoved}},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, nil, DiffRemoved}, node3Key: {node3, nil, DiffRemoved}},
 		},
 		"remove all": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{},
-			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node2Key: {node2, DiffRemoved}},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, nil, DiffRemoved}, node2Key: {node2, nil, DiffRemoved}},
 		},
 		"add and remove": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node2, node3},
-			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node3Key: {node3, DiffAdded}},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, nil, DiffRemoved}, node3Key: {nil, node3, DiffAdded}},
 		},
 		"no change": {
 			inputAssetsBefore: []Asset{node1, node2},
@@ -80,23 +80,23 @@ func TestDiff(t *testing.T) {
 		"disk add": {
 			inputAssetsBefore: []Asset{disk1, node1},
 			inputAssetsAfter:  []Asset{disk1, node1, disk2},
-			expected:          map[string]Diff[Asset]{disk2Key: {disk2, DiffAdded}},
+			expected:          map[string]Diff[Asset]{disk2Key: {nil, disk2, DiffAdded}},
 		},
 		"disk and node add": {
 			inputAssetsBefore: []Asset{disk1, node1},
 			inputAssetsAfter:  []Asset{disk1, node1, disk2, node2},
-			expected:          map[string]Diff[Asset]{disk2Key: {disk2, DiffAdded}, node2Key: {node2, DiffAdded}},
+			expected:          map[string]Diff[Asset]{disk2Key: {nil, disk2, DiffAdded}, node2Key: {nil, node2, DiffAdded}},
 		},
 		"disk and node removed": {
 			inputAssetsBefore: []Asset{disk1, node1, disk2, node2},
 			inputAssetsAfter:  []Asset{disk2, node2},
-			expected:          map[string]Diff[Asset]{disk1Key: {disk1, DiffRemoved}, node1Key: {node1, DiffRemoved}},
+			expected:          map[string]Diff[Asset]{disk1Key: {disk1, nil, DiffRemoved}, node1Key: {node1, nil, DiffRemoved}},
 		},
 		"cost change more than 10%": {
 			inputAssetsBefore: []Asset{node1},
 			inputAssetsAfter:  []Asset{node1b},
 			costChangeRatio:   0.1,
-			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffChanged}},
+			expected:          map[string]Diff[Asset]{node1Key: {node1, node1b, DiffChanged}},
 		},
 		"cost change less than 10%": {
 			inputAssetsBefore: []Asset{node2},

--- a/pkg/kubecost/diff_test.go
+++ b/pkg/kubecost/diff_test.go
@@ -31,74 +31,61 @@ func TestDiff(t *testing.T) {
 	cases := map[string]struct {
 		inputAssetsBefore []Asset
 		inputAssetsAfter  []Asset
-		test              []Node
-		costChange        []int
 		expected          map[string]Diff[Asset]
 	}{
 		"added node": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node1, node2, node3},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{node3Key: {node3, DiffAdded}},
 		},
 		"multiple adds": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node1, node2, node3, node4},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{node3Key: {node3, DiffAdded}, node4Key: {node4, DiffAdded}},
 		},
 		"removed node": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}},
 		},
 		"multiple removes": {
 			inputAssetsBefore: []Asset{node1, node2, node3},
 			inputAssetsAfter:  []Asset{node2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node3Key: {node3, DiffRemoved}},
 		},
 		"remove all": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node2Key: {node2, DiffRemoved}},
 		},
 		"add and remove": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node2, node3},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{node1Key: {node1, DiffRemoved}, node3Key: {node3, DiffAdded}},
 		},
 		"no change": {
 			inputAssetsBefore: []Asset{node1, node2},
 			inputAssetsAfter:  []Asset{node1, node2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{},
 		},
 		"order switch": {
 			inputAssetsBefore: []Asset{node2, node1},
 			inputAssetsAfter:  []Asset{node1, node2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{},
 		},
 		"disk add": {
 			inputAssetsBefore: []Asset{disk1, node1},
 			inputAssetsAfter:  []Asset{disk1, node1, disk2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{disk2Key: {disk2, DiffAdded}},
 		},
 		"disk and node add": {
 			inputAssetsBefore: []Asset{disk1, node1},
 			inputAssetsAfter:  []Asset{disk1, node1, disk2, node2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{disk2Key: {disk2, DiffAdded}, node2Key: {node2, DiffAdded}},
 		},
 		"disk and node removed": {
 			inputAssetsBefore: []Asset{disk1, node1, disk2, node2},
 			inputAssetsAfter:  []Asset{disk2, node2},
-			costChange:        []int{},
 			expected:          map[string]Diff[Asset]{disk1Key: {disk1, DiffRemoved}, node1Key: {node1, DiffRemoved}},
 		},
 		"cost change": {


### PR DESCRIPTION
## What does this PR change?
* Diff asset function will keep track of total cost changes

## Does this PR relate to any other PRs?
* [Yes](https://github.com/kubecost/docs/pull/301)

## How will this PR impact users?
* If an asset changed cost between two windows, it will be returned back to the user

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Unit tests

## Does this PR require changes to documentation?
* Yes

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* No, don't have access
