### PR TITLE
updated container and pod labels, added ability to query metrics of a…

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -306,12 +306,14 @@ const HourlyRateCodeCn = ".Q7UJUT2CE6"
 // name and the EC2 API.
 var volTypes = map[string]string{
 	"EBS:VolumeUsage.gp2":    "gp2",
+	"EBS:VolumeUsage.gp3":    "gp3",
 	"EBS:VolumeUsage":        "standard",
 	"EBS:VolumeUsage.sc1":    "sc1",
 	"EBS:VolumeP-IOPS.piops": "io1",
 	"EBS:VolumeUsage.st1":    "st1",
 	"EBS:VolumeUsage.piops":  "io1",
 	"gp2":                    "EBS:VolumeUsage.gp2",
+	"gp3":                    "EBS:VolumeUsage.gp3",
 	"standard":               "EBS:VolumeUsage",
 	"sc1":                    "EBS:VolumeUsage.sc1",
 	"io1":                    "EBS:VolumeUsage.piops",

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -576,7 +576,7 @@ func (az *Azure) GetAzureStorageConfig(forceReload bool, cp *CustomPricing) (*Az
 				Message: "Azure Storage Config exists",
 				Status:  true,
 			})
-			
+
 			return asc, nil
 		}
 	}

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-
 	"github.com/opencost/opencost/pkg/kubecost"
 
 	"github.com/opencost/opencost/pkg/util"

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -435,7 +435,7 @@ func buildRAMUserPctMap(resNodeRAMUserPct []*prom.QueryResult) map[nodeIdentifie
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("instance")
+		name, err := result.GetString("node")
 		if err != nil {
 			log.Warnf("ClusterNodes: RAM user percent missing node")
 			continue
@@ -464,7 +464,7 @@ func buildRAMSystemPctMap(resNodeRAMSystemPct []*prom.QueryResult) map[nodeIdent
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("instance")
+		name, err := result.GetString("node")
 		if err != nil {
 			log.Warnf("ClusterNodes: RAM system percent missing node")
 			continue

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -159,7 +159,7 @@ func NewContainerMetricsFromPod(pod *v1.Pod, clusterID string) ([]*ContainerMetr
 // instance
 func NewContainerMetricFromPrometheus(metrics map[string]interface{}, defaultClusterID string) (*ContainerMetric, error) {
 	// TODO: Can we use *prom.QueryResult.GetString() here?
-	cName, ok := metrics["container_name"]
+	cName, ok := metrics[env.GetPromContainerLabel()]
 	if !ok {
 		return nil, NoContainerErr
 	}
@@ -167,7 +167,7 @@ func NewContainerMetricFromPrometheus(metrics map[string]interface{}, defaultClu
 	if !ok {
 		return nil, NoContainerNameErr
 	}
-	pName, ok := metrics["pod_name"]
+	pName, ok := metrics[env.GetPromPodLabel()]
 	if !ok {
 		return nil, NoPodErr
 	}

--- a/pkg/costmodel/key.go
+++ b/pkg/costmodel/key.go
@@ -103,12 +103,9 @@ func resultPodKey(res *prom.QueryResult, clusterLabel, namespaceLabel string) (p
 	}
 	key.Namespace = namespace
 
-	pod, err := res.GetString("pod")
-	if pod == "" || err != nil {
-		pod, err = res.GetString("pod_name")
-		if err != nil {
-			return key, err
-		}
+	pod, err := res.GetString(env.GetPromPodLabel())
+	if err != nil {
+		return key, err
 	}
 	key.Pod = pod
 

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -142,7 +142,7 @@ func getNetworkUsage(qrs []*prom.QueryResult, defaultClusterID string) (map[stri
 	ncdmap := make(map[string]*NetworkUsageVector)
 
 	for _, val := range qrs {
-		podName, err := val.GetString("pod_name")
+		podName, err := val.GetString(env.GetPromPodLabel())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"time"
@@ -61,7 +62,8 @@ const (
 
 	KubeConfigPathEnvVar = "KUBECONFIG_PATH"
 
-	UTCOffsetEnvVar = "UTC_OFFSET"
+	UseCurrentClusterOnlyEnvVar = "USE_CURRENT_CLUSTER_ONLY"
+	UTCOffsetEnvVar             = "UTC_OFFSET"
 
 	CacheWarmingEnabledEnvVar            = "CACHE_WARMING_ENABLED"
 	ETLEnabledEnvVar                     = "ETL_ENABLED"
@@ -227,6 +229,13 @@ func GetClusterProfile() string {
 // configurable identifier used for multi-cluster metric emission.
 func GetClusterID() string {
 	return Get(ClusterIDEnvVar, "")
+}
+
+func GetPromClusterFilter() string {
+	if GetBool(UseCurrentClusterOnlyEnvVar, false) {
+		return fmt.Sprintf("%s=\"%s\"", GetPromClusterLabel(), GetClusterID())
+	}
+	return ""
 }
 
 // GetPrometheusServerEndpoint returns the environment variable value for PrometheusServerEndpointEnvVar which
@@ -474,6 +483,16 @@ func LegacyExternalCostsAPIDisabled() bool {
 // GetPromClusterLabel returns the environemnt variable value for PromClusterIDLabel
 func GetPromClusterLabel() string {
 	return Get(PromClusterIDLabelEnvVar, "cluster_id")
+}
+
+// GetPromPodLabel returns a pod label name
+func GetPromPodLabel() string {
+	return "pod"
+}
+
+// GetPromContainerLabel returns a container label name
+func GetPromContainerLabel() string {
+	return "container"
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"bytes"
+	"text/template"
+)
+
+type TemplateBuffer struct {
+	buffer *bytes.Buffer
+}
+
+func NewTemplateBuffer() *TemplateBuffer {
+	return &TemplateBuffer{
+		buffer: new(bytes.Buffer),
+	}
+}
+
+func (tb *TemplateBuffer) Render(str string, values map[string]interface{}) string {
+	tb.buffer.Reset()
+	tpl := template.Must(template.New("default").Delims("<<", ">>").Parse(str))
+	if err := tpl.Execute(tb.buffer, values); err != nil {
+		panic(err)
+	}
+	return tb.buffer.String()
+}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+ADD dist /var/www

--- a/ui/README.md
+++ b/ui/README.md
@@ -18,11 +18,11 @@ npm install
 This will install required depndencies and build tools. To launch the UI, run
 
 ```
-npx parcel src/index.html
+BASE_URL=<kubecost-url> npx parcel src/index.html
 ```
 
 This will launch a development server, serving the UI at `http://localhost:1234` and targeting the data for an instance of
-Kubecost running at `http://localhost:9090`. To access an arbitrary Kubecost install, you can use
+Kubecost running at `<kubecost-url>`. To access an arbitrary Kubecost install, you can use
 
 ```
 kubectl port-forward deployment/kubecost-cost-analyzer 9090

--- a/ui/src/Reports.js
+++ b/ui/src/Reports.js
@@ -153,13 +153,7 @@ const ReportsPage = () => {
       const resp = await AllocationService.fetchAllocation(window, aggregateBy, { accumulate })
       if (resp.data && resp.data.length > 0) {
         const allocationRange = resp.data
-        for (const i in allocationRange) {
-          // update cluster aggregations to use clusterName/clusterId names
-          if (aggregateBy == 'cluster') {
-            for (const k in allocationRange[i]) {
-              allocationRange[i][k].name = 'cluster-one';
-            }
-          }
+	for (const i in allocationRange) {
           allocationRange[i] = sortBy(allocationRange[i], a => a.totalCost)
         }
         setAllocationData(allocationRange)

--- a/ui/src/services/allocation.js
+++ b/ui/src/services/allocation.js
@@ -1,9 +1,15 @@
 import axios from 'axios';
+import { useLocation } from 'react-router';
+
+const env = process.env;
 
 class AllocationService {
-  BASE_URL = 'http://localhost:9090/allocation';
+
+  BASE_PATH = '/allocation';
 
   async fetchAllocation(win, aggregate, options) {
+    const url = process.env.BASE_URL ?? "";
+    const baseUrl = `${url}${this.BASE_PATH}`;
     const { accumulate, filters, } = options;
     const params = {
       window: win,
@@ -13,7 +19,7 @@ class AllocationService {
     if (typeof accumulate === 'boolean') {
       params.accumulate = accumulate;
     }
-    const result = await axios.get(`${this.BASE_URL}/compute`, { params });
+    const result = await axios.get(`${baseUrl}/compute`, { params });
     return result.data;
   }
 }


### PR DESCRIPTION
… certain cluster from prom

## What does this PR change?
* Adds USE_CURRENT_CLUSTER_ID bool variable which allows to get metrics of a cluster, where opencost is running
* Replaced container_name and pod_name labels to container and pod respectively
* Added dockerfile to serve static UI on nginx with kubecost behind it on /allocation/ path
* Made UI kubecost BASE_URL optional to put UI in docker

## How will this PR impact users?
* Users of Kubernetes < 1.16 (which is not supported already) will be affected

## How was this PR tested?
* Ran against my production environment

## Does this PR require changes to documentation?
* PR introduces new USE_CURRENT_CLUSTER_ID env variable that enables local cluster filtering
* PR disables support of Kubernetes < 1.16
