### PR TITLE
Add unmounted pvcs to unmounted alloc by namespace

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -2,6 +2,11 @@ package costmodel
 
 import (
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/opencost/opencost/pkg/cloud"
 	"github.com/opencost/opencost/pkg/env"
 	"github.com/opencost/opencost/pkg/kubecost"
@@ -9,10 +14,6 @@ import (
 	"github.com/opencost/opencost/pkg/prom"
 	"github.com/opencost/opencost/pkg/util/timeutil"
 	"k8s.io/apimachinery/pkg/labels"
-	"math"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // This is a bit of a hack to work around garbage data from cadvisor
@@ -1859,7 +1860,8 @@ func applyPVCsToPods(window kubecost.Window, podMap map[podKey]*pod, podPVCMap m
 			// If pod does not exist or the pod does not have any allocations
 			// get unmounted pod for cluster
 			if !ok2 || len(pod.Allocations) == 0 {
-				pod = getUnmountedPodForCluster(window, podMap, pvc.Cluster)
+				// Get namespace unmounted pod, as pvc will have a namespace
+				pod = getUnmountedPodForNamespace(window, podMap, pvc.Cluster, pvc.Namespace)
 			}
 			for _, alloc := range pod.Allocations {
 				s, e := pod.Start, pod.End
@@ -1909,6 +1911,8 @@ func applyUnmountedPVs(window kubecost.Window, podMap map[podKey]*pod, pvMap map
 		}
 
 		if !mounted {
+
+			// a pv without a pvc will not have a namespace, so get the cluster unmounted pod
 			pod := getUnmountedPodForCluster(window, podMap, pv.Cluster)
 
 			// Calculate pv Cost
@@ -1935,7 +1939,9 @@ func applyUnmountedPVs(window kubecost.Window, podMap map[podKey]*pod, pvMap map
 func applyUnmountedPVCs(window kubecost.Window, podMap map[podKey]*pod, pvcMap map[pvcKey]*pvc) {
 	for _, pvc := range pvcMap {
 		if !pvc.Mounted && pvc.Volume != nil {
-			pod := getUnmountedPodForCluster(window, podMap, pvc.Cluster)
+
+			// Get namespace unmounted pod, as pvc will have a namespace
+			pod := getUnmountedPodForNamespace(window, podMap, pvc.Cluster, pvc.Namespace)
 
 			// Calculate pv Cost
 
@@ -1971,6 +1977,37 @@ func getUnmountedPodForCluster(window kubecost.Window, podMap map[podKey]*pod, c
 	node := ""
 
 	thisPodKey := getUnmountedPodKey(cluster)
+	// Initialize pod and container if they do not already exist
+	thisPod, ok := podMap[thisPodKey]
+	if !ok {
+		thisPod = &pod{
+			Window:      window.Clone(),
+			Start:       *window.Start(),
+			End:         *window.End(),
+			Key:         thisPodKey,
+			Allocations: map[string]*kubecost.Allocation{},
+		}
+
+		thisPod.appendContainer(container)
+		thisPod.Allocations[container].Properties.Cluster = cluster
+		thisPod.Allocations[container].Properties.Node = node
+		thisPod.Allocations[container].Properties.Namespace = namespace
+		thisPod.Allocations[container].Properties.Pod = podName
+		thisPod.Allocations[container].Properties.Container = container
+
+		podMap[thisPodKey] = thisPod
+	}
+	return thisPod
+}
+
+// getUnmountedPodForNamespace is as getUnmountedPodForCluster, but keys allocation property pod/namespace field off namespace
+// This creates or adds allocations to an unmounted pod in the specified namespace, rather than in __unmounted__
+func getUnmountedPodForNamespace(window kubecost.Window, podMap map[podKey]*pod, cluster string, namespace string) *pod {
+	container := kubecost.UnmountedSuffix
+	podName := fmt.Sprintf("%s-unmounted-pvcs", namespace)
+	node := ""
+
+	thisPodKey := newPodKey(cluster, namespace, podName)
 	// Initialize pod and container if they do not already exist
 	thisPod, ok := podMap[thisPodKey]
 	if !ok {


### PR DESCRIPTION
Signed-off-by: Kaelan Patel <kaelanspatel@gmail.com>

## What does this PR change?
Alters the logic for processing unmounted PVCs which are bound to a PV to add their costs to a per-namespace `<NAMESPACE>-unmounted-pvcs` category, rather than a global cluster-wide `__unmounted__` namespace one.

This will allow users to filter/aggregate these costs by namespaces, in the case where a PVC in a namespace is dynamically provisioning a PV, but the PVC is not bound to a pod.

## Does this PR relate to any other PRs?
* Requires fix @ https://github.com/opencost/opencost/pull/1476 to function properly.

## How will this PR impact users?
* Adds costs of PVs dynamically provisioned by pvcs in a namespace to be aggregated by namespace by adding a pod line item `<namespace>-unmounted-pvcs` which represents the pv costs associated with said pvcs/pvs.

## Does this PR address any GitHub or Zendesk issues?
* Addresses https://github.com/kubecost/cost-analyzer-helm-chart/issues/1759

## How was this PR tested?
Tested by creating a pvc `some-pvc` that binds a pv:
```
default          some-pvc                      Bound    pvc-2cc1eab0-6058-45dd-ab56-4dcd4ed2fd23   1Gi        RWO            some-sc        28h
kubecost-three   kubecost3-cost-analyzer       Bound    pvc-1ab6a8eb-1ce3-4c8e-b897-0df81ddd5212   32Gi       RWO            standard       145d
kubecost-three   kubecost3-prometheus-server   Bound    pvc-a5c59254-9032-4624-9dcb-8a425248447f   32Gi       RWO            standard       145d
kubecost-two     kubecost2-cost-analyzer       Bound    pvc-4d8edae1-a8ad-4102-a4f2-10bd37b0ad23   32Gi       RWO            standard       145d
kubecost-two     kubecost2-prometheus-server   Bound    pvc-35841b8a-90b3-4d15-ade6-67949b918ff0   32Gi       RWO            standard       145d
kubecost         kubecost-cost-analyzer        Bound    pvc-20f62e22-ef8d-4935-bcde-8406c673485e   32Gi       RWO            standard       258d
kubecost         kubecost-prometheus-server    Bound    pvc-cc677dff-12c7-4c92-8961-05e897b4c406   32Gi       RWO            standard       258d
```
Then, by observing a corresponding allocation in Kubecost:
```
"default-unmounted-pvcs": {
...
  "pvBytes": 198343975.822222,
  "pvByteHours": 4760255419.733334,
  "pvCost": 0.000243,
  "pvs": {
    "cluster=cluster-one:name=pvc-2cc1eab0-6058-45dd-ab56-4dcd4ed2fd23": {
      "byteHours": 4760255419.733334,
      "cost": 0.00024292237442922375
  }
...
}
```

### Concerns
Spoke to Ajay + Sean about this, and open to more discussion. This no longer lumps unmounted pvcs under the traditional `__unmounted__/__unmounted__/__unmounted__` namespace/pod/container, instead adding them to `<pvc namespace>/<namespace>-unmounted-pvcs/__unmounted__`. This is a definite change in the app behavior.

Also, because certain pvcs will not have a relation at some point (e.g. during helm upgrade), there will exist a miniscule-cost item for many namespaces with pvs. E.g. on a cluster set to upgrade Kubecost every night to nightly, the Kubecost pvc is briefly unconnected with a pod, leading to an allocation item:
```
{
"name": "kubecost-unmounted-pvcs",
"cpuCost": 0,
"gpuCost": 0,
"ramCost": 0,
"pvCost": 0.0017944314,
"networkCost": 0,
"loadBalancerCost": 0,
"sharedCost": 0,
"externalCost": 0,
"averageCpuUtilization": 0,
"averageRamUtilization": 0,
"efficiency": 0,
"totalCost": 0.0017944314
},
```
![image](https://user-images.githubusercontent.com/32113845/200969408-b347a07a-3556-403c-bf4a-57fd8c2f6136.png)

It's possible to hide this, maybe, but also note that this is entirely correct behavior: for a moment, there was an unmounted pvc in the Kubecost namespace. Open to thoughts here.

## Does this PR require changes to documentation?
* Maybe? Did not see a section exactly describing this, but it is a change to the behavior of the app.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* Yes.
