### PR TITLE
allow full matches on cloud type assets

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2842,8 +2842,8 @@ func (as *AssetSet) ReconciliationMatchMap() map[string]map[string]Asset {
 			continue
 		}
 		props := asset.GetProperties()
-		// Ignore cloud assets and assets that cannot be matched when looking for reconciliation matches
-		if props == nil || props.ProviderID == "" || asset.Type() == CloudAssetType {
+		// Ignore assets that cannot be matched when looking for reconciliation matches
+		if props == nil || props.ProviderID == "" {
 			continue
 		}
 


### PR DESCRIPTION
## What does this PR change?
This PR address a bug in which Cloud type assets are not considered for full match when preforming reconciliation. Because of this each time reconciliation is run the full cost of the Cloud type asset is added to itself because partial matches are put into the asset set via `as.insert()`. This fix allows cloud type assets to be considered for full match, which on subsequent runs will occur and if there has been a change in cost it will be reflected in the adjustment. Considering Cloud Assets here is not expected to be a common occurrence because at this time they can only be added into the Asset store via the process described  here.
 
Adding Cloud type assets during reconciliation is important because in case of a providerID match without a category match, this generally indicates a failure on the part of our categorization. This graceful failure allows for these to be identified, while also keeping data accurate as Cloud Usages are filtered out exclusively by providerID.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* This fix was tested by making categorization for storage category assets coming from BigQuery to fail, in a similar way to what a user was experiencing. Once the bug had been reproduced by rerunning reconciliation multiple times.
![Screen Shot 2022-09-06 at 4 51 02 PM](https://user-images.githubusercontent.com/12225425/188759666-4286cbb8-e6a0-412a-9eaf-e74be87f950d.png)
![Screen Shot 2022-09-06 at 4 48 51 PM](https://user-images.githubusercontent.com/12225425/188759661-265dd32f-7d7d-493d-91ca-20b28f66a601.png)
Applying the fix and running reconciliation again allows for a full match, which reduces the value to the correct amount.
![Screen Shot 2022-09-06 at 4 48 29 PM](https://user-images.githubusercontent.com/12225425/188759792-9a735ea5-860b-45e5-92fd-ccd11d2fa1da.png)
An Asset rebuild clears the the incorrect data, and subsequent reconciliation runs no longer reproduce the bug

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
