### PR TITLE
Sanitize label name when filtering on alias

### DIFF
--- a/pkg/util/allocationfilterutil/queryfilters.go
+++ b/pkg/util/allocationfilterutil/queryfilters.go
@@ -282,6 +282,7 @@ func filterV1LabelMappedFromList(rawFilterValues []string, labelName string) kub
 	filter := kubecost.AllocationFilterOr{
 		Filters: []kubecost.AllocationFilter{},
 	}
+	labelName = prom.SanitizeLabelName(labelName)
 
 	for _, filterValue := range rawFilterValues {
 		filterValue = strings.TrimSpace(filterValue)
@@ -322,7 +323,7 @@ func filterV1DoubleValueFromList(rawFilterValuesUnsplit []string, filterField ku
 				log.Warnf("illegal key/value filter (ignoring): %s", unsplit)
 				continue
 			}
-			key := prom.SanitizeLabelName(strings.TrimSpace(split[0]))
+			labelName := prom.SanitizeLabelName(strings.TrimSpace(split[0]))
 			val := strings.TrimSpace(split[1])
 			val, wildcard := parseWildcardEnd(val)
 
@@ -330,7 +331,7 @@ func filterV1DoubleValueFromList(rawFilterValuesUnsplit []string, filterField ku
 				Field: filterField,
 				// All v1 filters are equality comparisons
 				Op:    kubecost.FilterEquals,
-				Key:   key,
+				Key:   labelName,
 				Value: val,
 			}
 

--- a/pkg/util/allocationfilterutil/queryfilters_test.go
+++ b/pkg/util/allocationfilterutil/queryfilters_test.go
@@ -365,21 +365,21 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			},
 		},
 		{
-			name: "single department",
+			name: "single department, sanitization required",
 			qp: map[string]string{
 				"filterDepartments": "pa-1",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
 					Labels: map[string]string{
-						"internal-product-umbrella": "pa-1",
+						"internal_product_umbrella": "pa-1",
 					},
 				}),
 			},
 			shouldNotMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
 					Labels: map[string]string{
-						"internal-product-umbrella": "ps-N",
+						"internal_product_umbrella": "ps-N",
 					},
 				}),
 			},
@@ -392,34 +392,34 @@ func TestFiltersFromParamsV1(t *testing.T) {
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
 					Labels: map[string]string{
-						"internal-product-umbrella": "pa-1",
+						"internal_product_umbrella": "pa-1",
 					},
 				}),
 			},
 			shouldNotMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
 					Labels: map[string]string{
-						"internal-product-umbrella": "ps-N",
+						"internal_product_umbrella": "ps-N",
 					},
 				}),
 			},
 		},
 		{
-			name: "single label",
+			name: "single label, sanitization required",
 			qp: map[string]string{
-				"filterLabels": "app:cost-analyzer",
+				"filterLabels": "app-a:cost-analyzer",
 			},
 			shouldMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
 					Labels: map[string]string{
-						"app": "cost-analyzer",
+						"app_a": "cost-analyzer",
 					},
 				}),
 			},
 			shouldNotMatch: []kubecost.Allocation{
 				allocGenerator(kubecost.AllocationProperties{
 					Labels: map[string]string{
-						"app": "foo",
+						"app_a": "foo",
 					},
 				}),
 				allocGenerator(kubecost.AllocationProperties{


### PR DESCRIPTION
## What does this PR change?
The filter parsing logic was not sanitizing the label name when the label name came from a label mapping (e.g. Product, Department). Updates logic to sanitize the label name and modifies the unit tests by correctly using Prom-sanitized label names in the test AllocationProperties.

## How will this PR impact users?
* Allocation(Summary) API requests that use label-mapped filters (e.g. `filterDepartments=`) will now correctly handle mappings that are not already Prom-sanitized (e.g. `kubecostProductConfigs.labelMappingConfigs.owner_label=kubecost.com/test-label`). See https://github.com/kubecost/cost-analyzer-helm-chart/issues/1665 for a further explanation.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1665

## How was this PR tested?
* Unit tests in this PR.