### PR TITLE
add additional region codes

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -55,6 +55,9 @@ var (
 		"us": "us",
 		"za": "southafrica",
 		"no": "norway",
+		"ch": "switzerland",
+		"de": "germany",
+		"ue": "uae",
 	}
 
 	//mtBasic, _     = regexp.Compile("^BASIC.A\\d+[_Promo]*$")


### PR DESCRIPTION
Signed-off-by: Sean Holcomb <seanholcomb@gmail.com>

## What does this PR change?
* Adds additional Region codes so that the rate card api does not fail for the added regions

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* closes https://github.com/kubecost/kubecost-cost-model/issues/853
* ZD2089

## How was this PR tested?
* This was tested by creating a cluster in swiss north region and reproducing the error. Adding this change removed the error message.
![Screen Shot 2022-08-03 at 4 33 06 PM](https://user-images.githubusercontent.com/12225425/182731622-b3e3541a-b08a-4e29-a84d-9cac3ceb1321.png)

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
