### PR TITLE
Support setting user agent when querying metrics store

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/opencost/opencost/pkg/config"
 	"github.com/opencost/opencost/pkg/env"
 	"github.com/opencost/opencost/pkg/log"
+	"github.com/opencost/opencost/pkg/util/httputil"
 	"github.com/opencost/opencost/pkg/util/watcher"
 
 	v1 "k8s.io/api/core/v1"
@@ -464,6 +466,9 @@ func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.
 			Config:           NewProviderConfig(config, cp.configFileName),
 			clusterRegion:    cp.region,
 			clusterProjectId: cp.projectID,
+			metadataClient: metadata.NewClient(&http.Client{
+				Transport: httputil.NewUserAgentTransport("kubecost", http.DefaultTransport),
+			}),
 		}, nil
 	case kubecost.AWSProvider:
 		log.Info("Found ProviderID starting with \"aws\", using AWS Provider")

--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -95,7 +95,7 @@ func (ctx *Context) Query(query string) QueryResultsChan {
 	return resCh
 }
 
-// QueryWithTime returns a QueryResultsChan, then runs the given query at the
+// QueryAtTime returns a QueryResultsChan, then runs the given query at the
 // given time (see time parameter here: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries)
 // and sends the results on the provided channel. Receiver is responsible for
 // closing the channel, preferably using the Read method.

--- a/pkg/util/httputil/roundtrip.go
+++ b/pkg/util/httputil/roundtrip.go
@@ -1,0 +1,31 @@
+package httputil
+
+import "net/http"
+
+type userAgentTransport struct {
+	userAgent string
+	base      http.RoundTripper
+}
+
+// NewUserAgentTransport creates a RoundTripper that attaches the configured user agent.
+func NewUserAgentTransport(userAgent string, base http.RoundTripper) http.RoundTripper {
+	return &userAgentTransport{
+		userAgent: userAgent,
+		base:      base,
+	}
+}
+
+func (t userAgentTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// The specification of http.RoundTripper says that it shouldn't mutate
+	// the request so make a copy of req.Header since this is all that is
+	// modified.
+	r2 := new(http.Request)
+	*r2 = *r
+	r2.Header = make(http.Header)
+	for k, s := range r.Header {
+		r2.Header[k] = s
+	}
+	r2.Header.Set("User-Agent", t.userAgent)
+	r = r2
+	return t.base.RoundTrip(r)
+}

--- a/pkg/util/httputil/roundtrip_test.go
+++ b/pkg/util/httputil/roundtrip_test.go
@@ -1,0 +1,57 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+type reqValidateRoundTripper struct {
+	expectedReq *http.Request
+}
+
+func (rt *reqValidateRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if !reflect.DeepEqual(r, rt.expectedReq) {
+		return nil, fmt.Errorf("expected req %v, got %v", rt.expectedReq, r)
+	}
+	return nil, nil
+}
+
+func TestUserAgentTransport(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		ua     string
+		req    *http.Request
+		expReq *http.Request
+	}{
+		{
+			name:   "opencost",
+			ua:     "opencost",
+			req:    &http.Request{},
+			expReq: &http.Request{Header: http.Header{"User-Agent": []string{"opencost"}}},
+		},
+		{
+			name:   "foo",
+			ua:     "foo",
+			req:    &http.Request{},
+			expReq: &http.Request{Header: http.Header{"User-Agent": []string{"foo"}}},
+		},
+		{
+			name:   "overwrite user agent if exists",
+			ua:     "opencost",
+			req:    &http.Request{Header: http.Header{"User-Agent": []string{"foo"}}},
+			expReq: &http.Request{Header: http.Header{"User-Agent": []string{"opencost"}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := NewUserAgentTransport(tc.ua, &reqValidateRoundTripper{
+				expectedReq: tc.expReq,
+			})
+			_, err := rt.RoundTrip(tc.req)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

Fixes https://github.com/opencost/opencost/issues/1426

## What does this PR change?
* When querying metrics store like Prometheus, Cortex, etc, user agent like `Opencost/<version>` will be added so that downstream service can identify open cost requests.
