### PR TITLE
ETL Data Structure Cleanup Part 1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/prometheus/common v0.32.1
 	github.com/rs/cors v1.7.0
 	github.com/rs/zerolog v1.26.1
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	go.etcd.io/bbolt v1.3.5
@@ -110,7 +111,6 @@ require (
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rs/xid v1.3.0 // indirect
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/pkg/kubecost/allocation_json.go
+++ b/pkg/kubecost/allocation_json.go
@@ -97,9 +97,7 @@ func (as *AllocationSet) MarshalJSON() ([]byte, error) {
 	if as == nil {
 		return json.Marshal(map[string]*Allocation{})
 	}
-	as.RLock()
-	defer as.RUnlock()
-	return json.Marshal(as.allocations)
+	return json.Marshal(as.Allocations)
 }
 
 // MarshalJSON JSON-encodes the range
@@ -108,7 +106,5 @@ func (asr *AllocationSetRange) MarshalJSON() ([]byte, error) {
 		return json.Marshal([]*AllocationSet{})
 	}
 
-	asr.RLock()
-	defer asr.RUnlock()
-	return json.Marshal(asr.allocations)
+	return json.Marshal(asr.Allocations)
 }

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/opencost/opencost/pkg/log"
@@ -23,25 +22,26 @@ type Asset interface {
 	// be defined by the underlying type implementing the interface.
 	Type() AssetType
 
-	// Properties are a map of predefined traits, which may or may not exist,
+	// GetProperties are a map of predefined traits, which may or may not exist,
 	// but must conform to the AssetProperty schema
-	Properties() *AssetProperties
+	GetProperties() *AssetProperties
 	SetProperties(*AssetProperties)
 
-	// Labels are a map of undefined string-to-string values
-	Labels() AssetLabels
+	// GetLabels are a map of undefined string-to-string values
+	GetLabels() AssetLabels
 	SetLabels(AssetLabels)
 
 	// Monetary values
-	Adjustment() float64
+	GetAdjustment() float64
 	SetAdjustment(float64)
 	TotalCost() float64
 
 	// Temporal values
-	Start() time.Time
-	End() time.Time
+	GetStart() time.Time
+	GetEnd() time.Time
 	SetStartEnd(time.Time, time.Time)
-	Window() Window
+	GetWindow() Window
+	SetWindow(Window)
 	ExpandWindow(Window)
 	Minutes() float64
 
@@ -58,7 +58,7 @@ type Asset interface {
 }
 
 // AssetToExternalAllocation converts the given asset to an Allocation, given
-// the properties to use to aggregate, and the mapping from Allocation property
+// the Properties to use to aggregate, and the mapping from Allocation property
 // to Asset label. For example, consider this asset:
 //
 // CURRENT: Asset ETL stores its data ALREADY MAPPED from label to k8s concept. This isn't ideal-- see the TOOD.
@@ -154,7 +154,7 @@ func AssetToExternalAllocation(asset Asset, aggregateBy []string, labelConfig *L
 	// and the asset has label "kubens":"kubecost", then file the asset as an
 	// external cost under "kubecost").
 	for _, aggBy := range aggregateBy {
-		name := labelConfig.GetExternalAllocationName(asset.Labels(), aggBy)
+		name := labelConfig.GetExternalAllocationName(asset.GetLabels(), aggBy)
 
 		if name == "" {
 			// No matching label has been defined in the cost-analyzer label config
@@ -232,9 +232,9 @@ func AssetToExternalAllocation(asset Asset, aggregateBy []string, labelConfig *L
 	return &Allocation{
 		Name:         strings.Join(names, "/"),
 		Properties:   &props,
-		Window:       asset.Window().Clone(),
-		Start:        asset.Start(),
-		End:          asset.End(),
+		Window:       asset.GetWindow().Clone(),
+		Start:        asset.GetStart(),
+		End:          asset.GetEnd(),
 		ExternalCost: asset.TotalCost(),
 	}, nil
 }
@@ -267,26 +267,26 @@ func key(a Asset, aggregateBy []string) (string, error) {
 		key := ""
 		switch true {
 		case s == string(AssetProviderProp):
-			key = a.Properties().Provider
+			key = a.GetProperties().Provider
 		case s == string(AssetAccountProp):
-			key = a.Properties().Account
+			key = a.GetProperties().Account
 		case s == string(AssetProjectProp):
-			key = a.Properties().Project
+			key = a.GetProperties().Project
 		case s == string(AssetClusterProp):
-			key = a.Properties().Cluster
+			key = a.GetProperties().Cluster
 		case s == string(AssetCategoryProp):
-			key = a.Properties().Category
+			key = a.GetProperties().Category
 		case s == string(AssetTypeProp):
 			key = a.Type().String()
 		case s == string(AssetServiceProp):
-			key = a.Properties().Service
+			key = a.GetProperties().Service
 		case s == string(AssetProviderIDProp):
-			key = a.Properties().ProviderID
+			key = a.GetProperties().ProviderID
 		case s == string(AssetNameProp):
-			key = a.Properties().Name
+			key = a.GetProperties().Name
 		case strings.HasPrefix(s, "label:"):
 			if labelKey := strings.TrimPrefix(s, "label:"); labelKey != "" {
-				labelVal := a.Labels()[labelKey]
+				labelVal := a.GetLabels()[labelKey]
 				if labelVal == "" {
 					key = "__undefined__"
 				} else {
@@ -313,7 +313,7 @@ func key(a Asset, aggregateBy []string) (string, error) {
 }
 
 func toString(a Asset) string {
-	return fmt.Sprintf("%s{%s}%s=%.2f", a.Type().String(), a.Properties(), a.Window(), a.TotalCost())
+	return fmt.Sprintf("%s{%s}%s=%.2f", a.Type().String(), a.GetProperties(), a.GetWindow(), a.TotalCost())
 }
 
 // AssetLabels is a schema-free mapping of key/value pairs that can be
@@ -447,23 +447,23 @@ func (at AssetType) String() string {
 // Any is the most general Asset, which is usually created as a result of
 // adding two Assets of different types.
 type Any struct {
-	labels     AssetLabels
-	properties *AssetProperties
-	start      time.Time
-	end        time.Time
-	window     Window
-	adjustment float64
+	Labels     AssetLabels
+	Properties *AssetProperties
+	Start      time.Time
+	End        time.Time
+	Window     Window
+	Adjustment float64
 	Cost       float64
 }
 
 // NewAsset creates a new Any-type Asset for the given period of time
 func NewAsset(start, end time.Time, window Window) *Any {
 	return &Any{
-		labels:     AssetLabels{},
-		properties: &AssetProperties{},
-		start:      start,
-		end:        end,
-		window:     window.Clone(),
+		Labels:     AssetLabels{},
+		Properties: &AssetProperties{},
+		Start:      start,
+		End:        end,
+		Window:     window.Clone(),
 	}
 }
 
@@ -472,106 +472,110 @@ func (a *Any) Type() AssetType {
 	return AnyAssetType
 }
 
-// Properties returns the Asset's properties
-func (a *Any) Properties() *AssetProperties {
-	return a.properties
+// Properties returns the Asset's Properties
+func (a *Any) GetProperties() *AssetProperties {
+	return a.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (a *Any) SetProperties(props *AssetProperties) {
-	a.properties = props
+	a.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (a *Any) Labels() AssetLabels {
-	return a.labels
+func (a *Any) GetLabels() AssetLabels {
+	return a.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (a *Any) SetLabels(labels AssetLabels) {
-	a.labels = labels
+	a.Labels = labels
 }
 
 // Adjustment returns the Asset's cost adjustment
-func (a *Any) Adjustment() float64 {
-	return a.adjustment
+func (a *Any) GetAdjustment() float64 {
+	return a.Adjustment
 }
 
 // SetAdjustment sets the Asset's cost adjustment
 func (a *Any) SetAdjustment(adj float64) {
-	a.adjustment = adj
+	a.Adjustment = adj
 }
 
 // TotalCost returns the Asset's TotalCost
 func (a *Any) TotalCost() float64 {
-	return a.Cost + a.adjustment
+	return a.Cost + a.Adjustment
 }
 
 // Start returns the Asset's start time within the window
-func (a *Any) Start() time.Time {
-	return a.start
+func (a *Any) GetStart() time.Time {
+	return a.Start
 }
 
 // End returns the Asset's end time within the window
-func (a *Any) End() time.Time {
-	return a.end
+func (a *Any) GetEnd() time.Time {
+	return a.End
 }
 
 // Minutes returns the number of minutes the Asset was active within the window
 func (a *Any) Minutes() float64 {
-	return a.End().Sub(a.Start()).Minutes()
+	return a.End.Sub(a.Start).Minutes()
 }
 
 // Window returns the Asset's window
-func (a *Any) Window() Window {
-	return a.window
+func (a *Any) GetWindow() Window {
+	return a.Window
+}
+
+func (a *Any) SetWindow(window Window) {
+	a.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (a *Any) ExpandWindow(window Window) {
-	a.window = a.window.Expand(window)
+	a.Window = a.Window.Expand(window)
 }
 
 // SetStartEnd sets the Asset's Start and End fields
 func (a *Any) SetStartEnd(start, end time.Time) {
-	if a.Window().Contains(start) {
-		a.start = start
+	if a.Window.Contains(start) {
+		a.Start = start
 	} else {
-		log.Warnf("Any.SetStartEnd: start %s not in %s", start, a.Window())
+		log.Warnf("Any.SetStartEnd: start %s not in %s", start, a.Window)
 	}
 
-	if a.Window().Contains(end) {
-		a.end = end
+	if a.Window.Contains(end) {
+		a.End = end
 	} else {
-		log.Warnf("Any.SetStartEnd: end %s not in %s", end, a.Window())
+		log.Warnf("Any.SetStartEnd: end %s not in %s", end, a.Window)
 	}
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (a *Any) Add(that Asset) Asset {
 	this := a.Clone().(*Any)
 
-	props := a.Properties().Merge(that.Properties())
-	labels := a.Labels().Merge(that.Labels())
+	props := a.Properties.Merge(that.GetProperties())
+	labels := a.Labels.Merge(that.GetLabels())
 
-	start := a.Start()
-	if that.Start().Before(start) {
-		start = that.Start()
+	start := a.Start
+	if that.GetStart().Before(start) {
+		start = that.GetStart()
 	}
-	end := a.End()
-	if that.End().After(end) {
-		end = that.End()
+	end := a.End
+	if that.GetEnd().After(end) {
+		end = that.GetEnd()
 	}
-	window := a.Window().Expand(that.Window())
+	window := a.Window.Expand(that.GetWindow())
 
-	this.start = start
-	this.end = end
-	this.window = window
+	this.Start = start
+	this.End = end
+	this.Window = window
 	this.SetProperties(props)
 	this.SetLabels(labels)
-	this.adjustment += that.Adjustment()
-	this.Cost += (that.TotalCost() - that.Adjustment())
+	this.Adjustment += that.GetAdjustment()
+	this.Cost += (that.TotalCost() - that.GetAdjustment())
 
 	return this
 }
@@ -579,12 +583,12 @@ func (a *Any) Add(that Asset) Asset {
 // Clone returns a cloned instance of the Asset
 func (a *Any) Clone() Asset {
 	return &Any{
-		labels:     a.labels.Clone(),
-		properties: a.properties.Clone(),
-		start:      a.start,
-		end:        a.end,
-		window:     a.window.Clone(),
-		adjustment: a.adjustment,
+		Labels:     a.Labels.Clone(),
+		Properties: a.Properties.Clone(),
+		Start:      a.Start,
+		End:        a.End,
+		Window:     a.Window.Clone(),
+		Adjustment: a.Adjustment,
 		Cost:       a.Cost,
 	}
 }
@@ -596,20 +600,20 @@ func (a *Any) Equal(that Asset) bool {
 		return false
 	}
 
-	if !a.Labels().Equal(that.Labels()) {
+	if !a.Labels.Equal(t.Labels) {
 		return false
 	}
-	if !a.Properties().Equal(that.Properties()) {
+	if !a.Properties.Equal(t.Properties) {
 		return false
 	}
 
-	if !a.start.Equal(t.start) {
+	if !a.Start.Equal(t.Start) {
 		return false
 	}
-	if !a.end.Equal(t.end) {
+	if !a.End.Equal(t.End) {
 		return false
 	}
-	if !a.window.Equal(t.window) {
+	if !a.Window.Equal(t.Window) {
 		return false
 	}
 
@@ -627,12 +631,12 @@ func (a *Any) String() string {
 
 // Cloud describes a cloud asset
 type Cloud struct {
-	labels     AssetLabels
-	properties *AssetProperties
-	start      time.Time
-	end        time.Time
-	window     Window
-	adjustment float64
+	Labels     AssetLabels
+	Properties *AssetProperties
+	Start      time.Time
+	End        time.Time
+	Window     Window
+	Adjustment float64
 	Cost       float64
 	Credit     float64 // Credit is a negative value representing dollars credited back to a given line-item
 }
@@ -645,11 +649,11 @@ func NewCloud(category, providerID string, start, end time.Time, window Window) 
 	}
 
 	return &Cloud{
-		labels:     AssetLabels{},
-		properties: properties,
-		start:      start,
-		end:        end,
-		window:     window.Clone(),
+		Labels:     AssetLabels{},
+		Properties: properties,
+		Start:      start,
+		End:        end,
+		Window:     window.Clone(),
 	}
 }
 
@@ -659,82 +663,86 @@ func (ca *Cloud) Type() AssetType {
 }
 
 // Properties returns the AssetProperties
-func (ca *Cloud) Properties() *AssetProperties {
-	return ca.properties
+func (ca *Cloud) GetProperties() *AssetProperties {
+	return ca.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (ca *Cloud) SetProperties(props *AssetProperties) {
-	ca.properties = props
+	ca.Properties = props
 }
 
 // Labels returns the AssetLabels
-func (ca *Cloud) Labels() AssetLabels {
-	return ca.labels
+func (ca *Cloud) GetLabels() AssetLabels {
+	return ca.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (ca *Cloud) SetLabels(labels AssetLabels) {
-	ca.labels = labels
+	ca.Labels = labels
 }
 
 // Adjustment returns the Asset's adjustment value
-func (ca *Cloud) Adjustment() float64 {
-	return ca.adjustment
+func (ca *Cloud) GetAdjustment() float64 {
+	return ca.Adjustment
 }
 
 // SetAdjustment sets the Asset's adjustment value
 func (ca *Cloud) SetAdjustment(adj float64) {
-	ca.adjustment = adj
+	ca.Adjustment = adj
 }
 
 // TotalCost returns the Asset's total cost
 func (ca *Cloud) TotalCost() float64 {
-	return ca.Cost + ca.adjustment + ca.Credit
+	return ca.Cost + ca.Adjustment + ca.Credit
 }
 
 // Start returns the Asset's precise start time within the window
-func (ca *Cloud) Start() time.Time {
-	return ca.start
+func (ca *Cloud) GetStart() time.Time {
+	return ca.Start
 }
 
 // End returns the Asset's precise end time within the window
-func (ca *Cloud) End() time.Time {
-	return ca.end
+func (ca *Cloud) GetEnd() time.Time {
+	return ca.End
 }
 
 // Minutes returns the number of Minutes the Asset ran
 func (ca *Cloud) Minutes() float64 {
-	return ca.End().Sub(ca.Start()).Minutes()
+	return ca.End.Sub(ca.Start).Minutes()
 }
 
 // Window returns the window within which the Asset ran
-func (ca *Cloud) Window() Window {
-	return ca.window
+func (ca *Cloud) GetWindow() Window {
+	return ca.Window
+}
+
+func (ca *Cloud) SetWindow(window Window) {
+	ca.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (ca *Cloud) ExpandWindow(window Window) {
-	ca.window = ca.window.Expand(window)
+	ca.Window = ca.Window.Expand(window)
 }
 
 // SetStartEnd sets the Asset's Start and End fields
 func (ca *Cloud) SetStartEnd(start, end time.Time) {
-	if ca.Window().Contains(start) {
-		ca.start = start
+	if ca.Window.Contains(start) {
+		ca.Start = start
 	} else {
-		log.Warnf("Cloud.SetStartEnd: start %s not in %s", start, ca.Window())
+		log.Warnf("Cloud.SetStartEnd: start %s not in %s", start, ca.Window)
 	}
 
-	if ca.Window().Contains(end) {
-		ca.end = end
+	if ca.Window.Contains(end) {
+		ca.End = end
 	} else {
-		log.Warnf("Cloud.SetStartEnd: end %s not in %s", end, ca.Window())
+		log.Warnf("Cloud.SetStartEnd: end %s not in %s", end, ca.Window)
 	}
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (ca *Cloud) Add(a Asset) Asset {
 	// Cloud + Cloud = Cloud
 	if that, ok := a.(*Cloud); ok {
@@ -743,25 +751,25 @@ func (ca *Cloud) Add(a Asset) Asset {
 		return this
 	}
 
-	props := ca.Properties().Merge(a.Properties())
-	labels := ca.Labels().Merge(a.Labels())
+	props := ca.Properties.Merge(a.GetProperties())
+	labels := ca.Labels.Merge(a.GetLabels())
 
-	start := ca.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := ca.Start
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := ca.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := ca.End
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := ca.Window().Expand(a.Window())
+	window := ca.Window.Expand(a.GetWindow())
 
 	// Cloud + !Cloud = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = ca.Adjustment() + a.Adjustment()
-	any.Cost = (ca.TotalCost() - ca.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = ca.Adjustment + a.GetAdjustment()
+	any.Cost = (ca.TotalCost() - ca.Adjustment) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -772,25 +780,25 @@ func (ca *Cloud) add(that *Cloud) {
 		return
 	}
 
-	props := ca.Properties().Merge(that.Properties())
-	labels := ca.Labels().Merge(that.Labels())
+	props := ca.Properties.Merge(that.Properties)
+	labels := ca.Labels.Merge(that.Labels)
 
-	start := ca.Start()
-	if that.Start().Before(start) {
-		start = that.Start()
+	start := ca.Start
+	if that.Start.Before(start) {
+		start = that.Start
 	}
-	end := ca.End()
-	if that.End().After(end) {
-		end = that.End()
+	end := ca.End
+	if that.End.After(end) {
+		end = that.End
 	}
-	window := ca.Window().Expand(that.Window())
+	window := ca.Window.Expand(that.Window)
 
-	ca.start = start
-	ca.end = end
-	ca.window = window
+	ca.Start = start
+	ca.End = end
+	ca.Window = window
 	ca.SetProperties(props)
 	ca.SetLabels(labels)
-	ca.adjustment += that.adjustment
+	ca.Adjustment += that.Adjustment
 	ca.Cost += that.Cost
 	ca.Credit += that.Credit
 }
@@ -798,12 +806,12 @@ func (ca *Cloud) add(that *Cloud) {
 // Clone returns a cloned instance of the Asset
 func (ca *Cloud) Clone() Asset {
 	return &Cloud{
-		labels:     ca.labels.Clone(),
-		properties: ca.properties.Clone(),
-		start:      ca.start,
-		end:        ca.end,
-		window:     ca.window.Clone(),
-		adjustment: ca.adjustment,
+		Labels:     ca.Labels.Clone(),
+		Properties: ca.Properties.Clone(),
+		Start:      ca.Start,
+		End:        ca.End,
+		Window:     ca.Window.Clone(),
+		Adjustment: ca.Adjustment,
 		Cost:       ca.Cost,
 		Credit:     ca.Credit,
 	}
@@ -816,27 +824,24 @@ func (ca *Cloud) Equal(a Asset) bool {
 		return false
 	}
 
-	if !ca.Labels().Equal(that.Labels()) {
+	if !ca.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !ca.Properties().Equal(that.Properties()) {
+	if !ca.Properties.Equal(that.Properties) {
 		return false
 	}
-
-	if !ca.start.Equal(that.start) {
+	if !ca.Start.Equal(that.Start) {
 		return false
 	}
-	if !ca.end.Equal(that.end) {
+	if !ca.End.Equal(that.End) {
 		return false
 	}
-	if !ca.window.Equal(that.window) {
+	if !ca.Window.Equal(that.Window) {
 		return false
 	}
-
-	if ca.adjustment != that.adjustment {
+	if ca.Adjustment != that.Adjustment {
 		return false
 	}
-
 	if ca.Cost != that.Cost {
 		return false
 	}
@@ -854,11 +859,11 @@ func (ca *Cloud) String() string {
 
 // ClusterManagement describes a provider's cluster management fee
 type ClusterManagement struct {
-	labels     AssetLabels
-	properties *AssetProperties
-	window     Window
+	Labels     AssetLabels
+	Properties *AssetProperties
+	Window     Window
 	Cost       float64
-	adjustment float64 // @bingen:field[version=16]
+	Adjustment float64 // @bingen:field[version=16]
 }
 
 // NewClusterManagement creates and returns a new ClusterManagement instance
@@ -871,9 +876,9 @@ func NewClusterManagement(provider, cluster string, window Window) *ClusterManag
 	}
 
 	return &ClusterManagement{
-		labels:     AssetLabels{},
-		properties: properties,
-		window:     window.Clone(),
+		Labels:     AssetLabels{},
+		Properties: properties,
+		Window:     window.Clone(),
 	}
 }
 
@@ -882,64 +887,68 @@ func (cm *ClusterManagement) Type() AssetType {
 	return ClusterManagementAssetType
 }
 
-// Properties returns the Asset's properties
-func (cm *ClusterManagement) Properties() *AssetProperties {
-	return cm.properties
+// Properties returns the Asset's Properties
+func (cm *ClusterManagement) GetProperties() *AssetProperties {
+	return cm.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (cm *ClusterManagement) SetProperties(props *AssetProperties) {
-	cm.properties = props
+	cm.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (cm *ClusterManagement) Labels() AssetLabels {
-	return cm.labels
+func (cm *ClusterManagement) GetLabels() AssetLabels {
+	return cm.Labels
 }
 
-// SetLabels sets the Asset's properties
+// SetLabels sets the Asset's Properties
 func (cm *ClusterManagement) SetLabels(props AssetLabels) {
-	cm.labels = props
+	cm.Labels = props
 }
 
 // Adjustment does not apply to ClusterManagement
-func (cm *ClusterManagement) Adjustment() float64 {
-	return cm.adjustment
+func (cm *ClusterManagement) GetAdjustment() float64 {
+	return cm.Adjustment
 }
 
 // SetAdjustment does not apply to ClusterManagement
 func (cm *ClusterManagement) SetAdjustment(adj float64) {
-	cm.adjustment = adj
+	cm.Adjustment = adj
 }
 
 // TotalCost returns the Asset's total cost
 func (cm *ClusterManagement) TotalCost() float64 {
-	return cm.Cost + cm.adjustment
+	return cm.Cost + cm.Adjustment
 }
 
 // Start returns the Asset's precise start time within the window
-func (cm *ClusterManagement) Start() time.Time {
-	return *cm.window.Start()
+func (cm *ClusterManagement) GetStart() time.Time {
+	return *cm.Window.Start()
 }
 
 // End returns the Asset's precise end time within the window
-func (cm *ClusterManagement) End() time.Time {
-	return *cm.window.End()
+func (cm *ClusterManagement) GetEnd() time.Time {
+	return *cm.Window.End()
 }
 
 // Minutes returns the number of minutes the Asset ran
 func (cm *ClusterManagement) Minutes() float64 {
-	return cm.Window().Minutes()
+	return cm.Window.Minutes()
 }
 
 // Window return the Asset's window
-func (cm *ClusterManagement) Window() Window {
-	return cm.window
+func (cm *ClusterManagement) GetWindow() Window {
+	return cm.Window
+}
+
+func (cm *ClusterManagement) SetWindow(window Window) {
+	cm.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (cm *ClusterManagement) ExpandWindow(window Window) {
-	cm.window = cm.window.Expand(window)
+	cm.Window = cm.Window.Expand(window)
 }
 
 // SetStartEnd sets the Asset's Start and End fields (not applicable here)
@@ -948,7 +957,7 @@ func (cm *ClusterManagement) SetStartEnd(start, end time.Time) {
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (cm *ClusterManagement) Add(a Asset) Asset {
 	// ClusterManagement + ClusterManagement = ClusterManagement
 	if that, ok := a.(*ClusterManagement); ok {
@@ -957,25 +966,25 @@ func (cm *ClusterManagement) Add(a Asset) Asset {
 		return this
 	}
 
-	props := cm.Properties().Merge(a.Properties())
-	labels := cm.Labels().Merge(a.Labels())
+	props := cm.Properties.Merge(a.GetProperties())
+	labels := cm.Labels.Merge(a.GetLabels())
 
-	start := cm.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := cm.GetStart()
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := cm.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := cm.GetEnd()
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := cm.Window().Expand(a.Window())
+	window := cm.Window.Expand(a.GetWindow())
 
 	// ClusterManagement + !ClusterManagement = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = cm.Adjustment() + a.Adjustment()
-	any.Cost = (cm.TotalCost() - cm.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = cm.Adjustment + a.GetAdjustment()
+	any.Cost = (cm.TotalCost() - cm.Adjustment) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -986,24 +995,24 @@ func (cm *ClusterManagement) add(that *ClusterManagement) {
 		return
 	}
 
-	props := cm.Properties().Merge(that.Properties())
-	labels := cm.Labels().Merge(that.Labels())
-	window := cm.Window().Expand(that.Window())
+	props := cm.Properties.Merge(that.Properties)
+	labels := cm.Labels.Merge(that.Labels)
+	window := cm.Window.Expand(that.Window)
 
-	cm.window = window
+	cm.Window = window
 	cm.SetProperties(props)
 	cm.SetLabels(labels)
-	cm.adjustment += that.adjustment
+	cm.Adjustment += that.Adjustment
 	cm.Cost += that.Cost
 }
 
 // Clone returns a cloned instance of the Asset
 func (cm *ClusterManagement) Clone() Asset {
 	return &ClusterManagement{
-		labels:     cm.labels.Clone(),
-		properties: cm.properties.Clone(),
-		window:     cm.window.Clone(),
-		adjustment: cm.adjustment,
+		Labels:     cm.Labels.Clone(),
+		Properties: cm.Properties.Clone(),
+		Window:     cm.Window.Clone(),
+		Adjustment: cm.Adjustment,
 		Cost:       cm.Cost,
 	}
 }
@@ -1015,18 +1024,18 @@ func (cm *ClusterManagement) Equal(a Asset) bool {
 		return false
 	}
 
-	if !cm.Labels().Equal(that.Labels()) {
+	if !cm.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !cm.Properties().Equal(that.Properties()) {
-		return false
-	}
-
-	if !cm.window.Equal(that.window) {
+	if !cm.Properties.Equal(that.Properties) {
 		return false
 	}
 
-	if cm.adjustment != that.adjustment {
+	if !cm.Window.Equal(that.Window) {
+		return false
+	}
+
+	if cm.Adjustment != that.Adjustment {
 		return false
 	}
 
@@ -1044,12 +1053,12 @@ func (cm *ClusterManagement) String() string {
 
 // Disk represents an in-cluster disk Asset
 type Disk struct {
-	labels     AssetLabels
-	properties *AssetProperties
-	start      time.Time
-	end        time.Time
-	window     Window
-	adjustment float64
+	Labels     AssetLabels
+	Properties *AssetProperties
+	Start      time.Time
+	End        time.Time
+	Window     Window
+	Adjustment float64
 	Cost       float64
 	ByteHours  float64
 	Local      float64
@@ -1067,11 +1076,11 @@ func NewDisk(name, cluster, providerID string, start, end time.Time, window Wind
 	}
 
 	return &Disk{
-		labels:     AssetLabels{},
-		properties: properties,
-		start:      start,
-		end:        end,
-		window:     window,
+		Labels:     AssetLabels{},
+		Properties: properties,
+		Start:      start,
+		End:        end,
+		Window:     window,
 		Breakdown:  &Breakdown{},
 	}
 }
@@ -1081,55 +1090,55 @@ func (d *Disk) Type() AssetType {
 	return DiskAssetType
 }
 
-// Properties returns the Asset's properties
-func (d *Disk) Properties() *AssetProperties {
-	return d.properties
+// Properties returns the Asset's Properties
+func (d *Disk) GetProperties() *AssetProperties {
+	return d.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (d *Disk) SetProperties(props *AssetProperties) {
-	d.properties = props
+	d.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (d *Disk) Labels() AssetLabels {
-	return d.labels
+func (d *Disk) GetLabels() AssetLabels {
+	return d.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (d *Disk) SetLabels(labels AssetLabels) {
-	d.labels = labels
+	d.Labels = labels
 }
 
 // Adjustment returns the Asset's cost adjustment
-func (d *Disk) Adjustment() float64 {
-	return d.adjustment
+func (d *Disk) GetAdjustment() float64 {
+	return d.Adjustment
 }
 
 // SetAdjustment sets the Asset's cost adjustment
 func (d *Disk) SetAdjustment(adj float64) {
-	d.adjustment = adj
+	d.Adjustment = adj
 }
 
 // TotalCost returns the Asset's total cost
 func (d *Disk) TotalCost() float64 {
-	return d.Cost + d.adjustment
+	return d.Cost + d.Adjustment
 }
 
 // Start returns the precise start time of the Asset within the window
-func (d *Disk) Start() time.Time {
-	return d.start
+func (d *Disk) GetStart() time.Time {
+	return d.Start
 }
 
 // End returns the precise start time of the Asset within the window
-func (d *Disk) End() time.Time {
-	return d.end
+func (d *Disk) GetEnd() time.Time {
+	return d.End
 }
 
 // Minutes returns the number of minutes the Asset ran
 func (d *Disk) Minutes() float64 {
-	diskMins := d.end.Sub(d.start).Minutes()
-	windowMins := d.window.Minutes()
+	diskMins := d.End.Sub(d.Start).Minutes()
+	windowMins := d.Window.Minutes()
 
 	if diskMins > windowMins {
 		log.Warnf("Asset ETL: Disk.Minutes exceeds window: %.2f > %.2f", diskMins, windowMins)
@@ -1144,32 +1153,36 @@ func (d *Disk) Minutes() float64 {
 }
 
 // Window returns the window within which the Asset
-func (d *Disk) Window() Window {
-	return d.window
+func (d *Disk) GetWindow() Window {
+	return d.Window
+}
+
+func (d *Disk) SetWindow(window Window) {
+	d.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (d *Disk) ExpandWindow(window Window) {
-	d.window = d.window.Expand(window)
+	d.Window = d.Window.Expand(window)
 }
 
 // SetStartEnd sets the Asset's Start and End fields
 func (d *Disk) SetStartEnd(start, end time.Time) {
-	if d.Window().Contains(start) {
-		d.start = start
+	if d.Window.Contains(start) {
+		d.Start = start
 	} else {
-		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, d.Window())
+		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, d.Window)
 	}
 
-	if d.Window().Contains(end) {
-		d.end = end
+	if d.Window.Contains(end) {
+		d.End = end
 	} else {
-		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, d.Window())
+		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, d.Window)
 	}
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (d *Disk) Add(a Asset) Asset {
 	// Disk + Disk = Disk
 	if that, ok := a.(*Disk); ok {
@@ -1178,25 +1191,25 @@ func (d *Disk) Add(a Asset) Asset {
 		return this
 	}
 
-	props := d.Properties().Merge(a.Properties())
-	labels := d.Labels().Merge(a.Labels())
+	props := d.Properties.Merge(a.GetProperties())
+	labels := d.Labels.Merge(a.GetLabels())
 
-	start := d.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := d.Start
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := d.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := d.End
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := d.Window().Expand(a.Window())
+	window := d.Window.Expand(a.GetWindow())
 
 	// Disk + !Disk = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = d.Adjustment() + a.Adjustment()
-	any.Cost = (d.TotalCost() - d.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = d.Adjustment + a.GetAdjustment()
+	any.Cost = (d.TotalCost() - d.Adjustment) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -1207,23 +1220,23 @@ func (d *Disk) add(that *Disk) {
 		return
 	}
 
-	props := d.Properties().Merge(that.Properties())
-	labels := d.Labels().Merge(that.Labels())
+	props := d.Properties.Merge(that.Properties)
+	labels := d.Labels.Merge(that.Labels)
 	d.SetProperties(props)
 	d.SetLabels(labels)
 
-	start := d.Start()
-	if that.Start().Before(start) {
-		start = that.Start()
+	start := d.Start
+	if that.Start.Before(start) {
+		start = that.Start
 	}
-	end := d.End()
-	if that.End().After(end) {
-		end = that.End()
+	end := d.End
+	if that.End.After(end) {
+		end = that.End
 	}
-	window := d.Window().Expand(that.Window())
-	d.start = start
-	d.end = end
-	d.window = window
+	window := d.Window.Expand(that.Window)
+	d.Start = start
+	d.End = end
+	d.Window = window
 
 	totalCost := d.Cost + that.Cost
 	if totalCost > 0.0 {
@@ -1237,7 +1250,7 @@ func (d *Disk) add(that *Disk) {
 		d.Local = (d.Local + that.Local) / 2.0
 	}
 
-	d.adjustment += that.adjustment
+	d.Adjustment += that.Adjustment
 	d.Cost += that.Cost
 
 	d.ByteHours += that.ByteHours
@@ -1246,12 +1259,12 @@ func (d *Disk) add(that *Disk) {
 // Clone returns a cloned instance of the Asset
 func (d *Disk) Clone() Asset {
 	return &Disk{
-		properties: d.properties.Clone(),
-		labels:     d.labels.Clone(),
-		start:      d.start,
-		end:        d.end,
-		window:     d.window.Clone(),
-		adjustment: d.adjustment,
+		Properties: d.Properties.Clone(),
+		Labels:     d.Labels.Clone(),
+		Start:      d.Start,
+		End:        d.End,
+		Window:     d.Window.Clone(),
+		Adjustment: d.Adjustment,
 		Cost:       d.Cost,
 		ByteHours:  d.ByteHours,
 		Local:      d.Local,
@@ -1266,30 +1279,27 @@ func (d *Disk) Equal(a Asset) bool {
 		return false
 	}
 
-	if !d.Labels().Equal(that.Labels()) {
+	if !d.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !d.Properties().Equal(that.Properties()) {
+	if !d.Properties.Equal(that.Properties) {
 		return false
 	}
-
-	if !d.Start().Equal(that.Start()) {
+	if !d.Start.Equal(that.Start) {
 		return false
 	}
-	if !d.End().Equal(that.End()) {
+	if !d.End.Equal(that.End) {
 		return false
 	}
-	if !d.window.Equal(that.window) {
+	if !d.Window.Equal(that.Window) {
 		return false
 	}
-
-	if d.adjustment != that.adjustment {
+	if d.Adjustment != that.Adjustment {
 		return false
 	}
 	if d.Cost != that.Cost {
 		return false
 	}
-
 	if d.ByteHours != that.ByteHours {
 		return false
 	}
@@ -1369,12 +1379,12 @@ func (b *Breakdown) Equal(that *Breakdown) bool {
 
 // Network is an Asset representing a single node's network costs
 type Network struct {
-	properties *AssetProperties
-	labels     AssetLabels
-	start      time.Time
-	end        time.Time
-	window     Window
-	adjustment float64
+	Properties *AssetProperties
+	Labels     AssetLabels
+	Start      time.Time
+	End        time.Time
+	Window     Window
+	Adjustment float64
 	Cost       float64
 }
 
@@ -1389,11 +1399,11 @@ func NewNetwork(name, cluster, providerID string, start, end time.Time, window W
 	}
 
 	return &Network{
-		properties: properties,
-		labels:     AssetLabels{},
-		start:      start,
-		end:        end,
-		window:     window.Clone(),
+		Properties: properties,
+		Labels:     AssetLabels{},
+		Start:      start,
+		End:        end,
+		Window:     window.Clone(),
 	}
 }
 
@@ -1402,55 +1412,55 @@ func (n *Network) Type() AssetType {
 	return NetworkAssetType
 }
 
-// Properties returns the Asset's properties
-func (n *Network) Properties() *AssetProperties {
-	return n.properties
+// Properties returns the Asset's Properties
+func (n *Network) GetProperties() *AssetProperties {
+	return n.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (n *Network) SetProperties(props *AssetProperties) {
-	n.properties = props
+	n.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (n *Network) Labels() AssetLabels {
-	return n.labels
+func (n *Network) GetLabels() AssetLabels {
+	return n.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (n *Network) SetLabels(labels AssetLabels) {
-	n.labels = labels
+	n.Labels = labels
 }
 
 // Adjustment returns the Asset's cost adjustment
-func (n *Network) Adjustment() float64 {
-	return n.adjustment
+func (n *Network) GetAdjustment() float64 {
+	return n.Adjustment
 }
 
 // SetAdjustment sets the Asset's cost adjustment
 func (n *Network) SetAdjustment(adj float64) {
-	n.adjustment = adj
+	n.Adjustment = adj
 }
 
 // TotalCost returns the Asset's total cost
 func (n *Network) TotalCost() float64 {
-	return n.Cost + n.adjustment
+	return n.Cost + n.Adjustment
 }
 
 // Start returns the precise start time of the Asset within the window
-func (n *Network) Start() time.Time {
-	return n.start
+func (n *Network) GetStart() time.Time {
+	return n.Start
 }
 
 // End returns the precise end time of the Asset within the window
-func (n *Network) End() time.Time {
-	return n.end
+func (n *Network) GetEnd() time.Time {
+	return n.End
 }
 
 // Minutes returns the number of minutes the Asset ran within the window
 func (n *Network) Minutes() float64 {
-	netMins := n.end.Sub(n.start).Minutes()
-	windowMins := n.window.Minutes()
+	netMins := n.End.Sub(n.Start).Minutes()
+	windowMins := n.Window.Minutes()
 
 	if netMins > windowMins {
 		log.Warnf("Asset ETL: Network.Minutes exceeds window: %.2f > %.2f", netMins, windowMins)
@@ -1465,32 +1475,36 @@ func (n *Network) Minutes() float64 {
 }
 
 // Window returns the window within which the Asset ran
-func (n *Network) Window() Window {
-	return n.window
+func (n *Network) GetWindow() Window {
+	return n.Window
+}
+
+func (n *Network) SetWindow(window Window) {
+	n.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (n *Network) ExpandWindow(window Window) {
-	n.window = n.window.Expand(window)
+	n.Window = n.Window.Expand(window)
 }
 
 // SetStartEnd sets the Asset's Start and End fields
 func (n *Network) SetStartEnd(start, end time.Time) {
-	if n.Window().Contains(start) {
-		n.start = start
+	if n.Window.Contains(start) {
+		n.Start = start
 	} else {
-		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, n.Window())
+		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, n.Window)
 	}
 
-	if n.Window().Contains(end) {
-		n.end = end
+	if n.Window.Contains(end) {
+		n.End = end
 	} else {
-		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, n.Window())
+		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, n.Window)
 	}
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (n *Network) Add(a Asset) Asset {
 	// Network + Network = Network
 	if that, ok := a.(*Network); ok {
@@ -1499,25 +1513,25 @@ func (n *Network) Add(a Asset) Asset {
 		return this
 	}
 
-	props := n.Properties().Merge(a.Properties())
-	labels := n.Labels().Merge(a.Labels())
+	props := n.Properties.Merge(a.GetProperties())
+	labels := n.Labels.Merge(a.GetLabels())
 
-	start := n.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := n.Start
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := n.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := n.End
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := n.Window().Expand(a.Window())
+	window := n.Window.Expand(a.GetWindow())
 
 	// Network + !Network = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = n.Adjustment() + a.Adjustment()
-	any.Cost = (n.TotalCost() - n.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = n.Adjustment + a.GetAdjustment()
+	any.Cost = (n.TotalCost() - n.Adjustment) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -1528,26 +1542,26 @@ func (n *Network) add(that *Network) {
 		return
 	}
 
-	props := n.Properties().Merge(that.Properties())
-	labels := n.Labels().Merge(that.Labels())
+	props := n.Properties.Merge(that.Properties)
+	labels := n.Labels.Merge(that.Labels)
 	n.SetProperties(props)
 	n.SetLabels(labels)
 
-	start := n.Start()
-	if that.Start().Before(start) {
-		start = that.Start()
+	start := n.Start
+	if that.Start.Before(start) {
+		start = that.Start
 	}
-	end := n.End()
-	if that.End().After(end) {
-		end = that.End()
+	end := n.End
+	if that.End.After(end) {
+		end = that.End
 	}
-	window := n.Window().Expand(that.Window())
-	n.start = start
-	n.end = end
-	n.window = window
+	window := n.Window.Expand(that.Window)
+	n.Start = start
+	n.End = end
+	n.Window = window
 
 	n.Cost += that.Cost
-	n.adjustment += that.adjustment
+	n.Adjustment += that.Adjustment
 }
 
 // Clone returns a deep copy of the given Network
@@ -1557,12 +1571,12 @@ func (n *Network) Clone() Asset {
 	}
 
 	return &Network{
-		properties: n.properties.Clone(),
-		labels:     n.labels.Clone(),
-		start:      n.start,
-		end:        n.end,
-		window:     n.window.Clone(),
-		adjustment: n.adjustment,
+		Properties: n.Properties.Clone(),
+		Labels:     n.Labels.Clone(),
+		Start:      n.Start,
+		End:        n.End,
+		Window:     n.Window.Clone(),
+		Adjustment: n.Adjustment,
 		Cost:       n.Cost,
 	}
 }
@@ -1574,24 +1588,24 @@ func (n *Network) Equal(a Asset) bool {
 		return false
 	}
 
-	if !n.Labels().Equal(that.Labels()) {
+	if !n.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !n.Properties().Equal(that.Properties()) {
-		return false
-	}
-
-	if !n.Start().Equal(that.Start()) {
-		return false
-	}
-	if !n.End().Equal(that.End()) {
-		return false
-	}
-	if !n.window.Equal(that.window) {
+	if !n.Properties.Equal(that.Properties) {
 		return false
 	}
 
-	if n.adjustment != that.adjustment {
+	if !n.Start.Equal(that.Start) {
+		return false
+	}
+	if !n.End.Equal(that.End) {
+		return false
+	}
+	if !n.Window.Equal(that.Window) {
+		return false
+	}
+
+	if n.Adjustment != that.Adjustment {
 		return false
 	}
 	if n.Cost != that.Cost {
@@ -1608,12 +1622,12 @@ func (n *Network) String() string {
 
 // Node is an Asset representing a single node in a cluster
 type Node struct {
-	properties   *AssetProperties
-	labels       AssetLabels
-	start        time.Time
-	end          time.Time
-	window       Window
-	adjustment   float64
+	Properties   *AssetProperties
+	Labels       AssetLabels
+	Start        time.Time
+	End          time.Time
+	Window       Window
+	Adjustment   float64
 	NodeType     string
 	CPUCoreHours float64
 	RAMByteHours float64
@@ -1639,11 +1653,11 @@ func NewNode(name, cluster, providerID string, start, end time.Time, window Wind
 	}
 
 	return &Node{
-		properties:   properties,
-		labels:       AssetLabels{},
-		start:        start,
-		end:          end,
-		window:       window.Clone(),
+		Properties:   properties,
+		Labels:       AssetLabels{},
+		Start:        start,
+		End:          end,
+		Window:       window.Clone(),
 		CPUBreakdown: &Breakdown{},
 		RAMBreakdown: &Breakdown{},
 	}
@@ -1654,55 +1668,55 @@ func (n *Node) Type() AssetType {
 	return NodeAssetType
 }
 
-// Properties returns the Asset's properties
-func (n *Node) Properties() *AssetProperties {
-	return n.properties
+// Properties returns the Asset's Properties
+func (n *Node) GetProperties() *AssetProperties {
+	return n.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (n *Node) SetProperties(props *AssetProperties) {
-	n.properties = props
+	n.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (n *Node) Labels() AssetLabels {
-	return n.labels
+func (n *Node) GetLabels() AssetLabels {
+	return n.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (n *Node) SetLabels(labels AssetLabels) {
-	n.labels = labels
+	n.Labels = labels
 }
 
 // Adjustment returns the Asset's cost adjustment
-func (n *Node) Adjustment() float64 {
-	return n.adjustment
+func (n *Node) GetAdjustment() float64 {
+	return n.Adjustment
 }
 
 // SetAdjustment sets the Asset's cost adjustment
 func (n *Node) SetAdjustment(adj float64) {
-	n.adjustment = adj
+	n.Adjustment = adj
 }
 
 // TotalCost returns the Asset's total cost
 func (n *Node) TotalCost() float64 {
-	return ((n.CPUCost + n.RAMCost) * (1.0 - n.Discount)) + n.GPUCost + n.adjustment
+	return ((n.CPUCost + n.RAMCost) * (1.0 - n.Discount)) + n.GPUCost + n.Adjustment
 }
 
 // Start returns the precise start time of the Asset within the window
-func (n *Node) Start() time.Time {
-	return n.start
+func (n *Node) GetStart() time.Time {
+	return n.Start
 }
 
 // End returns the precise end time of the Asset within the window
-func (n *Node) End() time.Time {
-	return n.end
+func (n *Node) GetEnd() time.Time {
+	return n.End
 }
 
 // Minutes returns the number of minutes the Asset ran within the window
 func (n *Node) Minutes() float64 {
-	nodeMins := n.end.Sub(n.start).Minutes()
-	windowMins := n.window.Minutes()
+	nodeMins := n.End.Sub(n.Start).Minutes()
+	windowMins := n.Window.Minutes()
 
 	if nodeMins > windowMins {
 		log.Warnf("Asset ETL: Node.Minutes exceeds window: %.2f > %.2f", nodeMins, windowMins)
@@ -1717,32 +1731,36 @@ func (n *Node) Minutes() float64 {
 }
 
 // Window returns the window within which the Asset ran
-func (n *Node) Window() Window {
-	return n.window
+func (n *Node) GetWindow() Window {
+	return n.Window
+}
+
+func (n *Node) SetWindow(window Window) {
+	n.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (n *Node) ExpandWindow(window Window) {
-	n.window = n.window.Expand(window)
+	n.Window = n.Window.Expand(window)
 }
 
 // SetStartEnd sets the Asset's Start and End fields
 func (n *Node) SetStartEnd(start, end time.Time) {
-	if n.Window().Contains(start) {
-		n.start = start
+	if n.Window.Contains(start) {
+		n.Start = start
 	} else {
-		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, n.Window())
+		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, n.Window)
 	}
 
-	if n.Window().Contains(end) {
-		n.end = end
+	if n.Window.Contains(end) {
+		n.End = end
 	} else {
-		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, n.Window())
+		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, n.Window)
 	}
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (n *Node) Add(a Asset) Asset {
 	// Node + Node = Node
 	if that, ok := a.(*Node); ok {
@@ -1751,25 +1769,25 @@ func (n *Node) Add(a Asset) Asset {
 		return this
 	}
 
-	props := n.Properties().Merge(a.Properties())
-	labels := n.Labels().Merge(a.Labels())
+	props := n.Properties.Merge(a.GetProperties())
+	labels := n.Labels.Merge(a.GetLabels())
 
-	start := n.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := n.Start
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := n.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := n.End
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := n.Window().Expand(a.Window())
+	window := n.Window.Expand(a.GetWindow())
 
 	// Node + !Node = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = n.Adjustment() + a.Adjustment()
-	any.Cost = (n.TotalCost() - n.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = n.Adjustment + a.GetAdjustment()
+	any.Cost = (n.TotalCost() - n.Adjustment) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -1780,8 +1798,8 @@ func (n *Node) add(that *Node) {
 		return
 	}
 
-	props := n.Properties().Merge(that.Properties())
-	labels := n.Labels().Merge(that.Labels())
+	props := n.Properties.Merge(that.Properties)
+	labels := n.Labels.Merge(that.Labels)
 	n.SetProperties(props)
 	n.SetLabels(labels)
 
@@ -1789,18 +1807,18 @@ func (n *Node) add(that *Node) {
 		n.NodeType = ""
 	}
 
-	start := n.Start()
-	if that.Start().Before(start) {
-		start = that.Start()
+	start := n.Start
+	if that.Start.Before(start) {
+		start = that.Start
 	}
-	end := n.End()
-	if that.End().After(end) {
-		end = that.End()
+	end := n.End
+	if that.End.After(end) {
+		end = that.End
 	}
-	window := n.Window().Expand(that.Window())
-	n.start = start
-	n.end = end
-	n.window = window
+	window := n.Window.Expand(that.Window)
+	n.Start = start
+	n.End = end
+	n.Window = window
 
 	// Order of operations for node costs is:
 	//   Discount(CPU + RAM) + GPU + Adjustment
@@ -1818,8 +1836,8 @@ func (n *Node) add(that *Node) {
 		n.Discount = (n.Discount + that.Discount) / 2.0
 	}
 
-	nNoAdj := n.TotalCost() - n.Adjustment()
-	thatNoAdj := that.TotalCost() - that.Adjustment()
+	nNoAdj := n.TotalCost() - n.Adjustment
+	thatNoAdj := that.TotalCost() - that.Adjustment
 	if (nNoAdj + thatNoAdj) > 0 {
 		n.Preemptible = (nNoAdj*n.Preemptible + thatNoAdj*that.Preemptible) / (nNoAdj + thatNoAdj)
 	} else {
@@ -1849,7 +1867,7 @@ func (n *Node) add(that *Node) {
 	n.CPUCost += that.CPUCost
 	n.GPUCost += that.GPUCost
 	n.RAMCost += that.RAMCost
-	n.adjustment += that.adjustment
+	n.Adjustment += that.Adjustment
 }
 
 // Clone returns a deep copy of the given Node
@@ -1859,12 +1877,12 @@ func (n *Node) Clone() Asset {
 	}
 
 	return &Node{
-		properties:   n.properties.Clone(),
-		labels:       n.labels.Clone(),
-		start:        n.start,
-		end:          n.end,
-		window:       n.window.Clone(),
-		adjustment:   n.adjustment,
+		Properties:   n.Properties.Clone(),
+		Labels:       n.Labels.Clone(),
+		Start:        n.Start,
+		End:          n.End,
+		Window:       n.Window.Clone(),
+		Adjustment:   n.Adjustment,
 		NodeType:     n.NodeType,
 		CPUCoreHours: n.CPUCoreHours,
 		RAMByteHours: n.RAMByteHours,
@@ -1887,27 +1905,24 @@ func (n *Node) Equal(a Asset) bool {
 		return false
 	}
 
-	if !n.Labels().Equal(that.Labels()) {
+	if !n.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !n.Properties().Equal(that.Properties()) {
+	if !n.Properties.Equal(that.Properties) {
 		return false
 	}
-
-	if !n.Start().Equal(that.Start()) {
+	if !n.Start.Equal(that.Start) {
 		return false
 	}
-	if !n.End().Equal(that.End()) {
+	if !n.End.Equal(that.End) {
 		return false
 	}
-	if !n.window.Equal(that.window) {
+	if !n.Window.Equal(that.Window) {
 		return false
 	}
-
-	if n.adjustment != that.adjustment {
+	if n.Adjustment != that.Adjustment {
 		return false
 	}
-
 	if n.NodeType != that.NodeType {
 		return false
 	}
@@ -2005,12 +2020,12 @@ func (n *Node) GPUs() float64 {
 // LoadBalancer is an Asset representing a single load balancer in a cluster
 // TODO: add GB of ingress processed, numForwardingRules once we start recording those to prometheus metric
 type LoadBalancer struct {
-	properties *AssetProperties
-	labels     AssetLabels
-	start      time.Time
-	end        time.Time
-	window     Window
-	adjustment float64
+	Properties *AssetProperties
+	Labels     AssetLabels
+	Start      time.Time
+	End        time.Time
+	Window     Window
+	Adjustment float64
 	Cost       float64
 }
 
@@ -2025,11 +2040,11 @@ func NewLoadBalancer(name, cluster, providerID string, start, end time.Time, win
 	}
 
 	return &LoadBalancer{
-		properties: properties,
-		labels:     AssetLabels{},
-		start:      start,
-		end:        end,
-		window:     window,
+		Properties: properties,
+		Labels:     AssetLabels{},
+		Start:      start,
+		End:        end,
+		Window:     window,
 	}
 }
 
@@ -2038,83 +2053,87 @@ func (lb *LoadBalancer) Type() AssetType {
 	return LoadBalancerAssetType
 }
 
-// Properties returns the Asset's properties
-func (lb *LoadBalancer) Properties() *AssetProperties {
-	return lb.properties
+// Properties returns the Asset's Properties
+func (lb *LoadBalancer) GetProperties() *AssetProperties {
+	return lb.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (lb *LoadBalancer) SetProperties(props *AssetProperties) {
-	lb.properties = props
+	lb.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (lb *LoadBalancer) Labels() AssetLabels {
-	return lb.labels
+func (lb *LoadBalancer) GetLabels() AssetLabels {
+	return lb.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (lb *LoadBalancer) SetLabels(labels AssetLabels) {
-	lb.labels = labels
+	lb.Labels = labels
 }
 
 // Adjustment returns the Asset's cost adjustment
-func (lb *LoadBalancer) Adjustment() float64 {
-	return lb.adjustment
+func (lb *LoadBalancer) GetAdjustment() float64 {
+	return lb.Adjustment
 }
 
 // SetAdjustment sets the Asset's cost adjustment
 func (lb *LoadBalancer) SetAdjustment(adj float64) {
-	lb.adjustment = adj
+	lb.Adjustment = adj
 }
 
 // TotalCost returns the total cost of the Asset
 func (lb *LoadBalancer) TotalCost() float64 {
-	return lb.Cost + lb.adjustment
+	return lb.Cost + lb.Adjustment
 }
 
 // Start returns the preceise start point of the Asset within the window
-func (lb *LoadBalancer) Start() time.Time {
-	return lb.start
+func (lb *LoadBalancer) GetStart() time.Time {
+	return lb.Start
 }
 
 // End returns the preceise end point of the Asset within the window
-func (lb *LoadBalancer) End() time.Time {
-	return lb.end
+func (lb *LoadBalancer) GetEnd() time.Time {
+	return lb.End
 }
 
 // Minutes returns the number of minutes the Asset ran within the window
 func (lb *LoadBalancer) Minutes() float64 {
-	return lb.end.Sub(lb.start).Minutes()
+	return lb.End.Sub(lb.Start).Minutes()
 }
 
 // Window returns the window within which the Asset ran
-func (lb *LoadBalancer) Window() Window {
-	return lb.window
+func (lb *LoadBalancer) GetWindow() Window {
+	return lb.Window
+}
+
+func (lb *LoadBalancer) SetWindow(window Window) {
+	lb.Window = window
 }
 
 // ExpandWindow expands the Asset's window by the given window
 func (lb *LoadBalancer) ExpandWindow(w Window) {
-	lb.window = lb.window.Expand(w)
+	lb.Window = lb.Window.Expand(w)
 }
 
 // SetStartEnd sets the Asset's Start and End fields
 func (lb *LoadBalancer) SetStartEnd(start, end time.Time) {
-	if lb.Window().Contains(start) {
-		lb.start = start
+	if lb.Window.Contains(start) {
+		lb.Start = start
 	} else {
-		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, lb.Window())
+		log.Warnf("Disk.SetStartEnd: start %s not in %s", start, lb.Window)
 	}
 
-	if lb.Window().Contains(end) {
-		lb.end = end
+	if lb.Window.Contains(end) {
+		lb.End = end
 	} else {
-		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, lb.Window())
+		log.Warnf("Disk.SetStartEnd: end %s not in %s", end, lb.Window)
 	}
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (lb *LoadBalancer) Add(a Asset) Asset {
 	// LoadBalancer + LoadBalancer = LoadBalancer
 	if that, ok := a.(*LoadBalancer); ok {
@@ -2123,25 +2142,25 @@ func (lb *LoadBalancer) Add(a Asset) Asset {
 		return this
 	}
 
-	props := lb.Properties().Merge(a.Properties())
-	labels := lb.Labels().Merge(a.Labels())
+	props := lb.GetProperties().Merge(a.GetProperties())
+	labels := lb.Labels.Merge(a.GetLabels())
 
-	start := lb.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := lb.Start
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := lb.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := lb.End
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := lb.Window().Expand(a.Window())
+	window := lb.Window.Expand(a.GetWindow())
 
 	// LoadBalancer + !LoadBalancer = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = lb.Adjustment() + a.Adjustment()
-	any.Cost = (lb.TotalCost() - lb.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = lb.Adjustment + a.GetAdjustment()
+	any.Cost = (lb.TotalCost() - lb.Adjustment) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -2152,37 +2171,37 @@ func (lb *LoadBalancer) add(that *LoadBalancer) {
 		return
 	}
 
-	props := lb.Properties().Merge(that.Properties())
-	labels := lb.Labels().Merge(that.Labels())
+	props := lb.Properties.Merge(that.GetProperties())
+	labels := lb.Labels.Merge(that.GetLabels())
 	lb.SetProperties(props)
 	lb.SetLabels(labels)
 
-	start := lb.Start()
-	if that.Start().Before(start) {
-		start = that.Start()
+	start := lb.Start
+	if that.Start.Before(start) {
+		start = that.Start
 	}
-	end := lb.End()
-	if that.End().After(end) {
-		end = that.End()
+	end := lb.End
+	if that.End.After(end) {
+		end = that.End
 	}
-	window := lb.Window().Expand(that.Window())
-	lb.start = start
-	lb.end = end
-	lb.window = window
+	window := lb.Window.Expand(that.Window)
+	lb.Start = start
+	lb.End = end
+	lb.Window = window
 
 	lb.Cost += that.Cost
-	lb.adjustment += that.adjustment
+	lb.Adjustment += that.Adjustment
 }
 
 // Clone returns a cloned instance of the given Asset
 func (lb *LoadBalancer) Clone() Asset {
 	return &LoadBalancer{
-		properties: lb.properties.Clone(),
-		labels:     lb.labels.Clone(),
-		start:      lb.start,
-		end:        lb.end,
-		window:     lb.window.Clone(),
-		adjustment: lb.adjustment,
+		Properties: lb.Properties.Clone(),
+		Labels:     lb.Labels.Clone(),
+		Start:      lb.Start,
+		End:        lb.End,
+		Window:     lb.Window.Clone(),
+		Adjustment: lb.Adjustment,
 		Cost:       lb.Cost,
 	}
 }
@@ -2194,24 +2213,22 @@ func (lb *LoadBalancer) Equal(a Asset) bool {
 		return false
 	}
 
-	if !lb.Labels().Equal(that.Labels()) {
+	if !lb.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !lb.Properties().Equal(that.Properties()) {
+	if !lb.Properties.Equal(that.Properties) {
 		return false
 	}
-
-	if !lb.Start().Equal(that.Start()) {
+	if !lb.Start.Equal(that.Start) {
 		return false
 	}
-	if !lb.End().Equal(that.End()) {
+	if !lb.End.Equal(that.End) {
 		return false
 	}
-	if !lb.window.Equal(that.window) {
+	if !lb.Window.Equal(that.Window) {
 		return false
 	}
-
-	if lb.adjustment != that.adjustment {
+	if lb.Adjustment != that.Adjustment {
 		return false
 	}
 	if lb.Cost != that.Cost {
@@ -2228,9 +2245,9 @@ func (lb *LoadBalancer) String() string {
 
 // SharedAsset is an Asset representing a shared cost
 type SharedAsset struct {
-	properties *AssetProperties
-	labels     AssetLabels
-	window     Window
+	Properties *AssetProperties
+	Labels     AssetLabels
+	Window     Window
 	Cost       float64
 }
 
@@ -2243,9 +2260,9 @@ func NewSharedAsset(name string, window Window) *SharedAsset {
 	}
 
 	return &SharedAsset{
-		properties: properties,
-		labels:     AssetLabels{},
-		window:     window.Clone(),
+		Properties: properties,
+		Labels:     AssetLabels{},
+		Window:     window.Clone(),
 	}
 }
 
@@ -2254,28 +2271,28 @@ func (sa *SharedAsset) Type() AssetType {
 	return SharedAssetType
 }
 
-// Properties returns the Asset's properties
-func (sa *SharedAsset) Properties() *AssetProperties {
-	return sa.properties
+// Properties returns the Asset's Properties
+func (sa *SharedAsset) GetProperties() *AssetProperties {
+	return sa.Properties
 }
 
-// SetProperties sets the Asset's properties
+// SetProperties sets the Asset's Properties
 func (sa *SharedAsset) SetProperties(props *AssetProperties) {
-	sa.properties = props
+	sa.Properties = props
 }
 
 // Labels returns the Asset's labels
-func (sa *SharedAsset) Labels() AssetLabels {
-	return sa.labels
+func (sa *SharedAsset) GetLabels() AssetLabels {
+	return sa.Labels
 }
 
 // SetLabels sets the Asset's labels
 func (sa *SharedAsset) SetLabels(labels AssetLabels) {
-	sa.labels = labels
+	sa.Labels = labels
 }
 
 // Adjustment is not relevant to SharedAsset, but required to implement Asset
-func (sa *SharedAsset) Adjustment() float64 {
+func (sa *SharedAsset) GetAdjustment() float64 {
 	return 0.0
 }
 
@@ -2290,28 +2307,32 @@ func (sa *SharedAsset) TotalCost() float64 {
 }
 
 // Start returns the start time of the Asset
-func (sa *SharedAsset) Start() time.Time {
-	return *sa.window.start
+func (sa *SharedAsset) GetStart() time.Time {
+	return *sa.Window.start
 }
 
 // End returns the end time of the Asset
-func (sa *SharedAsset) End() time.Time {
-	return *sa.window.end
+func (sa *SharedAsset) GetEnd() time.Time {
+	return *sa.Window.end
 }
 
 // Minutes returns the number of minutes the SharedAsset ran within the window
 func (sa *SharedAsset) Minutes() float64 {
-	return sa.window.Minutes()
+	return sa.Window.Minutes()
 }
 
 // Window returns the window within the SharedAsset ran
-func (sa *SharedAsset) Window() Window {
-	return sa.window
+func (sa *SharedAsset) GetWindow() Window {
+	return sa.Window
+}
+
+func (sa *SharedAsset) SetWindow(window Window) {
+	sa.Window = window
 }
 
 // ExpandWindow expands the Asset's window
 func (sa *SharedAsset) ExpandWindow(w Window) {
-	sa.window = sa.window.Expand(w)
+	sa.Window = sa.Window.Expand(w)
 }
 
 // SetStartEnd sets the Asset's Start and End fields (not applicable here)
@@ -2320,7 +2341,7 @@ func (sa *SharedAsset) SetStartEnd(start, end time.Time) {
 }
 
 // Add sums the Asset with the given Asset to produce a new Asset, maintaining
-// as much relevant information as possible (i.e. type, properties, labels).
+// as much relevant information as possible (i.e. type, Properties, labels).
 func (sa *SharedAsset) Add(a Asset) Asset {
 	// SharedAsset + SharedAsset = SharedAsset
 	if that, ok := a.(*SharedAsset); ok {
@@ -2329,25 +2350,25 @@ func (sa *SharedAsset) Add(a Asset) Asset {
 		return this
 	}
 
-	props := sa.Properties().Merge(a.Properties())
-	labels := sa.Labels().Merge(a.Labels())
+	props := sa.Properties.Merge(a.GetProperties())
+	labels := sa.Labels.Merge(a.GetLabels())
 
-	start := sa.Start()
-	if a.Start().Before(start) {
-		start = a.Start()
+	start := sa.GetStart()
+	if a.GetStart().Before(start) {
+		start = a.GetStart()
 	}
-	end := sa.End()
-	if a.End().After(end) {
-		end = a.End()
+	end := sa.GetEnd()
+	if a.GetEnd().After(end) {
+		end = a.GetEnd()
 	}
-	window := sa.Window().Expand(a.Window())
+	window := sa.Window.Expand(a.GetWindow())
 
 	// SharedAsset + !SharedAsset = Any
 	any := NewAsset(start, end, window)
 	any.SetProperties(props)
 	any.SetLabels(labels)
-	any.adjustment = sa.Adjustment() + a.Adjustment()
-	any.Cost = (sa.TotalCost() - sa.Adjustment()) + (a.TotalCost() - a.Adjustment())
+	any.Adjustment = sa.GetAdjustment() + a.GetAdjustment()
+	any.Cost = (sa.TotalCost() - sa.GetAdjustment()) + (a.TotalCost() - a.GetAdjustment())
 
 	return any
 }
@@ -2358,13 +2379,13 @@ func (sa *SharedAsset) add(that *SharedAsset) {
 		return
 	}
 
-	props := sa.Properties().Merge(that.Properties())
-	labels := sa.Labels().Merge(that.Labels())
+	props := sa.Properties.Merge(that.GetProperties())
+	labels := sa.Labels.Merge(that.GetLabels())
 	sa.SetProperties(props)
 	sa.SetLabels(labels)
 
-	window := sa.Window().Expand(that.Window())
-	sa.window = window
+	window := sa.Window.Expand(that.Window)
+	sa.Window = window
 
 	sa.Cost += that.Cost
 }
@@ -2376,9 +2397,9 @@ func (sa *SharedAsset) Clone() Asset {
 	}
 
 	return &SharedAsset{
-		properties: sa.properties.Clone(),
-		labels:     sa.labels.Clone(),
-		window:     sa.window.Clone(),
+		Properties: sa.Properties.Clone(),
+		Labels:     sa.Labels.Clone(),
+		Window:     sa.Window.Clone(),
 		Cost:       sa.Cost,
 	}
 }
@@ -2390,23 +2411,15 @@ func (sa *SharedAsset) Equal(a Asset) bool {
 		return false
 	}
 
-	if !sa.Labels().Equal(that.Labels()) {
+	if !sa.Labels.Equal(that.Labels) {
 		return false
 	}
-	if !sa.Properties().Equal(that.Properties()) {
+	if !sa.Properties.Equal(that.Properties) {
 		return false
 	}
-
-	if !sa.Start().Equal(that.Start()) {
+	if !sa.Window.Equal(that.Window) {
 		return false
 	}
-	if !sa.End().Equal(that.End()) {
-		return false
-	}
-	if !sa.window.Equal(that.window) {
-		return false
-	}
-
 	if sa.Cost != that.Cost {
 		return false
 	}
@@ -2429,20 +2442,127 @@ type AssetSetResponse struct {
 // AssetSet stores a set of Assets, each with a unique name, that share
 // a window. An AssetSet is mutable, so treat it like a threadsafe map.
 type AssetSet struct {
-	sync.RWMutex
-	aggregateBy []string
-	assets      map[string]Asset
-	FromSource  string // stores the name of the source used to compute the data
-	Window      Window
-	Warnings    []string
-	Errors      []string
+	AggregationKeys   []string
+	Assets            map[string]Asset
+	Any               map[string]*Any               //@bingen:field[ignore]
+	Cloud             map[string]*Cloud             //@bingen:field[ignore]
+	ClusterManagement map[string]*ClusterManagement //@bingen:field[ignore]
+	Disks             map[string]*Disk              //@bingen:field[ignore]
+	Network           map[string]*Network           //@bingen:field[ignore]
+	Nodes             map[string]*Node              //@bingen:field[ignore]
+	LoadBalancers     map[string]*LoadBalancer      //@bingen:field[ignore]
+	SharedAssets      map[string]*SharedAsset       //@bingen:field[ignore]
+	FromSource        string                        // stores the name of the source used to compute the data
+	Window            Window
+	Warnings          []string
+	Errors            []string
+}
+
+// This methid is executed before marshalling the AssetSet binary.
+func preProcessAssetSet(assetSet *AssetSet) {
+	length := len(assetSet.Any) + len(assetSet.Cloud) + len(assetSet.ClusterManagement) + len(assetSet.Disks) +
+		len(assetSet.Network) + len(assetSet.Nodes) + len(assetSet.LoadBalancers) + len(assetSet.SharedAssets)
+
+	if length != len(assetSet.Assets) {
+		log.Warnf("AssetSet concrete Asset maps are out of sync with AssetSet.Assets map.")
+	}
+}
+
+// This method is executed after unmarshalling the AssetSet binary.
+func postProcessAssetSet(assetSet *AssetSet) {
+	for key, as := range assetSet.Assets {
+		addToConcreteMap(assetSet, key, as)
+	}
+}
+
+// addToConcreteMap adds the Asset to the correct concrete map in the AssetSet. This is used
+// in the postProcessAssetSet method as well as AssetSet.Insert().
+func addToConcreteMap(assetSet *AssetSet, key string, as Asset) {
+	switch asset := as.(type) {
+	case *Any:
+		if assetSet.Any == nil {
+			assetSet.Any = make(map[string]*Any)
+		}
+		assetSet.Any[key] = asset
+
+	case *Cloud:
+		if assetSet.Cloud == nil {
+			assetSet.Cloud = make(map[string]*Cloud)
+		}
+		assetSet.Cloud[key] = asset
+
+	case *ClusterManagement:
+		if assetSet.ClusterManagement == nil {
+			assetSet.ClusterManagement = make(map[string]*ClusterManagement)
+		}
+		assetSet.ClusterManagement[key] = asset
+
+	case *Disk:
+		if assetSet.Disks == nil {
+			assetSet.Disks = make(map[string]*Disk)
+		}
+		assetSet.Disks[key] = asset
+
+	case *Network:
+		if assetSet.Network == nil {
+			assetSet.Network = make(map[string]*Network)
+		}
+		assetSet.Network[key] = asset
+
+	case *Node:
+		if assetSet.Nodes == nil {
+			assetSet.Nodes = make(map[string]*Node)
+		}
+		assetSet.Nodes[key] = asset
+
+	case *LoadBalancer:
+		if assetSet.LoadBalancers == nil {
+			assetSet.LoadBalancers = make(map[string]*LoadBalancer)
+		}
+		assetSet.LoadBalancers[key] = asset
+
+	case *SharedAsset:
+		if assetSet.SharedAssets == nil {
+			assetSet.SharedAssets = make(map[string]*SharedAsset)
+		}
+		assetSet.SharedAssets[key] = asset
+	}
+}
+
+// removeFromConcreteMap will remove an Asset from the AssetSet's concrete type mapping for the Asset and key.
+func removeFromConcreteMap(assetSet *AssetSet, key string, as Asset) {
+	switch as.(type) {
+	case *Any:
+		delete(assetSet.Any, key)
+
+	case *Cloud:
+		delete(assetSet.Cloud, key)
+
+	case *ClusterManagement:
+		delete(assetSet.ClusterManagement, key)
+
+	case *Disk:
+		delete(assetSet.Disks, key)
+
+	case *Network:
+		delete(assetSet.Network, key)
+
+	case *Node:
+		delete(assetSet.Nodes, key)
+
+	case *LoadBalancer:
+		delete(assetSet.LoadBalancers, key)
+
+	case *SharedAsset:
+		delete(assetSet.SharedAssets, key)
+	}
 }
 
 // NewAssetSet instantiates a new AssetSet and, optionally, inserts
 // the given list of Assets
 func NewAssetSet(start, end time.Time, assets ...Asset) *AssetSet {
 	as := &AssetSet{
-		assets: map[string]Asset{},
+		Assets: map[string]Asset{},
 		Window: NewWindow(&start, &end),
 	}
 
@@ -2465,11 +2585,8 @@ func (as *AssetSet) AggregateBy(aggregateBy []string, opts *AssetAggregationOpti
 		return nil
 	}
 
-	as.Lock()
-	defer as.Unlock()
-
 	aggSet := NewAssetSet(as.Start(), as.End())
-	aggSet.aggregateBy = aggregateBy
+	aggSet.AggregationKeys = aggregateBy
 
 	// Compute hours of the given AssetSet, and if it ends in the future,
 	// adjust the hours accordingly
@@ -2502,16 +2619,16 @@ func (as *AssetSet) AggregateBy(aggregateBy []string, opts *AssetAggregationOpti
 
 	// Delete the Assets that don't pass each filter
 	for _, ff := range opts.FilterFuncs {
-		for key, asset := range as.assets {
+		for key, asset := range as.Assets {
 			if !ff(asset) {
-				delete(as.assets, key)
+				delete(as.Assets, key)
 			}
 		}
 	}
 
 	// Insert each asset into the new set, which will be keyed by the `aggregateBy`
 	// on aggSet, resulting in aggregation.
-	for _, asset := range as.assets {
+	for _, asset := range as.Assets {
 		err := aggSet.Insert(asset)
 		if err != nil {
 			return err
@@ -2519,8 +2636,8 @@ func (as *AssetSet) AggregateBy(aggregateBy []string, opts *AssetAggregationOpti
 	}
 
 	// Assign the aggregated values back to the original set
-	as.assets = aggSet.assets
-	as.aggregateBy = aggregateBy
+	as.Assets = aggSet.Assets
+	as.AggregationKeys = aggregateBy
 
 	return nil
 }
@@ -2532,17 +2649,9 @@ func (as *AssetSet) Clone() *AssetSet {
 		return nil
 	}
 
-	as.RLock()
-	defer as.RUnlock()
-
 	var aggregateBy []string
-	if as.aggregateBy != nil {
-		aggregateBy = append([]string{}, as.aggregateBy...)
-	}
-
-	assets := make(map[string]Asset, len(as.assets))
-	for k, v := range as.assets {
-		assets[k] = v.Clone()
+	if as.AggregationKeys != nil {
+		aggregateBy = append(aggregateBy, as.AggregationKeys...)
 	}
 
 	s := as.Start()
@@ -2565,24 +2674,63 @@ func (as *AssetSet) Clone() *AssetSet {
 		warnings = nil
 	}
 
-	return &AssetSet{
-		Window:      NewWindow(&s, &e),
-		aggregateBy: aggregateBy,
-		assets:      assets,
-		Errors:      errors,
-		Warnings:    warnings,
+	var anyMap map[string]*Any
+	if as.Any != nil {
+		anyMap = make(map[string]*Any, len(as.Any))
 	}
-}
+	var cloudMap map[string]*Cloud
+	if as.Cloud != nil {
+		cloudMap = make(map[string]*Cloud, len(as.Cloud))
+	}
+	var clusterManagementMap map[string]*ClusterManagement
+	if as.ClusterManagement != nil {
+		clusterManagementMap = make(map[string]*ClusterManagement, len(as.ClusterManagement))
+	}
+	var disksMap map[string]*Disk
+	if as.Disks != nil {
+		disksMap = make(map[string]*Disk, len(as.Disks))
+	}
+	var networkMap map[string]*Network
+	if as.Network != nil {
+		networkMap = make(map[string]*Network, len(as.Network))
+	}
+	var nodesMap map[string]*Node
+	if as.Nodes != nil {
+		nodesMap = make(map[string]*Node, len(as.Nodes))
+	}
+	var loadBalancersMap map[string]*LoadBalancer
+	if as.LoadBalancers != nil {
+		loadBalancersMap = make(map[string]*LoadBalancer, len(as.LoadBalancers))
+	}
 
-// Each invokes the given function for each Asset in the set
-func (as *AssetSet) Each(f func(string, Asset)) {
-	if as == nil {
-		return
+	var sharedAssetsMap map[string]*SharedAsset
+	if as.SharedAssets != nil {
+		sharedAssetsMap = make(map[string]*SharedAsset, len(as.SharedAssets))
 	}
 
-	for k, a := range as.assets {
-		f(k, a)
+	assetSet := &AssetSet{
+		Window:            NewWindow(&s, &e),
+		AggregationKeys:   aggregateBy,
+		Assets:            make(map[string]Asset, len(as.Assets)),
+		Any:               anyMap,
+		Cloud:             cloudMap,
+		ClusterManagement: clusterManagementMap,
+		Disks:             disksMap,
+		Network:           networkMap,
+		Nodes:             nodesMap,
+		LoadBalancers:     loadBalancersMap,
+		SharedAssets:      sharedAssetsMap,
+		Errors:            errors,
+		Warnings:          warnings,
 	}
+
+	for k, v := range as.Assets {
+		newAsset := v.Clone()
+		assetSet.Assets[k] = newAsset
+		addToConcreteMap(assetSet, k, newAsset)
+	}
+
+	return assetSet
 }
 
 // End returns the end time of the AssetSet's window
@@ -2591,17 +2739,14 @@ func (as *AssetSet) End() time.Time {
 }
 
 // FindMatch attempts to find a match in the AssetSet for the given Asset on
-// the provided properties and labels. If a match is not found, FindMatch
+// the provided Properties and labels. If a match is not found, FindMatch
 // returns nil and a Not Found error.
 func (as *AssetSet) FindMatch(query Asset, aggregateBy []string) (Asset, error) {
-	as.RLock()
-	defer as.RUnlock()
-
 	matchKey, err := key(query, aggregateBy)
 	if err != nil {
 		return nil, err
 	}
-	for _, asset := range as.assets {
+	for _, asset := range as.Assets {
 		if k, err := key(asset, aggregateBy); err != nil {
 			return nil, err
 		} else if k == matchKey {
@@ -2618,14 +2763,11 @@ func (as *AssetSet) FindMatch(query Asset, aggregateBy []string) (Asset, error) 
 // (ProviderID). If that match is found, it returns the Asset with the intent
 // to insert the associated Cloud cost.
 func (as *AssetSet) ReconciliationMatch(query Asset) (Asset, bool, error) {
-	as.RLock()
-	defer as.RUnlock()
-
 	// Full match means matching on (Category, ProviderID)
 	fullMatchProps := []string{string(AssetCategoryProp), string(AssetProviderIDProp)}
 	fullMatchKey, err := key(query, fullMatchProps)
 
-	// This should never happen because we are using enumerated properties,
+	// This should never happen because we are using enumerated Properties,
 	// but the check is here in case that changes
 	if err != nil {
 		return nil, false, err
@@ -2635,14 +2777,14 @@ func (as *AssetSet) ReconciliationMatch(query Asset) (Asset, bool, error) {
 	providerIDMatchProps := []string{string(AssetProviderIDProp)}
 	providerIDMatchKey, err := key(query, providerIDMatchProps)
 
-	// This should never happen because we are using enumerated properties,
+	// This should never happen because we are using enumerated Properties,
 	// but the check is here in case that changes
 	if err != nil {
 		return nil, false, err
 	}
 
 	var providerIDMatch Asset
-	for _, asset := range as.assets {
+	for _, asset := range as.Assets {
 		// Ignore cloud assets when looking for reconciliation matches
 		if asset.Type() == CloudAssetType {
 			continue
@@ -2679,11 +2821,11 @@ func (as *AssetSet) ReconciliationMatchMap() map[string]map[string]Asset {
 		return matchMap
 	}
 
-	for _, asset := range as.assets {
+	for _, asset := range as.Assets {
 		if asset == nil {
 			continue
 		}
-		props := asset.Properties()
+		props := asset.GetProperties()
 		// Ignore cloud assets and assets that cannot be matched when looking for reconciliation matches
 		if props == nil || props.ProviderID == "" || asset.Type() == CloudAssetType {
 			continue
@@ -2697,9 +2839,9 @@ func (as *AssetSet) ReconciliationMatchMap() map[string]map[string]Asset {
 		if duplicateAsset, ok := matchMap[props.ProviderID][props.Category]; ok {
 			log.DedupedWarningf(5, "duplicate asset found when reconciling for %s", props.ProviderID)
 			// if one asset already has adjustment use that one
-			if duplicateAsset.Adjustment() == 0 && asset.Adjustment() != 0 {
+			if duplicateAsset.GetAdjustment() == 0 && asset.GetAdjustment() != 0 {
 				matchMap[props.ProviderID][props.Category] = asset
-			} else if duplicateAsset.Adjustment() != 0 && asset.Adjustment() == 0 {
+			} else if duplicateAsset.GetAdjustment() != 0 && asset.GetAdjustment() == 0 {
 				matchMap[props.ProviderID][props.Category] = duplicateAsset
 				// otherwise use the one with the higher cost
 			} else if duplicateAsset.TotalCost() < asset.TotalCost() {
@@ -2716,47 +2858,52 @@ func (as *AssetSet) ReconciliationMatchMap() map[string]map[string]Asset {
 // Get returns the Asset in the AssetSet at the given key, or nil and false
 // if no Asset exists for the given key
 func (as *AssetSet) Get(key string) (Asset, bool) {
-	as.RLock()
-	defer as.RUnlock()
-
-	if a, ok := as.assets[key]; ok {
+	if a, ok := as.Assets[key]; ok {
 		return a, true
 	}
 	return nil, false
 }
 
 // Insert inserts the given Asset into the AssetSet, using the AssetSet's
-// configured properties to determine the key under which the Asset will
+// configured Properties to determine the key under which the Asset will
 // be inserted.
 func (as *AssetSet) Insert(asset Asset) error {
 	if as == nil {
 		return fmt.Errorf("cannot Insert into nil AssetSet")
 	}
 
-	as.Lock()
-	defer as.Unlock()
-
-	if as.assets == nil {
-		as.assets = map[string]Asset{}
+	if as.Assets == nil {
+		as.Assets = map[string]Asset{}
 	}
 
 	// Determine key into which to Insert the Asset.
-	k, err := key(asset, as.aggregateBy)
+	k, err := key(asset, as.AggregationKeys)
 	if err != nil {
 		return err
 	}
 
 	// Add the given Asset to the existing entry, if there is one;
 	// otherwise just set directly into assets
-	if _, ok := as.assets[k]; !ok {
-		as.assets[k] = asset
+	if _, ok := as.Assets[k]; !ok {
+		as.Assets[k] = asset
+
+		// insert the asset into it's type specific map as well
+		addToConcreteMap(as, k, asset)
 	} else {
-		as.assets[k] = as.assets[k].Add(asset)
+		// possibly creates a new asset type, so we need to update the
+		// concrete type mappings
+		newAsset := as.Assets[k].Add(asset)
+		removeFromConcreteMap(as, k, as.Assets[k])
+
+		// overwrite the existing asset with the new one, and re-add the new
+		// asset to the concrete type mappings
+		as.Assets[k] = newAsset
+		addToConcreteMap(as, k, newAsset)
 	}
 
 	// Expand the window, just to be safe. It's possible that the asset will
 	// be set into the map without expanding it to the AssetSet's window.
-	as.assets[k].ExpandWindow(as.Window)
+	as.Assets[k].ExpandWindow(as.Window)
 
 	return nil
 }
@@ -2764,13 +2911,7 @@ func (as *AssetSet) Insert(asset Asset) error {
 // IsEmpty returns true if the AssetSet is nil, or if it contains
 // zero assets.
 func (as *AssetSet) IsEmpty() bool {
-	if as == nil || len(as.assets) == 0 {
-		return true
-	}
-
-	as.RLock()
-	defer as.RUnlock()
-	return as.assets == nil || len(as.assets) == 0
+	return as == nil || len(as.Assets) == 0
 }
 
 func (as *AssetSet) Length() int {
@@ -2778,18 +2919,7 @@ func (as *AssetSet) Length() int {
 		return 0
 	}
 
-	as.RLock()
-	defer as.RUnlock()
-	return len(as.assets)
-}
-
-// Map clones and returns a map of the AssetSet's Assets
-func (as *AssetSet) Map() map[string]Asset {
-	if as.IsEmpty() {
-		return map[string]Asset{}
-	}
-
-	return as.Clone().assets
+	return len(as.Assets)
 }
 
 // Resolution returns the AssetSet's window duration
@@ -2799,13 +2929,8 @@ func (as *AssetSet) Resolution() time.Duration {
 
 func (as *AssetSet) Set(asset Asset, aggregateBy []string) error {
 	if as.IsEmpty() {
-		as.Lock()
-		as.assets = map[string]Asset{}
-		as.Unlock()
+		as.Assets = map[string]Asset{}
 	}
-
-	as.Lock()
-	defer as.Unlock()
 
 	// Expand the window to match the AssetSet, then set it
 	asset.ExpandWindow(as.Window)
@@ -2813,7 +2938,10 @@ func (as *AssetSet) Set(asset Asset, aggregateBy []string) error {
 	if err != nil {
 		return err
 	}
-	as.assets[k] = asset
+
+	as.Assets[k] = asset
+	addToConcreteMap(as, k, asset)
+
 	return nil
 }
 
@@ -2824,10 +2952,7 @@ func (as *AssetSet) Start() time.Time {
 func (as *AssetSet) TotalCost() float64 {
 	tc := 0.0
 
-	as.Lock()
-	defer as.Unlock()
-
-	for _, a := range as.assets {
+	for _, a := range as.Assets {
 		tc += a.TotalCost()
 	}
 
@@ -2851,9 +2976,9 @@ func (as *AssetSet) accumulate(that *AssetSet) (*AssetSet, error) {
 	// In the case of an AssetSetRange with empty entries, we may end up with
 	// an incoming `as` without an `aggregateBy`, even though we are tring to
 	// aggregate here. This handles that case by assigning the correct `aggregateBy`.
-	if !sameContents(as.aggregateBy, that.aggregateBy) {
-		if len(as.aggregateBy) == 0 {
-			as.aggregateBy = that.aggregateBy
+	if !sameContents(as.AggregationKeys, that.AggregationKeys) {
+		if len(as.AggregationKeys) == 0 {
+			as.AggregationKeys = that.AggregationKeys
 		}
 	}
 
@@ -2874,22 +2999,16 @@ func (as *AssetSet) accumulate(that *AssetSet) (*AssetSet, error) {
 	}
 
 	acc := NewAssetSet(start, end)
-	acc.aggregateBy = as.aggregateBy
+	acc.AggregationKeys = as.AggregationKeys
 
-	as.RLock()
-	defer as.RUnlock()
-
-	that.RLock()
-	defer that.RUnlock()
-
-	for _, asset := range as.assets {
+	for _, asset := range as.Assets {
 		err := acc.Insert(asset)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	for _, asset := range that.assets {
+	for _, asset := range that.Assets {
 		err := acc.Insert(asset)
 		if err != nil {
 			return nil, err
@@ -2926,8 +3045,8 @@ func DiffAsset(before, after *AssetSet, ratioCostChange float64) (map[string]Dif
 
 	changedItems := map[string]Diff[Asset]{}
 
-	for assetKey1, asset1 := range before.assets {
-		if asset2, ok := after.assets[assetKey1]; !ok {
+	for assetKey1, asset1 := range before.Assets {
+		if asset2, ok := after.Assets[assetKey1]; !ok {
 			d := Diff[Asset]{asset1, nil, DiffRemoved}
 			changedItems[assetKey1] = d
 		} else if math.Abs(asset1.TotalCost()-asset2.TotalCost()) > ratioCostChange*asset1.TotalCost() { //check if either value exceeds the other by more than pctCostChange
@@ -2936,8 +3055,8 @@ func DiffAsset(before, after *AssetSet, ratioCostChange float64) (map[string]Dif
 		}
 	}
 
-	for assetKey2, asset2 := range after.assets {
-		if _, ok := before.assets[assetKey2]; !ok {
+	for assetKey2, asset2 := range after.Assets {
+		if _, ok := before.Assets[assetKey2]; !ok {
 			d := Diff[Asset]{nil, asset2, DiffAdded}
 			changedItems[assetKey2] = d
 		}
@@ -2948,11 +3067,10 @@ func DiffAsset(before, after *AssetSet, ratioCostChange float64) (map[string]Dif
 
 // AssetSetRange is a thread-safe slice of AssetSets. It is meant to
 // be used such that the AssetSets held are consecutive and coherent with
-// respect to using the same aggregation properties, UTC offset, and
+// respect to using the same aggregation Properties, UTC offset, and
 // resolution. However these rules are not necessarily enforced, so use wisely.
 type AssetSetRange struct {
-	sync.RWMutex
-	assets    []*AssetSet
+	Assets    []*AssetSet
 	FromStore string // stores the name of the store used to retrieve the data
 }
 
@@ -2960,7 +3078,7 @@ type AssetSetRange struct {
 // AssetSets in the order provided.
 func NewAssetSetRange(assets ...*AssetSet) *AssetSetRange {
 	return &AssetSetRange{
-		assets: assets,
+		Assets: assets,
 	}
 }
 
@@ -2970,10 +3088,7 @@ func (asr *AssetSetRange) Accumulate() (*AssetSet, error) {
 	var assetSet *AssetSet
 	var err error
 
-	asr.RLock()
-	defer asr.RUnlock()
-
-	for _, as := range asr.assets {
+	for _, as := range asr.Assets {
 		assetSet, err = assetSet.accumulate(as)
 		if err != nil {
 			return nil, err
@@ -2989,60 +3104,42 @@ type AssetAggregationOptions struct {
 }
 
 func (asr *AssetSetRange) AggregateBy(aggregateBy []string, opts *AssetAggregationOptions) error {
-	aggRange := &AssetSetRange{assets: []*AssetSet{}}
+	aggRange := &AssetSetRange{Assets: []*AssetSet{}}
 
-	asr.Lock()
-	defer asr.Unlock()
-
-	for _, as := range asr.assets {
+	for _, as := range asr.Assets {
 		err := as.AggregateBy(aggregateBy, opts)
 		if err != nil {
 			return err
 		}
 
-		aggRange.assets = append(aggRange.assets, as)
+		aggRange.Assets = append(aggRange.Assets, as)
 	}
 
-	asr.assets = aggRange.assets
+	asr.Assets = aggRange.Assets
 
 	return nil
 }
 
 func (asr *AssetSetRange) Append(that *AssetSet) {
-	asr.Lock()
-	defer asr.Unlock()
-	asr.assets = append(asr.assets, that)
+	asr.Assets = append(asr.Assets, that)
 }
 
-// Each invokes the given function for each AssetSet in the range
-func (asr *AssetSetRange) Each(f func(int, *AssetSet)) {
-	if asr == nil {
-		return
-	}
-
-	for i, as := range asr.assets {
-		f(i, as)
-	}
-}
-
+// Get provides bounds checked access into the AssetSetRange's AssetSets.
 func (asr *AssetSetRange) Get(i int) (*AssetSet, error) {
-	if i < 0 || i >= len(asr.assets) {
+	if i < 0 || i >= len(asr.Assets) {
 		return nil, fmt.Errorf("AssetSetRange: index out of range: %d", i)
 	}
 
-	asr.RLock()
-	defer asr.RUnlock()
-	return asr.assets[i], nil
+	return asr.Assets[i], nil
 }
 
+// Length returns the total number of AssetSets in the range.
 func (asr *AssetSetRange) Length() int {
-	if asr == nil || asr.assets == nil {
+	if asr == nil {
 		return 0
 	}
 
-	asr.RLock()
-	defer asr.RUnlock()
-	return len(asr.assets)
+	return len(asr.Assets)
 }
 
 // InsertRange merges the given AssetSetRange into the receiving one by
@@ -3058,12 +3155,12 @@ func (asr *AssetSetRange) InsertRange(that *AssetSetRange) error {
 
 	// keys maps window to index in asr
 	keys := map[string]int{}
-	asr.Each(func(i int, as *AssetSet) {
+	for i, as := range asr.Assets {
 		if as == nil {
-			return
+			continue
 		}
 		keys[as.Window.String()] = i
-	})
+	}
 
 	// Nothing to merge, so simply return
 	if len(keys) == 0 {
@@ -3071,32 +3168,32 @@ func (asr *AssetSetRange) InsertRange(that *AssetSetRange) error {
 	}
 
 	var err error
-	that.Each(func(j int, thatAS *AssetSet) {
+	for _, thatAS := range that.Assets {
 		if thatAS == nil || err != nil {
-			return
+			continue
 		}
 
 		// Find matching AssetSet in asr
 		i, ok := keys[thatAS.Window.String()]
 		if !ok {
 			err = fmt.Errorf("cannot merge AssetSet into window that does not exist: %s", thatAS.Window.String())
-			return
+			continue
 		}
 		as, err := asr.Get(i)
 		if err != nil {
 			err = fmt.Errorf("AssetSetRange index does not exist: %d", i)
-			return
+			continue
 		}
 
 		// Insert each Asset from the given set
-		thatAS.Each(func(k string, asset Asset) {
+		for _, asset := range thatAS.Assets {
 			err = as.Insert(asset)
 			if err != nil {
 				err = fmt.Errorf("error inserting asset: %s", err)
-				return
+				continue
 			}
-		})
-	})
+		}
+	}
 
 	// err might be nil
 	return err
@@ -3107,13 +3204,13 @@ func (asr *AssetSetRange) IsEmpty() bool {
 	if asr == nil || asr.Length() == 0 {
 		return true
 	}
-	asr.RLock()
-	defer asr.RUnlock()
-	for _, asset := range asr.assets {
+
+	for _, asset := range asr.Assets {
 		if !asset.IsEmpty() {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -3121,9 +3218,8 @@ func (asr *AssetSetRange) MarshalJSON() ([]byte, error) {
 	if asr == nil {
 		return json.Marshal([]*AssetSet{})
 	}
-	asr.RLock()
-	defer asr.RUnlock()
-	return json.Marshal(asr.assets)
+
+	return json.Marshal(asr.Assets)
 }
 
 // As with AssetSet, AssetSetRange does not serialize all its fields,
@@ -3153,8 +3249,8 @@ func (asr *AssetSetRange) Window() Window {
 		return NewWindow(nil, nil)
 	}
 
-	start := asr.assets[0].Start()
-	end := asr.assets[asr.Length()-1].End()
+	start := asr.Assets[0].Start()
+	end := asr.Assets[asr.Length()-1].End()
 
 	return NewWindow(&start, &end)
 }
@@ -3163,18 +3259,22 @@ func (asr *AssetSetRange) Window() Window {
 // It returns an error if there are no assets
 func (asr *AssetSetRange) Start() (time.Time, error) {
 	start := time.Time{}
+	if asr == nil {
+		return start, fmt.Errorf("had no data to compute a start from")
+	}
+
 	firstStartNotSet := true
-	asr.Each(func(i int, as *AssetSet) {
-		as.Each(func(s string, a Asset) {
+	for _, as := range asr.Assets {
+		for _, a := range as.Assets {
 			if firstStartNotSet {
-				start = a.Start()
+				start = a.GetStart()
 				firstStartNotSet = false
 			}
-			if a.Start().Before(start) {
-				start = a.Start()
+			if a.GetStart().Before(start) {
+				start = a.GetStart()
 			}
-		})
-	})
+		}
+	}
 
 	if firstStartNotSet {
 		return start, fmt.Errorf("had no data to compute a start from")
@@ -3187,18 +3287,22 @@ func (asr *AssetSetRange) Start() (time.Time, error) {
 // It returns an error if there are no assets.
 func (asr *AssetSetRange) End() (time.Time, error) {
 	end := time.Time{}
+	if asr == nil {
+		return end, fmt.Errorf("had no data to compute an end from")
+	}
+
 	firstEndNotSet := true
-	asr.Each(func(i int, as *AssetSet) {
-		as.Each(func(s string, a Asset) {
+	for _, as := range asr.Assets {
+		for _, a := range as.Assets {
 			if firstEndNotSet {
-				end = a.End()
+				end = a.GetEnd()
 				firstEndNotSet = false
 			}
-			if a.End().After(end) {
-				end = a.End()
+			if a.GetEnd().After(end) {
+				end = a.GetEnd()
 			}
-		})
-	})
+		}
+	}
 
 	if firstEndNotSet {
 		return end, fmt.Errorf("had no data to compute an end from")
@@ -3207,14 +3311,57 @@ func (asr *AssetSetRange) End() (time.Time, error) {
 	return end, nil
 }
 
+// Each iterates over all AssetSets in the AssetSetRange and returns the start and end over
+// the entire range
+func (asr *AssetSetRange) StartAndEnd() (time.Time, time.Time, error) {
+	start := time.Time{}
+	end := time.Time{}
+
+	if asr == nil {
+		return start, end, fmt.Errorf("had no data to compute a start and end from")
+	}
+
+	firstStartNotSet := true
+	firstEndNotSet := true
+
+	for _, as := range asr.Assets {
+		for _, a := range as.Assets {
+			if firstStartNotSet {
+				start = a.GetStart()
+				firstStartNotSet = false
+			}
+			if a.GetStart().Before(start) {
+				start = a.GetStart()
+			}
+			if firstEndNotSet {
+				end = a.GetEnd()
+				firstEndNotSet = false
+			}
+			if a.GetEnd().After(end) {
+				end = a.GetEnd()
+			}
+		}
+	}
+
+	if firstStartNotSet {
+		return start, end, fmt.Errorf("had no data to compute a start from")
+	}
+
+	if firstEndNotSet {
+		return start, end, fmt.Errorf("had no data to compute an end from")
+	}
+
+	return start, end, nil
+}
+
 // Minutes returns the duration, in minutes, between the earliest start
 // and the latest end of all assets in the AssetSetRange.
 func (asr *AssetSetRange) Minutes() float64 {
-	start, err := asr.Start()
-	if err != nil {
+	if asr == nil {
 		return 0
 	}
-	end, err := asr.End()
+
+	start, end, err := asr.StartAndEnd()
 	if err != nil {
 		return 0
 	}
@@ -3230,11 +3377,8 @@ func (asr *AssetSetRange) TotalCost() float64 {
 		return 0.0
 	}
 
-	asr.RLock()
-	defer asr.RUnlock()
-
 	tc := 0.0
-	for _, as := range asr.assets {
+	for _, as := range asr.Assets {
 		tc += as.TotalCost()
 	}
 

--- a/pkg/kubecost/asset_json.go
+++ b/pkg/kubecost/asset_json.go
@@ -16,13 +16,13 @@ import (
 // MarshalJSON implements json.Marshaler
 func (a *Any) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
-	jsonEncode(buffer, "properties", a.Properties(), ",")
-	jsonEncode(buffer, "labels", a.Labels(), ",")
-	jsonEncode(buffer, "window", a.Window(), ",")
-	jsonEncodeString(buffer, "start", a.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", a.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", a.Properties, ",")
+	jsonEncode(buffer, "labels", a.Labels, ",")
+	jsonEncode(buffer, "window", a.Window, ",")
+	jsonEncodeString(buffer, "start", a.Start.Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", a.End.Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", a.Minutes(), ",")
-	jsonEncodeFloat64(buffer, "adjustment", a.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", a.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "totalCost", a.TotalCost(), "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
@@ -70,20 +70,20 @@ func (a *Any) InterfaceToAny(itf interface{}) error {
 		return err
 	}
 
-	a.properties = &properties
-	a.labels = labels
-	a.start = start
-	a.end = end
-	a.window = Window{
+	a.Properties = &properties
+	a.Labels = labels
+	a.Start = start
+	a.End = end
+	a.Window = Window{
 		start: &start,
 		end:   &end,
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
-		a.adjustment = adjustment.(float64)
+		a.Adjustment = adjustment.(float64)
 	}
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
-		a.Cost = Cost.(float64) - a.adjustment
+		a.Cost = Cost.(float64) - a.Adjustment
 	}
 
 	return nil
@@ -95,13 +95,13 @@ func (a *Any) InterfaceToAny(itf interface{}) error {
 func (ca *Cloud) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", ca.Type().String(), ",")
-	jsonEncode(buffer, "properties", ca.Properties(), ",")
-	jsonEncode(buffer, "labels", ca.Labels(), ",")
-	jsonEncode(buffer, "window", ca.Window(), ",")
-	jsonEncodeString(buffer, "start", ca.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", ca.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", ca.Properties, ",")
+	jsonEncode(buffer, "labels", ca.Labels, ",")
+	jsonEncode(buffer, "window", ca.Window, ",")
+	jsonEncodeString(buffer, "start", ca.Start.Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", ca.End.Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", ca.Minutes(), ",")
-	jsonEncodeFloat64(buffer, "adjustment", ca.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", ca.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "credit", ca.Credit, ",")
 	jsonEncodeFloat64(buffer, "totalCost", ca.TotalCost(), "")
 	buffer.WriteString("}")
@@ -150,23 +150,23 @@ func (ca *Cloud) InterfaceToCloud(itf interface{}) error {
 		return err
 	}
 
-	ca.properties = &properties
-	ca.labels = labels
-	ca.start = start
-	ca.end = end
-	ca.window = Window{
+	ca.Properties = &properties
+	ca.Labels = labels
+	ca.Start = start
+	ca.End = end
+	ca.Window = Window{
 		start: &start,
 		end:   &end,
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
-		ca.adjustment = adjustment.(float64)
+		ca.Adjustment = adjustment.(float64)
 	}
 	if Credit, err := getTypedVal(fmap["credit"]); err == nil {
 		ca.Credit = Credit.(float64)
 	}
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
-		ca.Cost = Cost.(float64) - ca.adjustment - ca.Credit
+		ca.Cost = Cost.(float64) - ca.Adjustment - ca.Credit
 	}
 
 	return nil
@@ -178,11 +178,11 @@ func (ca *Cloud) InterfaceToCloud(itf interface{}) error {
 func (cm *ClusterManagement) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", cm.Type().String(), ",")
-	jsonEncode(buffer, "properties", cm.Properties(), ",")
-	jsonEncode(buffer, "labels", cm.Labels(), ",")
-	jsonEncode(buffer, "window", cm.Window(), ",")
-	jsonEncodeString(buffer, "start", cm.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", cm.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", cm.Properties, ",")
+	jsonEncode(buffer, "labels", cm.Labels, ",")
+	jsonEncode(buffer, "window", cm.Window, ",")
+	jsonEncodeString(buffer, "start", cm.GetStart().Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", cm.GetEnd().Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", cm.Minutes(), ",")
 	jsonEncodeFloat64(buffer, "totalCost", cm.TotalCost(), "")
 	buffer.WriteString("}")
@@ -231,9 +231,9 @@ func (cm *ClusterManagement) InterfaceToClusterManagement(itf interface{}) error
 		return err
 	}
 
-	cm.properties = &properties
-	cm.labels = labels
-	cm.window = Window{
+	cm.Properties = &properties
+	cm.Labels = labels
+	cm.Window = Window{
 		start: &start,
 		end:   &end,
 	}
@@ -251,16 +251,16 @@ func (cm *ClusterManagement) InterfaceToClusterManagement(itf interface{}) error
 func (d *Disk) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", d.Type().String(), ",")
-	jsonEncode(buffer, "properties", d.Properties(), ",")
-	jsonEncode(buffer, "labels", d.Labels(), ",")
-	jsonEncode(buffer, "window", d.Window(), ",")
-	jsonEncodeString(buffer, "start", d.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", d.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", d.Properties, ",")
+	jsonEncode(buffer, "labels", d.Labels, ",")
+	jsonEncode(buffer, "window", d.Window, ",")
+	jsonEncodeString(buffer, "start", d.Start.Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", d.End.Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", d.Minutes(), ",")
 	jsonEncodeFloat64(buffer, "byteHours", d.ByteHours, ",")
 	jsonEncodeFloat64(buffer, "bytes", d.Bytes(), ",")
 	jsonEncode(buffer, "breakdown", d.Breakdown, ",")
-	jsonEncodeFloat64(buffer, "adjustment", d.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", d.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "totalCost", d.TotalCost(), "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
@@ -312,21 +312,21 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 
 	breakdown := toBreakdown(fbreakdown)
 
-	d.properties = &properties
-	d.labels = labels
-	d.start = start
-	d.end = end
-	d.window = Window{
+	d.Properties = &properties
+	d.Labels = labels
+	d.Start = start
+	d.End = end
+	d.Window = Window{
 		start: &start,
 		end:   &end,
 	}
 	d.Breakdown = &breakdown
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
-		d.adjustment = adjustment.(float64)
+		d.Adjustment = adjustment.(float64)
 	}
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
-		d.Cost = Cost.(float64) - d.adjustment
+		d.Cost = Cost.(float64) - d.Adjustment
 	}
 	if ByteHours, err := getTypedVal(fmap["byteHours"]); err == nil {
 		d.ByteHours = ByteHours.(float64)
@@ -347,13 +347,13 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 func (n *Network) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", n.Type().String(), ",")
-	jsonEncode(buffer, "properties", n.Properties(), ",")
-	jsonEncode(buffer, "labels", n.Labels(), ",")
-	jsonEncode(buffer, "window", n.Window(), ",")
-	jsonEncodeString(buffer, "start", n.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", n.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", n.Properties, ",")
+	jsonEncode(buffer, "labels", n.Labels, ",")
+	jsonEncode(buffer, "window", n.Window, ",")
+	jsonEncodeString(buffer, "start", n.Start.Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", n.End.Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", n.Minutes(), ",")
-	jsonEncodeFloat64(buffer, "adjustment", n.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", n.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "totalCost", n.TotalCost(), "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
@@ -401,20 +401,20 @@ func (n *Network) InterfaceToNetwork(itf interface{}) error {
 		return err
 	}
 
-	n.properties = &properties
-	n.labels = labels
-	n.start = start
-	n.end = end
-	n.window = Window{
+	n.Properties = &properties
+	n.Labels = labels
+	n.Start = start
+	n.End = end
+	n.Window = Window{
 		start: &start,
 		end:   &end,
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
-		n.adjustment = adjustment.(float64)
+		n.Adjustment = adjustment.(float64)
 	}
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
-		n.Cost = Cost.(float64) - n.adjustment
+		n.Cost = Cost.(float64) - n.Adjustment
 	}
 
 	return nil
@@ -427,11 +427,11 @@ func (n *Network) InterfaceToNetwork(itf interface{}) error {
 func (n *Node) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", n.Type().String(), ",")
-	jsonEncode(buffer, "properties", n.Properties(), ",")
-	jsonEncode(buffer, "labels", n.Labels(), ",")
-	jsonEncode(buffer, "window", n.Window(), ",")
-	jsonEncodeString(buffer, "start", n.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", n.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", n.Properties, ",")
+	jsonEncode(buffer, "labels", n.Labels, ",")
+	jsonEncode(buffer, "window", n.Window, ",")
+	jsonEncodeString(buffer, "start", n.Start.Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", n.End.Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", n.Minutes(), ",")
 	jsonEncodeString(buffer, "nodeType", n.NodeType, ",")
 	jsonEncodeFloat64(buffer, "cpuCores", n.CPUCores(), ",")
@@ -447,7 +447,7 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "gpuCost", n.GPUCost, ",")
 	jsonEncodeFloat64(buffer, "gpuCount", n.GPUs(), ",")
 	jsonEncodeFloat64(buffer, "ramCost", n.RAMCost, ",")
-	jsonEncodeFloat64(buffer, "adjustment", n.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", n.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "totalCost", n.TotalCost(), "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
@@ -501,11 +501,11 @@ func (n *Node) InterfaceToNode(itf interface{}) error {
 	cpuBreakdown := toBreakdown(fcpuBreakdown)
 	ramBreakdown := toBreakdown(framBreakdown)
 
-	n.properties = &properties
-	n.labels = labels
-	n.start = start
-	n.end = end
-	n.window = Window{
+	n.Properties = &properties
+	n.Labels = labels
+	n.Start = start
+	n.End = end
+	n.Window = Window{
 		start: &start,
 		end:   &end,
 	}
@@ -513,7 +513,7 @@ func (n *Node) InterfaceToNode(itf interface{}) error {
 	n.RAMBreakdown = &ramBreakdown
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
-		n.adjustment = adjustment.(float64)
+		n.Adjustment = adjustment.(float64)
 	}
 	if NodeType, err := getTypedVal(fmap["nodeType"]); err == nil {
 		n.NodeType = NodeType.(string)
@@ -555,13 +555,13 @@ func (n *Node) InterfaceToNode(itf interface{}) error {
 func (lb *LoadBalancer) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", lb.Type().String(), ",")
-	jsonEncode(buffer, "properties", lb.Properties(), ",")
-	jsonEncode(buffer, "labels", lb.Labels(), ",")
-	jsonEncode(buffer, "window", lb.Window(), ",")
-	jsonEncodeString(buffer, "start", lb.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", lb.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", lb.Properties, ",")
+	jsonEncode(buffer, "labels", lb.Labels, ",")
+	jsonEncode(buffer, "window", lb.Window, ",")
+	jsonEncodeString(buffer, "start", lb.Start.Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", lb.End.Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", lb.Minutes(), ",")
-	jsonEncodeFloat64(buffer, "adjustment", lb.Adjustment(), ",")
+	jsonEncodeFloat64(buffer, "adjustment", lb.Adjustment, ",")
 	jsonEncodeFloat64(buffer, "totalCost", lb.TotalCost(), "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
@@ -609,20 +609,20 @@ func (lb *LoadBalancer) InterfaceToLoadBalancer(itf interface{}) error {
 		return err
 	}
 
-	lb.properties = &properties
-	lb.labels = labels
-	lb.start = start
-	lb.end = end
-	lb.window = Window{
+	lb.Properties = &properties
+	lb.Labels = labels
+	lb.Start = start
+	lb.End = end
+	lb.Window = Window{
 		start: &start,
 		end:   &end,
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
-		lb.adjustment = adjustment.(float64)
+		lb.Adjustment = adjustment.(float64)
 	}
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
-		lb.Cost = Cost.(float64) - lb.adjustment
+		lb.Cost = Cost.(float64) - lb.Adjustment
 	}
 
 	return nil
@@ -635,13 +635,11 @@ func (lb *LoadBalancer) InterfaceToLoadBalancer(itf interface{}) error {
 func (sa *SharedAsset) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	jsonEncodeString(buffer, "type", sa.Type().String(), ",")
-	jsonEncode(buffer, "properties", sa.Properties(), ",")
-	jsonEncode(buffer, "labels", sa.Labels(), ",")
-	jsonEncode(buffer, "properties", sa.Properties(), ",")
-	jsonEncode(buffer, "labels", sa.Labels(), ",")
-	jsonEncode(buffer, "window", sa.Window(), ",")
-	jsonEncodeString(buffer, "start", sa.Start().Format(time.RFC3339), ",")
-	jsonEncodeString(buffer, "end", sa.End().Format(time.RFC3339), ",")
+	jsonEncode(buffer, "properties", sa.Properties, ",")
+	jsonEncode(buffer, "labels", sa.Labels, ",")
+	jsonEncode(buffer, "window", sa.Window, ",")
+	jsonEncodeString(buffer, "start", sa.GetStart().Format(time.RFC3339), ",")
+	jsonEncodeString(buffer, "end", sa.GetEnd().Format(time.RFC3339), ",")
 	jsonEncodeFloat64(buffer, "minutes", sa.Minutes(), ",")
 	jsonEncodeFloat64(buffer, "totalCost", sa.TotalCost(), "")
 	buffer.WriteString("}")
@@ -690,9 +688,9 @@ func (sa *SharedAsset) InterfaceToSharedAsset(itf interface{}) error {
 		return err
 	}
 
-	sa.properties = &properties
-	sa.labels = labels
-	sa.window = Window{
+	sa.Properties = &properties
+	sa.Labels = labels
+	sa.Window = Window{
 		start: &start,
 		end:   &end,
 	}
@@ -712,9 +710,8 @@ func (as *AssetSet) MarshalJSON() ([]byte, error) {
 	if as == nil {
 		return json.Marshal(map[string]Asset{})
 	}
-	as.RLock()
-	defer as.RUnlock()
-	return json.Marshal(as.assets)
+
+	return json.Marshal(as.Assets)
 }
 
 // AssetSetResponse for unmarshaling of AssetSet.assets into AssetSet

--- a/pkg/kubecost/asset_json_test.go
+++ b/pkg/kubecost/asset_json_test.go
@@ -35,22 +35,22 @@ func TestAny_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial Any equal those in Any from unmarshal
-	if !any1.properties.Equal(any2.properties) {
+	if !any1.Properties.Equal(any2.Properties) {
 		t.Fatalf("Any Unmarshal: properties mutated in unmarshal")
 	}
-	if !any1.labels.Equal(any2.labels) {
+	if !any1.Labels.Equal(any2.Labels) {
 		t.Fatalf("Any Unmarshal: labels mutated in unmarshal")
 	}
-	if !any1.window.Equal(any2.window) {
+	if !any1.Window.Equal(any2.Window) {
 		t.Fatalf("Any Unmarshal: window mutated in unmarshal")
 	}
-	if !any1.start.Equal(any2.start) {
+	if !any1.Start.Equal(any2.Start) {
 		t.Fatalf("Any Unmarshal: start mutated in unmarshal")
 	}
-	if !any1.end.Equal(any2.end) {
+	if !any1.End.Equal(any2.End) {
 		t.Fatalf("Any Unmarshal: end mutated in unmarshal")
 	}
-	if any1.adjustment != any2.adjustment {
+	if any1.Adjustment != any2.Adjustment {
 		t.Fatalf("Any Unmarshal: adjustment mutated in unmarshal")
 	}
 	if any1.Cost != any2.Cost {
@@ -88,22 +88,22 @@ func TestCloud_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial Cloud equal those in Cloud from unmarshal
-	if !cloud1.properties.Equal(cloud2.properties) {
+	if !cloud1.Properties.Equal(cloud2.Properties) {
 		t.Fatalf("Cloud Unmarshal: properties mutated in unmarshal")
 	}
-	if !cloud1.labels.Equal(cloud2.labels) {
+	if !cloud1.Labels.Equal(cloud2.Labels) {
 		t.Fatalf("Cloud Unmarshal: labels mutated in unmarshal")
 	}
-	if !cloud1.window.Equal(cloud2.window) {
+	if !cloud1.Window.Equal(cloud2.Window) {
 		t.Fatalf("Cloud Unmarshal: window mutated in unmarshal")
 	}
-	if !cloud1.start.Equal(cloud2.start) {
+	if !cloud1.Start.Equal(cloud2.Start) {
 		t.Fatalf("Cloud Unmarshal: start mutated in unmarshal")
 	}
-	if !cloud1.end.Equal(cloud2.end) {
+	if !cloud1.End.Equal(cloud2.End) {
 		t.Fatalf("Cloud Unmarshal: end mutated in unmarshal")
 	}
-	if cloud1.adjustment != cloud2.adjustment {
+	if cloud1.Adjustment != cloud2.Adjustment {
 		t.Fatalf("Cloud Unmarshal: adjustment mutated in unmarshal")
 	}
 	if cloud1.Cost != cloud2.Cost {
@@ -138,13 +138,13 @@ func TestClusterManagement_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial ClusterManagement equal those in ClusterManagement from unmarshal
-	if !cm1.properties.Equal(cm2.properties) {
+	if !cm1.Properties.Equal(cm2.Properties) {
 		t.Fatalf("ClusterManagement Unmarshal: properties mutated in unmarshal")
 	}
-	if !cm1.labels.Equal(cm2.labels) {
+	if !cm1.Labels.Equal(cm2.Labels) {
 		t.Fatalf("ClusterManagement Unmarshal: labels mutated in unmarshal")
 	}
-	if !cm1.window.Equal(cm2.window) {
+	if !cm1.Window.Equal(cm2.Window) {
 		t.Fatalf("ClusterManagement Unmarshal: window mutated in unmarshal")
 	}
 	if cm1.Cost != cm2.Cost {
@@ -187,25 +187,25 @@ func TestDisk_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial Disk equal those in Disk from unmarshal
-	if !disk1.properties.Equal(disk2.properties) {
+	if !disk1.Properties.Equal(disk2.Properties) {
 		t.Fatalf("Disk Unmarshal: properties mutated in unmarshal")
 	}
-	if !disk1.labels.Equal(disk2.labels) {
+	if !disk1.Labels.Equal(disk2.Labels) {
 		t.Fatalf("Disk Unmarshal: labels mutated in unmarshal")
 	}
-	if !disk1.window.Equal(disk2.window) {
+	if !disk1.Window.Equal(disk2.Window) {
 		t.Fatalf("Disk Unmarshal: window mutated in unmarshal")
 	}
 	if !disk1.Breakdown.Equal(disk2.Breakdown) {
 		t.Fatalf("Disk Unmarshal: Breakdown mutated in unmarshal")
 	}
-	if !disk1.start.Equal(disk2.start) {
+	if !disk1.Start.Equal(disk2.Start) {
 		t.Fatalf("Disk Unmarshal: start mutated in unmarshal")
 	}
-	if !disk1.end.Equal(disk2.end) {
+	if !disk1.End.Equal(disk2.End) {
 		t.Fatalf("Disk Unmarshal: end mutated in unmarshal")
 	}
-	if disk1.adjustment != disk2.adjustment {
+	if disk1.Adjustment != disk2.Adjustment {
 		t.Fatalf("Disk Unmarshal: adjustment mutated in unmarshal")
 	}
 	if disk1.ByteHours != disk2.ByteHours {
@@ -241,22 +241,22 @@ func TestNetwork_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial Network equal those in Network from unmarshal
-	if !network1.properties.Equal(network2.properties) {
+	if !network1.Properties.Equal(network2.Properties) {
 		t.Fatalf("Network Unmarshal: properties mutated in unmarshal")
 	}
-	if !network1.labels.Equal(network2.labels) {
+	if !network1.Labels.Equal(network2.Labels) {
 		t.Fatalf("Network Unmarshal: labels mutated in unmarshal")
 	}
-	if !network1.window.Equal(network2.window) {
+	if !network1.Window.Equal(network2.Window) {
 		t.Fatalf("Network Unmarshal: window mutated in unmarshal")
 	}
-	if !network1.start.Equal(network2.start) {
+	if !network1.Start.Equal(network2.Start) {
 		t.Fatalf("Network Unmarshal: start mutated in unmarshal")
 	}
-	if !network1.end.Equal(network2.end) {
+	if !network1.End.Equal(network2.End) {
 		t.Fatalf("Network Unmarshal: end mutated in unmarshal")
 	}
-	if network1.adjustment != network2.adjustment {
+	if network1.Adjustment != network2.Adjustment {
 		t.Fatalf("Network Unmarshal: adjustment mutated in unmarshal")
 	}
 	if network1.Cost != network2.Cost {
@@ -309,13 +309,13 @@ func TestNode_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial Node equal those in Node from unmarshal
-	if !node1.properties.Equal(node2.properties) {
+	if !node1.Properties.Equal(node2.Properties) {
 		t.Fatalf("Node Unmarshal: properties mutated in unmarshal")
 	}
-	if !node1.labels.Equal(node2.labels) {
+	if !node1.Labels.Equal(node2.Labels) {
 		t.Fatalf("Node Unmarshal: labels mutated in unmarshal")
 	}
-	if !node1.window.Equal(node2.window) {
+	if !node1.Window.Equal(node2.Window) {
 		t.Fatalf("Node Unmarshal: window mutated in unmarshal")
 	}
 	if !node1.CPUBreakdown.Equal(node2.CPUBreakdown) {
@@ -324,13 +324,13 @@ func TestNode_Unmarshal(t *testing.T) {
 	if !node1.RAMBreakdown.Equal(node2.RAMBreakdown) {
 		t.Fatalf("Node Unmarshal: RAMBreakdown mutated in unmarshal")
 	}
-	if !node1.start.Equal(node2.start) {
+	if !node1.Start.Equal(node2.Start) {
 		t.Fatalf("Node Unmarshal: start mutated in unmarshal")
 	}
-	if !node1.end.Equal(node2.end) {
+	if !node1.End.Equal(node2.End) {
 		t.Fatalf("Node Unmarshal: end mutated in unmarshal")
 	}
-	if node1.adjustment != node2.adjustment {
+	if node1.Adjustment != node2.Adjustment {
 		t.Fatalf("Node Unmarshal: adjustment mutated in unmarshal")
 	}
 	if node1.NodeType != node2.NodeType {
@@ -390,22 +390,22 @@ func TestLoadBalancer_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial LoadBalancer equal those in LoadBalancer from unmarshal
-	if !lb1.properties.Equal(lb2.properties) {
+	if !lb1.Properties.Equal(lb2.Properties) {
 		t.Fatalf("LoadBalancer Unmarshal: properties mutated in unmarshal")
 	}
-	if !lb1.labels.Equal(lb2.labels) {
+	if !lb1.Labels.Equal(lb2.Labels) {
 		t.Fatalf("LoadBalancer Unmarshal: labels mutated in unmarshal")
 	}
-	if !lb1.window.Equal(lb2.window) {
+	if !lb1.Window.Equal(lb2.Window) {
 		t.Fatalf("LoadBalancer Unmarshal: window mutated in unmarshal")
 	}
-	if !lb1.start.Equal(lb2.start) {
+	if !lb1.Start.Equal(lb2.Start) {
 		t.Fatalf("LoadBalancer Unmarshal: start mutated in unmarshal")
 	}
-	if !lb1.end.Equal(lb2.end) {
+	if !lb1.End.Equal(lb2.End) {
 		t.Fatalf("LoadBalancer Unmarshal: end mutated in unmarshal")
 	}
-	if lb1.adjustment != lb2.adjustment {
+	if lb1.Adjustment != lb2.Adjustment {
 		t.Fatalf("LoadBalancer Unmarshal: adjustment mutated in unmarshal")
 	}
 	if lb1.Cost != lb2.Cost {
@@ -437,13 +437,13 @@ func TestSharedAsset_Unmarshal(t *testing.T) {
 	}
 
 	// Check if all fields in initial SharedAsset equal those in SharedAsset from unmarshal
-	if !sa1.properties.Equal(sa2.properties) {
+	if !sa1.Properties.Equal(sa2.Properties) {
 		t.Fatalf("SharedAsset Unmarshal: properties mutated in unmarshal")
 	}
-	if !sa1.labels.Equal(sa2.labels) {
+	if !sa1.Labels.Equal(sa2.Labels) {
 		t.Fatalf("SharedAsset Unmarshal: labels mutated in unmarshal")
 	}
-	if !sa1.window.Equal(sa2.window) {
+	if !sa1.Window.Equal(sa2.Window) {
 		t.Fatalf("SharedAsset Unmarshal: window mutated in unmarshal")
 	}
 	if sa1.Cost != sa2.Cost {
@@ -488,7 +488,7 @@ func TestAssetset_Unmarshal(t *testing.T) {
 	}
 
 	// For each asset in unmarshaled AssetSetResponse, check if it is equal to the corresponding AssetSet asset
-	for key, asset := range assetset.assets {
+	for key, asset := range assetset.Assets {
 
 		if unmarshaledAsset, exists := assetUnmarshalResponse.Assets[key]; exists {
 
@@ -500,23 +500,23 @@ func TestAssetset_Unmarshal(t *testing.T) {
 					asset, _ := asset.(*Disk)
 					unmarshaledAsset, _ := unmarshaledAsset.(*Disk)
 
-					if !asset.Labels().Equal(unmarshaledAsset.Labels()) {
+					if !asset.GetLabels().Equal(unmarshaledAsset.Labels) {
 						return false
 					}
-					if !asset.Properties().Equal(unmarshaledAsset.Properties()) {
+					if !asset.Properties.Equal(unmarshaledAsset.Properties) {
 						return false
 					}
 
-					if !asset.Start().Equal(unmarshaledAsset.Start()) {
+					if !asset.GetStart().Equal(unmarshaledAsset.Start) {
 						return false
 					}
-					if !asset.End().Equal(unmarshaledAsset.End()) {
+					if !asset.End.Equal(unmarshaledAsset.End) {
 						return false
 					}
-					if !asset.window.Equal(unmarshaledAsset.window) {
+					if !asset.Window.Equal(unmarshaledAsset.Window) {
 						return false
 					}
-					if asset.adjustment != unmarshaledAsset.adjustment {
+					if asset.Adjustment != unmarshaledAsset.Adjustment {
 						return false
 					}
 					if asset.Cost != unmarshaledAsset.Cost {

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -31,25 +31,25 @@ func assertAssetSet(t *testing.T, as *AssetSet, msg string, window Window, exps 
 	if !as.Window.Equal(window) {
 		t.Fatalf("AssetSet.AggregateBy[%s]: expected window %s, actual %s", msg, window, as.Window)
 	}
-	as.Each(func(key string, a Asset) {
+	for key, a := range as.Assets {
 		if exp, ok := exps[key]; ok {
 			if math.Round(a.TotalCost()*100) != math.Round(exp*100) {
 				t.Fatalf("AssetSet.AggregateBy[%s]: key %s expected total cost %.2f, actual %.2f", msg, key, exp, a.TotalCost())
 			}
-			if !a.Window().Equal(window) {
-				t.Fatalf("AssetSet.AggregateBy[%s]: key %s expected window %s, actual %s", msg, key, window, a.Window())
+			if !a.GetWindow().Equal(window) {
+				t.Fatalf("AssetSet.AggregateBy[%s]: key %s expected window %s, actual %s", msg, key, window, a.GetWindow())
 			}
 		} else {
 			t.Fatalf("AssetSet.AggregateBy[%s]: unexpected asset: %s", msg, key)
 		}
-	})
+	}
 }
 
 func printAssetSet(msg string, as *AssetSet) {
 	fmt.Printf("--- %s ---\n", msg)
-	as.Each(func(key string, a Asset) {
+	for key, a := range as.Assets {
 		fmt.Printf(" > %s: %s\n", key, a)
-	})
+	}
 }
 
 func TestAny_Add(t *testing.T) {
@@ -77,34 +77,34 @@ func TestAny_Add(t *testing.T) {
 	if any3.TotalCost() != 15.0 {
 		t.Fatalf("Any.Add: expected %f; got %f", 15.0, any3.TotalCost())
 	}
-	if any3.Adjustment() != 2.0 {
-		t.Fatalf("Any.Add: expected %f; got %f", 2.0, any3.Adjustment())
+	if any3.GetAdjustment() != 2.0 {
+		t.Fatalf("Any.Add: expected %f; got %f", 2.0, any3.GetAdjustment())
 	}
-	if any3.Properties().Cluster != "cluster1" {
-		t.Fatalf("Any.Add: expected %s; got %s", "cluster1", any3.Properties().Cluster)
+	if any3.GetProperties().Cluster != "cluster1" {
+		t.Fatalf("Any.Add: expected %s; got %s", "cluster1", any3.GetProperties().Cluster)
 	}
 	if any3.Type() != AnyAssetType {
 		t.Fatalf("Any.Add: expected %s; got %s", AnyAssetType, any3.Type())
 	}
-	if any3.Properties().ProviderID != "" {
-		t.Fatalf("Any.Add: expected %s; got %s", "", any3.Properties().ProviderID)
+	if any3.GetProperties().ProviderID != "" {
+		t.Fatalf("Any.Add: expected %s; got %s", "", any3.GetProperties().ProviderID)
 	}
-	if any3.Properties().Name != "" {
-		t.Fatalf("Any.Add: expected %s; got %s", "", any3.Properties().Name)
+	if any3.GetProperties().Name != "" {
+		t.Fatalf("Any.Add: expected %s; got %s", "", any3.GetProperties().Name)
 	}
 
 	// Check that the original assets are unchanged
 	if any1.TotalCost() != 10.0 {
 		t.Fatalf("Any.Add: expected %f; got %f", 10.0, any1.TotalCost())
 	}
-	if any1.Adjustment() != 1.0 {
-		t.Fatalf("Any.Add: expected %f; got %f", 1.0, any1.Adjustment())
+	if any1.Adjustment != 1.0 {
+		t.Fatalf("Any.Add: expected %f; got %f", 1.0, any1.Adjustment)
 	}
 	if any2.TotalCost() != 5.0 {
 		t.Fatalf("Any.Add: expected %f; got %f", 5.0, any2.TotalCost())
 	}
-	if any2.Adjustment() != 1.0 {
-		t.Fatalf("Any.Add: expected %f; got %f", 1.0, any2.Adjustment())
+	if any2.Adjustment != 1.0 {
+		t.Fatalf("Any.Add: expected %f; got %f", 1.0, any2.Adjustment)
 	}
 }
 
@@ -127,8 +127,8 @@ func TestAny_Clone(t *testing.T) {
 	if any2.TotalCost() != 10.0 {
 		t.Fatalf("Any.Clone: expected %f; got %f", 10.0, any2.TotalCost())
 	}
-	if any2.Adjustment() != 1.0 {
-		t.Fatalf("Any.Clone: expected %f; got %f", 1.0, any2.Adjustment())
+	if any2.GetAdjustment() != 1.0 {
+		t.Fatalf("Any.Clone: expected %f; got %f", 1.0, any2.GetAdjustment())
 	}
 }
 
@@ -194,20 +194,20 @@ func TestDisk_Add(t *testing.T) {
 	if diskT.TotalCost() != 15.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 15.0, diskT.TotalCost())
 	}
-	if diskT.Adjustment() != 2.0 {
-		t.Fatalf("Disk.Add: expected %f; got %f", 2.0, diskT.Adjustment())
+	if diskT.Adjustment != 2.0 {
+		t.Fatalf("Disk.Add: expected %f; got %f", 2.0, diskT.Adjustment)
 	}
-	if diskT.Properties().Cluster != "cluster1" {
-		t.Fatalf("Disk.Add: expected %s; got %s", "cluster1", diskT.Properties().Cluster)
+	if diskT.Properties.Cluster != "cluster1" {
+		t.Fatalf("Disk.Add: expected %s; got %s", "cluster1", diskT.Properties.Cluster)
 	}
 	if diskT.Type() != DiskAssetType {
 		t.Fatalf("Disk.Add: expected %s; got %s", AnyAssetType, diskT.Type())
 	}
-	if diskT.Properties().ProviderID != "" {
-		t.Fatalf("Disk.Add: expected %s; got %s", "", diskT.Properties().ProviderID)
+	if diskT.Properties.ProviderID != "" {
+		t.Fatalf("Disk.Add: expected %s; got %s", "", diskT.Properties.ProviderID)
 	}
-	if diskT.Properties().Name != "" {
-		t.Fatalf("Disk.Add: expected %s; got %s", "", diskT.Properties().Name)
+	if diskT.Properties.Name != "" {
+		t.Fatalf("Disk.Add: expected %s; got %s", "", diskT.Properties.Name)
 	}
 	if diskT.Bytes() != 160.0*gb {
 		t.Fatalf("Disk.Add: expected %f; got %f", 160.0*gb, diskT.Bytes())
@@ -220,8 +220,8 @@ func TestDisk_Add(t *testing.T) {
 	if disk1.TotalCost() != 10.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 10.0, disk1.TotalCost())
 	}
-	if disk1.Adjustment() != 1.0 {
-		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, disk1.Adjustment())
+	if disk1.Adjustment != 1.0 {
+		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, disk1.Adjustment)
 	}
 	if disk1.Local != 0.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 0.0, disk1.Local)
@@ -229,8 +229,8 @@ func TestDisk_Add(t *testing.T) {
 	if disk2.TotalCost() != 5.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 5.0, disk2.TotalCost())
 	}
-	if disk2.Adjustment() != 1.0 {
-		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, disk2.Adjustment())
+	if disk2.Adjustment != 1.0 {
+		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, disk2.Adjustment)
 	}
 	if disk2.Local != 1.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, disk2.Local)
@@ -274,20 +274,20 @@ func TestDisk_Add(t *testing.T) {
 	if diskAT.TotalCost() != 20.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 20.0, diskAT.TotalCost())
 	}
-	if diskAT.Adjustment() != 2.0 {
-		t.Fatalf("Disk.Add: expected %f; got %f", 2.0, diskAT.Adjustment())
+	if diskAT.Adjustment != 2.0 {
+		t.Fatalf("Disk.Add: expected %f; got %f", 2.0, diskAT.Adjustment)
 	}
-	if diskAT.Properties().Cluster != "cluster1" {
-		t.Fatalf("Disk.Add: expected %s; got %s", "cluster1", diskAT.Properties().Cluster)
+	if diskAT.Properties.Cluster != "cluster1" {
+		t.Fatalf("Disk.Add: expected %s; got %s", "cluster1", diskAT.Properties.Cluster)
 	}
 	if diskAT.Type() != DiskAssetType {
 		t.Fatalf("Disk.Add: expected %s; got %s", AnyAssetType, diskAT.Type())
 	}
-	if diskAT.Properties().ProviderID != "" {
-		t.Fatalf("Disk.Add: expected %s; got %s", "", diskAT.Properties().ProviderID)
+	if diskAT.Properties.ProviderID != "" {
+		t.Fatalf("Disk.Add: expected %s; got %s", "", diskAT.Properties.ProviderID)
 	}
-	if diskAT.Properties().Name != "" {
-		t.Fatalf("Disk.Add: expected %s; got %s", "", diskAT.Properties().Name)
+	if diskAT.Properties.Name != "" {
+		t.Fatalf("Disk.Add: expected %s; got %s", "", diskAT.Properties.Name)
 	}
 	if diskAT.Bytes() != 100.0*gb {
 		t.Fatalf("Disk.Add: expected %f; got %f", 100.0*gb, diskT.Bytes())
@@ -300,8 +300,8 @@ func TestDisk_Add(t *testing.T) {
 	if diskA1.TotalCost() != 10.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 10.0, diskA1.TotalCost())
 	}
-	if diskA1.Adjustment() != 1.0 {
-		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, diskA1.Adjustment())
+	if diskA1.Adjustment != 1.0 {
+		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, diskA1.Adjustment)
 	}
 	if diskA1.Local != 0.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 0.0, diskA1.Local)
@@ -309,8 +309,8 @@ func TestDisk_Add(t *testing.T) {
 	if diskA2.TotalCost() != 10.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 10.0, diskA2.TotalCost())
 	}
-	if diskA2.Adjustment() != 1.0 {
-		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, diskA2.Adjustment())
+	if diskA2.Adjustment != 1.0 {
+		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, diskA2.Adjustment)
 	}
 	if diskA2.Local != 0.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 0.0, diskA2.Local)
@@ -333,8 +333,8 @@ func TestDisk_Clone(t *testing.T) {
 	if disk2.TotalCost() != 10.0 {
 		t.Fatalf("Any.Clone: expected %f; got %f", 10.0, disk2.TotalCost())
 	}
-	if disk2.Adjustment() != 1.0 {
-		t.Fatalf("Any.Clone: expected %f; got %f", 1.0, disk2.Adjustment())
+	if disk2.Adjustment != 1.0 {
+		t.Fatalf("Any.Clone: expected %f; got %f", 1.0, disk2.Adjustment)
 	}
 	if disk2.Local != 1.0 {
 		t.Fatalf("Disk.Add: expected %f; got %f", 1.0, disk2.Local)
@@ -412,20 +412,20 @@ func TestNode_Add(t *testing.T) {
 	if !util.IsApproximately(nodeT.TotalCost(), 15.0) {
 		t.Fatalf("Node.Add: expected %f; got %f", 15.0, nodeT.TotalCost())
 	}
-	if nodeT.Adjustment() != 2.6 {
-		t.Fatalf("Node.Add: expected %f; got %f", 2.6, nodeT.Adjustment())
+	if nodeT.Adjustment != 2.6 {
+		t.Fatalf("Node.Add: expected %f; got %f", 2.6, nodeT.Adjustment)
 	}
-	if nodeT.Properties().Cluster != "cluster1" {
-		t.Fatalf("Node.Add: expected %s; got %s", "cluster1", nodeT.Properties().Cluster)
+	if nodeT.Properties.Cluster != "cluster1" {
+		t.Fatalf("Node.Add: expected %s; got %s", "cluster1", nodeT.Properties.Cluster)
 	}
 	if nodeT.Type() != NodeAssetType {
 		t.Fatalf("Node.Add: expected %s; got %s", AnyAssetType, nodeT.Type())
 	}
-	if nodeT.Properties().ProviderID != "" {
-		t.Fatalf("Node.Add: expected %s; got %s", "", nodeT.Properties().ProviderID)
+	if nodeT.Properties.ProviderID != "" {
+		t.Fatalf("Node.Add: expected %s; got %s", "", nodeT.Properties.ProviderID)
 	}
-	if nodeT.Properties().Name != "" {
-		t.Fatalf("Node.Add: expected %s; got %s", "", nodeT.Properties().Name)
+	if nodeT.Properties.Name != "" {
+		t.Fatalf("Node.Add: expected %s; got %s", "", nodeT.Properties.Name)
 	}
 	if nodeT.CPUCores() != 2.0 {
 		t.Fatalf("Node.Add: expected %f; got %f", 2.0, nodeT.CPUCores())
@@ -438,14 +438,14 @@ func TestNode_Add(t *testing.T) {
 	if !util.IsApproximately(node1.TotalCost(), 10.0) {
 		t.Fatalf("Node.Add: expected %f; got %f", 10.0, node1.TotalCost())
 	}
-	if node1.Adjustment() != 1.6 {
-		t.Fatalf("Node.Add: expected %f; got %f", 1.0, node1.Adjustment())
+	if node1.Adjustment != 1.6 {
+		t.Fatalf("Node.Add: expected %f; got %f", 1.0, node1.Adjustment)
 	}
 	if !util.IsApproximately(node2.TotalCost(), 5.0) {
 		t.Fatalf("Node.Add: expected %f; got %f", 5.0, node2.TotalCost())
 	}
-	if node2.Adjustment() != 1.0 {
-		t.Fatalf("Node.Add: expected %f; got %f", 1.0, node2.Adjustment())
+	if node2.Adjustment != 1.0 {
+		t.Fatalf("Node.Add: expected %f; got %f", 1.0, node2.Adjustment)
 	}
 
 	// Check that we don't divide by zero computing Local
@@ -506,20 +506,20 @@ func TestNode_Add(t *testing.T) {
 	if !util.IsApproximately(nodeAT.TotalCost(), 15.0) {
 		t.Fatalf("Node.Add: expected %f; got %f", 15.0, nodeAT.TotalCost())
 	}
-	if nodeAT.Adjustment() != 2.6 {
-		t.Fatalf("Node.Add: expected %f; got %f", 2.6, nodeAT.Adjustment())
+	if nodeAT.Adjustment != 2.6 {
+		t.Fatalf("Node.Add: expected %f; got %f", 2.6, nodeAT.Adjustment)
 	}
-	if nodeAT.Properties().Cluster != "cluster1" {
-		t.Fatalf("Node.Add: expected %s; got %s", "cluster1", nodeAT.Properties().Cluster)
+	if nodeAT.Properties.Cluster != "cluster1" {
+		t.Fatalf("Node.Add: expected %s; got %s", "cluster1", nodeAT.Properties.Cluster)
 	}
 	if nodeAT.Type() != NodeAssetType {
 		t.Fatalf("Node.Add: expected %s; got %s", AnyAssetType, nodeAT.Type())
 	}
-	if nodeAT.Properties().ProviderID != "" {
-		t.Fatalf("Node.Add: expected %s; got %s", "", nodeAT.Properties().ProviderID)
+	if nodeAT.Properties.ProviderID != "" {
+		t.Fatalf("Node.Add: expected %s; got %s", "", nodeAT.Properties.ProviderID)
 	}
-	if nodeAT.Properties().Name != "" {
-		t.Fatalf("Node.Add: expected %s; got %s", "", nodeAT.Properties().Name)
+	if nodeAT.Properties.Name != "" {
+		t.Fatalf("Node.Add: expected %s; got %s", "", nodeAT.Properties.Name)
 	}
 	if nodeAT.CPUCores() != 1.0 {
 		t.Fatalf("Node.Add: expected %f; got %f", 1.0, nodeAT.CPUCores())
@@ -535,14 +535,14 @@ func TestNode_Add(t *testing.T) {
 	if !util.IsApproximately(nodeA1.TotalCost(), 10.0) {
 		t.Fatalf("Node.Add: expected %f; got %f", 10.0, nodeA1.TotalCost())
 	}
-	if nodeA1.Adjustment() != 1.6 {
-		t.Fatalf("Node.Add: expected %f; got %f", 1.0, nodeA1.Adjustment())
+	if nodeA1.Adjustment != 1.6 {
+		t.Fatalf("Node.Add: expected %f; got %f", 1.0, nodeA1.Adjustment)
 	}
 	if !util.IsApproximately(nodeA2.TotalCost(), 5.0) {
 		t.Fatalf("Node.Add: expected %f; got %f", 5.0, nodeA2.TotalCost())
 	}
-	if nodeA2.Adjustment() != 1.0 {
-		t.Fatalf("Node.Add: expected %f; got %f", 1.0, nodeA2.Adjustment())
+	if nodeA2.Adjustment != 1.0 {
+		t.Fatalf("Node.Add: expected %f; got %f", 1.0, nodeA2.Adjustment)
 	}
 }
 
@@ -582,8 +582,8 @@ func TestClusterManagement_Add(t *testing.T) {
 	if cm3.TotalCost() != 13.0 {
 		t.Fatalf("ClusterManagement.Add: expected %f; got %f", 13.0, cm3.TotalCost())
 	}
-	if cm3.Properties().Cluster != "cluster1" {
-		t.Fatalf("ClusterManagement.Add: expected %s; got %s", "cluster1", cm3.Properties().Cluster)
+	if cm3.GetProperties().Cluster != "cluster1" {
+		t.Fatalf("ClusterManagement.Add: expected %s; got %s", "cluster1", cm3.GetProperties().Cluster)
 	}
 	if cm3.Type() != ClusterManagementAssetType {
 		t.Fatalf("ClusterManagement.Add: expected %s; got %s", ClusterManagementAssetType, cm3.Type())
@@ -617,8 +617,8 @@ func TestCloudAny_Add(t *testing.T) {
 	if ca3.TotalCost() != 15.0 {
 		t.Fatalf("Any.Add: expected %f; got %f", 15.0, ca3.TotalCost())
 	}
-	if ca3.Adjustment() != 2.0 {
-		t.Fatalf("Any.Add: expected %f; got %f", 2.0, ca3.Adjustment())
+	if ca3.GetAdjustment() != 2.0 {
+		t.Fatalf("Any.Add: expected %f; got %f", 2.0, ca3.GetAdjustment())
 	}
 	if ca3.Type() != CloudAssetType {
 		t.Fatalf("Any.Add: expected %s; got %s", CloudAssetType, ca3.Type())
@@ -628,14 +628,14 @@ func TestCloudAny_Add(t *testing.T) {
 	if ca1.TotalCost() != 10.0 {
 		t.Fatalf("Any.Add: expected %f; got %f", 10.0, ca1.TotalCost())
 	}
-	if ca1.Adjustment() != 1.0 {
-		t.Fatalf("Any.Add: expected %f; got %f", 1.0, ca1.Adjustment())
+	if ca1.Adjustment != 1.0 {
+		t.Fatalf("Any.Add: expected %f; got %f", 1.0, ca1.Adjustment)
 	}
 	if ca2.TotalCost() != 5.0 {
 		t.Fatalf("Any.Add: expected %f; got %f", 5.0, ca2.TotalCost())
 	}
-	if ca2.Adjustment() != 1.0 {
-		t.Fatalf("Any.Add: expected %f; got %f", 1.0, ca2.Adjustment())
+	if ca2.Adjustment != 1.0 {
+		t.Fatalf("Any.Add: expected %f; got %f", 1.0, ca2.Adjustment)
 	}
 }
 
@@ -824,13 +824,13 @@ func TestAssetSet_InsertMatchingWindow(t *testing.T) {
 	a1.SetProperties(&AssetProperties{
 		Name: "asset-1",
 	})
-	a1.window = NewClosedWindow(a1WindowStart, a1WindowEnd)
+	a1.Window = NewClosedWindow(a1WindowStart, a1WindowEnd)
 
 	a2 := &Disk{}
 	a2.SetProperties(&AssetProperties{
 		Name: "asset-2",
 	})
-	a2.window = NewClosedWindow(a2WindowStart, a2WindowEnd)
+	a2.Window = NewClosedWindow(a2WindowStart, a2WindowEnd)
 
 	as := NewAssetSet(setStart, setEnd)
 	as.Insert(a1)
@@ -840,14 +840,14 @@ func TestAssetSet_InsertMatchingWindow(t *testing.T) {
 		t.Errorf("AS length got %d, expected %d", as.Length(), 2)
 	}
 
-	as.Each(func(k string, a Asset) {
-		if !(*a.Window().Start()).Equal(setStart) {
-			t.Errorf("Asset %s window start is %s, expected %s", a.Properties().Name, *a.Window().Start(), setStart)
+	for _, a := range as.Assets {
+		if !(*a.GetWindow().Start()).Equal(setStart) {
+			t.Errorf("Asset %s window start is %s, expected %s", a.GetProperties().Name, *a.GetWindow().Start(), setStart)
 		}
-		if !(*a.Window().End()).Equal(setEnd) {
-			t.Errorf("Asset %s window end is %s, expected %s", a.Properties().Name, *a.Window().End(), setEnd)
+		if !(*a.GetWindow().End()).Equal(setEnd) {
+			t.Errorf("Asset %s window end is %s, expected %s", a.GetProperties().Name, *a.GetWindow().End(), setEnd)
 		}
-	})
+	}
 }
 
 func TestAssetSet_ReconciliationMatchMap(t *testing.T) {
@@ -859,15 +859,15 @@ func TestAssetSet_ReconciliationMatchMap(t *testing.T) {
 
 	// Determine the number of assets by provider ID
 	assetCountByProviderId := make(map[string]int, len(matchMap))
-	as.Each(func(key string, a Asset) {
-		if a == nil || a.Properties() == nil || a.Properties().ProviderID == "" {
+	for _, a := range as.Assets {
+		if a == nil || a.GetProperties() == nil || a.GetProperties().ProviderID == "" {
 			return
 		}
-		if _, ok := assetCountByProviderId[a.Properties().ProviderID]; !ok {
-			assetCountByProviderId[a.Properties().ProviderID] = 0
+		if _, ok := assetCountByProviderId[a.GetProperties().ProviderID]; !ok {
+			assetCountByProviderId[a.GetProperties().ProviderID] = 0
 		}
-		assetCountByProviderId[a.Properties().ProviderID] += 1
-	})
+		assetCountByProviderId[a.GetProperties().ProviderID] += 1
+	}
 
 	for k, count := range assetCountByProviderId {
 		if len(matchMap[k]) != count {
@@ -1180,11 +1180,11 @@ func TestAssetSetRange_Start(t *testing.T) {
 		{
 			name: "Single asset",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1196,14 +1196,14 @@ func TestAssetSetRange_Start(t *testing.T) {
 		{
 			name: "Two assets",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 							"b": &Node{
-								start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1215,18 +1215,18 @@ func TestAssetSetRange_Start(t *testing.T) {
 		{
 			name: "Two AssetSets",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
-					&AssetSet{
-						assets: map[string]Asset{
+					{
+						Assets: map[string]Asset{
 							"b": &Node{
-								start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1268,11 +1268,11 @@ func TestAssetSetRange_End(t *testing.T) {
 		{
 			name: "Single asset",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								end: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								End: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1284,14 +1284,14 @@ func TestAssetSetRange_End(t *testing.T) {
 		{
 			name: "Two assets",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								end: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								End: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 							"b": &Node{
-								end: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								End: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1303,18 +1303,18 @@ func TestAssetSetRange_End(t *testing.T) {
 		{
 			name: "Two AssetSets",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								end: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								End: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
-					&AssetSet{
-						assets: map[string]Asset{
+					{
+						Assets: map[string]Asset{
 							"b": &Node{
-								end: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								End: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1355,12 +1355,12 @@ func TestAssetSetRange_Minutes(t *testing.T) {
 		{
 			name: "Single asset",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
-								end:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1372,16 +1372,16 @@ func TestAssetSetRange_Minutes(t *testing.T) {
 		{
 			name: "Two assets",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
-								end:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 							"b": &Node{
-								start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
-								end:   time.Date(1970, 1, 3, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(1970, 1, 3, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1393,20 +1393,20 @@ func TestAssetSetRange_Minutes(t *testing.T) {
 		{
 			name: "Two AssetSets",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
-					&AssetSet{
-						assets: map[string]Asset{
+				Assets: []*AssetSet{
+					{
+						Assets: map[string]Asset{
 							"a": &Node{
-								start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
-								end:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
-					&AssetSet{
-						assets: map[string]Asset{
+					{
+						Assets: map[string]Asset{
 							"b": &Node{
-								start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
-								end:   time.Date(1970, 1, 3, 0, 0, 0, 0, time.UTC),
+								Start: time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC),
+								End:   time.Date(1970, 1, 3, 0, 0, 0, 0, time.UTC),
 							},
 						},
 					},
@@ -1443,11 +1443,11 @@ func TestAssetSetRange_MarshalJSON(t *testing.T) {
 		{
 			name: "Normal ASR",
 			arg: &AssetSetRange{
-				assets: []*AssetSet{
+				Assets: []*AssetSet{
 					{
-						assets: map[string]Asset{
+						Assets: map[string]Asset{
 							"a": &Any{
-								start: time.Now().UTC().Truncate(day),
+								Start: time.Now().UTC().Truncate(day),
 							},
 						},
 					},

--- a/pkg/kubecost/audit.go
+++ b/pkg/kubecost/audit.go
@@ -1,9 +1,10 @@
 package kubecost
 
 import (
-	"golang.org/x/exp/slices"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/slices"
 )
 
 // AuditType the types of Audits, each of which should be contained in an AuditSet
@@ -235,7 +236,6 @@ func (ea *EqualityAudit) Clone() *EqualityAudit {
 
 // AuditCoverage tracks coverage of each audit type
 type AuditCoverage struct {
-	sync.RWMutex
 	AllocationReconciliation Window `json:"allocationReconciliation"`
 	AllocationAgg            Window `json:"allocationAgg"`
 	AllocationTotal          Window `json:"allocationTotal"`

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -30,7 +30,7 @@ package kubecost
 // @bingen:generate:AssetLabels
 // @bingen:generate:AssetProperties
 // @bingen:generate:AssetProperty
-// @bingen:generate[stringtable]:AssetSet
+// @bingen:generate[stringtable,preprocess,postprocess]:AssetSet
 // @bingen:generate:AssetSetRange
 // @bingen:generate:Breakdown
 // @bingen:generate:Cloud

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -13,11 +13,12 @@ package kubecost
 
 import (
 	"fmt"
-	util "github.com/opencost/opencost/pkg/util"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
+
+	util "github.com/opencost/opencost/pkg/util"
 )
 
 const (
@@ -33,17 +34,17 @@ const (
 )
 
 const (
-	// AllocationCodecVersion is used for any resources listed in the Allocation version set
-	AllocationCodecVersion uint8 = 15
-
-	// AuditCodecVersion is used for any resources listed in the Audit version set
-	AuditCodecVersion uint8 = 1
-
 	// DefaultCodecVersion is used for any resources listed in the Default version set
 	DefaultCodecVersion uint8 = 15
 
 	// AssetsCodecVersion is used for any resources listed in the Assets version set
 	AssetsCodecVersion uint8 = 16
+
+	// AllocationCodecVersion is used for any resources listed in the Allocation version set
+	AllocationCodecVersion uint8 = 15
+
+	// AuditCodecVersion is used for any resources listed in the Audit version set
+	AuditCodecVersion uint8 = 1
 )
 
 //--------------------------------------------------------------------------
@@ -456,159 +457,134 @@ func (target *AggAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err er
 		return fmt.Errorf("Invalid Version Unmarshaling AggAudit. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AuditStatus) ---
-		var a string
-		var c string
-		if ctx.IsStringTable() {
-			d := buff.ReadInt() // read string index
-			c = ctx.Table[d]
-		} else {
-			c = buff.ReadString() // read string
-		}
-		b := c
-		a = b
-
-		target.Status = AuditStatus(a)
-		// --- [end][read][alias](AuditStatus) ---
-
+	// --- [begin][read][alias](AuditStatus) ---
+	var a string
+	var c string
+	if ctx.IsStringTable() {
+		d := buff.ReadInt() // read string index
+		c = ctx.Table[d]
 	} else {
+		c = buff.ReadString() // read string
 	}
+	b := c
+	a = b
 
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.Description = e
+	target.Status = AuditStatus(a)
+	// --- [end][read][alias](AuditStatus) ---
 
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.Description = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.Description = e
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		h := &time.Time{}
-		k := buff.ReadInt()    // byte array length
-		l := buff.ReadBytes(k) // byte array
-		errA := h.UnmarshalBinary(l)
-		if errA != nil {
-			return errA
-		}
-		target.LastRun = *h
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][reference](time.Time) ---
+	h := &time.Time{}
+	k := buff.ReadInt()    // byte array length
+	l := buff.ReadBytes(k) // byte array
+	errA := h.UnmarshalBinary(l)
+	if errA != nil {
+		return errA
 	}
+	target.LastRun = *h
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Results = nil
-		} else {
-			// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
-			n := buff.ReadInt() // map len
-			m := make(map[string]map[string]*AuditFloatResult, n)
-			for i := 0; i < n; i++ {
-				var v string
-				var p string
-				if ctx.IsStringTable() {
-					q := buff.ReadInt() // read string index
-					p = ctx.Table[q]
-				} else {
-					p = buff.ReadString() // read string
-				}
-				o := p
-				v = o
-
-				var z map[string]*AuditFloatResult
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][map](map[string]*AuditFloatResult) ---
-					s := buff.ReadInt() // map len
-					r := make(map[string]*AuditFloatResult, s)
-					for j := 0; j < s; j++ {
-						var vv string
-						var u string
-						if ctx.IsStringTable() {
-							w := buff.ReadInt() // read string index
-							u = ctx.Table[w]
-						} else {
-							u = buff.ReadString() // read string
-						}
-						t := u
-						vv = t
-
-						var zz *AuditFloatResult
-						if buff.ReadUInt8() == uint8(0) {
-							zz = nil
-						} else {
-							// --- [begin][read][struct](AuditFloatResult) ---
-							x := &AuditFloatResult{}
-							buff.ReadInt() // [compatibility, unused]
-							errB := x.UnmarshalBinaryWithContext(ctx)
-							if errB != nil {
-								return errB
-							}
-							zz = x
-							// --- [end][read][struct](AuditFloatResult) ---
-
-						}
-						r[vv] = zz
-					}
-					z = r
-					// --- [end][read][map](map[string]*AuditFloatResult) ---
-
-				}
-				m[v] = z
-			}
-			target.Results = m
-			// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.Results = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.MissingValues = nil
-		} else {
-			// --- [begin][read][slice]([]*AuditMissingValue) ---
-			aa := buff.ReadInt() // array len
-			y := make([]*AuditMissingValue, aa)
-			for ii := 0; ii < aa; ii++ {
-				var bb *AuditMissingValue
-				if buff.ReadUInt8() == uint8(0) {
-					bb = nil
-				} else {
-					// --- [begin][read][struct](AuditMissingValue) ---
-					cc := &AuditMissingValue{}
-					buff.ReadInt() // [compatibility, unused]
-					errC := cc.UnmarshalBinaryWithContext(ctx)
-					if errC != nil {
-						return errC
-					}
-					bb = cc
-					// --- [end][read][struct](AuditMissingValue) ---
-
-				}
-				y[ii] = bb
-			}
-			target.MissingValues = y
-			// --- [end][read][slice]([]*AuditMissingValue) ---
-
-		}
 	} else {
-		target.MissingValues = nil
+		// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
+		n := buff.ReadInt() // map len
+		m := make(map[string]map[string]*AuditFloatResult, n)
+		for i := 0; i < n; i++ {
+			var v string
+			var p string
+			if ctx.IsStringTable() {
+				q := buff.ReadInt() // read string index
+				p = ctx.Table[q]
+			} else {
+				p = buff.ReadString() // read string
+			}
+			o := p
+			v = o
+
+			var z map[string]*AuditFloatResult
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][map](map[string]*AuditFloatResult) ---
+				s := buff.ReadInt() // map len
+				r := make(map[string]*AuditFloatResult, s)
+				for j := 0; j < s; j++ {
+					var vv string
+					var u string
+					if ctx.IsStringTable() {
+						w := buff.ReadInt() // read string index
+						u = ctx.Table[w]
+					} else {
+						u = buff.ReadString() // read string
+					}
+					t := u
+					vv = t
+
+					var zz *AuditFloatResult
+					if buff.ReadUInt8() == uint8(0) {
+						zz = nil
+					} else {
+						// --- [begin][read][struct](AuditFloatResult) ---
+						x := &AuditFloatResult{}
+						buff.ReadInt() // [compatibility, unused]
+						errB := x.UnmarshalBinaryWithContext(ctx)
+						if errB != nil {
+							return errB
+						}
+						zz = x
+						// --- [end][read][struct](AuditFloatResult) ---
+
+					}
+					r[vv] = zz
+				}
+				z = r
+				// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+			}
+			m[v] = z
+		}
+		target.Results = m
+		// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.MissingValues = nil
+	} else {
+		// --- [begin][read][slice]([]*AuditMissingValue) ---
+		aa := buff.ReadInt() // array len
+		y := make([]*AuditMissingValue, aa)
+		for ii := 0; ii < aa; ii++ {
+			var bb *AuditMissingValue
+			if buff.ReadUInt8() == uint8(0) {
+				bb = nil
+			} else {
+				// --- [begin][read][struct](AuditMissingValue) ---
+				cc := &AuditMissingValue{}
+				buff.ReadInt() // [compatibility, unused]
+				errC := cc.UnmarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				bb = cc
+				// --- [end][read][struct](AuditMissingValue) ---
 
+			}
+			y[ii] = bb
+		}
+		target.MissingValues = y
+		// --- [end][read][slice]([]*AuditMissingValue) ---
+
+	}
 	return nil
 }
 
@@ -828,328 +804,185 @@ func (target *Allocation) UnmarshalBinaryWithContext(ctx *DecodingContext) (err 
 		return fmt.Errorf("Invalid Version Unmarshaling Allocation. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		var b string
-		if ctx.IsStringTable() {
-			c := buff.ReadInt() // read string index
-			b = ctx.Table[c]
-		} else {
-			b = buff.ReadString() // read string
-		}
-		a := b
-		target.Name = a
-
+	var b string
+	if ctx.IsStringTable() {
+		c := buff.ReadInt() // read string index
+		b = ctx.Table[c]
 	} else {
-		target.Name = "" // default
+		b = buff.ReadString() // read string
 	}
+	a := b
+	target.Name = a
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Properties = nil
-		} else {
-			// --- [begin][read][struct](AllocationProperties) ---
-			d := &AllocationProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := d.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
-			}
-			target.Properties = d
-			// --- [end][read][struct](AllocationProperties) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.Properties = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		e := &Window{}
+	} else {
+		// --- [begin][read][struct](AllocationProperties) ---
+		d := &AllocationProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errB := e.UnmarshalBinaryWithContext(ctx)
-		if errB != nil {
-			return errB
+		errA := d.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.Window = *e
-		// --- [end][read][struct](Window) ---
+		target.Properties = d
+		// --- [end][read][struct](AllocationProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		f := &time.Time{}
-		g := buff.ReadInt()    // byte array length
-		h := buff.ReadBytes(g) // byte array
-		errC := f.UnmarshalBinary(h)
-		if errC != nil {
-			return errC
-		}
-		target.Start = *f
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][struct](Window) ---
+	e := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errB := e.UnmarshalBinaryWithContext(ctx)
+	if errB != nil {
+		return errB
 	}
+	target.Window = *e
+	// --- [end][read][struct](Window) ---
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		k := &time.Time{}
-		l := buff.ReadInt()    // byte array length
-		m := buff.ReadBytes(l) // byte array
-		errD := k.UnmarshalBinary(m)
-		if errD != nil {
-			return errD
-		}
-		target.End = *k
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][reference](time.Time) ---
+	f := &time.Time{}
+	g := buff.ReadInt()    // byte array length
+	h := buff.ReadBytes(g) // byte array
+	errC := f.UnmarshalBinary(h)
+	if errC != nil {
+		return errC
 	}
+	target.Start = *f
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		n := buff.ReadFloat64() // read float64
-		target.CPUCoreHours = n
-
-	} else {
-		target.CPUCoreHours = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	k := &time.Time{}
+	l := buff.ReadInt()    // byte array length
+	m := buff.ReadBytes(l) // byte array
+	errD := k.UnmarshalBinary(m)
+	if errD != nil {
+		return errD
 	}
+	target.End = *k
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		o := buff.ReadFloat64() // read float64
-		target.CPUCoreRequestAverage = o
+	n := buff.ReadFloat64() // read float64
+	target.CPUCoreHours = n
 
+	o := buff.ReadFloat64() // read float64
+	target.CPUCoreRequestAverage = o
+
+	p := buff.ReadFloat64() // read float64
+	target.CPUCoreUsageAverage = p
+
+	q := buff.ReadFloat64() // read float64
+	target.CPUCost = q
+
+	r := buff.ReadFloat64() // read float64
+	target.CPUCostAdjustment = r
+
+	s := buff.ReadFloat64() // read float64
+	target.GPUHours = s
+
+	t := buff.ReadFloat64() // read float64
+	target.GPUCost = t
+
+	u := buff.ReadFloat64() // read float64
+	target.GPUCostAdjustment = u
+
+	w := buff.ReadFloat64() // read float64
+	target.NetworkTransferBytes = w
+
+	x := buff.ReadFloat64() // read float64
+	target.NetworkReceiveBytes = x
+
+	y := buff.ReadFloat64() // read float64
+	target.NetworkCost = y
+
+	aa := buff.ReadFloat64() // read float64
+	target.NetworkCostAdjustment = aa
+
+	bb := buff.ReadFloat64() // read float64
+	target.LoadBalancerCost = bb
+
+	cc := buff.ReadFloat64() // read float64
+	target.LoadBalancerCostAdjustment = cc
+
+	// --- [begin][read][alias](PVAllocations) ---
+	var dd map[PVKey]*PVAllocation
+	if buff.ReadUInt8() == uint8(0) {
+		dd = nil
 	} else {
-		target.CPUCoreRequestAverage = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		p := buff.ReadFloat64() // read float64
-		target.CPUCoreUsageAverage = p
-
-	} else {
-		target.CPUCoreUsageAverage = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		q := buff.ReadFloat64() // read float64
-		target.CPUCost = q
-
-	} else {
-		target.CPUCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		r := buff.ReadFloat64() // read float64
-		target.CPUCostAdjustment = r
-
-	} else {
-		target.CPUCostAdjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		s := buff.ReadFloat64() // read float64
-		target.GPUHours = s
-
-	} else {
-		target.GPUHours = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.GPUCost = t
-
-	} else {
-		target.GPUCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		u := buff.ReadFloat64() // read float64
-		target.GPUCostAdjustment = u
-
-	} else {
-		target.GPUCostAdjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		w := buff.ReadFloat64() // read float64
-		target.NetworkTransferBytes = w
-
-	} else {
-		target.NetworkTransferBytes = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		x := buff.ReadFloat64() // read float64
-		target.NetworkReceiveBytes = x
-
-	} else {
-		target.NetworkReceiveBytes = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		y := buff.ReadFloat64() // read float64
-		target.NetworkCost = y
-
-	} else {
-		target.NetworkCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		aa := buff.ReadFloat64() // read float64
-		target.NetworkCostAdjustment = aa
-
-	} else {
-		target.NetworkCostAdjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		bb := buff.ReadFloat64() // read float64
-		target.LoadBalancerCost = bb
-
-	} else {
-		target.LoadBalancerCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		cc := buff.ReadFloat64() // read float64
-		target.LoadBalancerCostAdjustment = cc
-
-	} else {
-		target.LoadBalancerCostAdjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](PVAllocations) ---
-		var dd map[PVKey]*PVAllocation
-		if buff.ReadUInt8() == uint8(0) {
-			dd = nil
-		} else {
-			// --- [begin][read][map](map[PVKey]*PVAllocation) ---
-			ff := buff.ReadInt() // map len
-			ee := make(map[PVKey]*PVAllocation, ff)
-			for i := 0; i < ff; i++ {
-				// --- [begin][read][struct](PVKey) ---
-				gg := &PVKey{}
-				buff.ReadInt() // [compatibility, unused]
-				errE := gg.UnmarshalBinaryWithContext(ctx)
-				if errE != nil {
-					return errE
-				}
-				v := *gg
-				// --- [end][read][struct](PVKey) ---
-
-				var z *PVAllocation
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][struct](PVAllocation) ---
-					hh := &PVAllocation{}
-					buff.ReadInt() // [compatibility, unused]
-					errF := hh.UnmarshalBinaryWithContext(ctx)
-					if errF != nil {
-						return errF
-					}
-					z = hh
-					// --- [end][read][struct](PVAllocation) ---
-
-				}
-				ee[v] = z
-			}
-			dd = ee
-			// --- [end][read][map](map[PVKey]*PVAllocation) ---
-
-		}
-		target.PVs = PVAllocations(dd)
-		// --- [end][read][alias](PVAllocations) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		kk := buff.ReadFloat64() // read float64
-		target.PVCostAdjustment = kk
-
-	} else {
-		target.PVCostAdjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		ll := buff.ReadFloat64() // read float64
-		target.RAMByteHours = ll
-
-	} else {
-		target.RAMByteHours = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		mm := buff.ReadFloat64() // read float64
-		target.RAMBytesRequestAverage = mm
-
-	} else {
-		target.RAMBytesRequestAverage = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		nn := buff.ReadFloat64() // read float64
-		target.RAMBytesUsageAverage = nn
-
-	} else {
-		target.RAMBytesUsageAverage = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		oo := buff.ReadFloat64() // read float64
-		target.RAMCost = oo
-
-	} else {
-		target.RAMCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		pp := buff.ReadFloat64() // read float64
-		target.RAMCostAdjustment = pp
-
-	} else {
-		target.RAMCostAdjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		qq := buff.ReadFloat64() // read float64
-		target.SharedCost = qq
-
-	} else {
-		target.SharedCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		rr := buff.ReadFloat64() // read float64
-		target.ExternalCost = rr
-
-	} else {
-		target.ExternalCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.RawAllocationOnly = nil
-		} else {
-			// --- [begin][read][struct](RawAllocationOnlyData) ---
-			ss := &RawAllocationOnlyData{}
+		// --- [begin][read][map](map[PVKey]*PVAllocation) ---
+		ff := buff.ReadInt() // map len
+		ee := make(map[PVKey]*PVAllocation, ff)
+		for i := 0; i < ff; i++ {
+			// --- [begin][read][struct](PVKey) ---
+			gg := &PVKey{}
 			buff.ReadInt() // [compatibility, unused]
-			errG := ss.UnmarshalBinaryWithContext(ctx)
-			if errG != nil {
-				return errG
+			errE := gg.UnmarshalBinaryWithContext(ctx)
+			if errE != nil {
+				return errE
 			}
-			target.RawAllocationOnly = ss
-			// --- [end][read][struct](RawAllocationOnlyData) ---
+			v := *gg
+			// --- [end][read][struct](PVKey) ---
 
+			var z *PVAllocation
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][struct](PVAllocation) ---
+				hh := &PVAllocation{}
+				buff.ReadInt() // [compatibility, unused]
+				errF := hh.UnmarshalBinaryWithContext(ctx)
+				if errF != nil {
+					return errF
+				}
+				z = hh
+				// --- [end][read][struct](PVAllocation) ---
+
+			}
+			ee[v] = z
 		}
-	} else {
-		target.RawAllocationOnly = nil
+		dd = ee
+		// --- [end][read][map](map[PVKey]*PVAllocation) ---
 
 	}
+	target.PVs = PVAllocations(dd)
+	// --- [end][read][alias](PVAllocations) ---
 
+	kk := buff.ReadFloat64() // read float64
+	target.PVCostAdjustment = kk
+
+	ll := buff.ReadFloat64() // read float64
+	target.RAMByteHours = ll
+
+	mm := buff.ReadFloat64() // read float64
+	target.RAMBytesRequestAverage = mm
+
+	nn := buff.ReadFloat64() // read float64
+	target.RAMBytesUsageAverage = nn
+
+	oo := buff.ReadFloat64() // read float64
+	target.RAMCost = oo
+
+	pp := buff.ReadFloat64() // read float64
+	target.RAMCostAdjustment = pp
+
+	qq := buff.ReadFloat64() // read float64
+	target.SharedCost = qq
+
+	rr := buff.ReadFloat64() // read float64
+	target.ExternalCost = rr
+
+	if buff.ReadUInt8() == uint8(0) {
+		target.RawAllocationOnly = nil
+	} else {
+		// --- [begin][read][struct](RawAllocationOnlyData) ---
+		ss := &RawAllocationOnlyData{}
+		buff.ReadInt() // [compatibility, unused]
+		errG := ss.UnmarshalBinaryWithContext(ctx)
+		if errG != nil {
+			return errG
+		}
+		target.RawAllocationOnly = ss
+		// --- [end][read][struct](RawAllocationOnlyData) ---
+
+	}
 	return nil
 }
 
@@ -1370,243 +1203,189 @@ func (target *AllocationProperties) UnmarshalBinaryWithContext(ctx *DecodingCont
 		return fmt.Errorf("Invalid Version Unmarshaling AllocationProperties. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		var b string
-		if ctx.IsStringTable() {
-			c := buff.ReadInt() // read string index
-			b = ctx.Table[c]
-		} else {
-			b = buff.ReadString() // read string
-		}
-		a := b
-		target.Cluster = a
-
+	var b string
+	if ctx.IsStringTable() {
+		c := buff.ReadInt() // read string index
+		b = ctx.Table[c]
 	} else {
-		target.Cluster = "" // default
+		b = buff.ReadString() // read string
 	}
+	a := b
+	target.Cluster = a
 
-	if uint8(0) /* field version */ <= version {
-		var e string
-		if ctx.IsStringTable() {
-			f := buff.ReadInt() // read string index
-			e = ctx.Table[f]
-		} else {
-			e = buff.ReadString() // read string
-		}
-		d := e
-		target.Node = d
-
+	var e string
+	if ctx.IsStringTable() {
+		f := buff.ReadInt() // read string index
+		e = ctx.Table[f]
 	} else {
-		target.Node = "" // default
+		e = buff.ReadString() // read string
 	}
+	d := e
+	target.Node = d
 
-	if uint8(0) /* field version */ <= version {
-		var h string
-		if ctx.IsStringTable() {
-			k := buff.ReadInt() // read string index
-			h = ctx.Table[k]
-		} else {
-			h = buff.ReadString() // read string
-		}
-		g := h
-		target.Container = g
-
+	var h string
+	if ctx.IsStringTable() {
+		k := buff.ReadInt() // read string index
+		h = ctx.Table[k]
 	} else {
-		target.Container = "" // default
+		h = buff.ReadString() // read string
 	}
+	g := h
+	target.Container = g
 
-	if uint8(0) /* field version */ <= version {
-		var m string
-		if ctx.IsStringTable() {
-			n := buff.ReadInt() // read string index
-			m = ctx.Table[n]
-		} else {
-			m = buff.ReadString() // read string
-		}
-		l := m
-		target.Controller = l
-
+	var m string
+	if ctx.IsStringTable() {
+		n := buff.ReadInt() // read string index
+		m = ctx.Table[n]
 	} else {
-		target.Controller = "" // default
+		m = buff.ReadString() // read string
 	}
+	l := m
+	target.Controller = l
 
-	if uint8(0) /* field version */ <= version {
-		var p string
-		if ctx.IsStringTable() {
-			q := buff.ReadInt() // read string index
-			p = ctx.Table[q]
-		} else {
-			p = buff.ReadString() // read string
-		}
-		o := p
-		target.ControllerKind = o
-
+	var p string
+	if ctx.IsStringTable() {
+		q := buff.ReadInt() // read string index
+		p = ctx.Table[q]
 	} else {
-		target.ControllerKind = "" // default
+		p = buff.ReadString() // read string
 	}
+	o := p
+	target.ControllerKind = o
 
-	if uint8(0) /* field version */ <= version {
-		var s string
-		if ctx.IsStringTable() {
-			t := buff.ReadInt() // read string index
-			s = ctx.Table[t]
-		} else {
-			s = buff.ReadString() // read string
-		}
-		r := s
-		target.Namespace = r
-
+	var s string
+	if ctx.IsStringTable() {
+		t := buff.ReadInt() // read string index
+		s = ctx.Table[t]
 	} else {
-		target.Namespace = "" // default
+		s = buff.ReadString() // read string
 	}
+	r := s
+	target.Namespace = r
 
-	if uint8(0) /* field version */ <= version {
-		var w string
-		if ctx.IsStringTable() {
-			x := buff.ReadInt() // read string index
-			w = ctx.Table[x]
-		} else {
-			w = buff.ReadString() // read string
-		}
-		u := w
-		target.Pod = u
-
+	var w string
+	if ctx.IsStringTable() {
+		x := buff.ReadInt() // read string index
+		w = ctx.Table[x]
 	} else {
-		target.Pod = "" // default
+		w = buff.ReadString() // read string
 	}
+	u := w
+	target.Pod = u
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Services = nil
-		} else {
-			// --- [begin][read][slice]([]string) ---
-			aa := buff.ReadInt() // array len
-			y := make([]string, aa)
-			for i := 0; i < aa; i++ {
-				var bb string
-				var dd string
-				if ctx.IsStringTable() {
-					ee := buff.ReadInt() // read string index
-					dd = ctx.Table[ee]
-				} else {
-					dd = buff.ReadString() // read string
-				}
-				cc := dd
-				bb = cc
-
-				y[i] = bb
-			}
-			target.Services = y
-			// --- [end][read][slice]([]string) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.Services = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		var gg string
-		if ctx.IsStringTable() {
-			hh := buff.ReadInt() // read string index
-			gg = ctx.Table[hh]
-		} else {
-			gg = buff.ReadString() // read string
-		}
-		ff := gg
-		target.ProviderID = ff
-
 	} else {
-		target.ProviderID = "" // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AllocationLabels) ---
-		var kk map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			kk = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			mm := buff.ReadInt() // map len
-			ll := make(map[string]string, mm)
-			for j := 0; j < mm; j++ {
-				var v string
-				var oo string
-				if ctx.IsStringTable() {
-					pp := buff.ReadInt() // read string index
-					oo = ctx.Table[pp]
-				} else {
-					oo = buff.ReadString() // read string
-				}
-				nn := oo
-				v = nn
-
-				var z string
-				var rr string
-				if ctx.IsStringTable() {
-					ss := buff.ReadInt() // read string index
-					rr = ctx.Table[ss]
-				} else {
-					rr = buff.ReadString() // read string
-				}
-				qq := rr
-				z = qq
-
-				ll[v] = z
+		// --- [begin][read][slice]([]string) ---
+		aa := buff.ReadInt() // array len
+		y := make([]string, aa)
+		for i := 0; i < aa; i++ {
+			var bb string
+			var dd string
+			if ctx.IsStringTable() {
+				ee := buff.ReadInt() // read string index
+				dd = ctx.Table[ee]
+			} else {
+				dd = buff.ReadString() // read string
 			}
-			kk = ll
-			// --- [end][read][map](map[string]string) ---
+			cc := dd
+			bb = cc
 
+			y[i] = bb
 		}
-		target.Labels = AllocationLabels(kk)
-		// --- [end][read][alias](AllocationLabels) ---
+		target.Services = y
+		// --- [end][read][slice]([]string) ---
 
-	} else {
 	}
+	var gg string
+	if ctx.IsStringTable() {
+		hh := buff.ReadInt() // read string index
+		gg = ctx.Table[hh]
+	} else {
+		gg = buff.ReadString() // read string
+	}
+	ff := gg
+	target.ProviderID = ff
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AllocationAnnotations) ---
-		var tt map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			tt = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			ww := buff.ReadInt() // map len
-			uu := make(map[string]string, ww)
-			for ii := 0; ii < ww; ii++ {
-				var vv string
-				var yy string
-				if ctx.IsStringTable() {
-					aaa := buff.ReadInt() // read string index
-					yy = ctx.Table[aaa]
-				} else {
-					yy = buff.ReadString() // read string
-				}
-				xx := yy
-				vv = xx
-
-				var zz string
-				var ccc string
-				if ctx.IsStringTable() {
-					ddd := buff.ReadInt() // read string index
-					ccc = ctx.Table[ddd]
-				} else {
-					ccc = buff.ReadString() // read string
-				}
-				bbb := ccc
-				zz = bbb
-
-				uu[vv] = zz
+	// --- [begin][read][alias](AllocationLabels) ---
+	var kk map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		kk = nil
+	} else {
+		// --- [begin][read][map](map[string]string) ---
+		mm := buff.ReadInt() // map len
+		ll := make(map[string]string, mm)
+		for j := 0; j < mm; j++ {
+			var v string
+			var oo string
+			if ctx.IsStringTable() {
+				pp := buff.ReadInt() // read string index
+				oo = ctx.Table[pp]
+			} else {
+				oo = buff.ReadString() // read string
 			}
-			tt = uu
-			// --- [end][read][map](map[string]string) ---
+			nn := oo
+			v = nn
 
+			var z string
+			var rr string
+			if ctx.IsStringTable() {
+				ss := buff.ReadInt() // read string index
+				rr = ctx.Table[ss]
+			} else {
+				rr = buff.ReadString() // read string
+			}
+			qq := rr
+			z = qq
+
+			ll[v] = z
 		}
-		target.Annotations = AllocationAnnotations(tt)
-		// --- [end][read][alias](AllocationAnnotations) ---
+		kk = ll
+		// --- [end][read][map](map[string]string) ---
 
-	} else {
 	}
+	target.Labels = AllocationLabels(kk)
+	// --- [end][read][alias](AllocationLabels) ---
+
+	// --- [begin][read][alias](AllocationAnnotations) ---
+	var tt map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		tt = nil
+	} else {
+		// --- [begin][read][map](map[string]string) ---
+		ww := buff.ReadInt() // map len
+		uu := make(map[string]string, ww)
+		for ii := 0; ii < ww; ii++ {
+			var vv string
+			var yy string
+			if ctx.IsStringTable() {
+				aaa := buff.ReadInt() // read string index
+				yy = ctx.Table[aaa]
+			} else {
+				yy = buff.ReadString() // read string
+			}
+			xx := yy
+			vv = xx
+
+			var zz string
+			var ccc string
+			if ctx.IsStringTable() {
+				ddd := buff.ReadInt() // read string index
+				ccc = ctx.Table[ddd]
+			} else {
+				ccc = buff.ReadString() // read string
+			}
+			bbb := ccc
+			zz = bbb
+
+			uu[vv] = zz
+		}
+		tt = uu
+		// --- [end][read][map](map[string]string) ---
+
+	}
+	target.Annotations = AllocationAnnotations(tt)
+	// --- [end][read][alias](AllocationAnnotations) ---
 
 	return nil
 }
@@ -1808,159 +1587,134 @@ func (target *AllocationReconciliationAudit) UnmarshalBinaryWithContext(ctx *Dec
 		return fmt.Errorf("Invalid Version Unmarshaling AllocationReconciliationAudit. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AuditStatus) ---
-		var a string
-		var c string
-		if ctx.IsStringTable() {
-			d := buff.ReadInt() // read string index
-			c = ctx.Table[d]
-		} else {
-			c = buff.ReadString() // read string
-		}
-		b := c
-		a = b
-
-		target.Status = AuditStatus(a)
-		// --- [end][read][alias](AuditStatus) ---
-
+	// --- [begin][read][alias](AuditStatus) ---
+	var a string
+	var c string
+	if ctx.IsStringTable() {
+		d := buff.ReadInt() // read string index
+		c = ctx.Table[d]
 	} else {
+		c = buff.ReadString() // read string
 	}
+	b := c
+	a = b
 
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.Description = e
+	target.Status = AuditStatus(a)
+	// --- [end][read][alias](AuditStatus) ---
 
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.Description = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.Description = e
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		h := &time.Time{}
-		k := buff.ReadInt()    // byte array length
-		l := buff.ReadBytes(k) // byte array
-		errA := h.UnmarshalBinary(l)
-		if errA != nil {
-			return errA
-		}
-		target.LastRun = *h
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][reference](time.Time) ---
+	h := &time.Time{}
+	k := buff.ReadInt()    // byte array length
+	l := buff.ReadBytes(k) // byte array
+	errA := h.UnmarshalBinary(l)
+	if errA != nil {
+		return errA
 	}
+	target.LastRun = *h
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Resources = nil
-		} else {
-			// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
-			n := buff.ReadInt() // map len
-			m := make(map[string]map[string]*AuditFloatResult, n)
-			for i := 0; i < n; i++ {
-				var v string
-				var p string
-				if ctx.IsStringTable() {
-					q := buff.ReadInt() // read string index
-					p = ctx.Table[q]
-				} else {
-					p = buff.ReadString() // read string
-				}
-				o := p
-				v = o
-
-				var z map[string]*AuditFloatResult
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][map](map[string]*AuditFloatResult) ---
-					s := buff.ReadInt() // map len
-					r := make(map[string]*AuditFloatResult, s)
-					for j := 0; j < s; j++ {
-						var vv string
-						var u string
-						if ctx.IsStringTable() {
-							w := buff.ReadInt() // read string index
-							u = ctx.Table[w]
-						} else {
-							u = buff.ReadString() // read string
-						}
-						t := u
-						vv = t
-
-						var zz *AuditFloatResult
-						if buff.ReadUInt8() == uint8(0) {
-							zz = nil
-						} else {
-							// --- [begin][read][struct](AuditFloatResult) ---
-							x := &AuditFloatResult{}
-							buff.ReadInt() // [compatibility, unused]
-							errB := x.UnmarshalBinaryWithContext(ctx)
-							if errB != nil {
-								return errB
-							}
-							zz = x
-							// --- [end][read][struct](AuditFloatResult) ---
-
-						}
-						r[vv] = zz
-					}
-					z = r
-					// --- [end][read][map](map[string]*AuditFloatResult) ---
-
-				}
-				m[v] = z
-			}
-			target.Resources = m
-			// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.Resources = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.MissingValues = nil
-		} else {
-			// --- [begin][read][slice]([]*AuditMissingValue) ---
-			aa := buff.ReadInt() // array len
-			y := make([]*AuditMissingValue, aa)
-			for ii := 0; ii < aa; ii++ {
-				var bb *AuditMissingValue
-				if buff.ReadUInt8() == uint8(0) {
-					bb = nil
-				} else {
-					// --- [begin][read][struct](AuditMissingValue) ---
-					cc := &AuditMissingValue{}
-					buff.ReadInt() // [compatibility, unused]
-					errC := cc.UnmarshalBinaryWithContext(ctx)
-					if errC != nil {
-						return errC
-					}
-					bb = cc
-					// --- [end][read][struct](AuditMissingValue) ---
-
-				}
-				y[ii] = bb
-			}
-			target.MissingValues = y
-			// --- [end][read][slice]([]*AuditMissingValue) ---
-
-		}
 	} else {
-		target.MissingValues = nil
+		// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
+		n := buff.ReadInt() // map len
+		m := make(map[string]map[string]*AuditFloatResult, n)
+		for i := 0; i < n; i++ {
+			var v string
+			var p string
+			if ctx.IsStringTable() {
+				q := buff.ReadInt() // read string index
+				p = ctx.Table[q]
+			} else {
+				p = buff.ReadString() // read string
+			}
+			o := p
+			v = o
+
+			var z map[string]*AuditFloatResult
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][map](map[string]*AuditFloatResult) ---
+				s := buff.ReadInt() // map len
+				r := make(map[string]*AuditFloatResult, s)
+				for j := 0; j < s; j++ {
+					var vv string
+					var u string
+					if ctx.IsStringTable() {
+						w := buff.ReadInt() // read string index
+						u = ctx.Table[w]
+					} else {
+						u = buff.ReadString() // read string
+					}
+					t := u
+					vv = t
+
+					var zz *AuditFloatResult
+					if buff.ReadUInt8() == uint8(0) {
+						zz = nil
+					} else {
+						// --- [begin][read][struct](AuditFloatResult) ---
+						x := &AuditFloatResult{}
+						buff.ReadInt() // [compatibility, unused]
+						errB := x.UnmarshalBinaryWithContext(ctx)
+						if errB != nil {
+							return errB
+						}
+						zz = x
+						// --- [end][read][struct](AuditFloatResult) ---
+
+					}
+					r[vv] = zz
+				}
+				z = r
+				// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+			}
+			m[v] = z
+		}
+		target.Resources = m
+		// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.MissingValues = nil
+	} else {
+		// --- [begin][read][slice]([]*AuditMissingValue) ---
+		aa := buff.ReadInt() // array len
+		y := make([]*AuditMissingValue, aa)
+		for ii := 0; ii < aa; ii++ {
+			var bb *AuditMissingValue
+			if buff.ReadUInt8() == uint8(0) {
+				bb = nil
+			} else {
+				// --- [begin][read][struct](AuditMissingValue) ---
+				cc := &AuditMissingValue{}
+				buff.ReadInt() // [compatibility, unused]
+				errC := cc.UnmarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				bb = cc
+				// --- [end][read][struct](AuditMissingValue) ---
 
+			}
+			y[ii] = bb
+		}
+		target.MissingValues = y
+		// --- [end][read][slice]([]*AuditMissingValue) ---
+
+	}
 	return nil
 }
 
@@ -2006,14 +1760,14 @@ func (target *AllocationSet) MarshalBinaryWithContext(ctx *EncodingContext) (err
 	buff := ctx.Buffer
 	buff.WriteUInt8(AllocationCodecVersion) // version
 
-	if target.allocations == nil {
+	if target.Allocations == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]*Allocation) ---
-		buff.WriteInt(len(target.allocations)) // map length
-		for v, z := range target.allocations {
+		buff.WriteInt(len(target.Allocations)) // map length
+		for v, z := range target.Allocations {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -2038,14 +1792,14 @@ func (target *AllocationSet) MarshalBinaryWithContext(ctx *EncodingContext) (err
 		// --- [end][write][map](map[string]*Allocation) ---
 
 	}
-	if target.externalKeys == nil {
+	if target.ExternalKeys == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]bool) ---
-		buff.WriteInt(len(target.externalKeys)) // map length
-		for vv, zz := range target.externalKeys {
+		buff.WriteInt(len(target.ExternalKeys)) // map length
+		for vv, zz := range target.ExternalKeys {
 			if ctx.IsStringTable() {
 				b := ctx.Table.AddOrGet(vv)
 				buff.WriteInt(b) // write table index
@@ -2057,14 +1811,14 @@ func (target *AllocationSet) MarshalBinaryWithContext(ctx *EncodingContext) (err
 		// --- [end][write][map](map[string]bool) ---
 
 	}
-	if target.idleKeys == nil {
+	if target.IdleKeys == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]bool) ---
-		buff.WriteInt(len(target.idleKeys)) // map length
-		for vvv, zzz := range target.idleKeys {
+		buff.WriteInt(len(target.IdleKeys)) // map length
+		for vvv, zzz := range target.IdleKeys {
 			if ctx.IsStringTable() {
 				c := ctx.Table.AddOrGet(vvv)
 				buff.WriteInt(c) // write table index
@@ -2183,208 +1937,169 @@ func (target *AllocationSet) UnmarshalBinaryWithContext(ctx *DecodingContext) (e
 		return fmt.Errorf("Invalid Version Unmarshaling AllocationSet. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.allocations = nil
-		} else {
-			// --- [begin][read][map](map[string]*Allocation) ---
-			b := buff.ReadInt() // map len
-			a := make(map[string]*Allocation, b)
-			for i := 0; i < b; i++ {
-				var v string
-				var d string
-				if ctx.IsStringTable() {
-					e := buff.ReadInt() // read string index
-					d = ctx.Table[e]
-				} else {
-					d = buff.ReadString() // read string
-				}
-				c := d
-				v = c
-
-				var z *Allocation
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][struct](Allocation) ---
-					f := &Allocation{}
-					buff.ReadInt() // [compatibility, unused]
-					errA := f.UnmarshalBinaryWithContext(ctx)
-					if errA != nil {
-						return errA
-					}
-					z = f
-					// --- [end][read][struct](Allocation) ---
-
-				}
-				a[v] = z
+	if buff.ReadUInt8() == uint8(0) {
+		target.Allocations = nil
+	} else {
+		// --- [begin][read][map](map[string]*Allocation) ---
+		b := buff.ReadInt() // map len
+		a := make(map[string]*Allocation, b)
+		for i := 0; i < b; i++ {
+			var v string
+			var d string
+			if ctx.IsStringTable() {
+				e := buff.ReadInt() // read string index
+				d = ctx.Table[e]
+			} else {
+				d = buff.ReadString() // read string
 			}
-			target.allocations = a
-			// --- [end][read][map](map[string]*Allocation) ---
+			c := d
+			v = c
 
-		}
-	} else {
-		target.allocations = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.externalKeys = nil
-		} else {
-			// --- [begin][read][map](map[string]bool) ---
-			h := buff.ReadInt() // map len
-			g := make(map[string]bool, h)
-			for j := 0; j < h; j++ {
-				var vv string
-				var l string
-				if ctx.IsStringTable() {
-					m := buff.ReadInt() // read string index
-					l = ctx.Table[m]
-				} else {
-					l = buff.ReadString() // read string
+			var z *Allocation
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][struct](Allocation) ---
+				f := &Allocation{}
+				buff.ReadInt() // [compatibility, unused]
+				errA := f.UnmarshalBinaryWithContext(ctx)
+				if errA != nil {
+					return errA
 				}
-				k := l
-				vv = k
+				z = f
+				// --- [end][read][struct](Allocation) ---
 
-				var zz bool
-				n := buff.ReadBool() // read bool
-				zz = n
-
-				g[vv] = zz
 			}
-			target.externalKeys = g
-			// --- [end][read][map](map[string]bool) ---
-
+			a[v] = z
 		}
-	} else {
-		target.externalKeys = nil
+		target.Allocations = a
+		// --- [end][read][map](map[string]*Allocation) ---
 
 	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.idleKeys = nil
-		} else {
-			// --- [begin][read][map](map[string]bool) ---
-			p := buff.ReadInt() // map len
-			o := make(map[string]bool, p)
-			for ii := 0; ii < p; ii++ {
-				var vvv string
-				var r string
-				if ctx.IsStringTable() {
-					s := buff.ReadInt() // read string index
-					r = ctx.Table[s]
-				} else {
-					r = buff.ReadString() // read string
-				}
-				q := r
-				vvv = q
-
-				var zzz bool
-				t := buff.ReadBool() // read bool
-				zzz = t
-
-				o[vvv] = zzz
+	if buff.ReadUInt8() == uint8(0) {
+		target.ExternalKeys = nil
+	} else {
+		// --- [begin][read][map](map[string]bool) ---
+		h := buff.ReadInt() // map len
+		g := make(map[string]bool, h)
+		for j := 0; j < h; j++ {
+			var vv string
+			var l string
+			if ctx.IsStringTable() {
+				m := buff.ReadInt() // read string index
+				l = ctx.Table[m]
+			} else {
+				l = buff.ReadString() // read string
 			}
-			target.idleKeys = o
-			// --- [end][read][map](map[string]bool) ---
+			k := l
+			vv = k
 
+			var zz bool
+			n := buff.ReadBool() // read bool
+			zz = n
+
+			g[vv] = zz
 		}
-	} else {
-		target.idleKeys = nil
+		target.ExternalKeys = g
+		// --- [end][read][map](map[string]bool) ---
 
 	}
-
-	if uint8(0) /* field version */ <= version {
-		var w string
-		if ctx.IsStringTable() {
-			x := buff.ReadInt() // read string index
-			w = ctx.Table[x]
-		} else {
-			w = buff.ReadString() // read string
-		}
-		u := w
-		target.FromSource = u
-
+	if buff.ReadUInt8() == uint8(0) {
+		target.IdleKeys = nil
 	} else {
-		target.FromSource = "" // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		y := &Window{}
-		buff.ReadInt() // [compatibility, unused]
-		errB := y.UnmarshalBinaryWithContext(ctx)
-		if errB != nil {
-			return errB
-		}
-		target.Window = *y
-		// --- [end][read][struct](Window) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Warnings = nil
-		} else {
-			// --- [begin][read][slice]([]string) ---
-			bb := buff.ReadInt() // array len
-			aa := make([]string, bb)
-			for jj := 0; jj < bb; jj++ {
-				var cc string
-				var ee string
-				if ctx.IsStringTable() {
-					ff := buff.ReadInt() // read string index
-					ee = ctx.Table[ff]
-				} else {
-					ee = buff.ReadString() // read string
-				}
-				dd := ee
-				cc = dd
-
-				aa[jj] = cc
+		// --- [begin][read][map](map[string]bool) ---
+		p := buff.ReadInt() // map len
+		o := make(map[string]bool, p)
+		for ii := 0; ii < p; ii++ {
+			var vvv string
+			var r string
+			if ctx.IsStringTable() {
+				s := buff.ReadInt() // read string index
+				r = ctx.Table[s]
+			} else {
+				r = buff.ReadString() // read string
 			}
-			target.Warnings = aa
-			// --- [end][read][slice]([]string) ---
+			q := r
+			vvv = q
 
+			var zzz bool
+			t := buff.ReadBool() // read bool
+			zzz = t
+
+			o[vvv] = zzz
 		}
+		target.IdleKeys = o
+		// --- [end][read][map](map[string]bool) ---
+
+	}
+	var w string
+	if ctx.IsStringTable() {
+		x := buff.ReadInt() // read string index
+		w = ctx.Table[x]
 	} else {
+		w = buff.ReadString() // read string
+	}
+	u := w
+	target.FromSource = u
+
+	// --- [begin][read][struct](Window) ---
+	y := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errB := y.UnmarshalBinaryWithContext(ctx)
+	if errB != nil {
+		return errB
+	}
+	target.Window = *y
+	// --- [end][read][struct](Window) ---
+
+	if buff.ReadUInt8() == uint8(0) {
 		target.Warnings = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Errors = nil
-		} else {
-			// --- [begin][read][slice]([]string) ---
-			hh := buff.ReadInt() // array len
-			gg := make([]string, hh)
-			for iii := 0; iii < hh; iii++ {
-				var kk string
-				var mm string
-				if ctx.IsStringTable() {
-					nn := buff.ReadInt() // read string index
-					mm = ctx.Table[nn]
-				} else {
-					mm = buff.ReadString() // read string
-				}
-				ll := mm
-				kk = ll
-
-				gg[iii] = kk
-			}
-			target.Errors = gg
-			// --- [end][read][slice]([]string) ---
-
-		}
 	} else {
-		target.Errors = nil
+		// --- [begin][read][slice]([]string) ---
+		bb := buff.ReadInt() // array len
+		aa := make([]string, bb)
+		for jj := 0; jj < bb; jj++ {
+			var cc string
+			var ee string
+			if ctx.IsStringTable() {
+				ff := buff.ReadInt() // read string index
+				ee = ctx.Table[ff]
+			} else {
+				ee = buff.ReadString() // read string
+			}
+			dd := ee
+			cc = dd
+
+			aa[jj] = cc
+		}
+		target.Warnings = aa
+		// --- [end][read][slice]([]string) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Errors = nil
+	} else {
+		// --- [begin][read][slice]([]string) ---
+		hh := buff.ReadInt() // array len
+		gg := make([]string, hh)
+		for iii := 0; iii < hh; iii++ {
+			var kk string
+			var mm string
+			if ctx.IsStringTable() {
+				nn := buff.ReadInt() // read string index
+				mm = ctx.Table[nn]
+			} else {
+				mm = buff.ReadString() // read string
+			}
+			ll := mm
+			kk = ll
 
+			gg[iii] = kk
+		}
+		target.Errors = gg
+		// --- [end][read][slice]([]string) ---
+
+	}
 	return nil
 }
 
@@ -2428,22 +2143,22 @@ func (target *AllocationSetRange) MarshalBinaryWithContext(ctx *EncodingContext)
 	buff := ctx.Buffer
 	buff.WriteUInt8(AllocationCodecVersion) // version
 
-	if target.allocations == nil {
+	if target.Allocations == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][slice]([]*AllocationSet) ---
-		buff.WriteInt(len(target.allocations)) // array length
-		for i := 0; i < len(target.allocations); i++ {
-			if target.allocations[i] == nil {
+		buff.WriteInt(len(target.Allocations)) // array length
+		for i := 0; i < len(target.Allocations); i++ {
+			if target.Allocations[i] == nil {
 				buff.WriteUInt8(uint8(0)) // write nil byte
 			} else {
 				buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 				// --- [begin][write][struct](AllocationSet) ---
 				buff.WriteInt(0) // [compatibility, unused]
-				errA := target.allocations[i].MarshalBinaryWithContext(ctx)
+				errA := target.Allocations[i].MarshalBinaryWithContext(ctx)
 				if errA != nil {
 					return errA
 				}
@@ -2517,54 +2232,43 @@ func (target *AllocationSetRange) UnmarshalBinaryWithContext(ctx *DecodingContex
 		return fmt.Errorf("Invalid Version Unmarshaling AllocationSetRange. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.allocations = nil
-		} else {
-			// --- [begin][read][slice]([]*AllocationSet) ---
-			b := buff.ReadInt() // array len
-			a := make([]*AllocationSet, b)
-			for i := 0; i < b; i++ {
-				var c *AllocationSet
-				if buff.ReadUInt8() == uint8(0) {
-					c = nil
-				} else {
-					// --- [begin][read][struct](AllocationSet) ---
-					d := &AllocationSet{}
-					buff.ReadInt() // [compatibility, unused]
-					errA := d.UnmarshalBinaryWithContext(ctx)
-					if errA != nil {
-						return errA
-					}
-					c = d
-					// --- [end][read][struct](AllocationSet) ---
-
+	if buff.ReadUInt8() == uint8(0) {
+		target.Allocations = nil
+	} else {
+		// --- [begin][read][slice]([]*AllocationSet) ---
+		b := buff.ReadInt() // array len
+		a := make([]*AllocationSet, b)
+		for i := 0; i < b; i++ {
+			var c *AllocationSet
+			if buff.ReadUInt8() == uint8(0) {
+				c = nil
+			} else {
+				// --- [begin][read][struct](AllocationSet) ---
+				d := &AllocationSet{}
+				buff.ReadInt() // [compatibility, unused]
+				errA := d.UnmarshalBinaryWithContext(ctx)
+				if errA != nil {
+					return errA
 				}
-				a[i] = c
+				c = d
+				// --- [end][read][struct](AllocationSet) ---
+
 			}
-			target.allocations = a
-			// --- [end][read][slice]([]*AllocationSet) ---
-
+			a[i] = c
 		}
-	} else {
-		target.allocations = nil
+		target.Allocations = a
+		// --- [end][read][slice]([]*AllocationSet) ---
 
 	}
-
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.FromStore = e
-
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.FromStore = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.FromStore = e
 
 	return nil
 }
@@ -2610,14 +2314,14 @@ func (target *Any) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -2636,14 +2340,14 @@ func (target *Any) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	}
 	// --- [end][write][alias](AssetLabels) ---
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -2651,7 +2355,7 @@ func (target *Any) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	}
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -2660,7 +2364,7 @@ func (target *Any) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -2670,13 +2374,13 @@ func (target *Any) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
 	return nil
 }
@@ -2735,129 +2439,97 @@ func (target *Any) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error) 
 		return fmt.Errorf("Invalid Version Unmarshaling Any. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var a map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			a = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			c := buff.ReadInt() // map len
-			b := make(map[string]string, c)
-			for i := 0; i < c; i++ {
-				var v string
-				var e string
-				if ctx.IsStringTable() {
-					f := buff.ReadInt() // read string index
-					e = ctx.Table[f]
-				} else {
-					e = buff.ReadString() // read string
-				}
-				d := e
-				v = d
-
-				var z string
-				var h string
-				if ctx.IsStringTable() {
-					k := buff.ReadInt() // read string index
-					h = ctx.Table[k]
-				} else {
-					h = buff.ReadString() // read string
-				}
-				g := h
-				z = g
-
-				b[v] = z
+	// --- [begin][read][alias](AssetLabels) ---
+	var a map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		a = nil
+	} else {
+		// --- [begin][read][map](map[string]string) ---
+		c := buff.ReadInt() // map len
+		b := make(map[string]string, c)
+		for i := 0; i < c; i++ {
+			var v string
+			var e string
+			if ctx.IsStringTable() {
+				f := buff.ReadInt() // read string index
+				e = ctx.Table[f]
+			} else {
+				e = buff.ReadString() // read string
 			}
-			a = b
-			// --- [end][read][map](map[string]string) ---
+			d := e
+			v = d
 
-		}
-		target.labels = AssetLabels(a)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			l := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := l.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
+			var z string
+			var h string
+			if ctx.IsStringTable() {
+				k := buff.ReadInt() // read string index
+				h = ctx.Table[k]
+			} else {
+				h = buff.ReadString() // read string
 			}
-			target.properties = l
-			// --- [end][read][struct](AssetProperties) ---
+			g := h
+			z = g
 
+			b[v] = z
 		}
-	} else {
-		target.properties = nil
+		a = b
+		// --- [end][read][map](map[string]string) ---
 
 	}
+	target.Labels = AssetLabels(a)
+	// --- [end][read][alias](AssetLabels) ---
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		m := &time.Time{}
-		n := buff.ReadInt()    // byte array length
-		o := buff.ReadBytes(n) // byte array
-		errB := m.UnmarshalBinary(o)
-		if errB != nil {
-			return errB
-		}
-		target.start = *m
-		// --- [end][read][reference](time.Time) ---
-
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		p := &time.Time{}
-		q := buff.ReadInt()    // byte array length
-		r := buff.ReadBytes(q) // byte array
-		errC := p.UnmarshalBinary(r)
-		if errC != nil {
-			return errC
-		}
-		target.end = *p
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		s := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		l := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errD := s.UnmarshalBinaryWithContext(ctx)
-		if errD != nil {
-			return errD
+		errA := l.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *s
-		// --- [end][read][struct](Window) ---
+		target.Properties = l
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.adjustment = t
-
-	} else {
-		target.adjustment = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	m := &time.Time{}
+	n := buff.ReadInt()    // byte array length
+	o := buff.ReadBytes(n) // byte array
+	errB := m.UnmarshalBinary(o)
+	if errB != nil {
+		return errB
 	}
+	target.Start = *m
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		u := buff.ReadFloat64() // read float64
-		target.Cost = u
-
-	} else {
-		target.Cost = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	p := &time.Time{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errC := p.UnmarshalBinary(r)
+	if errC != nil {
+		return errC
 	}
+	target.End = *p
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][struct](Window) ---
+	s := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errD := s.UnmarshalBinaryWithContext(ctx)
+	if errD != nil {
+		return errD
+	}
+	target.Window = *s
+	// --- [end][read][struct](Window) ---
+
+	t := buff.ReadFloat64() // read float64
+	target.Adjustment = t
+
+	u := buff.ReadFloat64() // read float64
+	target.Cost = u
 
 	return nil
 }
@@ -3007,125 +2679,85 @@ func (target *AssetProperties) UnmarshalBinaryWithContext(ctx *DecodingContext) 
 		return fmt.Errorf("Invalid Version Unmarshaling AssetProperties. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		var b string
-		if ctx.IsStringTable() {
-			c := buff.ReadInt() // read string index
-			b = ctx.Table[c]
-		} else {
-			b = buff.ReadString() // read string
-		}
-		a := b
-		target.Category = a
-
+	var b string
+	if ctx.IsStringTable() {
+		c := buff.ReadInt() // read string index
+		b = ctx.Table[c]
 	} else {
-		target.Category = "" // default
+		b = buff.ReadString() // read string
 	}
+	a := b
+	target.Category = a
 
-	if uint8(0) /* field version */ <= version {
-		var e string
-		if ctx.IsStringTable() {
-			f := buff.ReadInt() // read string index
-			e = ctx.Table[f]
-		} else {
-			e = buff.ReadString() // read string
-		}
-		d := e
-		target.Provider = d
-
+	var e string
+	if ctx.IsStringTable() {
+		f := buff.ReadInt() // read string index
+		e = ctx.Table[f]
 	} else {
-		target.Provider = "" // default
+		e = buff.ReadString() // read string
 	}
+	d := e
+	target.Provider = d
 
-	if uint8(0) /* field version */ <= version {
-		var h string
-		if ctx.IsStringTable() {
-			k := buff.ReadInt() // read string index
-			h = ctx.Table[k]
-		} else {
-			h = buff.ReadString() // read string
-		}
-		g := h
-		target.Account = g
-
+	var h string
+	if ctx.IsStringTable() {
+		k := buff.ReadInt() // read string index
+		h = ctx.Table[k]
 	} else {
-		target.Account = "" // default
+		h = buff.ReadString() // read string
 	}
+	g := h
+	target.Account = g
 
-	if uint8(0) /* field version */ <= version {
-		var m string
-		if ctx.IsStringTable() {
-			n := buff.ReadInt() // read string index
-			m = ctx.Table[n]
-		} else {
-			m = buff.ReadString() // read string
-		}
-		l := m
-		target.Project = l
-
+	var m string
+	if ctx.IsStringTable() {
+		n := buff.ReadInt() // read string index
+		m = ctx.Table[n]
 	} else {
-		target.Project = "" // default
+		m = buff.ReadString() // read string
 	}
+	l := m
+	target.Project = l
 
-	if uint8(0) /* field version */ <= version {
-		var p string
-		if ctx.IsStringTable() {
-			q := buff.ReadInt() // read string index
-			p = ctx.Table[q]
-		} else {
-			p = buff.ReadString() // read string
-		}
-		o := p
-		target.Service = o
-
+	var p string
+	if ctx.IsStringTable() {
+		q := buff.ReadInt() // read string index
+		p = ctx.Table[q]
 	} else {
-		target.Service = "" // default
+		p = buff.ReadString() // read string
 	}
+	o := p
+	target.Service = o
 
-	if uint8(0) /* field version */ <= version {
-		var s string
-		if ctx.IsStringTable() {
-			t := buff.ReadInt() // read string index
-			s = ctx.Table[t]
-		} else {
-			s = buff.ReadString() // read string
-		}
-		r := s
-		target.Cluster = r
-
+	var s string
+	if ctx.IsStringTable() {
+		t := buff.ReadInt() // read string index
+		s = ctx.Table[t]
 	} else {
-		target.Cluster = "" // default
+		s = buff.ReadString() // read string
 	}
+	r := s
+	target.Cluster = r
 
-	if uint8(0) /* field version */ <= version {
-		var w string
-		if ctx.IsStringTable() {
-			x := buff.ReadInt() // read string index
-			w = ctx.Table[x]
-		} else {
-			w = buff.ReadString() // read string
-		}
-		u := w
-		target.Name = u
-
+	var w string
+	if ctx.IsStringTable() {
+		x := buff.ReadInt() // read string index
+		w = ctx.Table[x]
 	} else {
-		target.Name = "" // default
+		w = buff.ReadString() // read string
 	}
+	u := w
+	target.Name = u
 
-	if uint8(0) /* field version */ <= version {
-		var aa string
-		if ctx.IsStringTable() {
-			bb := buff.ReadInt() // read string index
-			aa = ctx.Table[bb]
-		} else {
-			aa = buff.ReadString() // read string
-		}
-		y := aa
-		target.ProviderID = y
-
+	var aa string
+	if ctx.IsStringTable() {
+		bb := buff.ReadInt() // read string index
+		aa = ctx.Table[bb]
 	} else {
-		target.ProviderID = "" // default
+		aa = buff.ReadString() // read string
 	}
+	y := aa
+	target.ProviderID = y
 
 	return nil
 }
@@ -3327,159 +2959,134 @@ func (target *AssetReconciliationAudit) UnmarshalBinaryWithContext(ctx *Decoding
 		return fmt.Errorf("Invalid Version Unmarshaling AssetReconciliationAudit. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AuditStatus) ---
-		var a string
-		var c string
-		if ctx.IsStringTable() {
-			d := buff.ReadInt() // read string index
-			c = ctx.Table[d]
-		} else {
-			c = buff.ReadString() // read string
-		}
-		b := c
-		a = b
-
-		target.Status = AuditStatus(a)
-		// --- [end][read][alias](AuditStatus) ---
-
+	// --- [begin][read][alias](AuditStatus) ---
+	var a string
+	var c string
+	if ctx.IsStringTable() {
+		d := buff.ReadInt() // read string index
+		c = ctx.Table[d]
 	} else {
+		c = buff.ReadString() // read string
 	}
+	b := c
+	a = b
 
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.Description = e
+	target.Status = AuditStatus(a)
+	// --- [end][read][alias](AuditStatus) ---
 
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.Description = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.Description = e
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		h := &time.Time{}
-		k := buff.ReadInt()    // byte array length
-		l := buff.ReadBytes(k) // byte array
-		errA := h.UnmarshalBinary(l)
-		if errA != nil {
-			return errA
-		}
-		target.LastRun = *h
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][reference](time.Time) ---
+	h := &time.Time{}
+	k := buff.ReadInt()    // byte array length
+	l := buff.ReadBytes(k) // byte array
+	errA := h.UnmarshalBinary(l)
+	if errA != nil {
+		return errA
 	}
+	target.LastRun = *h
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Results = nil
-		} else {
-			// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
-			n := buff.ReadInt() // map len
-			m := make(map[string]map[string]*AuditFloatResult, n)
-			for i := 0; i < n; i++ {
-				var v string
-				var p string
-				if ctx.IsStringTable() {
-					q := buff.ReadInt() // read string index
-					p = ctx.Table[q]
-				} else {
-					p = buff.ReadString() // read string
-				}
-				o := p
-				v = o
-
-				var z map[string]*AuditFloatResult
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][map](map[string]*AuditFloatResult) ---
-					s := buff.ReadInt() // map len
-					r := make(map[string]*AuditFloatResult, s)
-					for j := 0; j < s; j++ {
-						var vv string
-						var u string
-						if ctx.IsStringTable() {
-							w := buff.ReadInt() // read string index
-							u = ctx.Table[w]
-						} else {
-							u = buff.ReadString() // read string
-						}
-						t := u
-						vv = t
-
-						var zz *AuditFloatResult
-						if buff.ReadUInt8() == uint8(0) {
-							zz = nil
-						} else {
-							// --- [begin][read][struct](AuditFloatResult) ---
-							x := &AuditFloatResult{}
-							buff.ReadInt() // [compatibility, unused]
-							errB := x.UnmarshalBinaryWithContext(ctx)
-							if errB != nil {
-								return errB
-							}
-							zz = x
-							// --- [end][read][struct](AuditFloatResult) ---
-
-						}
-						r[vv] = zz
-					}
-					z = r
-					// --- [end][read][map](map[string]*AuditFloatResult) ---
-
-				}
-				m[v] = z
-			}
-			target.Results = m
-			// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.Results = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.MissingValues = nil
-		} else {
-			// --- [begin][read][slice]([]*AuditMissingValue) ---
-			aa := buff.ReadInt() // array len
-			y := make([]*AuditMissingValue, aa)
-			for ii := 0; ii < aa; ii++ {
-				var bb *AuditMissingValue
-				if buff.ReadUInt8() == uint8(0) {
-					bb = nil
-				} else {
-					// --- [begin][read][struct](AuditMissingValue) ---
-					cc := &AuditMissingValue{}
-					buff.ReadInt() // [compatibility, unused]
-					errC := cc.UnmarshalBinaryWithContext(ctx)
-					if errC != nil {
-						return errC
-					}
-					bb = cc
-					// --- [end][read][struct](AuditMissingValue) ---
-
-				}
-				y[ii] = bb
-			}
-			target.MissingValues = y
-			// --- [end][read][slice]([]*AuditMissingValue) ---
-
-		}
 	} else {
-		target.MissingValues = nil
+		// --- [begin][read][map](map[string]map[string]*AuditFloatResult) ---
+		n := buff.ReadInt() // map len
+		m := make(map[string]map[string]*AuditFloatResult, n)
+		for i := 0; i < n; i++ {
+			var v string
+			var p string
+			if ctx.IsStringTable() {
+				q := buff.ReadInt() // read string index
+				p = ctx.Table[q]
+			} else {
+				p = buff.ReadString() // read string
+			}
+			o := p
+			v = o
+
+			var z map[string]*AuditFloatResult
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][map](map[string]*AuditFloatResult) ---
+				s := buff.ReadInt() // map len
+				r := make(map[string]*AuditFloatResult, s)
+				for j := 0; j < s; j++ {
+					var vv string
+					var u string
+					if ctx.IsStringTable() {
+						w := buff.ReadInt() // read string index
+						u = ctx.Table[w]
+					} else {
+						u = buff.ReadString() // read string
+					}
+					t := u
+					vv = t
+
+					var zz *AuditFloatResult
+					if buff.ReadUInt8() == uint8(0) {
+						zz = nil
+					} else {
+						// --- [begin][read][struct](AuditFloatResult) ---
+						x := &AuditFloatResult{}
+						buff.ReadInt() // [compatibility, unused]
+						errB := x.UnmarshalBinaryWithContext(ctx)
+						if errB != nil {
+							return errB
+						}
+						zz = x
+						// --- [end][read][struct](AuditFloatResult) ---
+
+					}
+					r[vv] = zz
+				}
+				z = r
+				// --- [end][read][map](map[string]*AuditFloatResult) ---
+
+			}
+			m[v] = z
+		}
+		target.Results = m
+		// --- [end][read][map](map[string]map[string]*AuditFloatResult) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.MissingValues = nil
+	} else {
+		// --- [begin][read][slice]([]*AuditMissingValue) ---
+		aa := buff.ReadInt() // array len
+		y := make([]*AuditMissingValue, aa)
+		for ii := 0; ii < aa; ii++ {
+			var bb *AuditMissingValue
+			if buff.ReadUInt8() == uint8(0) {
+				bb = nil
+			} else {
+				// --- [begin][read][struct](AuditMissingValue) ---
+				cc := &AuditMissingValue{}
+				buff.ReadInt() // [compatibility, unused]
+				errC := cc.UnmarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				bb = cc
+				// --- [end][read][struct](AuditMissingValue) ---
 
+			}
+			y[ii] = bb
+		}
+		target.MissingValues = y
+		// --- [end][read][slice]([]*AuditMissingValue) ---
+
+	}
 	return nil
 }
 
@@ -3525,32 +3132,34 @@ func (target *AssetSet) MarshalBinaryWithContext(ctx *EncodingContext) (err erro
 	buff := ctx.Buffer
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
-	if target.aggregateBy == nil {
+	// execute pre-processing func
+	preProcessAssetSet(target)
+	if target.AggregationKeys == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][slice]([]string) ---
-		buff.WriteInt(len(target.aggregateBy)) // array length
-		for i := 0; i < len(target.aggregateBy); i++ {
+		buff.WriteInt(len(target.AggregationKeys)) // array length
+		for i := 0; i < len(target.AggregationKeys); i++ {
 			if ctx.IsStringTable() {
-				a := ctx.Table.AddOrGet(target.aggregateBy[i])
+				a := ctx.Table.AddOrGet(target.AggregationKeys[i])
 				buff.WriteInt(a) // write table index
 			} else {
-				buff.WriteString(target.aggregateBy[i]) // write string
+				buff.WriteString(target.AggregationKeys[i]) // write string
 			}
 		}
 		// --- [end][write][slice]([]string) ---
 
 	}
-	if target.assets == nil {
+	if target.Assets == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]Asset) ---
-		buff.WriteInt(len(target.assets)) // map length
-		for v, z := range target.assets {
+		buff.WriteInt(len(target.Assets)) // map length
+		for v, z := range target.Assets {
 			if ctx.IsStringTable() {
 				b := ctx.Table.AddOrGet(v)
 				buff.WriteInt(b) // write table index
@@ -3688,178 +3297,147 @@ func (target *AssetSet) UnmarshalBinaryWithContext(ctx *DecodingContext) (err er
 		return fmt.Errorf("Invalid Version Unmarshaling AssetSet. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.aggregateBy = nil
-		} else {
-			// --- [begin][read][slice]([]string) ---
-			b := buff.ReadInt() // array len
-			a := make([]string, b)
-			for i := 0; i < b; i++ {
-				var c string
-				var e string
-				if ctx.IsStringTable() {
-					f := buff.ReadInt() // read string index
-					e = ctx.Table[f]
-				} else {
-					e = buff.ReadString() // read string
-				}
-				d := e
-				c = d
-
-				a[i] = c
+	if buff.ReadUInt8() == uint8(0) {
+		target.AggregationKeys = nil
+	} else {
+		// --- [begin][read][slice]([]string) ---
+		b := buff.ReadInt() // array len
+		a := make([]string, b)
+		for i := 0; i < b; i++ {
+			var c string
+			var e string
+			if ctx.IsStringTable() {
+				f := buff.ReadInt() // read string index
+				e = ctx.Table[f]
+			} else {
+				e = buff.ReadString() // read string
 			}
-			target.aggregateBy = a
-			// --- [end][read][slice]([]string) ---
+			d := e
+			c = d
 
+			a[i] = c
 		}
-	} else {
-		target.aggregateBy = nil
+		target.AggregationKeys = a
+		// --- [end][read][slice]([]string) ---
 
 	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.assets = nil
-		} else {
-			// --- [begin][read][map](map[string]Asset) ---
-			h := buff.ReadInt() // map len
-			g := make(map[string]Asset, h)
-			for j := 0; j < h; j++ {
-				var v string
-				var l string
-				if ctx.IsStringTable() {
-					m := buff.ReadInt() // read string index
-					l = ctx.Table[m]
-				} else {
-					l = buff.ReadString() // read string
-				}
-				k := l
-				v = k
-
-				var z Asset
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][interface](Asset) ---
-					n := buff.ReadString()
-					_, o, _ := resolveType(n)
-					if _, ok := typeMap[o]; !ok {
-						return fmt.Errorf("Unknown Type: %s", o)
-					}
-					p, okA := reflect.New(typeMap[o]).Interface().(BinDecoder)
-					if !okA {
-						return fmt.Errorf("Type: %s does not implement %s.BinDecoder.", o, GeneratorPackageName)
-					}
-					buff.ReadInt() // [compatibility, unused]
-					errA := p.UnmarshalBinaryWithContext(ctx)
-					if errA != nil {
-						return errA
-					}
-					z = p.(Asset)
-					// --- [end][read][interface](Asset) ---
-
-				}
-				g[v] = z
+	if buff.ReadUInt8() == uint8(0) {
+		target.Assets = nil
+	} else {
+		// --- [begin][read][map](map[string]Asset) ---
+		h := buff.ReadInt() // map len
+		g := make(map[string]Asset, h)
+		for j := 0; j < h; j++ {
+			var v string
+			var l string
+			if ctx.IsStringTable() {
+				m := buff.ReadInt() // read string index
+				l = ctx.Table[m]
+			} else {
+				l = buff.ReadString() // read string
 			}
-			target.assets = g
-			// --- [end][read][map](map[string]Asset) ---
+			k := l
+			v = k
 
-		}
-	} else {
-		target.assets = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		var r string
-		if ctx.IsStringTable() {
-			s := buff.ReadInt() // read string index
-			r = ctx.Table[s]
-		} else {
-			r = buff.ReadString() // read string
-		}
-		q := r
-		target.FromSource = q
-
-	} else {
-		target.FromSource = "" // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		t := &Window{}
-		buff.ReadInt() // [compatibility, unused]
-		errB := t.UnmarshalBinaryWithContext(ctx)
-		if errB != nil {
-			return errB
-		}
-		target.Window = *t
-		// --- [end][read][struct](Window) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Warnings = nil
-		} else {
-			// --- [begin][read][slice]([]string) ---
-			w := buff.ReadInt() // array len
-			u := make([]string, w)
-			for ii := 0; ii < w; ii++ {
-				var x string
-				var aa string
-				if ctx.IsStringTable() {
-					bb := buff.ReadInt() // read string index
-					aa = ctx.Table[bb]
-				} else {
-					aa = buff.ReadString() // read string
+			var z Asset
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][interface](Asset) ---
+				n := buff.ReadString()
+				_, o, _ := resolveType(n)
+				if _, ok := typeMap[o]; !ok {
+					return fmt.Errorf("Unknown Type: %s", o)
 				}
-				y := aa
-				x = y
+				p, okA := reflect.New(typeMap[o]).Interface().(BinDecoder)
+				if !okA {
+					return fmt.Errorf("Type: %s does not implement %s.BinDecoder.", o, GeneratorPackageName)
+				}
+				buff.ReadInt() // [compatibility, unused]
+				errA := p.UnmarshalBinaryWithContext(ctx)
+				if errA != nil {
+					return errA
+				}
+				z = p.(Asset)
+				// --- [end][read][interface](Asset) ---
 
-				u[ii] = x
 			}
-			target.Warnings = u
-			// --- [end][read][slice]([]string) ---
-
+			g[v] = z
 		}
+		target.Assets = g
+		// --- [end][read][map](map[string]Asset) ---
+
+	}
+	var r string
+	if ctx.IsStringTable() {
+		s := buff.ReadInt() // read string index
+		r = ctx.Table[s]
 	} else {
+		r = buff.ReadString() // read string
+	}
+	q := r
+	target.FromSource = q
+
+	// --- [begin][read][struct](Window) ---
+	t := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errB := t.UnmarshalBinaryWithContext(ctx)
+	if errB != nil {
+		return errB
+	}
+	target.Window = *t
+	// --- [end][read][struct](Window) ---
+
+	if buff.ReadUInt8() == uint8(0) {
 		target.Warnings = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Errors = nil
-		} else {
-			// --- [begin][read][slice]([]string) ---
-			dd := buff.ReadInt() // array len
-			cc := make([]string, dd)
-			for jj := 0; jj < dd; jj++ {
-				var ee string
-				var gg string
-				if ctx.IsStringTable() {
-					hh := buff.ReadInt() // read string index
-					gg = ctx.Table[hh]
-				} else {
-					gg = buff.ReadString() // read string
-				}
-				ff := gg
-				ee = ff
-
-				cc[jj] = ee
-			}
-			target.Errors = cc
-			// --- [end][read][slice]([]string) ---
-
-		}
 	} else {
-		target.Errors = nil
+		// --- [begin][read][slice]([]string) ---
+		w := buff.ReadInt() // array len
+		u := make([]string, w)
+		for ii := 0; ii < w; ii++ {
+			var x string
+			var aa string
+			if ctx.IsStringTable() {
+				bb := buff.ReadInt() // read string index
+				aa = ctx.Table[bb]
+			} else {
+				aa = buff.ReadString() // read string
+			}
+			y := aa
+			x = y
+
+			u[ii] = x
+		}
+		target.Warnings = u
+		// --- [end][read][slice]([]string) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Errors = nil
+	} else {
+		// --- [begin][read][slice]([]string) ---
+		dd := buff.ReadInt() // array len
+		cc := make([]string, dd)
+		for jj := 0; jj < dd; jj++ {
+			var ee string
+			var gg string
+			if ctx.IsStringTable() {
+				hh := buff.ReadInt() // read string index
+				gg = ctx.Table[hh]
+			} else {
+				gg = buff.ReadString() // read string
+			}
+			ff := gg
+			ee = ff
 
+			cc[jj] = ee
+		}
+		target.Errors = cc
+		// --- [end][read][slice]([]string) ---
+
+	}
+	// execute post-processing func
+	postProcessAssetSet(target)
 	return nil
 }
 
@@ -3903,22 +3481,22 @@ func (target *AssetSetRange) MarshalBinaryWithContext(ctx *EncodingContext) (err
 	buff := ctx.Buffer
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
-	if target.assets == nil {
+	if target.Assets == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][slice]([]*AssetSet) ---
-		buff.WriteInt(len(target.assets)) // array length
-		for i := 0; i < len(target.assets); i++ {
-			if target.assets[i] == nil {
+		buff.WriteInt(len(target.Assets)) // array length
+		for i := 0; i < len(target.Assets); i++ {
+			if target.Assets[i] == nil {
 				buff.WriteUInt8(uint8(0)) // write nil byte
 			} else {
 				buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 				// --- [begin][write][struct](AssetSet) ---
 				buff.WriteInt(0) // [compatibility, unused]
-				errA := target.assets[i].MarshalBinaryWithContext(ctx)
+				errA := target.Assets[i].MarshalBinaryWithContext(ctx)
 				if errA != nil {
 					return errA
 				}
@@ -3992,54 +3570,43 @@ func (target *AssetSetRange) UnmarshalBinaryWithContext(ctx *DecodingContext) (e
 		return fmt.Errorf("Invalid Version Unmarshaling AssetSetRange. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.assets = nil
-		} else {
-			// --- [begin][read][slice]([]*AssetSet) ---
-			b := buff.ReadInt() // array len
-			a := make([]*AssetSet, b)
-			for i := 0; i < b; i++ {
-				var c *AssetSet
-				if buff.ReadUInt8() == uint8(0) {
-					c = nil
-				} else {
-					// --- [begin][read][struct](AssetSet) ---
-					d := &AssetSet{}
-					buff.ReadInt() // [compatibility, unused]
-					errA := d.UnmarshalBinaryWithContext(ctx)
-					if errA != nil {
-						return errA
-					}
-					c = d
-					// --- [end][read][struct](AssetSet) ---
-
+	if buff.ReadUInt8() == uint8(0) {
+		target.Assets = nil
+	} else {
+		// --- [begin][read][slice]([]*AssetSet) ---
+		b := buff.ReadInt() // array len
+		a := make([]*AssetSet, b)
+		for i := 0; i < b; i++ {
+			var c *AssetSet
+			if buff.ReadUInt8() == uint8(0) {
+				c = nil
+			} else {
+				// --- [begin][read][struct](AssetSet) ---
+				d := &AssetSet{}
+				buff.ReadInt() // [compatibility, unused]
+				errA := d.UnmarshalBinaryWithContext(ctx)
+				if errA != nil {
+					return errA
 				}
-				a[i] = c
+				c = d
+				// --- [end][read][struct](AssetSet) ---
+
 			}
-			target.assets = a
-			// --- [end][read][slice]([]*AssetSet) ---
-
+			a[i] = c
 		}
-	} else {
-		target.assets = nil
+		target.Assets = a
+		// --- [end][read][slice]([]*AssetSet) ---
 
 	}
-
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.FromStore = e
-
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.FromStore = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.FromStore = e
 
 	return nil
 }
@@ -4143,21 +3710,11 @@ func (target *AuditFloatResult) UnmarshalBinaryWithContext(ctx *DecodingContext)
 		return fmt.Errorf("Invalid Version Unmarshaling AuditFloatResult. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		a := buff.ReadFloat64() // read float64
-		target.Expected = a
+	a := buff.ReadFloat64() // read float64
+	target.Expected = a
 
-	} else {
-		target.Expected = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		b := buff.ReadFloat64() // read float64
-		target.Actual = b
-
-	} else {
-		target.Actual = float64(0) // default
-	}
+	b := buff.ReadFloat64() // read float64
+	target.Actual = b
 
 	return nil
 }
@@ -4271,35 +3828,25 @@ func (target *AuditMissingValue) UnmarshalBinaryWithContext(ctx *DecodingContext
 		return fmt.Errorf("Invalid Version Unmarshaling AuditMissingValue. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		var b string
-		if ctx.IsStringTable() {
-			c := buff.ReadInt() // read string index
-			b = ctx.Table[c]
-		} else {
-			b = buff.ReadString() // read string
-		}
-		a := b
-		target.Description = a
-
+	var b string
+	if ctx.IsStringTable() {
+		c := buff.ReadInt() // read string index
+		b = ctx.Table[c]
 	} else {
-		target.Description = "" // default
+		b = buff.ReadString() // read string
 	}
+	a := b
+	target.Description = a
 
-	if uint8(0) /* field version */ <= version {
-		var e string
-		if ctx.IsStringTable() {
-			f := buff.ReadInt() // read string index
-			e = ctx.Table[f]
-		} else {
-			e = buff.ReadString() // read string
-		}
-		d := e
-		target.Key = d
-
+	var e string
+	if ctx.IsStringTable() {
+		f := buff.ReadInt() // read string index
+		e = ctx.Table[f]
 	} else {
-		target.Key = "" // default
+		e = buff.ReadString() // read string
 	}
+	d := e
+	target.Key = d
 
 	return nil
 }
@@ -4495,139 +4042,99 @@ func (target *AuditSet) UnmarshalBinaryWithContext(ctx *DecodingContext) (err er
 		return fmt.Errorf("Invalid Version Unmarshaling AuditSet. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.AllocationReconciliation = nil
-		} else {
-			// --- [begin][read][struct](AllocationReconciliationAudit) ---
-			a := &AllocationReconciliationAudit{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := a.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
-			}
-			target.AllocationReconciliation = a
-			// --- [end][read][struct](AllocationReconciliationAudit) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.AllocationReconciliation = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.AllocationAgg = nil
-		} else {
-			// --- [begin][read][struct](AggAudit) ---
-			b := &AggAudit{}
-			buff.ReadInt() // [compatibility, unused]
-			errB := b.UnmarshalBinaryWithContext(ctx)
-			if errB != nil {
-				return errB
-			}
-			target.AllocationAgg = b
-			// --- [end][read][struct](AggAudit) ---
-
-		}
 	} else {
-		target.AllocationAgg = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.AllocationTotal = nil
-		} else {
-			// --- [begin][read][struct](TotalAudit) ---
-			c := &TotalAudit{}
-			buff.ReadInt() // [compatibility, unused]
-			errC := c.UnmarshalBinaryWithContext(ctx)
-			if errC != nil {
-				return errC
-			}
-			target.AllocationTotal = c
-			// --- [end][read][struct](TotalAudit) ---
-
-		}
-	} else {
-		target.AllocationTotal = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.AssetTotal = nil
-		} else {
-			// --- [begin][read][struct](TotalAudit) ---
-			d := &TotalAudit{}
-			buff.ReadInt() // [compatibility, unused]
-			errD := d.UnmarshalBinaryWithContext(ctx)
-			if errD != nil {
-				return errD
-			}
-			target.AssetTotal = d
-			// --- [end][read][struct](TotalAudit) ---
-
-		}
-	} else {
-		target.AssetTotal = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.AssetReconciliation = nil
-		} else {
-			// --- [begin][read][struct](AssetReconciliationAudit) ---
-			e := &AssetReconciliationAudit{}
-			buff.ReadInt() // [compatibility, unused]
-			errE := e.UnmarshalBinaryWithContext(ctx)
-			if errE != nil {
-				return errE
-			}
-			target.AssetReconciliation = e
-			// --- [end][read][struct](AssetReconciliationAudit) ---
-
-		}
-	} else {
-		target.AssetReconciliation = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.ClusterEquality = nil
-		} else {
-			// --- [begin][read][struct](EqualityAudit) ---
-			f := &EqualityAudit{}
-			buff.ReadInt() // [compatibility, unused]
-			errF := f.UnmarshalBinaryWithContext(ctx)
-			if errF != nil {
-				return errF
-			}
-			target.ClusterEquality = f
-			// --- [end][read][struct](EqualityAudit) ---
-
-		}
-	} else {
-		target.ClusterEquality = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		g := &Window{}
+		// --- [begin][read][struct](AllocationReconciliationAudit) ---
+		a := &AllocationReconciliationAudit{}
 		buff.ReadInt() // [compatibility, unused]
-		errG := g.UnmarshalBinaryWithContext(ctx)
-		if errG != nil {
-			return errG
+		errA := a.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.Window = *g
-		// --- [end][read][struct](Window) ---
+		target.AllocationReconciliation = a
+		// --- [end][read][struct](AllocationReconciliationAudit) ---
 
-	} else {
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.AllocationAgg = nil
+	} else {
+		// --- [begin][read][struct](AggAudit) ---
+		b := &AggAudit{}
+		buff.ReadInt() // [compatibility, unused]
+		errB := b.UnmarshalBinaryWithContext(ctx)
+		if errB != nil {
+			return errB
+		}
+		target.AllocationAgg = b
+		// --- [end][read][struct](AggAudit) ---
+
+	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.AllocationTotal = nil
+	} else {
+		// --- [begin][read][struct](TotalAudit) ---
+		c := &TotalAudit{}
+		buff.ReadInt() // [compatibility, unused]
+		errC := c.UnmarshalBinaryWithContext(ctx)
+		if errC != nil {
+			return errC
+		}
+		target.AllocationTotal = c
+		// --- [end][read][struct](TotalAudit) ---
+
+	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.AssetTotal = nil
+	} else {
+		// --- [begin][read][struct](TotalAudit) ---
+		d := &TotalAudit{}
+		buff.ReadInt() // [compatibility, unused]
+		errD := d.UnmarshalBinaryWithContext(ctx)
+		if errD != nil {
+			return errD
+		}
+		target.AssetTotal = d
+		// --- [end][read][struct](TotalAudit) ---
+
+	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.AssetReconciliation = nil
+	} else {
+		// --- [begin][read][struct](AssetReconciliationAudit) ---
+		e := &AssetReconciliationAudit{}
+		buff.ReadInt() // [compatibility, unused]
+		errE := e.UnmarshalBinaryWithContext(ctx)
+		if errE != nil {
+			return errE
+		}
+		target.AssetReconciliation = e
+		// --- [end][read][struct](AssetReconciliationAudit) ---
+
+	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.ClusterEquality = nil
+	} else {
+		// --- [begin][read][struct](EqualityAudit) ---
+		f := &EqualityAudit{}
+		buff.ReadInt() // [compatibility, unused]
+		errF := f.UnmarshalBinaryWithContext(ctx)
+		if errF != nil {
+			return errF
+		}
+		target.ClusterEquality = f
+		// --- [end][read][struct](EqualityAudit) ---
+
+	}
+	// --- [begin][read][struct](Window) ---
+	g := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errG := g.UnmarshalBinaryWithContext(ctx)
+	if errG != nil {
+		return errG
+	}
+	target.Window = *g
+	// --- [end][read][struct](Window) ---
 
 	return nil
 }
@@ -4833,37 +4340,17 @@ func (target *Breakdown) UnmarshalBinaryWithContext(ctx *DecodingContext) (err e
 		return fmt.Errorf("Invalid Version Unmarshaling Breakdown. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		a := buff.ReadFloat64() // read float64
-		target.Idle = a
+	a := buff.ReadFloat64() // read float64
+	target.Idle = a
 
-	} else {
-		target.Idle = float64(0) // default
-	}
+	b := buff.ReadFloat64() // read float64
+	target.Other = b
 
-	if uint8(0) /* field version */ <= version {
-		b := buff.ReadFloat64() // read float64
-		target.Other = b
+	c := buff.ReadFloat64() // read float64
+	target.System = c
 
-	} else {
-		target.Other = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		c := buff.ReadFloat64() // read float64
-		target.System = c
-
-	} else {
-		target.System = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		d := buff.ReadFloat64() // read float64
-		target.User = d
-
-	} else {
-		target.User = float64(0) // default
-	}
+	d := buff.ReadFloat64() // read float64
+	target.User = d
 
 	return nil
 }
@@ -4909,14 +4396,14 @@ func (target *Cloud) MarshalBinaryWithContext(ctx *EncodingContext) (err error) 
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -4935,14 +4422,14 @@ func (target *Cloud) MarshalBinaryWithContext(ctx *EncodingContext) (err error) 
 	}
 	// --- [end][write][alias](AssetLabels) ---
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -4950,7 +4437,7 @@ func (target *Cloud) MarshalBinaryWithContext(ctx *EncodingContext) (err error) 
 
 	}
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -4959,7 +4446,7 @@ func (target *Cloud) MarshalBinaryWithContext(ctx *EncodingContext) (err error) 
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -4969,13 +4456,13 @@ func (target *Cloud) MarshalBinaryWithContext(ctx *EncodingContext) (err error) 
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
 	buff.WriteFloat64(target.Credit)     // write float64
 	return nil
@@ -5035,137 +4522,100 @@ func (target *Cloud) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error
 		return fmt.Errorf("Invalid Version Unmarshaling Cloud. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var a map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			a = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			c := buff.ReadInt() // map len
-			b := make(map[string]string, c)
-			for i := 0; i < c; i++ {
-				var v string
-				var e string
-				if ctx.IsStringTable() {
-					f := buff.ReadInt() // read string index
-					e = ctx.Table[f]
-				} else {
-					e = buff.ReadString() // read string
-				}
-				d := e
-				v = d
-
-				var z string
-				var h string
-				if ctx.IsStringTable() {
-					k := buff.ReadInt() // read string index
-					h = ctx.Table[k]
-				} else {
-					h = buff.ReadString() // read string
-				}
-				g := h
-				z = g
-
-				b[v] = z
+	// --- [begin][read][alias](AssetLabels) ---
+	var a map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		a = nil
+	} else {
+		// --- [begin][read][map](map[string]string) ---
+		c := buff.ReadInt() // map len
+		b := make(map[string]string, c)
+		for i := 0; i < c; i++ {
+			var v string
+			var e string
+			if ctx.IsStringTable() {
+				f := buff.ReadInt() // read string index
+				e = ctx.Table[f]
+			} else {
+				e = buff.ReadString() // read string
 			}
-			a = b
-			// --- [end][read][map](map[string]string) ---
+			d := e
+			v = d
 
-		}
-		target.labels = AssetLabels(a)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			l := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := l.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
+			var z string
+			var h string
+			if ctx.IsStringTable() {
+				k := buff.ReadInt() // read string index
+				h = ctx.Table[k]
+			} else {
+				h = buff.ReadString() // read string
 			}
-			target.properties = l
-			// --- [end][read][struct](AssetProperties) ---
+			g := h
+			z = g
 
+			b[v] = z
 		}
-	} else {
-		target.properties = nil
+		a = b
+		// --- [end][read][map](map[string]string) ---
 
 	}
+	target.Labels = AssetLabels(a)
+	// --- [end][read][alias](AssetLabels) ---
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		m := &time.Time{}
-		n := buff.ReadInt()    // byte array length
-		o := buff.ReadBytes(n) // byte array
-		errB := m.UnmarshalBinary(o)
-		if errB != nil {
-			return errB
-		}
-		target.start = *m
-		// --- [end][read][reference](time.Time) ---
-
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		p := &time.Time{}
-		q := buff.ReadInt()    // byte array length
-		r := buff.ReadBytes(q) // byte array
-		errC := p.UnmarshalBinary(r)
-		if errC != nil {
-			return errC
-		}
-		target.end = *p
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		s := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		l := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errD := s.UnmarshalBinaryWithContext(ctx)
-		if errD != nil {
-			return errD
+		errA := l.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *s
-		// --- [end][read][struct](Window) ---
+		target.Properties = l
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.adjustment = t
-
-	} else {
-		target.adjustment = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	m := &time.Time{}
+	n := buff.ReadInt()    // byte array length
+	o := buff.ReadBytes(n) // byte array
+	errB := m.UnmarshalBinary(o)
+	if errB != nil {
+		return errB
 	}
+	target.Start = *m
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		u := buff.ReadFloat64() // read float64
-		target.Cost = u
-
-	} else {
-		target.Cost = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	p := &time.Time{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errC := p.UnmarshalBinary(r)
+	if errC != nil {
+		return errC
 	}
+	target.End = *p
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		w := buff.ReadFloat64() // read float64
-		target.Credit = w
-
-	} else {
-		target.Credit = float64(0) // default
+	// --- [begin][read][struct](Window) ---
+	s := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errD := s.UnmarshalBinaryWithContext(ctx)
+	if errD != nil {
+		return errD
 	}
+	target.Window = *s
+	// --- [end][read][struct](Window) ---
+
+	t := buff.ReadFloat64() // read float64
+	target.Adjustment = t
+
+	u := buff.ReadFloat64() // read float64
+	target.Cost = u
+
+	w := buff.ReadFloat64() // read float64
+	target.Credit = w
 
 	return nil
 }
@@ -5211,14 +4661,14 @@ func (target *ClusterManagement) MarshalBinaryWithContext(ctx *EncodingContext) 
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -5237,14 +4687,14 @@ func (target *ClusterManagement) MarshalBinaryWithContext(ctx *EncodingContext) 
 	}
 	// --- [end][write][alias](AssetLabels) ---
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -5253,14 +4703,14 @@ func (target *ClusterManagement) MarshalBinaryWithContext(ctx *EncodingContext) 
 	}
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errB := target.window.MarshalBinaryWithContext(ctx)
+	errB := target.Window.MarshalBinaryWithContext(ctx)
 	if errB != nil {
 		return errB
 	}
 	// --- [end][write][struct](Window) ---
 
 	buff.WriteFloat64(target.Cost)       // write float64
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	return nil
 }
 
@@ -5318,98 +4768,80 @@ func (target *ClusterManagement) UnmarshalBinaryWithContext(ctx *DecodingContext
 		return fmt.Errorf("Invalid Version Unmarshaling ClusterManagement. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var a map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			a = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			c := buff.ReadInt() // map len
-			b := make(map[string]string, c)
-			for i := 0; i < c; i++ {
-				var v string
-				var e string
-				if ctx.IsStringTable() {
-					f := buff.ReadInt() // read string index
-					e = ctx.Table[f]
-				} else {
-					e = buff.ReadString() // read string
-				}
-				d := e
-				v = d
-
-				var z string
-				var h string
-				if ctx.IsStringTable() {
-					k := buff.ReadInt() // read string index
-					h = ctx.Table[k]
-				} else {
-					h = buff.ReadString() // read string
-				}
-				g := h
-				z = g
-
-				b[v] = z
-			}
-			a = b
-			// --- [end][read][map](map[string]string) ---
-
-		}
-		target.labels = AssetLabels(a)
-		// --- [end][read][alias](AssetLabels) ---
-
+	// --- [begin][read][alias](AssetLabels) ---
+	var a map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		a = nil
 	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			l := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := l.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
+		// --- [begin][read][map](map[string]string) ---
+		c := buff.ReadInt() // map len
+		b := make(map[string]string, c)
+		for i := 0; i < c; i++ {
+			var v string
+			var e string
+			if ctx.IsStringTable() {
+				f := buff.ReadInt() // read string index
+				e = ctx.Table[f]
+			} else {
+				e = buff.ReadString() // read string
 			}
-			target.properties = l
-			// --- [end][read][struct](AssetProperties) ---
+			d := e
+			v = d
 
+			var z string
+			var h string
+			if ctx.IsStringTable() {
+				k := buff.ReadInt() // read string index
+				h = ctx.Table[k]
+			} else {
+				h = buff.ReadString() // read string
+			}
+			g := h
+			z = g
+
+			b[v] = z
 		}
-	} else {
-		target.properties = nil
+		a = b
+		// --- [end][read][map](map[string]string) ---
 
 	}
+	target.Labels = AssetLabels(a)
+	// --- [end][read][alias](AssetLabels) ---
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		m := &Window{}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
+	} else {
+		// --- [begin][read][struct](AssetProperties) ---
+		l := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errB := m.UnmarshalBinaryWithContext(ctx)
-		if errB != nil {
-			return errB
+		errA := l.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *m
-		// --- [end][read][struct](Window) ---
+		target.Properties = l
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		n := buff.ReadFloat64() // read float64
-		target.Cost = n
-
-	} else {
-		target.Cost = float64(0) // default
+	// --- [begin][read][struct](Window) ---
+	m := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errB := m.UnmarshalBinaryWithContext(ctx)
+	if errB != nil {
+		return errB
 	}
+	target.Window = *m
+	// --- [end][read][struct](Window) ---
 
-	if uint8(16) /* field version */ <= version {
+	n := buff.ReadFloat64() // read float64
+	target.Cost = n
+
+	// field version check
+	if uint8(16) <= version {
 		o := buff.ReadFloat64() // read float64
-		target.adjustment = o
+		target.Adjustment = o
 
 	} else {
-		target.adjustment = float64(0) // default
+		target.Adjustment = float64(0) // default
 	}
 
 	return nil
@@ -5456,14 +4888,14 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -5482,14 +4914,14 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	}
 	// --- [end][write][alias](AssetLabels) ---
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -5497,7 +4929,7 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	}
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -5506,7 +4938,7 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -5516,13 +4948,13 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
 	buff.WriteFloat64(target.ByteHours)  // write float64
 	buff.WriteFloat64(target.Local)      // write float64
@@ -5597,166 +5029,118 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		return fmt.Errorf("Invalid Version Unmarshaling Disk. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var a map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			a = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			c := buff.ReadInt() // map len
-			b := make(map[string]string, c)
-			for i := 0; i < c; i++ {
-				var v string
-				var e string
-				if ctx.IsStringTable() {
-					f := buff.ReadInt() // read string index
-					e = ctx.Table[f]
-				} else {
-					e = buff.ReadString() // read string
-				}
-				d := e
-				v = d
-
-				var z string
-				var h string
-				if ctx.IsStringTable() {
-					k := buff.ReadInt() // read string index
-					h = ctx.Table[k]
-				} else {
-					h = buff.ReadString() // read string
-				}
-				g := h
-				z = g
-
-				b[v] = z
+	// --- [begin][read][alias](AssetLabels) ---
+	var a map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		a = nil
+	} else {
+		// --- [begin][read][map](map[string]string) ---
+		c := buff.ReadInt() // map len
+		b := make(map[string]string, c)
+		for i := 0; i < c; i++ {
+			var v string
+			var e string
+			if ctx.IsStringTable() {
+				f := buff.ReadInt() // read string index
+				e = ctx.Table[f]
+			} else {
+				e = buff.ReadString() // read string
 			}
-			a = b
-			// --- [end][read][map](map[string]string) ---
+			d := e
+			v = d
 
-		}
-		target.labels = AssetLabels(a)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			l := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := l.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
+			var z string
+			var h string
+			if ctx.IsStringTable() {
+				k := buff.ReadInt() // read string index
+				h = ctx.Table[k]
+			} else {
+				h = buff.ReadString() // read string
 			}
-			target.properties = l
-			// --- [end][read][struct](AssetProperties) ---
+			g := h
+			z = g
 
+			b[v] = z
 		}
-	} else {
-		target.properties = nil
+		a = b
+		// --- [end][read][map](map[string]string) ---
 
 	}
+	target.Labels = AssetLabels(a)
+	// --- [end][read][alias](AssetLabels) ---
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		m := &time.Time{}
-		n := buff.ReadInt()    // byte array length
-		o := buff.ReadBytes(n) // byte array
-		errB := m.UnmarshalBinary(o)
-		if errB != nil {
-			return errB
-		}
-		target.start = *m
-		// --- [end][read][reference](time.Time) ---
-
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		p := &time.Time{}
-		q := buff.ReadInt()    // byte array length
-		r := buff.ReadBytes(q) // byte array
-		errC := p.UnmarshalBinary(r)
-		if errC != nil {
-			return errC
-		}
-		target.end = *p
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		s := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		l := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errD := s.UnmarshalBinaryWithContext(ctx)
-		if errD != nil {
-			return errD
+		errA := l.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *s
-		// --- [end][read][struct](Window) ---
+		target.Properties = l
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.adjustment = t
-
-	} else {
-		target.adjustment = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	m := &time.Time{}
+	n := buff.ReadInt()    // byte array length
+	o := buff.ReadBytes(n) // byte array
+	errB := m.UnmarshalBinary(o)
+	if errB != nil {
+		return errB
 	}
+	target.Start = *m
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		u := buff.ReadFloat64() // read float64
-		target.Cost = u
-
-	} else {
-		target.Cost = float64(0) // default
+	// --- [begin][read][reference](time.Time) ---
+	p := &time.Time{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errC := p.UnmarshalBinary(r)
+	if errC != nil {
+		return errC
 	}
+	target.End = *p
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		w := buff.ReadFloat64() // read float64
-		target.ByteHours = w
-
-	} else {
-		target.ByteHours = float64(0) // default
+	// --- [begin][read][struct](Window) ---
+	s := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errD := s.UnmarshalBinaryWithContext(ctx)
+	if errD != nil {
+		return errD
 	}
+	target.Window = *s
+	// --- [end][read][struct](Window) ---
 
-	if uint8(0) /* field version */ <= version {
-		x := buff.ReadFloat64() // read float64
-		target.Local = x
+	t := buff.ReadFloat64() // read float64
+	target.Adjustment = t
 
-	} else {
-		target.Local = float64(0) // default
-	}
+	u := buff.ReadFloat64() // read float64
+	target.Cost = u
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Breakdown = nil
-		} else {
-			// --- [begin][read][struct](Breakdown) ---
-			y := &Breakdown{}
-			buff.ReadInt() // [compatibility, unused]
-			errE := y.UnmarshalBinaryWithContext(ctx)
-			if errE != nil {
-				return errE
-			}
-			target.Breakdown = y
-			// --- [end][read][struct](Breakdown) ---
+	w := buff.ReadFloat64() // read float64
+	target.ByteHours = w
 
-		}
-	} else {
+	x := buff.ReadFloat64() // read float64
+	target.Local = x
+
+	if buff.ReadUInt8() == uint8(0) {
 		target.Breakdown = nil
+	} else {
+		// --- [begin][read][struct](Breakdown) ---
+		y := &Breakdown{}
+		buff.ReadInt() // [compatibility, unused]
+		errE := y.UnmarshalBinaryWithContext(ctx)
+		if errE != nil {
+			return errE
+		}
+		target.Breakdown = y
+		// --- [end][read][struct](Breakdown) ---
 
 	}
-
 	return nil
 }
 
@@ -5939,134 +5323,109 @@ func (target *EqualityAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (e
 		return fmt.Errorf("Invalid Version Unmarshaling EqualityAudit. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AuditStatus) ---
-		var a string
-		var c string
-		if ctx.IsStringTable() {
-			d := buff.ReadInt() // read string index
-			c = ctx.Table[d]
-		} else {
-			c = buff.ReadString() // read string
-		}
-		b := c
-		a = b
-
-		target.Status = AuditStatus(a)
-		// --- [end][read][alias](AuditStatus) ---
-
+	// --- [begin][read][alias](AuditStatus) ---
+	var a string
+	var c string
+	if ctx.IsStringTable() {
+		d := buff.ReadInt() // read string index
+		c = ctx.Table[d]
 	} else {
+		c = buff.ReadString() // read string
 	}
+	b := c
+	a = b
 
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.Description = e
+	target.Status = AuditStatus(a)
+	// --- [end][read][alias](AuditStatus) ---
 
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.Description = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.Description = e
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		h := &time.Time{}
-		k := buff.ReadInt()    // byte array length
-		l := buff.ReadBytes(k) // byte array
-		errA := h.UnmarshalBinary(l)
-		if errA != nil {
-			return errA
-		}
-		target.LastRun = *h
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][reference](time.Time) ---
+	h := &time.Time{}
+	k := buff.ReadInt()    // byte array length
+	l := buff.ReadBytes(k) // byte array
+	errA := h.UnmarshalBinary(l)
+	if errA != nil {
+		return errA
 	}
+	target.LastRun = *h
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.Clusters = nil
-		} else {
-			// --- [begin][read][map](map[string]*AuditFloatResult) ---
-			n := buff.ReadInt() // map len
-			m := make(map[string]*AuditFloatResult, n)
-			for i := 0; i < n; i++ {
-				var v string
-				var p string
-				if ctx.IsStringTable() {
-					q := buff.ReadInt() // read string index
-					p = ctx.Table[q]
-				} else {
-					p = buff.ReadString() // read string
-				}
-				o := p
-				v = o
-
-				var z *AuditFloatResult
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][struct](AuditFloatResult) ---
-					r := &AuditFloatResult{}
-					buff.ReadInt() // [compatibility, unused]
-					errB := r.UnmarshalBinaryWithContext(ctx)
-					if errB != nil {
-						return errB
-					}
-					z = r
-					// --- [end][read][struct](AuditFloatResult) ---
-
-				}
-				m[v] = z
-			}
-			target.Clusters = m
-			// --- [end][read][map](map[string]*AuditFloatResult) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.Clusters = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.MissingValues = nil
-		} else {
-			// --- [begin][read][slice]([]*AuditMissingValue) ---
-			t := buff.ReadInt() // array len
-			s := make([]*AuditMissingValue, t)
-			for j := 0; j < t; j++ {
-				var u *AuditMissingValue
-				if buff.ReadUInt8() == uint8(0) {
-					u = nil
-				} else {
-					// --- [begin][read][struct](AuditMissingValue) ---
-					w := &AuditMissingValue{}
-					buff.ReadInt() // [compatibility, unused]
-					errC := w.UnmarshalBinaryWithContext(ctx)
-					if errC != nil {
-						return errC
-					}
-					u = w
-					// --- [end][read][struct](AuditMissingValue) ---
-
-				}
-				s[j] = u
-			}
-			target.MissingValues = s
-			// --- [end][read][slice]([]*AuditMissingValue) ---
-
-		}
 	} else {
-		target.MissingValues = nil
+		// --- [begin][read][map](map[string]*AuditFloatResult) ---
+		n := buff.ReadInt() // map len
+		m := make(map[string]*AuditFloatResult, n)
+		for i := 0; i < n; i++ {
+			var v string
+			var p string
+			if ctx.IsStringTable() {
+				q := buff.ReadInt() // read string index
+				p = ctx.Table[q]
+			} else {
+				p = buff.ReadString() // read string
+			}
+			o := p
+			v = o
+
+			var z *AuditFloatResult
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][struct](AuditFloatResult) ---
+				r := &AuditFloatResult{}
+				buff.ReadInt() // [compatibility, unused]
+				errB := r.UnmarshalBinaryWithContext(ctx)
+				if errB != nil {
+					return errB
+				}
+				z = r
+				// --- [end][read][struct](AuditFloatResult) ---
+
+			}
+			m[v] = z
+		}
+		target.Clusters = m
+		// --- [end][read][map](map[string]*AuditFloatResult) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.MissingValues = nil
+	} else {
+		// --- [begin][read][slice]([]*AuditMissingValue) ---
+		t := buff.ReadInt() // array len
+		s := make([]*AuditMissingValue, t)
+		for j := 0; j < t; j++ {
+			var u *AuditMissingValue
+			if buff.ReadUInt8() == uint8(0) {
+				u = nil
+			} else {
+				// --- [begin][read][struct](AuditMissingValue) ---
+				w := &AuditMissingValue{}
+				buff.ReadInt() // [compatibility, unused]
+				errC := w.UnmarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				u = w
+				// --- [end][read][struct](AuditMissingValue) ---
 
+			}
+			s[j] = u
+		}
+		target.MissingValues = s
+		// --- [end][read][slice]([]*AuditMissingValue) ---
+
+	}
 	return nil
 }
 
@@ -6110,14 +5469,14 @@ func (target *LoadBalancer) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 	buff := ctx.Buffer
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -6125,14 +5484,14 @@ func (target *LoadBalancer) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 
 	}
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -6152,7 +5511,7 @@ func (target *LoadBalancer) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 	// --- [end][write][alias](AssetLabels) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -6161,7 +5520,7 @@ func (target *LoadBalancer) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -6171,13 +5530,13 @@ func (target *LoadBalancer) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
 	return nil
 }
@@ -6236,129 +5595,97 @@ func (target *LoadBalancer) UnmarshalBinaryWithContext(ctx *DecodingContext) (er
 		return fmt.Errorf("Invalid Version Unmarshaling LoadBalancer. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			a := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := a.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
-			}
-			target.properties = a
-			// --- [end][read][struct](AssetProperties) ---
-
-		}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-		target.properties = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var b map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			b = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			d := buff.ReadInt() // map len
-			c := make(map[string]string, d)
-			for i := 0; i < d; i++ {
-				var v string
-				var f string
-				if ctx.IsStringTable() {
-					g := buff.ReadInt() // read string index
-					f = ctx.Table[g]
-				} else {
-					f = buff.ReadString() // read string
-				}
-				e := f
-				v = e
-
-				var z string
-				var k string
-				if ctx.IsStringTable() {
-					l := buff.ReadInt() // read string index
-					k = ctx.Table[l]
-				} else {
-					k = buff.ReadString() // read string
-				}
-				h := k
-				z = h
-
-				c[v] = z
-			}
-			b = c
-			// --- [end][read][map](map[string]string) ---
-
-		}
-		target.labels = AssetLabels(b)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		m := &time.Time{}
-		n := buff.ReadInt()    // byte array length
-		o := buff.ReadBytes(n) // byte array
-		errB := m.UnmarshalBinary(o)
-		if errB != nil {
-			return errB
-		}
-		target.start = *m
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		p := &time.Time{}
-		q := buff.ReadInt()    // byte array length
-		r := buff.ReadBytes(q) // byte array
-		errC := p.UnmarshalBinary(r)
-		if errC != nil {
-			return errC
-		}
-		target.end = *p
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		s := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		a := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errD := s.UnmarshalBinaryWithContext(ctx)
-		if errD != nil {
-			return errD
+		errA := a.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *s
-		// --- [end][read][struct](Window) ---
+		target.Properties = a
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.adjustment = t
-
+	// --- [begin][read][alias](AssetLabels) ---
+	var b map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		b = nil
 	} else {
-		target.adjustment = float64(0) // default
-	}
+		// --- [begin][read][map](map[string]string) ---
+		d := buff.ReadInt() // map len
+		c := make(map[string]string, d)
+		for i := 0; i < d; i++ {
+			var v string
+			var f string
+			if ctx.IsStringTable() {
+				g := buff.ReadInt() // read string index
+				f = ctx.Table[g]
+			} else {
+				f = buff.ReadString() // read string
+			}
+			e := f
+			v = e
 
-	if uint8(0) /* field version */ <= version {
-		u := buff.ReadFloat64() // read float64
-		target.Cost = u
+			var z string
+			var k string
+			if ctx.IsStringTable() {
+				l := buff.ReadInt() // read string index
+				k = ctx.Table[l]
+			} else {
+				k = buff.ReadString() // read string
+			}
+			h := k
+			z = h
 
-	} else {
-		target.Cost = float64(0) // default
+			c[v] = z
+		}
+		b = c
+		// --- [end][read][map](map[string]string) ---
+
 	}
+	target.Labels = AssetLabels(b)
+	// --- [end][read][alias](AssetLabels) ---
+
+	// --- [begin][read][reference](time.Time) ---
+	m := &time.Time{}
+	n := buff.ReadInt()    // byte array length
+	o := buff.ReadBytes(n) // byte array
+	errB := m.UnmarshalBinary(o)
+	if errB != nil {
+		return errB
+	}
+	target.Start = *m
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][reference](time.Time) ---
+	p := &time.Time{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errC := p.UnmarshalBinary(r)
+	if errC != nil {
+		return errC
+	}
+	target.End = *p
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][struct](Window) ---
+	s := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errD := s.UnmarshalBinaryWithContext(ctx)
+	if errD != nil {
+		return errD
+	}
+	target.Window = *s
+	// --- [end][read][struct](Window) ---
+
+	t := buff.ReadFloat64() // read float64
+	target.Adjustment = t
+
+	u := buff.ReadFloat64() // read float64
+	target.Cost = u
 
 	return nil
 }
@@ -6403,14 +5730,14 @@ func (target *Network) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	buff := ctx.Buffer
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -6418,14 +5745,14 @@ func (target *Network) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 
 	}
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -6445,7 +5772,7 @@ func (target *Network) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	// --- [end][write][alias](AssetLabels) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -6454,7 +5781,7 @@ func (target *Network) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -6464,13 +5791,13 @@ func (target *Network) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
 	return nil
 }
@@ -6529,129 +5856,97 @@ func (target *Network) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 		return fmt.Errorf("Invalid Version Unmarshaling Network. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			a := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := a.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
-			}
-			target.properties = a
-			// --- [end][read][struct](AssetProperties) ---
-
-		}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-		target.properties = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var b map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			b = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			d := buff.ReadInt() // map len
-			c := make(map[string]string, d)
-			for i := 0; i < d; i++ {
-				var v string
-				var f string
-				if ctx.IsStringTable() {
-					g := buff.ReadInt() // read string index
-					f = ctx.Table[g]
-				} else {
-					f = buff.ReadString() // read string
-				}
-				e := f
-				v = e
-
-				var z string
-				var k string
-				if ctx.IsStringTable() {
-					l := buff.ReadInt() // read string index
-					k = ctx.Table[l]
-				} else {
-					k = buff.ReadString() // read string
-				}
-				h := k
-				z = h
-
-				c[v] = z
-			}
-			b = c
-			// --- [end][read][map](map[string]string) ---
-
-		}
-		target.labels = AssetLabels(b)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		m := &time.Time{}
-		n := buff.ReadInt()    // byte array length
-		o := buff.ReadBytes(n) // byte array
-		errB := m.UnmarshalBinary(o)
-		if errB != nil {
-			return errB
-		}
-		target.start = *m
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		p := &time.Time{}
-		q := buff.ReadInt()    // byte array length
-		r := buff.ReadBytes(q) // byte array
-		errC := p.UnmarshalBinary(r)
-		if errC != nil {
-			return errC
-		}
-		target.end = *p
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		s := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		a := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errD := s.UnmarshalBinaryWithContext(ctx)
-		if errD != nil {
-			return errD
+		errA := a.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *s
-		// --- [end][read][struct](Window) ---
+		target.Properties = a
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.adjustment = t
-
+	// --- [begin][read][alias](AssetLabels) ---
+	var b map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		b = nil
 	} else {
-		target.adjustment = float64(0) // default
-	}
+		// --- [begin][read][map](map[string]string) ---
+		d := buff.ReadInt() // map len
+		c := make(map[string]string, d)
+		for i := 0; i < d; i++ {
+			var v string
+			var f string
+			if ctx.IsStringTable() {
+				g := buff.ReadInt() // read string index
+				f = ctx.Table[g]
+			} else {
+				f = buff.ReadString() // read string
+			}
+			e := f
+			v = e
 
-	if uint8(0) /* field version */ <= version {
-		u := buff.ReadFloat64() // read float64
-		target.Cost = u
+			var z string
+			var k string
+			if ctx.IsStringTable() {
+				l := buff.ReadInt() // read string index
+				k = ctx.Table[l]
+			} else {
+				k = buff.ReadString() // read string
+			}
+			h := k
+			z = h
 
-	} else {
-		target.Cost = float64(0) // default
+			c[v] = z
+		}
+		b = c
+		// --- [end][read][map](map[string]string) ---
+
 	}
+	target.Labels = AssetLabels(b)
+	// --- [end][read][alias](AssetLabels) ---
+
+	// --- [begin][read][reference](time.Time) ---
+	m := &time.Time{}
+	n := buff.ReadInt()    // byte array length
+	o := buff.ReadBytes(n) // byte array
+	errB := m.UnmarshalBinary(o)
+	if errB != nil {
+		return errB
+	}
+	target.Start = *m
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][reference](time.Time) ---
+	p := &time.Time{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errC := p.UnmarshalBinary(r)
+	if errC != nil {
+		return errC
+	}
+	target.End = *p
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][struct](Window) ---
+	s := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errD := s.UnmarshalBinaryWithContext(ctx)
+	if errD != nil {
+		return errD
+	}
+	target.Window = *s
+	// --- [end][read][struct](Window) ---
+
+	t := buff.ReadFloat64() // read float64
+	target.Adjustment = t
+
+	u := buff.ReadFloat64() // read float64
+	target.Cost = u
 
 	return nil
 }
@@ -6696,14 +5991,14 @@ func (target *Node) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	buff := ctx.Buffer
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -6711,14 +6006,14 @@ func (target *Node) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	}
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -6738,7 +6033,7 @@ func (target *Node) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	// --- [end][write][alias](AssetLabels) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	c, errB := target.start.MarshalBinary()
+	c, errB := target.Start.MarshalBinary()
 	if errB != nil {
 		return errB
 	}
@@ -6747,7 +6042,7 @@ func (target *Node) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	// --- [end][write][reference](time.Time) ---
 
 	// --- [begin][write][reference](time.Time) ---
-	d, errC := target.end.MarshalBinary()
+	d, errC := target.End.MarshalBinary()
 	if errC != nil {
 		return errC
 	}
@@ -6757,13 +6052,13 @@ func (target *Node) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errD := target.window.MarshalBinaryWithContext(ctx)
+	errD := target.Window.MarshalBinaryWithContext(ctx)
 	if errD != nil {
 		return errD
 	}
 	// --- [end][write][struct](Window) ---
 
-	buff.WriteFloat64(target.adjustment) // write float64
+	buff.WriteFloat64(target.Adjustment) // write float64
 	if ctx.IsStringTable() {
 		e := ctx.Table.AddOrGet(target.NodeType)
 		buff.WriteInt(e) // write table index
@@ -6864,248 +6159,159 @@ func (target *Node) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 		return fmt.Errorf("Invalid Version Unmarshaling Node. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			a := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := a.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
-			}
-			target.properties = a
-			// --- [end][read][struct](AssetProperties) ---
-
-		}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-		target.properties = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var b map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			b = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			d := buff.ReadInt() // map len
-			c := make(map[string]string, d)
-			for i := 0; i < d; i++ {
-				var v string
-				var f string
-				if ctx.IsStringTable() {
-					g := buff.ReadInt() // read string index
-					f = ctx.Table[g]
-				} else {
-					f = buff.ReadString() // read string
-				}
-				e := f
-				v = e
-
-				var z string
-				var k string
-				if ctx.IsStringTable() {
-					l := buff.ReadInt() // read string index
-					k = ctx.Table[l]
-				} else {
-					k = buff.ReadString() // read string
-				}
-				h := k
-				z = h
-
-				c[v] = z
-			}
-			b = c
-			// --- [end][read][map](map[string]string) ---
-
-		}
-		target.labels = AssetLabels(b)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		m := &time.Time{}
-		n := buff.ReadInt()    // byte array length
-		o := buff.ReadBytes(n) // byte array
-		errB := m.UnmarshalBinary(o)
-		if errB != nil {
-			return errB
-		}
-		target.start = *m
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		p := &time.Time{}
-		q := buff.ReadInt()    // byte array length
-		r := buff.ReadBytes(q) // byte array
-		errC := p.UnmarshalBinary(r)
-		if errC != nil {
-			return errC
-		}
-		target.end = *p
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		s := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		a := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errD := s.UnmarshalBinaryWithContext(ctx)
-		if errD != nil {
-			return errD
+		errA := a.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *s
-		// --- [end][read][struct](Window) ---
+		target.Properties = a
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		t := buff.ReadFloat64() // read float64
-		target.adjustment = t
-
+	// --- [begin][read][alias](AssetLabels) ---
+	var b map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		b = nil
 	} else {
-		target.adjustment = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		var w string
-		if ctx.IsStringTable() {
-			x := buff.ReadInt() // read string index
-			w = ctx.Table[x]
-		} else {
-			w = buff.ReadString() // read string
-		}
-		u := w
-		target.NodeType = u
-
-	} else {
-		target.NodeType = "" // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		y := buff.ReadFloat64() // read float64
-		target.CPUCoreHours = y
-
-	} else {
-		target.CPUCoreHours = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		aa := buff.ReadFloat64() // read float64
-		target.RAMByteHours = aa
-
-	} else {
-		target.RAMByteHours = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		bb := buff.ReadFloat64() // read float64
-		target.GPUHours = bb
-
-	} else {
-		target.GPUHours = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.CPUBreakdown = nil
-		} else {
-			// --- [begin][read][struct](Breakdown) ---
-			cc := &Breakdown{}
-			buff.ReadInt() // [compatibility, unused]
-			errE := cc.UnmarshalBinaryWithContext(ctx)
-			if errE != nil {
-				return errE
+		// --- [begin][read][map](map[string]string) ---
+		d := buff.ReadInt() // map len
+		c := make(map[string]string, d)
+		for i := 0; i < d; i++ {
+			var v string
+			var f string
+			if ctx.IsStringTable() {
+				g := buff.ReadInt() // read string index
+				f = ctx.Table[g]
+			} else {
+				f = buff.ReadString() // read string
 			}
-			target.CPUBreakdown = cc
-			// --- [end][read][struct](Breakdown) ---
+			e := f
+			v = e
 
+			var z string
+			var k string
+			if ctx.IsStringTable() {
+				l := buff.ReadInt() // read string index
+				k = ctx.Table[l]
+			} else {
+				k = buff.ReadString() // read string
+			}
+			h := k
+			z = h
+
+			c[v] = z
 		}
+		b = c
+		// --- [end][read][map](map[string]string) ---
+
+	}
+	target.Labels = AssetLabels(b)
+	// --- [end][read][alias](AssetLabels) ---
+
+	// --- [begin][read][reference](time.Time) ---
+	m := &time.Time{}
+	n := buff.ReadInt()    // byte array length
+	o := buff.ReadBytes(n) // byte array
+	errB := m.UnmarshalBinary(o)
+	if errB != nil {
+		return errB
+	}
+	target.Start = *m
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][reference](time.Time) ---
+	p := &time.Time{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errC := p.UnmarshalBinary(r)
+	if errC != nil {
+		return errC
+	}
+	target.End = *p
+	// --- [end][read][reference](time.Time) ---
+
+	// --- [begin][read][struct](Window) ---
+	s := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errD := s.UnmarshalBinaryWithContext(ctx)
+	if errD != nil {
+		return errD
+	}
+	target.Window = *s
+	// --- [end][read][struct](Window) ---
+
+	t := buff.ReadFloat64() // read float64
+	target.Adjustment = t
+
+	var w string
+	if ctx.IsStringTable() {
+		x := buff.ReadInt() // read string index
+		w = ctx.Table[x]
 	} else {
+		w = buff.ReadString() // read string
+	}
+	u := w
+	target.NodeType = u
+
+	y := buff.ReadFloat64() // read float64
+	target.CPUCoreHours = y
+
+	aa := buff.ReadFloat64() // read float64
+	target.RAMByteHours = aa
+
+	bb := buff.ReadFloat64() // read float64
+	target.GPUHours = bb
+
+	if buff.ReadUInt8() == uint8(0) {
 		target.CPUBreakdown = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.RAMBreakdown = nil
-		} else {
-			// --- [begin][read][struct](Breakdown) ---
-			dd := &Breakdown{}
-			buff.ReadInt() // [compatibility, unused]
-			errF := dd.UnmarshalBinaryWithContext(ctx)
-			if errF != nil {
-				return errF
-			}
-			target.RAMBreakdown = dd
-			// --- [end][read][struct](Breakdown) ---
-
+	} else {
+		// --- [begin][read][struct](Breakdown) ---
+		cc := &Breakdown{}
+		buff.ReadInt() // [compatibility, unused]
+		errE := cc.UnmarshalBinaryWithContext(ctx)
+		if errE != nil {
+			return errE
 		}
-	} else {
+		target.CPUBreakdown = cc
+		// --- [end][read][struct](Breakdown) ---
+
+	}
+	if buff.ReadUInt8() == uint8(0) {
 		target.RAMBreakdown = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		ee := buff.ReadFloat64() // read float64
-		target.CPUCost = ee
-
 	} else {
-		target.CPUCost = float64(0) // default
+		// --- [begin][read][struct](Breakdown) ---
+		dd := &Breakdown{}
+		buff.ReadInt() // [compatibility, unused]
+		errF := dd.UnmarshalBinaryWithContext(ctx)
+		if errF != nil {
+			return errF
+		}
+		target.RAMBreakdown = dd
+		// --- [end][read][struct](Breakdown) ---
+
 	}
+	ee := buff.ReadFloat64() // read float64
+	target.CPUCost = ee
 
-	if uint8(0) /* field version */ <= version {
-		ff := buff.ReadFloat64() // read float64
-		target.GPUCost = ff
+	ff := buff.ReadFloat64() // read float64
+	target.GPUCost = ff
 
-	} else {
-		target.GPUCost = float64(0) // default
-	}
+	gg := buff.ReadFloat64() // read float64
+	target.GPUCount = gg
 
-	if uint8(0) /* field version */ <= version {
-		gg := buff.ReadFloat64() // read float64
-		target.GPUCount = gg
+	hh := buff.ReadFloat64() // read float64
+	target.RAMCost = hh
 
-	} else {
-		target.GPUCount = float64(0) // default
-	}
+	kk := buff.ReadFloat64() // read float64
+	target.Discount = kk
 
-	if uint8(0) /* field version */ <= version {
-		hh := buff.ReadFloat64() // read float64
-		target.RAMCost = hh
-
-	} else {
-		target.RAMCost = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		kk := buff.ReadFloat64() // read float64
-		target.Discount = kk
-
-	} else {
-		target.Discount = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		ll := buff.ReadFloat64() // read float64
-		target.Preemptible = ll
-
-	} else {
-		target.Preemptible = float64(0) // default
-	}
+	ll := buff.ReadFloat64() // read float64
+	target.Preemptible = ll
 
 	return nil
 }
@@ -7209,21 +6415,11 @@ func (target *PVAllocation) UnmarshalBinaryWithContext(ctx *DecodingContext) (er
 		return fmt.Errorf("Invalid Version Unmarshaling PVAllocation. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		a := buff.ReadFloat64() // read float64
-		target.ByteHours = a
+	a := buff.ReadFloat64() // read float64
+	target.ByteHours = a
 
-	} else {
-		target.ByteHours = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		b := buff.ReadFloat64() // read float64
-		target.Cost = b
-
-	} else {
-		target.Cost = float64(0) // default
-	}
+	b := buff.ReadFloat64() // read float64
+	target.Cost = b
 
 	return nil
 }
@@ -7337,35 +6533,25 @@ func (target *PVKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error
 		return fmt.Errorf("Invalid Version Unmarshaling PVKey. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		var b string
-		if ctx.IsStringTable() {
-			c := buff.ReadInt() // read string index
-			b = ctx.Table[c]
-		} else {
-			b = buff.ReadString() // read string
-		}
-		a := b
-		target.Cluster = a
-
+	var b string
+	if ctx.IsStringTable() {
+		c := buff.ReadInt() // read string index
+		b = ctx.Table[c]
 	} else {
-		target.Cluster = "" // default
+		b = buff.ReadString() // read string
 	}
+	a := b
+	target.Cluster = a
 
-	if uint8(0) /* field version */ <= version {
-		var e string
-		if ctx.IsStringTable() {
-			f := buff.ReadInt() // read string index
-			e = ctx.Table[f]
-		} else {
-			e = buff.ReadString() // read string
-		}
-		d := e
-		target.Name = d
-
+	var e string
+	if ctx.IsStringTable() {
+		f := buff.ReadInt() // read string index
+		e = ctx.Table[f]
 	} else {
-		target.Name = "" // default
+		e = buff.ReadString() // read string
 	}
+	d := e
+	target.Name = d
 
 	return nil
 }
@@ -7469,21 +6655,11 @@ func (target *RawAllocationOnlyData) UnmarshalBinaryWithContext(ctx *DecodingCon
 		return fmt.Errorf("Invalid Version Unmarshaling RawAllocationOnlyData. Expected %d or less, got %d", AllocationCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		a := buff.ReadFloat64() // read float64
-		target.CPUCoreUsageMax = a
+	a := buff.ReadFloat64() // read float64
+	target.CPUCoreUsageMax = a
 
-	} else {
-		target.CPUCoreUsageMax = float64(0) // default
-	}
-
-	if uint8(0) /* field version */ <= version {
-		b := buff.ReadFloat64() // read float64
-		target.RAMBytesUsageMax = b
-
-	} else {
-		target.RAMBytesUsageMax = float64(0) // default
-	}
+	b := buff.ReadFloat64() // read float64
+	target.RAMBytesUsageMax = b
 
 	return nil
 }
@@ -7528,14 +6704,14 @@ func (target *SharedAsset) MarshalBinaryWithContext(ctx *EncodingContext) (err e
 	buff := ctx.Buffer
 	buff.WriteUInt8(AssetsCodecVersion) // version
 
-	if target.properties == nil {
+	if target.Properties == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][struct](AssetProperties) ---
 		buff.WriteInt(0) // [compatibility, unused]
-		errA := target.properties.MarshalBinaryWithContext(ctx)
+		errA := target.Properties.MarshalBinaryWithContext(ctx)
 		if errA != nil {
 			return errA
 		}
@@ -7543,14 +6719,14 @@ func (target *SharedAsset) MarshalBinaryWithContext(ctx *EncodingContext) (err e
 
 	}
 	// --- [begin][write][alias](AssetLabels) ---
-	if map[string]string(target.labels) == nil {
+	if map[string]string(target.Labels) == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
 		buff.WriteUInt8(uint8(1)) // write non-nil byte
 
 		// --- [begin][write][map](map[string]string) ---
-		buff.WriteInt(len(map[string]string(target.labels))) // map length
-		for v, z := range map[string]string(target.labels) {
+		buff.WriteInt(len(map[string]string(target.Labels))) // map length
+		for v, z := range map[string]string(target.Labels) {
 			if ctx.IsStringTable() {
 				a := ctx.Table.AddOrGet(v)
 				buff.WriteInt(a) // write table index
@@ -7571,7 +6747,7 @@ func (target *SharedAsset) MarshalBinaryWithContext(ctx *EncodingContext) (err e
 
 	// --- [begin][write][struct](Window) ---
 	buff.WriteInt(0) // [compatibility, unused]
-	errB := target.window.MarshalBinaryWithContext(ctx)
+	errB := target.Window.MarshalBinaryWithContext(ctx)
 	if errB != nil {
 		return errB
 	}
@@ -7635,91 +6811,72 @@ func (target *SharedAsset) UnmarshalBinaryWithContext(ctx *DecodingContext) (err
 		return fmt.Errorf("Invalid Version Unmarshaling SharedAsset. Expected %d or less, got %d", AssetsCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.properties = nil
-		} else {
-			// --- [begin][read][struct](AssetProperties) ---
-			a := &AssetProperties{}
-			buff.ReadInt() // [compatibility, unused]
-			errA := a.UnmarshalBinaryWithContext(ctx)
-			if errA != nil {
-				return errA
-			}
-			target.properties = a
-			// --- [end][read][struct](AssetProperties) ---
-
-		}
+	if buff.ReadUInt8() == uint8(0) {
+		target.Properties = nil
 	} else {
-		target.properties = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AssetLabels) ---
-		var b map[string]string
-		if buff.ReadUInt8() == uint8(0) {
-			b = nil
-		} else {
-			// --- [begin][read][map](map[string]string) ---
-			d := buff.ReadInt() // map len
-			c := make(map[string]string, d)
-			for i := 0; i < d; i++ {
-				var v string
-				var f string
-				if ctx.IsStringTable() {
-					g := buff.ReadInt() // read string index
-					f = ctx.Table[g]
-				} else {
-					f = buff.ReadString() // read string
-				}
-				e := f
-				v = e
-
-				var z string
-				var k string
-				if ctx.IsStringTable() {
-					l := buff.ReadInt() // read string index
-					k = ctx.Table[l]
-				} else {
-					k = buff.ReadString() // read string
-				}
-				h := k
-				z = h
-
-				c[v] = z
-			}
-			b = c
-			// --- [end][read][map](map[string]string) ---
-
-		}
-		target.labels = AssetLabels(b)
-		// --- [end][read][alias](AssetLabels) ---
-
-	} else {
-	}
-
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][struct](Window) ---
-		m := &Window{}
+		// --- [begin][read][struct](AssetProperties) ---
+		a := &AssetProperties{}
 		buff.ReadInt() // [compatibility, unused]
-		errB := m.UnmarshalBinaryWithContext(ctx)
-		if errB != nil {
-			return errB
+		errA := a.UnmarshalBinaryWithContext(ctx)
+		if errA != nil {
+			return errA
 		}
-		target.window = *m
-		// --- [end][read][struct](Window) ---
+		target.Properties = a
+		// --- [end][read][struct](AssetProperties) ---
 
-	} else {
 	}
-
-	if uint8(0) /* field version */ <= version {
-		n := buff.ReadFloat64() // read float64
-		target.Cost = n
-
+	// --- [begin][read][alias](AssetLabels) ---
+	var b map[string]string
+	if buff.ReadUInt8() == uint8(0) {
+		b = nil
 	} else {
-		target.Cost = float64(0) // default
+		// --- [begin][read][map](map[string]string) ---
+		d := buff.ReadInt() // map len
+		c := make(map[string]string, d)
+		for i := 0; i < d; i++ {
+			var v string
+			var f string
+			if ctx.IsStringTable() {
+				g := buff.ReadInt() // read string index
+				f = ctx.Table[g]
+			} else {
+				f = buff.ReadString() // read string
+			}
+			e := f
+			v = e
+
+			var z string
+			var k string
+			if ctx.IsStringTable() {
+				l := buff.ReadInt() // read string index
+				k = ctx.Table[l]
+			} else {
+				k = buff.ReadString() // read string
+			}
+			h := k
+			z = h
+
+			c[v] = z
+		}
+		b = c
+		// --- [end][read][map](map[string]string) ---
+
 	}
+	target.Labels = AssetLabels(b)
+	// --- [end][read][alias](AssetLabels) ---
+
+	// --- [begin][read][struct](Window) ---
+	m := &Window{}
+	buff.ReadInt() // [compatibility, unused]
+	errB := m.UnmarshalBinaryWithContext(ctx)
+	if errB != nil {
+		return errB
+	}
+	target.Window = *m
+	// --- [end][read][struct](Window) ---
+
+	n := buff.ReadFloat64() // read float64
+	target.Cost = n
 
 	return nil
 }
@@ -7935,179 +7092,148 @@ func (target *TotalAudit) UnmarshalBinaryWithContext(ctx *DecodingContext) (err 
 		return fmt.Errorf("Invalid Version Unmarshaling TotalAudit. Expected %d or less, got %d", AuditCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][alias](AuditStatus) ---
-		var a string
-		var c string
-		if ctx.IsStringTable() {
-			d := buff.ReadInt() // read string index
-			c = ctx.Table[d]
-		} else {
-			c = buff.ReadString() // read string
-		}
-		b := c
-		a = b
-
-		target.Status = AuditStatus(a)
-		// --- [end][read][alias](AuditStatus) ---
-
+	// --- [begin][read][alias](AuditStatus) ---
+	var a string
+	var c string
+	if ctx.IsStringTable() {
+		d := buff.ReadInt() // read string index
+		c = ctx.Table[d]
 	} else {
+		c = buff.ReadString() // read string
 	}
+	b := c
+	a = b
 
-	if uint8(0) /* field version */ <= version {
-		var f string
-		if ctx.IsStringTable() {
-			g := buff.ReadInt() // read string index
-			f = ctx.Table[g]
-		} else {
-			f = buff.ReadString() // read string
-		}
-		e := f
-		target.Description = e
+	target.Status = AuditStatus(a)
+	// --- [end][read][alias](AuditStatus) ---
 
+	var f string
+	if ctx.IsStringTable() {
+		g := buff.ReadInt() // read string index
+		f = ctx.Table[g]
 	} else {
-		target.Description = "" // default
+		f = buff.ReadString() // read string
 	}
+	e := f
+	target.Description = e
 
-	if uint8(0) /* field version */ <= version {
-		// --- [begin][read][reference](time.Time) ---
-		h := &time.Time{}
-		k := buff.ReadInt()    // byte array length
-		l := buff.ReadBytes(k) // byte array
-		errA := h.UnmarshalBinary(l)
-		if errA != nil {
-			return errA
-		}
-		target.LastRun = *h
-		// --- [end][read][reference](time.Time) ---
-
-	} else {
+	// --- [begin][read][reference](time.Time) ---
+	h := &time.Time{}
+	k := buff.ReadInt()    // byte array length
+	l := buff.ReadBytes(k) // byte array
+	errA := h.UnmarshalBinary(l)
+	if errA != nil {
+		return errA
 	}
+	target.LastRun = *h
+	// --- [end][read][reference](time.Time) ---
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.TotalByNode = nil
-		} else {
-			// --- [begin][read][map](map[string]*AuditFloatResult) ---
-			n := buff.ReadInt() // map len
-			m := make(map[string]*AuditFloatResult, n)
-			for i := 0; i < n; i++ {
-				var v string
-				var p string
-				if ctx.IsStringTable() {
-					q := buff.ReadInt() // read string index
-					p = ctx.Table[q]
-				} else {
-					p = buff.ReadString() // read string
-				}
-				o := p
-				v = o
-
-				var z *AuditFloatResult
-				if buff.ReadUInt8() == uint8(0) {
-					z = nil
-				} else {
-					// --- [begin][read][struct](AuditFloatResult) ---
-					r := &AuditFloatResult{}
-					buff.ReadInt() // [compatibility, unused]
-					errB := r.UnmarshalBinaryWithContext(ctx)
-					if errB != nil {
-						return errB
-					}
-					z = r
-					// --- [end][read][struct](AuditFloatResult) ---
-
-				}
-				m[v] = z
-			}
-			target.TotalByNode = m
-			// --- [end][read][map](map[string]*AuditFloatResult) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.TotalByNode = nil
+	} else {
+		// --- [begin][read][map](map[string]*AuditFloatResult) ---
+		n := buff.ReadInt() // map len
+		m := make(map[string]*AuditFloatResult, n)
+		for i := 0; i < n; i++ {
+			var v string
+			var p string
+			if ctx.IsStringTable() {
+				q := buff.ReadInt() // read string index
+				p = ctx.Table[q]
+			} else {
+				p = buff.ReadString() // read string
+			}
+			o := p
+			v = o
+
+			var z *AuditFloatResult
+			if buff.ReadUInt8() == uint8(0) {
+				z = nil
+			} else {
+				// --- [begin][read][struct](AuditFloatResult) ---
+				r := &AuditFloatResult{}
+				buff.ReadInt() // [compatibility, unused]
+				errB := r.UnmarshalBinaryWithContext(ctx)
+				if errB != nil {
+					return errB
+				}
+				z = r
+				// --- [end][read][struct](AuditFloatResult) ---
+
+			}
+			m[v] = z
+		}
+		target.TotalByNode = m
+		// --- [end][read][map](map[string]*AuditFloatResult) ---
 
 	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.TotalByCluster = nil
-		} else {
-			// --- [begin][read][map](map[string]*AuditFloatResult) ---
-			t := buff.ReadInt() // map len
-			s := make(map[string]*AuditFloatResult, t)
-			for j := 0; j < t; j++ {
-				var vv string
-				var w string
-				if ctx.IsStringTable() {
-					x := buff.ReadInt() // read string index
-					w = ctx.Table[x]
-				} else {
-					w = buff.ReadString() // read string
-				}
-				u := w
-				vv = u
-
-				var zz *AuditFloatResult
-				if buff.ReadUInt8() == uint8(0) {
-					zz = nil
-				} else {
-					// --- [begin][read][struct](AuditFloatResult) ---
-					y := &AuditFloatResult{}
-					buff.ReadInt() // [compatibility, unused]
-					errC := y.UnmarshalBinaryWithContext(ctx)
-					if errC != nil {
-						return errC
-					}
-					zz = y
-					// --- [end][read][struct](AuditFloatResult) ---
-
-				}
-				s[vv] = zz
-			}
-			target.TotalByCluster = s
-			// --- [end][read][map](map[string]*AuditFloatResult) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.TotalByCluster = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.MissingValues = nil
-		} else {
-			// --- [begin][read][slice]([]*AuditMissingValue) ---
-			bb := buff.ReadInt() // array len
-			aa := make([]*AuditMissingValue, bb)
-			for ii := 0; ii < bb; ii++ {
-				var cc *AuditMissingValue
-				if buff.ReadUInt8() == uint8(0) {
-					cc = nil
-				} else {
-					// --- [begin][read][struct](AuditMissingValue) ---
-					dd := &AuditMissingValue{}
-					buff.ReadInt() // [compatibility, unused]
-					errD := dd.UnmarshalBinaryWithContext(ctx)
-					if errD != nil {
-						return errD
-					}
-					cc = dd
-					// --- [end][read][struct](AuditMissingValue) ---
-
-				}
-				aa[ii] = cc
-			}
-			target.MissingValues = aa
-			// --- [end][read][slice]([]*AuditMissingValue) ---
-
-		}
 	} else {
-		target.MissingValues = nil
+		// --- [begin][read][map](map[string]*AuditFloatResult) ---
+		t := buff.ReadInt() // map len
+		s := make(map[string]*AuditFloatResult, t)
+		for j := 0; j < t; j++ {
+			var vv string
+			var w string
+			if ctx.IsStringTable() {
+				x := buff.ReadInt() // read string index
+				w = ctx.Table[x]
+			} else {
+				w = buff.ReadString() // read string
+			}
+			u := w
+			vv = u
+
+			var zz *AuditFloatResult
+			if buff.ReadUInt8() == uint8(0) {
+				zz = nil
+			} else {
+				// --- [begin][read][struct](AuditFloatResult) ---
+				y := &AuditFloatResult{}
+				buff.ReadInt() // [compatibility, unused]
+				errC := y.UnmarshalBinaryWithContext(ctx)
+				if errC != nil {
+					return errC
+				}
+				zz = y
+				// --- [end][read][struct](AuditFloatResult) ---
+
+			}
+			s[vv] = zz
+		}
+		target.TotalByCluster = s
+		// --- [end][read][map](map[string]*AuditFloatResult) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.MissingValues = nil
+	} else {
+		// --- [begin][read][slice]([]*AuditMissingValue) ---
+		bb := buff.ReadInt() // array len
+		aa := make([]*AuditMissingValue, bb)
+		for ii := 0; ii < bb; ii++ {
+			var cc *AuditMissingValue
+			if buff.ReadUInt8() == uint8(0) {
+				cc = nil
+			} else {
+				// --- [begin][read][struct](AuditMissingValue) ---
+				dd := &AuditMissingValue{}
+				buff.ReadInt() // [compatibility, unused]
+				errD := dd.UnmarshalBinaryWithContext(ctx)
+				if errD != nil {
+					return errD
+				}
+				cc = dd
+				// --- [end][read][struct](AuditMissingValue) ---
 
+			}
+			aa[ii] = cc
+		}
+		target.MissingValues = aa
+		// --- [end][read][slice]([]*AuditMissingValue) ---
+
+	}
 	return nil
 }
 
@@ -8238,47 +7364,35 @@ func (target *Window) UnmarshalBinaryWithContext(ctx *DecodingContext) (err erro
 		return fmt.Errorf("Invalid Version Unmarshaling Window. Expected %d or less, got %d", DefaultCodecVersion, version)
 	}
 
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.start = nil
-		} else {
-			// --- [begin][read][reference](time.Time) ---
-			a := &time.Time{}
-			b := buff.ReadInt()    // byte array length
-			c := buff.ReadBytes(b) // byte array
-			errA := a.UnmarshalBinary(c)
-			if errA != nil {
-				return errA
-			}
-			target.start = a
-			// --- [end][read][reference](time.Time) ---
-
-		}
-	} else {
+	if buff.ReadUInt8() == uint8(0) {
 		target.start = nil
-
-	}
-
-	if uint8(0) /* field version */ <= version {
-		if buff.ReadUInt8() == uint8(0) {
-			target.end = nil
-		} else {
-			// --- [begin][read][reference](time.Time) ---
-			d := &time.Time{}
-			e := buff.ReadInt()    // byte array length
-			f := buff.ReadBytes(e) // byte array
-			errB := d.UnmarshalBinary(f)
-			if errB != nil {
-				return errB
-			}
-			target.end = d
-			// --- [end][read][reference](time.Time) ---
-
-		}
 	} else {
-		target.end = nil
+		// --- [begin][read][reference](time.Time) ---
+		a := &time.Time{}
+		b := buff.ReadInt()    // byte array length
+		c := buff.ReadBytes(b) // byte array
+		errA := a.UnmarshalBinary(c)
+		if errA != nil {
+			return errA
+		}
+		target.start = a
+		// --- [end][read][reference](time.Time) ---
 
 	}
+	if buff.ReadUInt8() == uint8(0) {
+		target.end = nil
+	} else {
+		// --- [begin][read][reference](time.Time) ---
+		d := &time.Time{}
+		e := buff.ReadInt()    // byte array length
+		f := buff.ReadBytes(e) // byte array
+		errB := d.UnmarshalBinary(f)
+		if errB != nil {
+			return errB
+		}
+		target.end = d
+		// --- [end][read][reference](time.Time) ---
 
+	}
 	return nil
 }

--- a/pkg/kubecost/kubecost_codecs_test.go
+++ b/pkg/kubecost/kubecost_codecs_test.go
@@ -51,7 +51,7 @@ func BenchmarkAllocationSetRange_BinaryEncoding(b *testing.B) {
 			b.Fatalf("AllocationSetRange.Binary: expected %s; found %s", asr0.Window(), asr1.Window())
 		}
 
-		asr0.Each(func(i int, as0 *AllocationSet) {
+		for i, as0 := range asr0.Allocations {
 			as1, err := asr1.Get(i)
 			if err != nil {
 				b.Fatalf("AllocationSetRange.Binary: unexpected error: %s", err)
@@ -64,7 +64,7 @@ func BenchmarkAllocationSetRange_BinaryEncoding(b *testing.B) {
 				b.Fatalf("AllocationSetRange.Binary: expected %s; found %s", as0.Window, as1.Window)
 			}
 
-			as0.Each(func(k string, a0 *Allocation) {
+			for k, a0 := range as0.Allocations {
 				a1 := as1.Get(k)
 				if a1 == nil {
 					b.Fatalf("AllocationSetRange.Binary: missing Allocation: %s", a0)
@@ -73,8 +73,8 @@ func BenchmarkAllocationSetRange_BinaryEncoding(b *testing.B) {
 				if !a0.Equal(a1) {
 					b.Fatalf("AllocationSetRange.Binary: unequal Allocations \"%s\": expected %s; found %s", k, a0, a1)
 				}
-			})
-		})
+			}
+		}
 	}
 }
 
@@ -115,7 +115,7 @@ func TestAllocationSetRange_BinaryEncoding(t *testing.T) {
 		t.Fatalf("AllocationSetRange.Binary: expected %s; found %s", asr0.Window(), asr1.Window())
 	}
 
-	asr0.Each(func(i int, as0 *AllocationSet) {
+	for i, as0 := range asr0.Allocations {
 		as1, err := asr1.Get(i)
 		if err != nil {
 			t.Fatalf("AllocationSetRange.Binary: unexpected error: %s", err)
@@ -128,7 +128,7 @@ func TestAllocationSetRange_BinaryEncoding(t *testing.T) {
 			t.Fatalf("AllocationSetRange.Binary: expected %s; found %s", as0.Window, as1.Window)
 		}
 
-		as0.Each(func(k string, a0 *Allocation) {
+		for k, a0 := range as0.Allocations {
 			a1 := as1.Get(k)
 			if a1 == nil {
 				t.Fatalf("AllocationSetRange.Binary: missing Allocation: %s", a0)
@@ -137,10 +137,10 @@ func TestAllocationSetRange_BinaryEncoding(t *testing.T) {
 			// TODO Sean: fix JSON marshaling of PVs
 			a1.PVs = a0.PVs
 			if !a0.Equal(a1) {
-				t.Fatalf("AllocationSetRange.Binary: unequal Allocations \"%s\": expected %s; found %s", k, a0, a1)
+				t.Fatalf("AllocationSetRange.Binary: unequal Allocations \"%s\": expected \"%s\"; found \"%s\"", k, a0, a1)
 			}
-		})
-	})
+		}
+	}
 }
 
 func TestAny_BinaryEncoding(t *testing.T) {
@@ -172,23 +172,23 @@ func TestAny_BinaryEncoding(t *testing.T) {
 		t.Fatalf("Any.Binary: unexpected error: %s", err)
 	}
 
-	if a1.Properties().Name != a0.Properties().Name {
-		t.Fatalf("Any.Binary: expected %s, found %s", a0.Properties().Name, a1.Properties().Name)
+	if a1.Properties.Name != a0.Properties.Name {
+		t.Fatalf("Any.Binary: expected %s, found %s", a0.Properties.Name, a1.Properties.Name)
 	}
-	if a1.Properties().Cluster != a0.Properties().Cluster {
-		t.Fatalf("Any.Binary: expected %s, found %s", a0.Properties().Cluster, a1.Properties().Cluster)
+	if a1.Properties.Cluster != a0.Properties.Cluster {
+		t.Fatalf("Any.Binary: expected %s, found %s", a0.Properties.Cluster, a1.Properties.Cluster)
 	}
-	if a1.Properties().ProviderID != a0.Properties().ProviderID {
-		t.Fatalf("Any.Binary: expected %s, found %s", a0.Properties().ProviderID, a1.Properties().ProviderID)
+	if a1.Properties.ProviderID != a0.Properties.ProviderID {
+		t.Fatalf("Any.Binary: expected %s, found %s", a0.Properties.ProviderID, a1.Properties.ProviderID)
 	}
-	if a1.Adjustment() != a0.Adjustment() {
-		t.Fatalf("Any.Binary: expected %f, found %f", a0.Adjustment(), a1.Adjustment())
+	if a1.Adjustment != a0.Adjustment {
+		t.Fatalf("Any.Binary: expected %f, found %f", a0.Adjustment, a1.Adjustment)
 	}
 	if a1.TotalCost() != a0.TotalCost() {
 		t.Fatalf("Any.Binary: expected %f, found %f", a0.TotalCost(), a1.TotalCost())
 	}
-	if !a1.Window().Equal(a0.Window()) {
-		t.Fatalf("Any.Binary: expected %s, found %s", a0.Window(), a1.Window())
+	if !a1.Window.Equal(a0.Window) {
+		t.Fatalf("Any.Binary: expected %s, found %s", a0.Window, a1.Window)
 	}
 }
 
@@ -237,7 +237,7 @@ func TestAssetSetRange_BinaryEncoding(t *testing.T) {
 		t.Fatalf("AssetSetRange.Binary: expected %s; found %s", asr0.Window(), asr1.Window())
 	}
 
-	asr0.Each(func(i int, as0 *AssetSet) {
+	for i, as0 := range asr0.Assets {
 		as1, err := asr1.Get(i)
 		if err != nil {
 			t.Fatalf("AssetSetRange.Binary: unexpected error: %s", err)
@@ -250,7 +250,7 @@ func TestAssetSetRange_BinaryEncoding(t *testing.T) {
 			t.Fatalf("AssetSetRange.Binary: expected %s; found %s", as0.Window, as1.Window)
 		}
 
-		as0.Each(func(k string, a0 Asset) {
+		for k, a0 := range as0.Assets {
 			a1, ok := as1.Get(k)
 			if !ok {
 				t.Fatalf("AssetSetRange.Binary: missing Asset: %s", a0)
@@ -259,8 +259,8 @@ func TestAssetSetRange_BinaryEncoding(t *testing.T) {
 			if !a0.Equal(a1) {
 				t.Fatalf("AssetSetRange.Binary: unequal Assets \"%s\": expected %s; found %s", k, a0, a1)
 			}
-		})
-	})
+		}
+	}
 }
 
 func TestBreakdown_BinaryEncoding(t *testing.T) {

--- a/pkg/kubecost/mock.go
+++ b/pkg/kubecost/mock.go
@@ -331,7 +331,7 @@ func GenerateMockAllocationSetWithAssetProperties(start time.Time) *AllocationSe
 		Cluster: "cluster2",
 		Name:    "disk2",
 	}
-	for _, a := range as.allocations {
+	for _, a := range as.Allocations {
 		// add reconcilable pvs to pod-mno
 		if a.Properties.Pod == "pod-mno" {
 			a.PVs = a.PVs.Add(PVAllocations{
@@ -401,7 +401,7 @@ func GenerateMockAssetSets(start, end time.Time) []*AssetSet {
 	cluster1Nodes.CPUCost = 55.0
 	cluster1Nodes.RAMCost = 44.0
 	cluster1Nodes.GPUCost = 11.0
-	cluster1Nodes.adjustment = -10.00
+	cluster1Nodes.Adjustment = -10.00
 	cluster1Nodes.CPUCoreHours = 8
 	cluster1Nodes.RAMByteHours = 6
 	cluster1Nodes.GPUHours = 24
@@ -433,12 +433,12 @@ func GenerateMockAssetSets(start, end time.Time) []*AssetSet {
 	// Add PVs
 	cluster2Disk1 := NewDisk("disk1", "cluster2", "disk1", start, end, NewWindow(&start, &end))
 	cluster2Disk1.Cost = 5.0
-	cluster2Disk1.adjustment = 1.0
+	cluster2Disk1.Adjustment = 1.0
 	cluster2Disk1.ByteHours = 5 * gb
 
 	cluster2Disk2 := NewDisk("disk2", "cluster2", "disk2", start, end, NewWindow(&start, &end))
 	cluster2Disk2.Cost = 10.0
-	cluster2Disk2.adjustment = 3.0
+	cluster2Disk2.Adjustment = 3.0
 	cluster2Disk2.ByteHours = 10 * gb
 
 	cluster2Node1Disk := NewDisk("node1", "cluster2", "node1", start, end, NewWindow(&start, &end))
@@ -517,7 +517,7 @@ func GenerateMockAssetSets(start, end time.Time) []*AssetSet {
 	cluster1Nodes.CPUCost = 5.0
 	cluster1Nodes.RAMCost = 4.0
 	cluster1Nodes.GPUCost = 1.0
-	cluster1Nodes.adjustment = 90.00
+	cluster1Nodes.Adjustment = 90.00
 	cluster1Nodes.CPUCoreHours = 8
 	cluster1Nodes.RAMByteHours = 6
 	cluster1Nodes.GPUHours = 24
@@ -549,12 +549,12 @@ func GenerateMockAssetSets(start, end time.Time) []*AssetSet {
 	// Add PVs
 	cluster2Disk1 = NewDisk("disk1", "cluster2", "disk1", start, end, NewWindow(&start, &end))
 	cluster2Disk1.Cost = 5.0
-	cluster2Disk1.adjustment = 1.0
+	cluster2Disk1.Adjustment = 1.0
 	cluster2Disk1.ByteHours = 5 * gb
 
 	cluster2Disk2 = NewDisk("disk2", "cluster2", "disk2", start, end, NewWindow(&start, &end))
 	cluster2Disk2.Cost = 12.0
-	cluster2Disk2.adjustment = 4.0
+	cluster2Disk2.Adjustment = 4.0
 	cluster2Disk2.ByteHours = 20 * gb
 
 	assetSet2 := NewAssetSet(start, end, cluster1Nodes, cluster2Node1, cluster2Node2, cluster2Node3, cluster2Disk1,

--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -318,7 +318,7 @@ func NewSummaryAllocationSet(as *AllocationSet, filter AllocationFilter, kfs []A
 	if filter == nil && len(kfs) == 0 {
 		// No filters, so make the map of summary allocations exactly the size
 		// of the origin allocation set.
-		sasMap = make(map[string]*SummaryAllocation, len(as.allocations))
+		sasMap = make(map[string]*SummaryAllocation, len(as.Allocations))
 	} else {
 		// There are filters, so start with a standard map
 		sasMap = make(map[string]*SummaryAllocation)
@@ -329,7 +329,7 @@ func NewSummaryAllocationSet(as *AllocationSet, filter AllocationFilter, kfs []A
 		Window:             as.Window.Clone(),
 	}
 
-	for _, alloc := range as.allocations {
+	for _, alloc := range as.Allocations {
 		// First, detect if the allocation should be kept. If so, mark it as
 		// such, insert it, and continue.
 		shouldKeep := false
@@ -358,11 +358,11 @@ func NewSummaryAllocationSet(as *AllocationSet, filter AllocationFilter, kfs []A
 		}
 	}
 
-	for key := range as.externalKeys {
+	for key := range as.ExternalKeys {
 		sas.externalKeys[key] = true
 	}
 
-	for key := range as.idleKeys {
+	for key := range as.IdleKeys {
 		sas.idleKeys[key] = true
 	}
 
@@ -1313,27 +1313,27 @@ func (sasr *SummaryAllocationSetRange) InsertExternalAllocations(that *Allocatio
 	}
 
 	var err error
-	that.Each(func(j int, thatAS *AllocationSet) {
+	for _, thatAS := range that.Allocations {
 		if thatAS == nil || err != nil {
-			return
+			continue
 		}
 
 		// Find matching AllocationSet in asr
 		i, ok := keys[thatAS.Window.String()]
 		if !ok {
 			err = fmt.Errorf("cannot merge AllocationSet into window that does not exist: %s", thatAS.Window.String())
-			return
+			continue
 		}
 		sas := sasr.SummaryAllocationSets[i]
 
 		// Insert each Allocation from the given set
-		thatAS.Each(func(k string, alloc *Allocation) {
+		for _, alloc := range thatAS.Allocations {
 			externalSA := NewSummaryAllocation(alloc, true, true)
 			// This error will be returned below
 			// TODO:CLEANUP should Each have early-error-return functionality?
 			err = sas.Insert(externalSA)
-		})
-	})
+		}
+	}
 
 	// err might be nil
 	return err


### PR DESCRIPTION
## What does this PR change?
* Updates all ETL Data Structures:
  * Removes Mutex, as locking hasn't been necessary for a while now. 
  * Changes access for fields to public
  * Remove the `Each` function, as regular map iteration is possible now. 
  * Remove the `Map` function, as it was really confusing and expensive.
  * Asset fields changed from ie: `Window()` to `GetWindow()`
  * Asset interface adds `SetWindow(window Window)`

## Bingen Ignore and Pre/Post Process Release Notes

##### Ignoring Fields
You can also ignore fields in the generation process. This is useful if you have a transient field you wish to be ignored during marshal and unmarshal. This is done by adding the `@bingen:field[ignore]` annotation directly after the field:

```go
type Person struct {
      FirstName string 
      LastName string
      FullName string //@bingen:field[ignore]
}
```

In this example, `FirstName` and `LastName` will both be marshalled and unmarshalled. `FullName` will be ignored.

##### Pre and Post Processing Types
You can apply pre and post processing hooks to any generated type. These hooks often work well with ignored/transient fields to ensure that any data being encoded can be populated from the transient data. Likewise, you can also ensure that any transient fields are populated on decode as well. These hooks are enabled via the `generate` options:

```go
// @bingen:generate[stringtable,preprocess,postprocess]:Person
```

Using the `Person` from the previous example, let's have the pre and post processor functions manage the `FullName` field. It's important to note that when you mark a type with `preprocess` and/or `postprocess`, you must also ensure the existence of two functions in the package you have targetting for generation: 

For the `preprocess`, the function name will be `preProcess<Type>(myType *<Type>)`. For our `Person` example, it would look like this:
```go
func preProcessPerson(p *Person) {
      // If the FullName field is set, update the FirstName and LastName fields
      if p.FullName != "" {
            firstAndLast := strings.Split(p.FullName, " ")
            // Make FullName contains a first and last name separated by space
            if len(firstAndLast) != 2 {
                  return
            }

            p.FirstName = firstAndLast[0]
            p.LastName = firstAndLast[1]
      }
}
```

For the `postprocess`, the function name will be `postProcess<Type>(myType *<Type>)`. For our `Person` example, it would look like this:
```go
func postProcessPerson(p *Person) {
      // Set the FullName field to the concatenation of FirstName and LastName separated by a space
      p.FullName = fmt.Sprintf("%s %s", p.FirstName, p.LastName)
}
```

## AssetSet Concrete Asset Type Projection
![image](https://user-images.githubusercontent.com/334480/184746449-4494ab99-d6a7-444c-868f-aa25db44d3ac.png)


## How will this PR impact users?
* It should not impact users - code maintenance.

## How was this PR tested?
* ETL Unit Tests, Live Environment Tests, Still needs more iteration on testing.
