### PR TITLE
Remove autoscaling/v2beta1 HPA data from cluster cache in order to support K8s v1.25

### DIFF
--- a/pkg/clustercache/clusterexporter.go
+++ b/pkg/clustercache/clusterexporter.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opencost/opencost/pkg/util/json"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
@@ -18,21 +17,20 @@ import (
 
 // clusterEncoding is used to represent the cluster objects in the encoded states.
 type clusterEncoding struct {
-	Namespaces               []*v1.Namespace                        `json:"namespaces,omitempty"`
-	Nodes                    []*v1.Node                             `json:"nodes,omitempty"`
-	Pods                     []*v1.Pod                              `json:"pods,omitempty"`
-	Services                 []*v1.Service                          `json:"services,omitempty"`
-	DaemonSets               []*appsv1.DaemonSet                    `json:"daemonSets,omitempty"`
-	Deployments              []*appsv1.Deployment                   `json:"deployments,omitempty"`
-	StatefulSets             []*appsv1.StatefulSet                  `json:"statefulSets,omitempty"`
-	ReplicaSets              []*appsv1.ReplicaSet                   `json:"replicaSets,omitempty"`
-	PersistentVolumes        []*v1.PersistentVolume                 `json:"persistentVolumes,omitempty"`
-	PersistentVolumeClaims   []*v1.PersistentVolumeClaim            `json:"persistentVolumeClaims,omitempty"`
-	StorageClasses           []*stv1.StorageClass                   `json:"storageClasses,omitempty"`
-	Jobs                     []*batchv1.Job                         `json:"jobs,omitempty"`
-	HorizontalPodAutoscalers []*autoscaling.HorizontalPodAutoscaler `json:"horizontalPodAutoscalers,omitempty"`
-	PodDisruptionBudgets     []*v1beta1.PodDisruptionBudget         `json:"podDisruptionBudgets,omitEmpty"`
-	ReplicationControllers   []*v1.ReplicationController            `json:"replicationController,omitEmpty"`
+	Namespaces             []*v1.Namespace                `json:"namespaces,omitempty"`
+	Nodes                  []*v1.Node                     `json:"nodes,omitempty"`
+	Pods                   []*v1.Pod                      `json:"pods,omitempty"`
+	Services               []*v1.Service                  `json:"services,omitempty"`
+	DaemonSets             []*appsv1.DaemonSet            `json:"daemonSets,omitempty"`
+	Deployments            []*appsv1.Deployment           `json:"deployments,omitempty"`
+	StatefulSets           []*appsv1.StatefulSet          `json:"statefulSets,omitempty"`
+	ReplicaSets            []*appsv1.ReplicaSet           `json:"replicaSets,omitempty"`
+	PersistentVolumes      []*v1.PersistentVolume         `json:"persistentVolumes,omitempty"`
+	PersistentVolumeClaims []*v1.PersistentVolumeClaim    `json:"persistentVolumeClaims,omitempty"`
+	StorageClasses         []*stv1.StorageClass           `json:"storageClasses,omitempty"`
+	Jobs                   []*batchv1.Job                 `json:"jobs,omitempty"`
+	PodDisruptionBudgets   []*v1beta1.PodDisruptionBudget `json:"podDisruptionBudgets,omitEmpty"`
+	ReplicationControllers []*v1.ReplicationController    `json:"replicationController,omitEmpty"`
 }
 
 // ClusterExporter manages and runs an file export process which dumps the local kubernetes cluster to a target location.
@@ -90,21 +88,20 @@ func (ce *ClusterExporter) Stop() {
 func (ce *ClusterExporter) Export() error {
 	c := ce.cluster
 	encoding := &clusterEncoding{
-		Namespaces:               c.GetAllNamespaces(),
-		Nodes:                    c.GetAllNodes(),
-		Pods:                     c.GetAllPods(),
-		Services:                 c.GetAllServices(),
-		DaemonSets:               c.GetAllDaemonSets(),
-		Deployments:              c.GetAllDeployments(),
-		StatefulSets:             c.GetAllStatefulSets(),
-		ReplicaSets:              c.GetAllReplicaSets(),
-		PersistentVolumes:        c.GetAllPersistentVolumes(),
-		PersistentVolumeClaims:   c.GetAllPersistentVolumeClaims(),
-		StorageClasses:           c.GetAllStorageClasses(),
-		Jobs:                     c.GetAllJobs(),
-		HorizontalPodAutoscalers: c.GetAllHorizontalPodAutoscalers(),
-		PodDisruptionBudgets:     c.GetAllPodDisruptionBudgets(),
-		ReplicationControllers:   c.GetAllReplicationControllers(),
+		Namespaces:             c.GetAllNamespaces(),
+		Nodes:                  c.GetAllNodes(),
+		Pods:                   c.GetAllPods(),
+		Services:               c.GetAllServices(),
+		DaemonSets:             c.GetAllDaemonSets(),
+		Deployments:            c.GetAllDeployments(),
+		StatefulSets:           c.GetAllStatefulSets(),
+		ReplicaSets:            c.GetAllReplicaSets(),
+		PersistentVolumes:      c.GetAllPersistentVolumes(),
+		PersistentVolumeClaims: c.GetAllPersistentVolumeClaims(),
+		StorageClasses:         c.GetAllStorageClasses(),
+		Jobs:                   c.GetAllJobs(),
+		PodDisruptionBudgets:   c.GetAllPodDisruptionBudgets(),
+		ReplicationControllers: c.GetAllReplicationControllers(),
 	}
 
 	data, err := json.Marshal(encoding)

--- a/pkg/clustercache/clusterimporter.go
+++ b/pkg/clustercache/clusterimporter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opencost/opencost/pkg/log"
 	"github.com/opencost/opencost/pkg/util/json"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscaling "k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
@@ -266,21 +265,6 @@ func (ci *ClusterImporter) GetAllJobs() []*batchv1.Job {
 	jobs := ci.data.Jobs
 	cloneList := make([]*batchv1.Job, 0, len(jobs))
 	for _, v := range jobs {
-		cloneList = append(cloneList, v.DeepCopy())
-	}
-	return cloneList
-}
-
-// GetAllHorizontalPodAutoscalers() returns all cached horizontal pod autoscalers
-func (ci *ClusterImporter) GetAllHorizontalPodAutoscalers() []*autoscaling.HorizontalPodAutoscaler {
-	ci.dataLock.Lock()
-	defer ci.dataLock.Unlock()
-
-	// Deep copy here to avoid callers from corrupting the cache
-	// This also mimics the behavior of the default cluster cache impl.
-	hpas := ci.data.HorizontalPodAutoscalers
-	cloneList := make([]*autoscaling.HorizontalPodAutoscaler, 0, len(hpas))
-	for _, v := range hpas {
 		cloneList = append(cloneList, v.DeepCopy())
 	}
 	return cloneList


### PR DESCRIPTION
## What does this PR change?
HPA data is not used anywhere by OpenCost or Kubecost. It is causing a problem when installing on K8s v1.25 because we are using `autoscaling/v2beta` for the GPA data which was previously deprecated and is now removed in v1.25.

While we could bump to `autoscaling/v2`, that would remove support for K8s versions before v1.23 (the release in which autoscaling/v2 went GA).

Opting to remove this data entirely for the time being. We can choose which _stable_ version of the autoscaling API to support here sometime in the future, once we know that we need the data.

See https://github.com/opencost/opencost/issues/1440#issuecomment-1291053721 for a full outline of current state and proposed options. This PR implements option 2.

## Does this PR relate to any other PRs?
* Supercedes https://github.com/opencost/opencost/pull/1447

## How will this PR impact users?
* Adds support for K8s v1.25+ by removing dependency on `autoscaling/v2beta1` API

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/1440
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1753

## How was this PR tested?
By building and deploying an image to a v1.25 K3s/k3d cluster.

Cluster creation:
```sh
k3d cluster create --image rancher/k3s:v1.25.3-rc3-k3s1
```

Deployed an image before this change, observed the failing logs as described in https://github.com/kubecost/cost-analyzer-helm-chart/issues/1753.

Deployed an image after this change. Observed normal startup and run logs. Tested the `/allocation` API and received valid data.