### PR TITLE
Add optional configuration of regions for AWS, Azure, GCP, and Scaleway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	golang.org/x/exp v0.0.0-20220609121020-a51bd0440498
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
+	golang.org/x/text v0.4.0
 	google.golang.org/api v0.44.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.4
@@ -125,7 +126,6 @@ require (
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
-	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -83,7 +83,7 @@ var (
 // List obtained by installing the Azure CLI tool "az", described here:
 // https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 // logging into an Azure account, and running command `az account list-locations`
-var azureRegions = []string{
+var azureDefaultRegions = []string{
 	"eastus",
 	"eastus2",
 	"southcentralus",
@@ -1348,7 +1348,18 @@ func (az *Azure) CombinedDiscountForNode(instanceType string, isPreemptible bool
 }
 
 func (az *Azure) Regions() []string {
-	return azureRegions
+	cfg, err := az.GetConfig()
+	if err != nil {
+		log.Warnf("Falling back to hardcoded default Azure regions; failed to load config: %v", err)
+		return azureDefaultRegions
+	}
+
+	if len(cfg.Regions) == 0 {
+		log.Info("Falling back to hardcoded default Azure regions; no regions specified in config")
+		return azureDefaultRegions
+	}
+
+	return cfg.Regions
 }
 
 func parseAzureSubscriptionID(id string) string {

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -38,7 +38,7 @@ const BigqueryUpdateType = "bigqueryupdate"
 // List obtained by installing the `gcloud` CLI tool,
 // logging into gcp account, and running command
 // `gcloud compute regions list`
-var gcpRegions = []string{
+var gcpDefaultRegions = []string{
 	"asia-east1",
 	"asia-east2",
 	"asia-northeast1",
@@ -1381,7 +1381,18 @@ func (gcp *GCP) CombinedDiscountForNode(instanceType string, isPreemptible bool,
 }
 
 func (gcp *GCP) Regions() []string {
-	return gcpRegions
+	cfg, err := gcp.GetConfig()
+	if err != nil {
+		log.Warnf("Falling back to hardcoded default GCP regions; failed to load config: %v", err)
+		return gcpDefaultRegions
+	}
+
+	if len(cfg.Regions) == 0 {
+		log.Info("Falling back to hardcoded default GCP regions; no regions specified in config")
+		return gcpDefaultRegions
+	}
+
+	return cfg.Regions
 }
 
 func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible bool) float64 {

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -138,67 +138,68 @@ type OutOfClusterAllocation struct {
 }
 
 type CustomPricing struct {
-	Provider                     string `json:"provider"`
-	Description                  string `json:"description"`
-	CPU                          string `json:"CPU"`
-	SpotCPU                      string `json:"spotCPU"`
-	RAM                          string `json:"RAM"`
-	SpotRAM                      string `json:"spotRAM"`
-	GPU                          string `json:"GPU"`
-	SpotGPU                      string `json:"spotGPU"`
-	Storage                      string `json:"storage"`
-	ZoneNetworkEgress            string `json:"zoneNetworkEgress"`
-	RegionNetworkEgress          string `json:"regionNetworkEgress"`
-	InternetNetworkEgress        string `json:"internetNetworkEgress"`
-	FirstFiveForwardingRulesCost string `json:"firstFiveForwardingRulesCost"`
-	AdditionalForwardingRuleCost string `json:"additionalForwardingRuleCost"`
-	LBIngressDataCost            string `json:"LBIngressDataCost"`
-	SpotLabel                    string `json:"spotLabel,omitempty"`
-	SpotLabelValue               string `json:"spotLabelValue,omitempty"`
-	GpuLabel                     string `json:"gpuLabel,omitempty"`
-	GpuLabelValue                string `json:"gpuLabelValue,omitempty"`
-	ServiceKeyName               string `json:"awsServiceKeyName,omitempty"`
-	ServiceKeySecret             string `json:"awsServiceKeySecret,omitempty"`
-	SpotDataRegion               string `json:"awsSpotDataRegion,omitempty"`
-	SpotDataBucket               string `json:"awsSpotDataBucket,omitempty"`
-	SpotDataPrefix               string `json:"awsSpotDataPrefix,omitempty"`
-	ProjectID                    string `json:"projectID,omitempty"`
-	AthenaProjectID              string `json:"athenaProjectID,omitempty"`
-	AthenaBucketName             string `json:"athenaBucketName"`
-	AthenaRegion                 string `json:"athenaRegion"`
-	AthenaDatabase               string `json:"athenaDatabase"`
-	AthenaTable                  string `json:"athenaTable"`
-	AthenaWorkgroup              string `json:"athenaWorkgroup"`
-	MasterPayerARN               string `json:"masterPayerARN"`
-	BillingDataDataset           string `json:"billingDataDataset,omitempty"`
-	CustomPricesEnabled          string `json:"customPricesEnabled"`
-	DefaultIdle                  string `json:"defaultIdle"`
-	AzureSubscriptionID          string `json:"azureSubscriptionID"`
-	AzureClientID                string `json:"azureClientID"`
-	AzureClientSecret            string `json:"azureClientSecret"`
-	AzureTenantID                string `json:"azureTenantID"`
-	AzureBillingRegion           string `json:"azureBillingRegion"`
-	AzureOfferDurableID          string `json:"azureOfferDurableID"`
-	AzureStorageSubscriptionID   string `json:"azureStorageSubscriptionID"`
-	AzureStorageAccount          string `json:"azureStorageAccount"`
-	AzureStorageAccessKey        string `json:"azureStorageAccessKey"`
-	AzureStorageContainer        string `json:"azureStorageContainer"`
-	AzureContainerPath           string `json:"azureContainerPath"`
-	AzureCloud                   string `json:"azureCloud"`
-	CurrencyCode                 string `json:"currencyCode"`
-	Discount                     string `json:"discount"`
-	NegotiatedDiscount           string `json:"negotiatedDiscount"`
-	SharedOverhead               string `json:"sharedOverhead"`
-	ClusterName                  string `json:"clusterName"`
-	SharedNamespaces             string `json:"sharedNamespaces"`
-	SharedLabelNames             string `json:"sharedLabelNames"`
-	SharedLabelValues            string `json:"sharedLabelValues"`
-	ShareTenancyCosts            string `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
-	ReadOnly                     string `json:"readOnly"`
-	EditorAccess                 string `json:"editorAccess"`
-	KubecostToken                string `json:"kubecostToken"`
-	GoogleAnalyticsTag           string `json:"googleAnalyticsTag"`
-	ExcludeProviderID            string `json:"excludeProviderID"`
+	Provider                     string   `json:"provider"`
+	Description                  string   `json:"description"`
+	CPU                          string   `json:"CPU"`
+	SpotCPU                      string   `json:"spotCPU"`
+	RAM                          string   `json:"RAM"`
+	SpotRAM                      string   `json:"spotRAM"`
+	GPU                          string   `json:"GPU"`
+	SpotGPU                      string   `json:"spotGPU"`
+	Storage                      string   `json:"storage"`
+	ZoneNetworkEgress            string   `json:"zoneNetworkEgress"`
+	RegionNetworkEgress          string   `json:"regionNetworkEgress"`
+	InternetNetworkEgress        string   `json:"internetNetworkEgress"`
+	FirstFiveForwardingRulesCost string   `json:"firstFiveForwardingRulesCost"`
+	AdditionalForwardingRuleCost string   `json:"additionalForwardingRuleCost"`
+	LBIngressDataCost            string   `json:"LBIngressDataCost"`
+	SpotLabel                    string   `json:"spotLabel,omitempty"`
+	SpotLabelValue               string   `json:"spotLabelValue,omitempty"`
+	GpuLabel                     string   `json:"gpuLabel,omitempty"`
+	GpuLabelValue                string   `json:"gpuLabelValue,omitempty"`
+	ServiceKeyName               string   `json:"awsServiceKeyName,omitempty"`
+	ServiceKeySecret             string   `json:"awsServiceKeySecret,omitempty"`
+	SpotDataRegion               string   `json:"awsSpotDataRegion,omitempty"`
+	SpotDataBucket               string   `json:"awsSpotDataBucket,omitempty"`
+	SpotDataPrefix               string   `json:"awsSpotDataPrefix,omitempty"`
+	ProjectID                    string   `json:"projectID,omitempty"`
+	AthenaProjectID              string   `json:"athenaProjectID,omitempty"`
+	AthenaBucketName             string   `json:"athenaBucketName"`
+	AthenaRegion                 string   `json:"athenaRegion"`
+	AthenaDatabase               string   `json:"athenaDatabase"`
+	AthenaTable                  string   `json:"athenaTable"`
+	AthenaWorkgroup              string   `json:"athenaWorkgroup"`
+	MasterPayerARN               string   `json:"masterPayerARN"`
+	BillingDataDataset           string   `json:"billingDataDataset,omitempty"`
+	CustomPricesEnabled          string   `json:"customPricesEnabled"`
+	DefaultIdle                  string   `json:"defaultIdle"`
+	AzureSubscriptionID          string   `json:"azureSubscriptionID"`
+	AzureClientID                string   `json:"azureClientID"`
+	AzureClientSecret            string   `json:"azureClientSecret"`
+	AzureTenantID                string   `json:"azureTenantID"`
+	AzureBillingRegion           string   `json:"azureBillingRegion"`
+	AzureOfferDurableID          string   `json:"azureOfferDurableID"`
+	AzureStorageSubscriptionID   string   `json:"azureStorageSubscriptionID"`
+	AzureStorageAccount          string   `json:"azureStorageAccount"`
+	AzureStorageAccessKey        string   `json:"azureStorageAccessKey"`
+	AzureStorageContainer        string   `json:"azureStorageContainer"`
+	AzureContainerPath           string   `json:"azureContainerPath"`
+	AzureCloud                   string   `json:"azureCloud"`
+	CurrencyCode                 string   `json:"currencyCode"`
+	Discount                     string   `json:"discount"`
+	NegotiatedDiscount           string   `json:"negotiatedDiscount"`
+	SharedOverhead               string   `json:"sharedOverhead"`
+	ClusterName                  string   `json:"clusterName"`
+	SharedNamespaces             string   `json:"sharedNamespaces"`
+	SharedLabelNames             string   `json:"sharedLabelNames"`
+	SharedLabelValues            string   `json:"sharedLabelValues"`
+	ShareTenancyCosts            string   `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
+	ReadOnly                     string   `json:"readOnly"`
+	EditorAccess                 string   `json:"editorAccess"`
+	KubecostToken                string   `json:"kubecostToken"`
+	GoogleAnalyticsTag           string   `json:"googleAnalyticsTag"`
+	ExcludeProviderID            string   `json:"excludeProviderID"`
+	Regions                      []string `json:"regions"`
 }
 
 // GetSharedOverheadCostPerMonth parses and returns a float64 representation
@@ -517,7 +518,7 @@ func getClusterProperties(node *v1.Node) clusterProperties {
 		accountID:      "",
 		projectID:      "",
 	}
-	if metadata.OnGCE() {
+	if metadata.OnGCE() || strings.HasPrefix(providerID, "gce") {
 		cp.provider = kubecost.GCPProvider
 		cp.configFileName = "gcp.json"
 		cp.projectID = parseGCPProjectID(providerID)

--- a/test/cloud_test.go
+++ b/test/cloud_test.go
@@ -376,7 +376,7 @@ type FakeClusterMap struct {
 }
 
 func TestNodePriceFromCSVWithBadConfig(t *testing.T) {
-	os.Setenv("CONFIG_PATH", "../config")
+	t.Setenv("CONFIG_PATH", "../config")
 	confMan := config.NewConfigFileManager(&config.ConfigFileManagerOpts{
 		LocalConfigPath: "./",
 	})
@@ -409,7 +409,7 @@ func TestNodePriceFromCSVWithBadConfig(t *testing.T) {
 }
 
 func TestSourceMatchesFromCSV(t *testing.T) {
-	os.Setenv("CONFIG_PATH", "../configs")
+	t.Setenv("CONFIG_PATH", "../configs")
 
 	confMan := config.NewConfigFileManager(&config.ConfigFileManagerOpts{
 		LocalConfigPath: "./",


### PR DESCRIPTION
## What does this PR change?
* Add optional configuration of regions for AWS, Azure, GCP, and Scaleway, instead of strictly hardcoded regions
* A change to how GCP is identified as a provider was made to facilitate testing - this needs review by someone more familiar with this project

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* If desired, users will be able to add `"regions":["name", ...]` to their cloud configuration files.

## Does this PR address any GitHub or Zendesk issues?
* Closes #1382

## How was this PR tested?
* Tests were added to `test/cloud_test.go` to confirm proper functionality under happy path and other cases.

## Does this PR require changes to documentation?
* Possibly. Comments on #1382 indicate that issue was going to be ignored because cloud providers will, in the future, not be part of OpenCost. In that case, it may be preferred to leave this as an undocumented feature.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* No. This does not seem like my decision, but that of the project maintainers.
