### PR TITLE
Add Prom context name for ContainerStats

### DIFF
--- a/pkg/prom/contextnames.go
+++ b/pkg/prom/contextnames.go
@@ -24,4 +24,8 @@ const (
 
 	// DiagnosticContextName is the name we assign queries that check the state of the prometheus connection
 	DiagnosticContextName = "diagnostic"
+
+	// ContainerStatsContextName is the name we assign queries that build
+	// container stats aggregations.
+	ContainerStatsContextName = "container-stats"
 )


### PR DESCRIPTION
## What does this PR change?
Introduces a new Prometheus context name for the new container stats pipeline (closed source).

## How will this PR impact users?
N/A