### PR TITLE
Make usage of Disk resilient to absence of metrics

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -121,7 +121,7 @@ type Disk struct {
 	// a new set of metrics that may or may not be available. Thus, they must
 	// be nilable to represent the complete absence of the data.
 	//
-	// In other words, nilability here let's us distinguish between
+	// In other words, nilability here lets us distinguish between
 	// "metric is not available" and "metric is available but is 0".
 	//
 	// They end in "Ptr" to distinguish from an earlier version in order to

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1308,6 +1308,11 @@ func (d *Disk) Clone() Asset {
 		copied := *d.ByteUsageMax
 		max = &copied
 	}
+	var byteHoursUsed *float64
+	if d.ByteHoursUsed != nil {
+		copied := *d.ByteHoursUsed
+		byteHoursUsed = &copied
+	}
 
 	return &Disk{
 		Properties:     d.Properties.Clone(),
@@ -1318,7 +1323,7 @@ func (d *Disk) Clone() Asset {
 		Adjustment:     d.Adjustment,
 		Cost:           d.Cost,
 		ByteHours:      d.ByteHours,
-		ByteHoursUsed:  d.ByteHoursUsed,
+		ByteHoursUsed:  byteHoursUsed,
 		ByteUsageMax:   max,
 		Local:          d.Local,
 		Breakdown:      d.Breakdown.Clone(),
@@ -1360,7 +1365,13 @@ func (d *Disk) Equal(a Asset) bool {
 	if d.ByteHours != that.ByteHours {
 		return false
 	}
-	if d.ByteHoursUsed != that.ByteHoursUsed {
+	if d.ByteHoursUsed != nil && that.ByteHoursUsed == nil {
+		return false
+	}
+	if d.ByteHoursUsed == nil && that.ByteHoursUsed != nil {
+		return false
+	}
+	if (d.ByteHoursUsed != nil && that.ByteHoursUsed != nil) && *d.ByteHoursUsed != *that.ByteHoursUsed {
 		return false
 	}
 	if d.ByteUsageMax != nil && that.ByteUsageMax == nil {

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1072,7 +1072,7 @@ type Disk struct {
 	Local          float64
 	Breakdown      *Breakdown
 	StorageClass   string   // @bingen:field[version=17]
-	ByteHoursUsed  float64  // @bingen:field[version=18]
+	ByteHoursUsed  *float64 // @bingen:field[version=18]
 	ByteUsageMax   *float64 // @bingen:field[version=18]
 	VolumeName     string   // @bingen:field[version=18]
 	ClaimName      string   // @bingen:field[version=18]
@@ -1268,7 +1268,21 @@ func (d *Disk) add(that *Disk) {
 	d.Cost += that.Cost
 
 	d.ByteHours += that.ByteHours
-	d.ByteHoursUsed += that.ByteHoursUsed
+
+	if d.ByteHoursUsed == nil && that.ByteHoursUsed != nil {
+		copy := *that.ByteHoursUsed
+		d.ByteHoursUsed = &copy
+	} else if d.ByteHoursUsed != nil && that.ByteHoursUsed == nil {
+		// do nothing
+	} else if d.ByteHoursUsed != nil && that.ByteHoursUsed != nil {
+		sum := *d.ByteHoursUsed
+		sum += *that.ByteHoursUsed
+		d.ByteHoursUsed = &sum
+	}
+
+	// We have to nil out the max because we don't know if we're
+	// aggregating across time our properties. See RawAllocationOnly on
+	// Allocation for further reference.
 	d.ByteUsageMax = nil
 
 	// If storage class don't match default it to empty storage class

--- a/pkg/kubecost/asset_json.go
+++ b/pkg/kubecost/asset_json.go
@@ -259,7 +259,11 @@ func (d *Disk) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "minutes", d.Minutes(), ",")
 	jsonEncodeFloat64(buffer, "byteHours", d.ByteHours, ",")
 	jsonEncodeFloat64(buffer, "bytes", d.Bytes(), ",")
-	jsonEncodeFloat64(buffer, "byteHoursUsed", d.ByteHoursUsed, ",")
+	if d.ByteHoursUsed == nil {
+		jsonEncode(buffer, "byteHoursUsed", nil, ",")
+	} else {
+		jsonEncodeFloat64(buffer, "byteHoursUsed", *d.ByteHoursUsed, ",")
+	}
 	if d.ByteUsageMax == nil {
 		jsonEncode(buffer, "byteUsageMax", nil, ",")
 	} else {
@@ -342,7 +346,12 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 		d.ByteHours = ByteHours.(float64)
 	}
 	if ByteHoursUsed, err := getTypedVal(fmap["byteHoursUsed"]); err == nil {
-		d.ByteHoursUsed = ByteHoursUsed.(float64)
+		if ByteHoursUsed == nil {
+			d.ByteHoursUsed = nil
+		} else {
+			byteHours := ByteHoursUsed.(float64)
+			d.ByteHoursUsed = &byteHours
+		}
 	}
 	if ByteUsageMax, err := getTypedVal(fmap["byteUsageMax"]); err == nil {
 		if ByteUsageMax == nil {

--- a/pkg/kubecost/asset_json_test.go
+++ b/pkg/kubecost/asset_json_test.go
@@ -164,7 +164,8 @@ func TestDisk_Unmarshal(t *testing.T) {
 
 	disk1 := NewDisk("disk1", "cluster1", "disk1", *unmarshalWindow.start, *unmarshalWindow.end, unmarshalWindow)
 	disk1.ByteHours = 60.0 * gb * hours
-	disk1.ByteHoursUsed = 40.0 * gb * hours
+	used := 40.0 * gb * hours
+	disk1.ByteHoursUsed = &used
 	max := 50.0 * gb * hours
 	disk1.ByteUsageMax = &max
 	disk1.Cost = 4.0
@@ -214,7 +215,7 @@ func TestDisk_Unmarshal(t *testing.T) {
 	if disk1.ByteHours != disk2.ByteHours {
 		t.Fatalf("Disk Unmarshal: ByteHours mutated in unmarshal")
 	}
-	if disk1.ByteHoursUsed != disk2.ByteHoursUsed {
+	if *disk1.ByteHoursUsed != *disk2.ByteHoursUsed {
 		t.Fatalf("Disk Unmarshal: ByteHoursUsed mutated in unmarshal")
 	}
 	if *disk1.ByteUsageMax != *disk2.ByteUsageMax {
@@ -232,7 +233,7 @@ func TestDisk_Unmarshal(t *testing.T) {
 	disk3 := NewDisk("disk3", "cluster1", "disk3", *unmarshalWindow.start, *unmarshalWindow.end, unmarshalWindow)
 
 	disk3.ByteHours = 60.0 * gb * hours
-	disk3.ByteHoursUsed = 40.0 * gb * hours
+	disk3.ByteHoursUsed = nil
 	disk3.ByteUsageMax = nil
 	disk3.Cost = 4.0
 	disk3.Local = 1.0
@@ -256,6 +257,10 @@ func TestDisk_Unmarshal(t *testing.T) {
 		t.Fatalf("Disk Unmarshal: unexpected error: %s", err)
 	}
 
+	// Check that both disks have nil usage
+	if disk3.ByteHoursUsed != disk4.ByteHoursUsed {
+		t.Fatalf("Disk Unmarshal: ByteHoursUsed mutated in unmarshal")
+	}
 	// Check that both disks have nil max usage
 	if disk3.ByteUsageMax != disk4.ByteUsageMax {
 		t.Fatalf("Disk Unmarshal: ByteUsageMax mutated in unmarshal")

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -4978,7 +4978,13 @@ func (target *Disk) MarshalBinaryWithContext(ctx *EncodingContext) (err error) {
 	} else {
 		buff.WriteString(target.StorageClass) // write string
 	}
-	buff.WriteFloat64(target.ByteHoursUsed) // write float64
+	if target.ByteHoursUsed == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		buff.WriteFloat64(*target.ByteHoursUsed) // write float64
+	}
 	if target.ByteUsageMax == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
@@ -5191,11 +5197,16 @@ func (target *Disk) UnmarshalBinaryWithContext(ctx *DecodingContext) (err error)
 
 	// field version check
 	if uint8(18) <= version {
-		dd := buff.ReadFloat64() // read float64
-		target.ByteHoursUsed = dd
+		if buff.ReadUInt8() == uint8(0) {
+			target.ByteHoursUsed = nil
+		} else {
+			dd := buff.ReadFloat64() // read float64
+			target.ByteHoursUsed = &dd
 
+		}
 	} else {
-		target.ByteHoursUsed = float64(0) // default
+		target.ByteHoursUsed = nil
+
 	}
 
 	// field version check


### PR DESCRIPTION
## What does this PR change?
Before this change, we were unable to distinguish between these scenarios:

A. Usage metric exists in Prometheus and has a value of 0 

B. Usage metric does not exist in Prometheus

Because we were using a float64, situation B would cause usage to be unset, making it the Go default value: 0. This is bad data because the usage is probably not 0.

With this commit, the Go default value becomes nil, making it easy to distinguish between situations A and B.

## Does this PR relate to any other PRs?
* Supercedes https://github.com/kubecost/kubecost-cost-model/pull/1008
* Required for https://github.com/kubecost/kubecost-cost-model/pull/1010

## How will this PR impact users?
* Users of nightly images between the release of v1.97 and v1.98 may need to rebuild Asset data to correct byte usage data of Disks.

## How was this PR tested?
See KCM PR test notes.

### Deserializing schema v18 data built before this PR

We've never changed the type of a bingen-serialized field before. We considered it acceptable because this schema has never hit a stable or "proper" release of Kubecost. I wanted to verify that deserialized would fail as expected, thus forcing a standard rebuild of data created from the prerelase v18 schema.

I built two scenarios of data with the schema BEFORE this PR using unit tests and wrote them to disk:

```go
const marshalFile1 = "/tmp/marshaledAS_zero.bin"
const marshalFile2 = "/tmp/marshaledAS_nonzero.bin"

func TestWriteMarshaled1(t *testing.T) {
	windowStart := time.Now().UTC().Add(-4 * time.Hour).Truncate(time.Hour)
	windowEnd := windowStart.Add(1 * time.Hour)
	as := NewAssetSet(
		windowStart,
		windowEnd,
		&Disk{
			Properties: &AssetProperties{},
			Start:      windowStart,
			End:        windowEnd,

			ByteHoursUsed: 0,
		},
	)

	bytes, err := as.MarshalBinary()
	if err != nil {
		t.Fatalf("marshaling: %s", err)
	}

	err = ioutil.WriteFile(marshalFile1, bytes, 0600)
	if err != nil {
		t.Fatalf("writing: %s", err)
	}
}

func TestWriteMarshaled2(t *testing.T) {
	windowStart := time.Now().UTC().Add(-4 * time.Hour).Truncate(time.Hour)
	windowEnd := windowStart.Add(1 * time.Hour)
	as := NewAssetSet(
		windowStart,
		windowEnd,
		&Disk{
			Properties: &AssetProperties{},
			Start:      windowStart,
			End:        windowEnd,

			ByteHoursUsed: 300,
		},
	)

	bytes, err := as.MarshalBinary()
	if err != nil {
		t.Fatalf("marshaling: %s", err)
	}

	err = ioutil.WriteFile(marshalFile2, bytes, 0600)
	if err != nil {
		t.Fatalf("writing: %s", err)
	}
}
```

I then switched to this branch and attempted an unmarshal:
```go
func TestUnmarshalFile1(t *testing.T) {
	bytes, err := ioutil.ReadFile(marshalFile1)
	if err != nil {
		t.Fatalf("reading: %s", err)
	}

	var as AssetSet
	err = as.UnmarshalBinary(bytes)
	if err != nil {
		t.Fatalf("unmarshaling: %s", err)
	}
}

func TestUnmarshalFile2(t *testing.T) {
	bytes, err := ioutil.ReadFile(marshalFile2)
	if err != nil {
		t.Fatalf("reading: %s", err)
	}

	var as AssetSet
	err = as.UnmarshalBinary(bytes)
	if err != nil {
		t.Fatalf("unmarshaling: %s", err)
	}
}
```

Got expected (but funky!) unmarshal errors:
```
--- FAIL: TestUnmarshalFile1 (0.00s)
    migration_test.go:73: unmarshaling: runtime error: index out of range [16777216] with length 2
--- FAIL: TestUnmarshalFile2 (0.00s)
    migration_test.go:86: unmarshaling: runtime error: index out of range [-1073741824]

```