### PR TITLE
feat(config): Expose DisableCache as an environment variable

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1037,7 +1037,7 @@ func DefaultAggregateQueryOpts() *AggregateQueryOpts {
 		AllocateIdle:          false,
 		IncludeTimeSeries:     true,
 		IncludeEfficiency:     true,
-		DisableCache:          false,
+		DisableCache:          env.IsCacheDisabled(),
 		ClearCache:            false,
 		NoCache:               false,
 		NoExpireCache:         false,

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -32,7 +32,7 @@ const (
 	CSVPathEnvVar                  = "CSV_PATH"
 	ConfigPathEnvVar               = "CONFIG_PATH"
 	CloudProviderAPIKeyEnvVar      = "CLOUD_PROVIDER_API_KEY"
-	DisableCache                   = "DISABLE_CACHE"
+	DisableAggregateCostModelCache = "DISABLE_AGGREGATE_COST_MODEL_CACHE"
 
 	EmitPodAnnotationsMetricEnvVar       = "EMIT_POD_ANNOTATIONS_METRIC"
 	EmitNamespaceAnnotationsMetricEnvVar = "EMIT_NAMESPACE_ANNOTATIONS_METRIC"
@@ -240,10 +240,10 @@ func GetInsecureSkipVerify() bool {
 	return GetBool(InsecureSkipVerify, false)
 }
 
-// IsCacheDisabled returns the environment variable value for DisableCache which
+// IsAggregateCostModelCacheDisabled returns the environment variable value for DisableAggregateCostModelCache which
 // will inform the aggregator on whether to load cached data. Defaults to false
-func IsCacheDisabled() bool {
-	return GetBool(DisableCache, false)
+func IsAggregateCostModelCacheDisabled() bool {
+	return GetBool(DisableAggregateCostModelCache, false)
 }
 
 // IsRemoteEnabled returns the environment variable value for RemoteEnabledEnvVar which represents whether

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -32,6 +32,7 @@ const (
 	CSVPathEnvVar                  = "CSV_PATH"
 	ConfigPathEnvVar               = "CONFIG_PATH"
 	CloudProviderAPIKeyEnvVar      = "CLOUD_PROVIDER_API_KEY"
+	DisableCache                   = "DISABLE_CACHE"
 
 	EmitPodAnnotationsMetricEnvVar       = "EMIT_POD_ANNOTATIONS_METRIC"
 	EmitNamespaceAnnotationsMetricEnvVar = "EMIT_NAMESPACE_ANNOTATIONS_METRIC"
@@ -237,6 +238,12 @@ func GetPrometheusServerEndpoint() string {
 
 func GetInsecureSkipVerify() bool {
 	return GetBool(InsecureSkipVerify, false)
+}
+
+// IsCacheDisabled returns the environment variable value for DisableCache which
+// will inform the aggregator on whether to load cached data. Defaults to false
+func IsCacheDisabled() bool {
+	return GetBool(DisableCache, false)
 }
 
 // IsRemoteEnabled returns the environment variable value for RemoteEnabledEnvVar which represents whether

--- a/pkg/env/costmodelenv_test.go
+++ b/pkg/env/costmodelenv_test.go
@@ -1,0 +1,43 @@
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsCacheDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		pre  func()
+	}{
+		{
+			name: "Ensure the default value is false",
+			want: false,
+		},
+		{
+			name: "Ensure the value is false when DISABLE_CACHE is set to valse",
+			want: false,
+			pre: func() {
+				os.Setenv("DISABLE_CACHE", "false")
+			},
+		},
+		{
+			name: "Ensure the value is false when DISABLE_CACHE is set to valse",
+			want: true,
+			pre: func() {
+				os.Setenv("DISABLE_CACHE", "true")
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.pre != nil {
+			tt.pre()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCacheDisabled(); got != tt.want {
+				t.Errorf("IsCacheDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/env/costmodelenv_test.go
+++ b/pkg/env/costmodelenv_test.go
@@ -16,17 +16,17 @@ func TestIsCacheDisabled(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Ensure the value is false when DISABLE_CACHE is set to valse",
+			name: "Ensure the value is false when DISABLE_AGGREGATE_COST_MODEL_CACHE is set to false",
 			want: false,
 			pre: func() {
-				os.Setenv("DISABLE_CACHE", "false")
+				os.Setenv("DISABLE_AGGREGATE_COST_MODEL_CACHE", "false")
 			},
 		},
 		{
-			name: "Ensure the value is false when DISABLE_CACHE is set to valse",
+			name: "Ensure the value is true when DISABLE_AGGREGATE_COST_MODEL_CACHE is set to true",
 			want: true,
 			pre: func() {
-				os.Setenv("DISABLE_CACHE", "true")
+				os.Setenv("DISABLE_AGGREGATE_COST_MODEL_CACHE", "true")
 			},
 		},
 	}
@@ -35,8 +35,8 @@ func TestIsCacheDisabled(t *testing.T) {
 			tt.pre()
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsCacheDisabled(); got != tt.want {
-				t.Errorf("IsCacheDisabled() = %v, want %v", got, tt.want)
+			if got := IsAggregateCostModelCacheDisabled(); got != tt.want {
+				t.Errorf("IsAggregateCostModelCacheDisabled() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This adds the ability to set the value for `disableCache` via an environment variable `DISABLE_CACHE`. The default value is set to false. This will influence whether ComputeAggregateCostModel will use data if it's found in the cache.

- Relates to #1472

Signed-off-by: pokom <mark.poko@grafana.com>

## What does this PR change?
* Adds an environment variable `DISABLE_CACHE` that defaults to false

## Does this PR relate to any other PRs?
* #1473

## How will this PR impact users?
* Users can now *opt in* to disabling the cache

## Does this PR address any GitHub or Zendesk issues?
* 

## How was this PR tested?
* Added unit tests to ensure the value defaults to false and can be updated

## Does this PR require changes to documentation?
* Most likely need to add `DISABLE_CACHE` to environment variables that can be overriden

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
