### PR TITLE
Tweak titling to match develop PR

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -42,6 +42,8 @@ const (
 	AzureStorageUpdateType           = "AzureStorage"
 )
 
+var toTitle = cases.Title(language.Und, cases.NoLower)
+
 var (
 	regionCodeMappings = map[string]string{
 		"ap": "asia",
@@ -1226,7 +1228,7 @@ func (az *Azure) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, e
 
 			for k, v := range a {
 				// Just so we consistently supply / receive the same values, uppercase the first letter.
-				kUpper := cases.Title(language.Und, cases.NoLower).String(k)
+				kUpper := toTitle.String(k)
 				vstr, ok := v.(string)
 				if ok {
 					err := SetCustomPricingField(c, kUpper, vstr)


### PR DESCRIPTION
Changes were requested on https://github.com/opencost/opencost/pull/1445, but the cherry-pick PR on this repo was already merged. This small change syncs the two branches.