### PR TITLE
Support MSI authentication for Azure by always returning config values if secret not found 

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -523,9 +523,23 @@ func (az *Azure) getAzureRateCardAuth(forceReload bool, cp *CustomPricing) (subs
 		tenantID = s.ServiceKey.Tenant
 		return
 	}
+	// 2. Check config values (set though endpoint)
+	if cp.AzureSubscriptionID != "" && cp.AzureClientID != "" && cp.AzureClientSecret != "" && cp.AzureTenantID != "" {
+		subscriptionID = cp.AzureSubscriptionID
+		clientID = cp.AzureClientID
+		clientSecret = cp.AzureClientSecret
+		tenantID = cp.AzureTenantID
+		return
+	}
+	// 3. Check if AzureSubscriptionID is set in config (set though endpoint)
+	// MSI credentials will be attempted if the subscription ID is set, but clientID, clientSecret and tenantID are not
+	if cp.AzureSubscriptionID != "" {
+		subscriptionID = cp.AzureSubscriptionID
+		return
+	}
+	// 4. Empty values
+	return "", "", "", ""
 
-	// 2. Return config values if not returned by Secret (set though endpoint)
-	return cp.AzureSubscriptionID, cp.AzureClientID, cp.AzureClientSecret, cp.AzureTenantID
 }
 
 // GetAzureStorageConfig retrieves storage config from secret and sets default values

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -523,17 +523,9 @@ func (az *Azure) getAzureRateCardAuth(forceReload bool, cp *CustomPricing) (subs
 		tenantID = s.ServiceKey.Tenant
 		return
 	}
-	// 2. Check config values (set though endpoint)
-	if cp.AzureSubscriptionID != "" && cp.AzureClientID != "" && cp.AzureClientSecret != "" && cp.AzureTenantID != "" {
-		subscriptionID = cp.AzureSubscriptionID
-		clientID = cp.AzureClientID
-		clientSecret = cp.AzureClientSecret
-		tenantID = cp.AzureTenantID
-		return
-	}
 
-	// 3. Empty values
-	return "", "", "", ""
+	// 2. Return config values if not returned by Secret (set though endpoint)
+	return cp.AzureSubscriptionID, cp.AzureClientID, cp.AzureClientSecret, cp.AzureTenantID
 }
 
 // GetAzureStorageConfig retrieves storage config from secret and sets default values
@@ -576,7 +568,7 @@ func (az *Azure) GetAzureStorageConfig(forceReload bool, cp *CustomPricing) (*Az
 				Message: "Azure Storage Config exists",
 				Status:  true,
 			})
-			
+
 			return asc, nil
 		}
 	}


### PR DESCRIPTION
## What does this PR change?
* By always returning the configValues, we can use MSI (aadpodidentity) to authenticate for the ratecard query. This uses the already auth.NewAuthorizerFromEnvironment existing on https://github.com/opencost/opencost/blob/develop/pkg/cloud/azureprovider.go#L788. Using MSI, we'd only need the subscriptionId as config to create the NewRateCardClientWithBaseURI. However, before this PR, the subscriptionId would never be returned if the client-secret, client-id and tenant-id where not set. 

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* A user can now also use aadpodidentity to authenticate . Only config values to be set are:
  currencyCode
  azureBillingRegion
  azureOfferDurableID
  azureSubscriptionID


## How was this PR tested?
* Build the container and run on an AKS cluster with AAD podidentity
