### PR TITLE
Improving usage of v1 filter function

### DIFF
--- a/pkg/util/allocationfilterutil/queryfilters.go
+++ b/pkg/util/allocationfilterutil/queryfilters.go
@@ -7,7 +7,7 @@ import (
 	"github.com/opencost/opencost/pkg/kubecost"
 	"github.com/opencost/opencost/pkg/log"
 	"github.com/opencost/opencost/pkg/prom"
-	"github.com/opencost/opencost/pkg/util/httputil"
+	"github.com/opencost/opencost/pkg/util/mapper"
 )
 
 // ============================================================================
@@ -41,7 +41,7 @@ func parseWildcardEnd(rawFilterValue string) (string, bool) {
 // filtering. This turns all `filterClusters=foo` arguments into the equivalent
 // of `clusterID = "foo" OR clusterName = "foo"`.
 func AllocationFilterFromParamsV1(
-	qp httputil.QueryParams,
+	qp mapper.PrimitiveMapReader,
 	labelConfig *kubecost.LabelConfig,
 	clusterMap clusters.ClusterMap,
 ) kubecost.AllocationFilter {


### PR DESCRIPTION
## What does this PR change?
* v1 filter function currently takes  variable type of httputil.QueryParams but you only really need the variable of the interface type mapper.PrimitiveMapReader, this change would make it easier to use the function when it's not a REST call. 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* wont impact

## Does this PR address any GitHub or Zendesk issues?
* Closes ...None 

## How was this PR tested?
* Unit test in opencost
* UNit test in KCM ( Allocation summary sets are failing not related to this branch)
* Run few REST calls /allocation /allocationsummary to use v1 filters

## Does this PR require changes to documentation?
* Nopes

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* No permission!!!
