### PR TITLE
Implement .Equals() for the AllocationFilter interface

### DIFF
--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -105,10 +105,6 @@ type AllocationFilter interface {
 	// Equals returns true if the two AllocationFilters are logically
 	// equivalent.
 	Equals(AllocationFilter) bool
-
-	// empty returns true if the filter isn't filtering anything, i.e. the
-	// filter is a no-op.
-	empty() bool
 }
 
 // AllocationFilterCondition is the lowest-level type of filter. It represents
@@ -147,10 +143,6 @@ func (left AllocationFilterCondition) Equals(right AllocationFilter) bool {
 	if rightAFC, ok := right.(AllocationFilterCondition); ok {
 		return left == rightAFC
 	}
-	return false
-}
-
-func (filter AllocationFilterCondition) empty() bool {
 	return false
 }
 
@@ -223,10 +215,7 @@ func (filter AllocationFilterOr) sort() {
 }
 
 func (left AllocationFilterOr) Equals(right AllocationFilter) bool {
-	if left.empty() {
-		return right == nil || right.empty()
-	}
-
+	// The type cast takes care of right == nil as well
 	rightOr, ok := right.(AllocationFilterOr)
 	if !ok {
 		return false
@@ -237,18 +226,6 @@ func (left AllocationFilterOr) Equals(right AllocationFilter) bool {
 	left.sort()
 	rightOr.sort()
 	return left.String() == rightOr.String()
-}
-
-func (filter AllocationFilterOr) empty() bool {
-	for _, inner := range filter.Filters {
-		if inner == nil {
-			continue
-		}
-		if !inner.empty() {
-			return false
-		}
-	}
-	return true
 }
 
 // AllocationFilterOr is a set of filters that should be evaluated as a logical
@@ -304,10 +281,7 @@ func (filter AllocationFilterAnd) sort() {
 }
 
 func (left AllocationFilterAnd) Equals(right AllocationFilter) bool {
-	if left.empty() {
-		return right == nil || right.empty()
-	}
-
+	// The type cast takes care of right == nil as well
 	rightAnd, ok := right.(AllocationFilterAnd)
 	if !ok {
 		return false
@@ -318,18 +292,6 @@ func (left AllocationFilterAnd) Equals(right AllocationFilter) bool {
 	left.sort()
 	rightAnd.sort()
 	return left.String() == rightAnd.String()
-}
-
-func (filter AllocationFilterAnd) empty() bool {
-	for _, inner := range filter.Filters {
-		if inner == nil {
-			continue
-		}
-		if !inner.empty() {
-			return false
-		}
-	}
-	return true
 }
 
 func (filter AllocationFilterCondition) Matches(a *Allocation) bool {
@@ -543,8 +505,4 @@ func (afn AllocationFilterNone) Matches(a *Allocation) bool { return false }
 func (left AllocationFilterNone) Equals(right AllocationFilter) bool {
 	_, ok := right.(AllocationFilterNone)
 	return ok
-}
-
-func (afn AllocationFilterNone) empty() bool {
-	return false
 }

--- a/pkg/kubecost/allocationfilter.go
+++ b/pkg/kubecost/allocationfilter.go
@@ -208,7 +208,7 @@ func (filter AllocationFilterOr) sort() {
 	}
 
 	// While a slight hack, we can rely on the string serialization of the
-	// inner filters.
+	// inner filters to get a sortable representation.
 	sort.SliceStable(filter.Filters, func(i, j int) bool {
 		return filter.Filters[i].String() < filter.Filters[j].String()
 	})
@@ -221,11 +221,19 @@ func (left AllocationFilterOr) Equals(right AllocationFilter) bool {
 		return false
 	}
 
-	// Once sorted, the string representations should be equal. We can sort
-	// because ordering of logical OR statements does not matter.
+	if len(left.Filters) != len(rightOr.Filters) {
+		return false
+	}
+
 	left.sort()
 	rightOr.sort()
-	return left.String() == rightOr.String()
+
+	for i := range left.Filters {
+		if !left.Filters[i].Equals(rightOr.Filters[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // AllocationFilterOr is a set of filters that should be evaluated as a logical
@@ -287,11 +295,19 @@ func (left AllocationFilterAnd) Equals(right AllocationFilter) bool {
 		return false
 	}
 
-	// Once sorted, the string representations should be equal. We can sort
-	// because ordering of logical AND statements does not matter.
+	if len(left.Filters) != len(rightAnd.Filters) {
+		return false
+	}
+
 	left.sort()
 	rightAnd.sort()
-	return left.String() == rightAnd.String()
+
+	for i := range left.Filters {
+		if !left.Filters[i].Equals(rightAnd.Filters[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (filter AllocationFilterCondition) Matches(a *Allocation) bool {

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -1444,6 +1444,54 @@ func Test_AllocationFilter_Equals(t *testing.T) {
 			}},
 			expected: false,
 		},
+		{
+			left: AllocationFilterOr{Filters: []AllocationFilter{
+				AllocationFilterNone{},
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterStartsWith,
+					Key:   "xyz",
+					Value: "kubecost",
+				},
+				AllocationFilterAnd{
+					Filters: []AllocationFilter{
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns1",
+						},
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns2",
+						},
+					},
+				},
+			}},
+			right: AllocationFilterOr{Filters: []AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterStartsWith,
+					Key:   "xyz",
+					Value: "kubecost",
+				},
+				AllocationFilterAnd{
+					Filters: []AllocationFilter{
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns1",
+						},
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns2",
+						},
+					},
+				},
+			}},
+			expected: false,
+		},
 		// AND
 		// EMPTY
 		{
@@ -1664,6 +1712,54 @@ func Test_AllocationFilter_Equals(t *testing.T) {
 							Field: FilterNamespace,
 							Op:    FilterEquals,
 							Value: "ns3",
+						},
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns2",
+						},
+					},
+				},
+			}},
+			expected: false,
+		},
+		{
+			left: AllocationFilterAnd{Filters: []AllocationFilter{
+				AllocationFilterNone{},
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterStartsWith,
+					Key:   "xyz",
+					Value: "kubecost",
+				},
+				AllocationFilterOr{
+					Filters: []AllocationFilter{
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns1",
+						},
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns2",
+						},
+					},
+				},
+			}},
+			right: AllocationFilterAnd{Filters: []AllocationFilter{
+				AllocationFilterCondition{
+					Field: FilterLabel,
+					Op:    FilterStartsWith,
+					Key:   "xyz",
+					Value: "kubecost",
+				},
+				AllocationFilterOr{
+					Filters: []AllocationFilter{
+						AllocationFilterCondition{
+							Field: FilterNamespace,
+							Op:    FilterEquals,
+							Value: "ns1",
 						},
 						AllocationFilterCondition{
 							Field: FilterNamespace,

--- a/pkg/kubecost/allocationfilter_test.go
+++ b/pkg/kubecost/allocationfilter_test.go
@@ -1218,12 +1218,12 @@ func Test_AllocationFilter_Equals(t *testing.T) {
 		{
 			left:     AllocationFilterOr{},
 			right:    nil,
-			expected: true,
+			expected: false,
 		},
 		{
 			left:     AllocationFilterOr{Filters: []AllocationFilter{}},
 			right:    nil,
-			expected: true,
+			expected: false,
 		},
 
 		{
@@ -1449,12 +1449,12 @@ func Test_AllocationFilter_Equals(t *testing.T) {
 		{
 			left:     AllocationFilterAnd{},
 			right:    nil,
-			expected: true,
+			expected: false,
 		},
 		{
 			left:     AllocationFilterAnd{Filters: []AllocationFilter{}},
 			right:    nil,
-			expected: true,
+			expected: false,
 		},
 
 		{


### PR DESCRIPTION
## What does this PR change?
Introduces `.Equals()` to the `type AllocationFilter interface`.

This is for logical equivalence between values of the
AllocationFilter type. This equivalence is for checking e.g. that two
ORs with filters in different orders are, at their core, filtering
the same thing: `(or a b c) = (or b c a)`

This is motivated by the need to check filter equivalence in unit tests
that don't have stable filter construction, like when constructing a
filter while iterating over a map.

## How will this PR impact users?
* N/A

## How was this PR tested?
* Unit tests