### PR TITLE
Making storage class available for persistent volume by pulling infor…

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -351,11 +351,6 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, start, end 
 		if disk.ProviderID == "" {
 			disk.ProviderID = disk.Name
 		}
-
-		// Explicitly specify unknown storage class for disk whose information is unavailable in prometheus metrics of kubecost_pv_info
-		if disk.StorageClass == "" {
-			disk.StorageClass = kubecost.UnknownStorageClass
-		}
 	}
 
 	return diskMap, nil

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -305,7 +305,7 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, start, end 
 		diskMap[key].Minutes = mins
 	}
 
-	//Iterating through Persistent Volume given by kube_persistentvolumeclaim_info and assign the storage class if known and unknown if not known.
+	//Iterating through Persistent Volume given by custom metrics kubecost_pv_info and assign the storage class if known and __unknown__ if not populated.
 	for _, result := range resPVStorageClass {
 		cluster, err := result.GetString(env.GetPromClusterLabel())
 		if err != nil {
@@ -342,7 +342,7 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, start, end 
 			disk.ProviderID = disk.Name
 		}
 
-		// Explicitly specify unknown storage class for disk whose information is unavailable in prometheus metrics of kube_persistentvolumeclaim_info
+		// Explicitly specify unknown storage class for disk whose information is unavailable in prometheus metrics of kubecost_pv_info
 		if disk.StorageClass == "" {
 			disk.StorageClass = kubecost.UnknownStorageClass
 		}

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1069,7 +1069,7 @@ type Disk struct {
 	ByteHours    float64
 	Local        float64
 	Breakdown    *Breakdown
-	StorageClass string // @bingen:field[version=17, default=__unknown__]
+	StorageClass string // @bingen:field[version=17]
 }
 
 // NewDisk creates and returns a new Disk Asset
@@ -1262,9 +1262,9 @@ func (d *Disk) add(that *Disk) {
 
 	d.ByteHours += that.ByteHours
 
-	// If storage class don't match default it to Unknown storage class
+	// If storage class don't match default it to empty storage class
 	if d.StorageClass != that.StorageClass {
-		d.StorageClass = UnknownStorageClass
+		d.StorageClass = ""
 	}
 }
 

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -15,6 +15,12 @@ import (
 // E.g. if aggregating on Cluster, Assets in the AssetSet where Asset has no cluster will be grouped under key "__undefined__"
 const UndefinedKey = "__undefined__"
 
+// LocalStorageClass is used to assign storage class of local disks.
+const LocalStorageClass = "__local__"
+
+// UnknownStorageClass is used to assign storage class of persistent volume whose information is unable to be traced.
+const UnknownStorageClass = "__unknown__"
+
 // Asset defines an entity within a cluster that has a defined cost over a
 // given period of time.
 type Asset interface {
@@ -1256,7 +1262,7 @@ func (d *Disk) add(that *Disk) {
 
 	d.ByteHours += that.ByteHours
 
-	if that.StorageClass != "" && that.StorageClass != "Unknown" {
+	if that.StorageClass != "" && that.StorageClass != UnknownStorageClass {
 		d.StorageClass = that.StorageClass
 	}
 }

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1069,7 +1069,7 @@ type Disk struct {
 	ByteHours    float64
 	Local        float64
 	Breakdown    *Breakdown
-	StorageClass string // @bingen:field[version=17]
+	StorageClass string // @bingen:field[version=17, default=__unknown__]
 }
 
 // NewDisk creates and returns a new Disk Asset

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1262,7 +1262,7 @@ func (d *Disk) add(that *Disk) {
 
 	d.ByteHours += that.ByteHours
 
-	if that.StorageClass != "" && that.StorageClass != UnknownStorageClass {
+	if that.StorageClass != UnknownStorageClass {
 		d.StorageClass = that.StorageClass
 	}
 }

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1059,12 +1059,12 @@ func (cm *ClusterManagement) String() string {
 
 // Disk represents an in-cluster disk Asset
 type Disk struct {
-	labels       AssetLabels
-	properties   *AssetProperties
-	start        time.Time
-	end          time.Time
-	window       Window
-	adjustment   float64
+	Labels       AssetLabels
+	Properties   *AssetProperties
+	Start        time.Time
+	End          time.Time
+	Window       Window
+	Adjustment   float64
 	Cost         float64
 	ByteHours    float64
 	Local        float64
@@ -1262,20 +1262,21 @@ func (d *Disk) add(that *Disk) {
 
 	d.ByteHours += that.ByteHours
 
-	if that.StorageClass != UnknownStorageClass {
-		d.StorageClass = that.StorageClass
+	// If storage class don't match default it to Unknown storage class
+	if d.StorageClass != that.StorageClass {
+		d.StorageClass = UnknownStorageClass
 	}
 }
 
 // Clone returns a cloned instance of the Asset
 func (d *Disk) Clone() Asset {
 	return &Disk{
-		properties:   d.properties.Clone(),
-		labels:       d.labels.Clone(),
-		start:        d.start,
-		end:          d.end,
-		window:       d.window.Clone(),
-		adjustment:   d.adjustment,
+		Properties:   d.Properties.Clone(),
+		Labels:       d.Labels.Clone(),
+		Start:        d.Start,
+		End:          d.End,
+		Window:       d.Window.Clone(),
+		Adjustment:   d.Adjustment,
 		Cost:         d.Cost,
 		ByteHours:    d.ByteHours,
 		Local:        d.Local,

--- a/pkg/kubecost/asset_json.go
+++ b/pkg/kubecost/asset_json.go
@@ -260,8 +260,9 @@ func (d *Disk) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "byteHours", d.ByteHours, ",")
 	jsonEncodeFloat64(buffer, "bytes", d.Bytes(), ",")
 	jsonEncode(buffer, "breakdown", d.Breakdown, ",")
-	jsonEncodeFloat64(buffer, "adjustment", d.Adjustment, ",")
-	jsonEncodeFloat64(buffer, "totalCost", d.TotalCost(), "")
+	jsonEncodeFloat64(buffer, "adjustment", d.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "totalCost", d.TotalCost(), ",")
+	jsonEncodeString(buffer, "storageClass", d.StorageClass, "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
 }
@@ -330,6 +331,10 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 	}
 	if ByteHours, err := getTypedVal(fmap["byteHours"]); err == nil {
 		d.ByteHours = ByteHours.(float64)
+	}
+
+	if StorageClass, err := getTypedVal(fmap["storageClass"]); err == nil {
+		d.StorageClass = StorageClass.(string)
 	}
 
 	// d.Local is not marhsaled, and cannot be calculated from marshaled values.

--- a/pkg/kubecost/asset_json.go
+++ b/pkg/kubecost/asset_json.go
@@ -260,7 +260,7 @@ func (d *Disk) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "byteHours", d.ByteHours, ",")
 	jsonEncodeFloat64(buffer, "bytes", d.Bytes(), ",")
 	jsonEncode(buffer, "breakdown", d.Breakdown, ",")
-	jsonEncodeFloat64(buffer, "adjustment", d.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", d.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "totalCost", d.TotalCost(), ",")
 	jsonEncodeString(buffer, "storageClass", d.StorageClass, "")
 	buffer.WriteString("}")

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -24,7 +24,7 @@ package kubecost
 // @bingen:generate:Window
 
 // Asset Version Set: Includes Asset pipeline specific resources
-// @bingen:set[name=Assets,version=16]
+// @bingen:set[name=Assets,version=17]
 // @bingen:generate:Any
 // @bingen:generate:Asset
 // @bingen:generate:AssetLabels

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -5159,7 +5159,7 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		target.StorageClass = aa
 
 	} else {
-		target.StorageClass = "" // default
+		target.StorageClass = "__unknown__" // default
 	}
 
 	return nil

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -33,6 +33,9 @@ const (
 )
 
 const (
+	// AssetsCodecVersion is used for any resources listed in the Assets version set
+	AssetsCodecVersion uint8 = 17
+
 	// AllocationCodecVersion is used for any resources listed in the Allocation version set
 	AllocationCodecVersion uint8 = 15
 
@@ -41,9 +44,6 @@ const (
 
 	// DefaultCodecVersion is used for any resources listed in the Default version set
 	DefaultCodecVersion uint8 = 15
-
-	// AssetsCodecVersion is used for any resources listed in the Assets version set
-	AssetsCodecVersion uint8 = 17
 )
 
 //--------------------------------------------------------------------------
@@ -4887,14 +4887,14 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -4913,14 +4913,14 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	}
 	// --- [end][write][alias](AssetLabels) ---
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -4928,7 +4928,7 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	}
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -4937,7 +4937,7 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -4947,13 +4947,13 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
 	buff.WriteFloat64(target.ByteHours)  // write float64
 	buff.WriteFloat64(target.Local)      // write float64
@@ -5071,11 +5071,11 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		// --- [end][read][map](map[string]string) ---
 
 	}
-	target.labels = AssetLabels(a)
+	target.Labels = AssetLabels(a)
 	// --- [end][read][alias](AssetLabels) ---
 
 	if buff.ReadUInt8() == uint8(0) {
-		target.properties = nil
+		target.Properties = nil
 	} else {
 		// --- [begin][read][struct](AssetProperties) ---
 		l := &AssetProperties{}
@@ -5084,7 +5084,7 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		if errA != nil {
 			return errA
 		}
-		target.properties = l
+		target.Properties = l
 		// --- [end][read][struct](AssetProperties) ---
 
 	}
@@ -5096,7 +5096,7 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 	if errB != nil {
 		return errB
 	}
-	target.start = *m
+	target.Start = *m
 	// --- [end][read][reference](time.Time) ---
 
 	// --- [begin][read][reference](time.Time) ---
@@ -5107,7 +5107,7 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 	if errC != nil {
 		return errC
 	}
-	target.end = *p
+	target.End = *p
 	// --- [end][read][reference](time.Time) ---
 
 	// --- [begin][read][struct](Window) ---
@@ -5117,11 +5117,11 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 	if errD != nil {
 		return errD
 	}
-	target.window = *s
+	target.Window = *s
 	// --- [end][read][struct](Window) ---
 
 	t := buff.ReadFloat64() // read float64
-	target.adjustment = t
+	target.Adjustment = t
 
 	u := buff.ReadFloat64() // read float64
 	target.Cost = u

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -33,6 +33,9 @@ const (
 )
 
 const (
+	// DefaultCodecVersion is used for any resources listed in the Default version set
+	DefaultCodecVersion uint8 = 15
+
 	// AssetsCodecVersion is used for any resources listed in the Assets version set
 	AssetsCodecVersion uint8 = 17
 
@@ -41,9 +44,6 @@ const (
 
 	// AuditCodecVersion is used for any resources listed in the Audit version set
 	AuditCodecVersion uint8 = 1
-
-	// DefaultCodecVersion is used for any resources listed in the Default version set
-	DefaultCodecVersion uint8 = 15
 )
 
 //--------------------------------------------------------------------------
@@ -5159,7 +5159,7 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		target.StorageClass = aa
 
 	} else {
-		target.StorageClass = "__unknown__" // default
+		target.StorageClass = "" // default
 	}
 
 	return nil


### PR DESCRIPTION
…mation from Prometheus metrics and assigning local storage storageClass as Local

Signed-off-by: Alan Rodrigues <alanr5691@yahoo.com>

## What does this PR change?
*  Disk objects will have storage class, Storage class information is gather from custom Prometheus metrics `kubecost_pv_info` and local storage will have default storage class as `__local__` and unknown will have storage class `__unknown`.

## Does this PR relate to any other PRs?
*[ KCM PR](https://github.com/kubecost/kubecost-cost-model/pull/909)
*[cost-analyzer-helm-chart PR](https://github.com/kubecost/cost-analyzer-helm-chart/pull/1619)

## How will this PR impact users?
*  Probably None from the Backend, it will have storage class information for Persistent volumes and Local storage.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...[Issue Link](https://github.com/kubecost/cost-analyzer-helm-chart/issues/1575) 

## How was this PR tested?
*  KCM image pointing to respective Opencost branch was put in the Thanos backend cluster i have in my namespace and the information about gather from 'kubectl get pv' and local storage of external cluster was listed in [Rest Call ](http://34.170.146.238:9095/model/assets?window=1d&aggregate=&accumulate=true&filterTypes=Disk), Placed around with different setting like 1h, 7h and 1d. 

## Does this PR require changes to documentation?
* No, not that I am aware, but if it needs i will do it.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* This was Bug for v1.96 but can go in v1.97 or nightly,upto Adam and others discretion
