### PR TITLE
Update bingen asset version number, fix adjustment field on cluster m…

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -856,8 +856,8 @@ type ClusterManagement struct {
 	labels     AssetLabels
 	properties *AssetProperties
 	window     Window
-	adjustment float64
 	Cost       float64
+	adjustment float64 // @bingen:field[version=16]
 }
 
 // NewClusterManagement creates and returns a new ClusterManagement instance

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -24,7 +24,7 @@ package kubecost
 // @bingen:generate:Window
 
 // Asset Version Set: Includes Asset pipeline specific resources
-// @bingen:set[name=Assets,version=15]
+// @bingen:set[name=Assets,version=16]
 // @bingen:generate:Any
 // @bingen:generate:Asset
 // @bingen:generate:AssetLabels

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -13,12 +13,11 @@ package kubecost
 
 import (
 	"fmt"
+	util "github.com/opencost/opencost/pkg/util"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
-
-	util "github.com/opencost/opencost/pkg/util"
 )
 
 const (
@@ -34,17 +33,17 @@ const (
 )
 
 const (
-	// DefaultCodecVersion is used for any resources listed in the Default version set
-	DefaultCodecVersion uint8 = 15
-
-	// AssetsCodecVersion is used for any resources listed in the Assets version set
-	AssetsCodecVersion uint8 = 15
-
 	// AllocationCodecVersion is used for any resources listed in the Allocation version set
 	AllocationCodecVersion uint8 = 15
 
 	// AuditCodecVersion is used for any resources listed in the Audit version set
 	AuditCodecVersion uint8 = 1
+
+	// DefaultCodecVersion is used for any resources listed in the Default version set
+	DefaultCodecVersion uint8 = 15
+
+	// AssetsCodecVersion is used for any resources listed in the Assets version set
+	AssetsCodecVersion uint8 = 16
 )
 
 //--------------------------------------------------------------------------
@@ -5260,8 +5259,8 @@ func (target *ClusterManagement) MarshalBinaryWithContext(ctx *EncodingContext) 
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
+	buff.WriteFloat64(target.adjustment) // write float64
 	return nil
 }
 
@@ -5399,18 +5398,18 @@ func (target *ClusterManagement) UnmarshalBinaryWithContext(ctx *DecodingContext
 
 	if uint8(0) /* field version */ <= version {
 		n := buff.ReadFloat64() // read float64
-		target.adjustment = n
-
-	} else {
-		target.adjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		o := buff.ReadFloat64() // read float64
-		target.Cost = o
+		target.Cost = n
 
 	} else {
 		target.Cost = float64(0) // default
+	}
+
+	if uint8(16) /* field version */ <= version {
+		o := buff.ReadFloat64() // read float64
+		target.adjustment = o
+
+	} else {
+		target.adjustment = float64(0) // default
 	}
 
 	return nil


### PR DESCRIPTION
…anagement

Signed-off-by: Sean Holcomb <seanholcomb@gmail.com>

## What does this PR change?
* This PR moves adjustment to the end of the cluster management struct and adds a bingen version annotation. 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* This PR should address decoding errors that have appeared in v1.95.0

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested by rebuilding cluster experiencing decoding error and then swapping to this new image and ensuring that the decoding error does not occur.

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
