### PR TITLE
filter shared assets in aggby

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2484,9 +2484,19 @@ func (as *AssetSet) AggregateBy(aggregateBy []string, opts *AssetAggregationOpti
 		sa := NewSharedAsset(name, as.Window.Clone())
 		sa.Cost = hourlyCost * hours
 
-		err := aggSet.Insert(sa)
-		if err != nil {
-			return err
+		// Insert shared asset if it passes all filters
+		insert := true
+		for _, ff := range opts.FilterFuncs {
+			if !ff(sa) {
+				insert = false
+				break
+			}
+		}
+		if insert {
+			err := aggSet.Insert(sa)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR change?
* This PR applies filters to shared assets before they are added into the asset by the `AggregateBy` function.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* Users will see the same number for the total when they drill into an asset row when using the shared cost feature

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-frontend/issues/911

## How was this PR tested?
* PR was tested on nightly cluster where issue was called out
* ![Screen Shot 2022-08-02 at 5 42 21 PM](https://user-images.githubusercontent.com/12225425/182501351-82af92f9-ecde-4677-915c-6fbae3395059.png)
![Screen Shot 2022-08-02 at 5 42 34 PM](https://user-images.githubusercontent.com/12225425/182501344-20250384-85f2-411f-b813-964f8a029781.png)



## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
