### PR TITLE
allow the ability to disable writing to storage

### DIFF
--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -67,6 +67,7 @@ const (
 	ETLEnabledEnvVar                     = "ETL_ENABLED"
 	ETLMaxPrometheusQueryDurationMinutes = "ETL_MAX_PROMETHEUS_QUERY_DURATION_MINUTES"
 	ETLResolutionSeconds                 = "ETL_RESOLUTION_SECONDS"
+	ETLStoreReadOnlyMode                 = "ETL_STORE_READ_ONLY"
 	LegacyExternalAPIDisabledVar         = "LEGACY_EXTERNAL_API_DISABLED"
 
 	PromClusterIDLabelEnvVar = "PROM_CLUSTER_ID_LABEL"
@@ -99,6 +100,10 @@ func IsETLReadOnlyMode() bool {
 // a subset of kubecost configurations that require sharing via remote storage.
 func GetKubecostConfigBucket() string {
 	return Get(KubecostConfigBucketEnvVar, "")
+}
+
+func IsETLStoreReadOnlyMode() bool {
+	return GetBool(ETLStoreReadOnlyMode, false)
 }
 
 // IsClusterInfoFileEnabled returns true if the cluster info is read from a file or pulled from the local

--- a/pkg/storage/accessstorage.go
+++ b/pkg/storage/accessstorage.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"github.com/opencost/opencost/pkg/env"
+	"github.com/opencost/opencost/pkg/log"
+)
+
+// AccessStorage is a Storage implementation that sits on top of other Storage implementations. It controls which functions
+// make it to the underlying interface based configurations allowing all storage types to share these behaviours.
+type AccessStorage struct {
+	storage Storage
+}
+
+// StorageType returns a string identifier for the type of storage used by the implementation.
+func (as *AccessStorage) StorageType() StorageType {
+	return as.storage.StorageType()
+}
+
+// FullPath returns the storage working path combined with the path provided
+func (as *AccessStorage) FullPath(path string) string {
+	return as.storage.FullPath(path)
+}
+
+// Stat returns the StorageStats for the specific path.
+func (as *AccessStorage) Stat(path string) (*StorageInfo, error) {
+	return as.storage.Stat(path)
+}
+
+// Read uses the relative path of the storage combined with the provided path to
+// read the contents.
+func (as *AccessStorage) Read(path string) ([]byte, error) {
+	return as.storage.Read(path)
+}
+
+// Write uses the relative path of the storage combined with the provided path
+// to write a new file or overwrite an existing file.
+func (as *AccessStorage) Write(path string, data []byte) error {
+	if env.IsETLStoreReadOnlyMode() {
+		log.DedupedInfof(1, "AccessStorage: skipping storage Write")
+		return nil
+	}
+	return as.storage.Write(path, data)
+}
+
+// Remove uses the relative path of the storage combined with the provided path to
+// remove a file from storage permanently.
+func (as *AccessStorage) Remove(path string) error {
+	if env.IsETLStoreReadOnlyMode() {
+		log.DedupedInfof(1, "AccessStorage: skipping storage Remove")
+		return nil
+	}
+	return as.storage.Remove(path)
+}
+
+// Exists uses the relative path of the storage combined with the provided path to
+// determine if the file exists.
+func (as *AccessStorage) Exists(path string) (bool, error) {
+	return as.storage.Exists(path)
+}
+
+// List uses the relative path of the storage combined with the provided path to return
+// storage information for the files.
+func (as *AccessStorage) List(path string) ([]*StorageInfo, error) {
+	return as.storage.List(path)
+}

--- a/pkg/storage/bucketstorage.go
+++ b/pkg/storage/bucketstorage.go
@@ -54,7 +54,7 @@ func NewBucketStorage(config []byte) (Storage, error) {
 		return nil, errors.Wrap(err, fmt.Sprintf("create %s client", storageConfig.Type))
 	}
 
-	return storage, nil
+	return &AccessStorage{storage}, nil
 }
 
 // trimLeading removes a leading / from the file name
@@ -71,6 +71,8 @@ func trimLeading(file string) string {
 
 // trimName removes the leading directory prefix
 func trimName(file string) string {
+	// remove final slash to prevent wiping the whole file name
+	file = strings.TrimSuffix(file, "/")
 	slashIndex := strings.LastIndex(file, "/")
 	if slashIndex < 0 {
 		return file

--- a/pkg/storage/filestorage.go
+++ b/pkg/storage/filestorage.go
@@ -18,7 +18,7 @@ type FileStorage struct {
 
 // NewFileStorage returns a new storage API which leverages the file system.
 func NewFileStorage(baseDir string) Storage {
-	return &FileStorage{baseDir}
+	return &AccessStorage{&FileStorage{baseDir}}
 }
 
 // StorageType returns a string identifier for the type of storage used by the implementation.


### PR DESCRIPTION
## What does this PR change?
* This PR adds a layer between the storage object and it creator which can block certain operation. In this case using an env variable ETL_STORE_READ_ONLY it will disable writes and deletes. This prevents an attached instance of kubecost from changing the store.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/901

## How will this PR impact users?
* this feature is not meant for users

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested by setting the Environmental variable variable to true and ensuring that only loads were occurring.

## Does this PR require changes to documentation?
* Documentation to be included in the deployments repo and etl data generation repo

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
