### PR TITLE
PV pricing for cloud disk attached to the Alibaba K8s Cluster

### DIFF
--- a/pkg/cloud/aliyunprovider.go
+++ b/pkg/cloud/aliyunprovider.go
@@ -153,10 +153,14 @@ func NewSlimK8sNode(instanceType, regionID, priceUnit, memorySizeInKiB, osType, 
 // Basic Attributes needed atleast to get the key, Some attributes from k8s Node response
 // be populated directly into *Node object.
 type AlibabaNodeAttributes struct {
-	InstanceType    string `json:"instanceType"`
+	// InstanceType represents the type of instance.
+	InstanceType string `json:"instanceType"`
+	// MemorySizeInKiB represents the size of memory of instance.
 	MemorySizeInKiB string `json:"memorySizeInKiB"`
-	IsIoOptimized   bool   `json:"isIoOptimized"`
-	OSType          string `json:"osType"`
+	// IsIoOptimized represents the if instance is I/O optimized.
+	IsIoOptimized bool `json:"isIoOptimized"`
+	// OSType represents the OS installed in the Instance.
+	OSType string `json:"osType"`
 }
 
 func NewAlibabaNodeAttributes(node *SlimK8sNode) *AlibabaNodeAttributes {
@@ -410,14 +414,14 @@ func (alibaba *Alibaba) DownloadPricingData() error {
 	return nil
 }
 
-// AllNodePricing returns all the billing data for nodes and pvs
+// AllNodePricing returns all the pricing data for all nodes and pvs
 func (alibaba *Alibaba) AllNodePricing() (interface{}, error) {
 	alibaba.DownloadPricingDataLock.RLock()
 	defer alibaba.DownloadPricingDataLock.RUnlock()
 	return alibaba.Pricing, nil
 }
 
-// NodePricing gives a specific node pricing information given by the key
+// NodePricing gives pricing information of a specific node given by the key
 func (alibaba *Alibaba) NodePricing(key Key) (*Node, error) {
 	alibaba.DownloadPricingDataLock.RLock()
 	defer alibaba.DownloadPricingDataLock.RUnlock()
@@ -437,7 +441,7 @@ func (alibaba *Alibaba) NodePricing(key Key) (*Node, error) {
 	return returnNode, nil
 }
 
-// PVPricing gives a specific PV price for the PVkey
+// PVPricing gives a pricing information of a specific PV gien by PVkey
 func (alibaba *Alibaba) PVPricing(pvk PVKey) (*PV, error) {
 	alibaba.DownloadPricingDataLock.RLock()
 	defer alibaba.DownloadPricingDataLock.RUnlock()
@@ -957,19 +961,10 @@ func generateSlimK8sDiskFromV1PV(pv *v1.PersistentVolume, regionID string) *Slim
 		}
 	}
 
-	// Highly unlikely that label "csi.alibabacloud.com/disktype" doesn't exist but if occured default to cloud (most basic disk type)
+	// Highly unlikely that label pv.Spec.CSI.VolumeAttributes["type"] doesn't exist but if occured default to cloud (most basic disk type)
 	if diskCategory == "" {
 		diskCategory = ALIBABA_DISK_CLOUD_CATEGORY
 	}
 
-	return &SlimK8sDisk{
-		DiskType:         diskType,
-		RegionID:         regionID,
-		PriceUnit:        priceUnit,
-		SizeInGiB:        sizeInGiB,
-		DiskCategory:     diskCategory,
-		PerformanceLevel: performanceLevel,
-		ProviderID:       providerID,
-		StorageClass:     pv.Spec.StorageClassName,
-	}
+	return NewSlimK8sDisk(diskType, regionID, priceUnit, diskCategory, performanceLevel, providerID, pv.Spec.StorageClassName, sizeInGiB)
 }

--- a/pkg/cloud/aliyunprovider.go
+++ b/pkg/cloud/aliyunprovider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,7 @@ const (
 	ALIBABA_ECS_VERSION                        = "2014-05-26"
 	ALIBABA_ECS_DOMAIN                         = "ecs.aliyuncs.com"
 	ALIBABA_DESCRIBE_PRICE_API_ACTION          = "DescribePrice"
+	ALIBABA_DESCRIBE_DISK_API_ACTION           = "DescribeDisks"
 	ALIBABA_INSTANCE_RESOURCE_TYPE             = "instance"
 	ALIBABA_DISK_RESOURCE_TYPE                 = "disk"
 	ALIBABA_PAY_AS_YOU_GO_BILLING              = "Pay-As-You-Go"
@@ -42,8 +44,13 @@ const (
 	ALIBABA_NOT_SUPPORTED_INSTANCE_FAMILY_TYPE = "unsupported"
 	ALIBABA_ENHANCED_GENERAL_PURPOSE_TYPE      = "g6e"
 	ALIBABA_DISK_CLOUD_ESSD_CATEGORY           = "cloud_essd"
-	ALIBABA_PV_DISK_CATEGORY                   = "system"
-	ALIBABA_LOCAL_DISK_CATEGORY                = "data"
+	ALIBABA_DISK_CLOUD_CATEGORY                = "cloud"
+	ALIBABA_DATA_DISK_CATEGORY                 = "data"
+	ALIBABA_SYSTEM_DISK_CATEGORY               = "system"
+	ALIBABA_DATA_DISK_PREFIX                   = "DataDisk"
+	ALIBABA_PV_CLOUD_DISK_TYPE                 = "CloudDisk"
+	ALIBABA_PV_NAS_TYPE                        = "NAS"
+	ALIBABA_PV_OSS_TYPE                        = "OSS"
 )
 
 // Why predefined and dependency on code? Can be converted to API call - https://www.alibabacloud.com/help/en/elastic-compute-service/latest/regions-describeregions
@@ -97,13 +104,14 @@ type SlimK8sDisk struct {
 	DiskType         string
 	RegionID         string
 	PriceUnit        string
-	SizeInGiB        int
+	SizeInGiB        string
 	DiskCategory     string
 	PerformanceLevel string
 	ProviderID       string
+	StorageClass     string
 }
 
-func NewSlimK8sDisk(diskType, regionID, priceUnit, diskCategory, performanceLevel, providerID string, sizeInGiB int) *SlimK8sDisk {
+func NewSlimK8sDisk(diskType, regionID, priceUnit, diskCategory, performanceLevel, providerID, storageClass, sizeInGiB string) *SlimK8sDisk {
 	return &SlimK8sDisk{
 		DiskType:         diskType,
 		RegionID:         regionID,
@@ -112,6 +120,7 @@ func NewSlimK8sDisk(diskType, regionID, priceUnit, diskCategory, performanceLeve
 		DiskCategory:     diskCategory,
 		PerformanceLevel: performanceLevel,
 		ProviderID:       providerID,
+		StorageClass:     storageClass,
 	}
 }
 
@@ -140,7 +149,7 @@ func NewSlimK8sNode(instanceType, regionID, priceUnit, memorySizeInKiB, osType, 
 	}
 }
 
-// AlibabaNodeAttributes represents metadata about the product used to map to a node.
+// AlibabaNodeAttributes represents metadata about the product pricing information used to map to a node.
 // Basic Attributes needed atleast to get the key, Some attributes from k8s Node response
 // be populated directly into *Node object.
 type AlibabaNodeAttributes struct {
@@ -159,14 +168,34 @@ func NewAlibabaNodeAttributes(node *SlimK8sNode) *AlibabaNodeAttributes {
 	}
 }
 
-// AlibabaPVAttributes represents metadata about the product used to map to a PV.
-// Basic Attributes needed atleast to get the keys, Some attributes from k8s Node response
+// AlibabaPVAttributes represents metadata about the product pricing information used to map to a PV.
+// Basic Attributes needed atleast to get the keys.Some attributes from k8s PV response
 // be populated directly into *PV object.
-// TO_DO: In next PR improve this
 type AlibabaPVAttributes struct {
-	DiskType         int32  `json:"diskType"`
-	DiskCategory     string `json:"diskCategory"`
-	PerformanceLevel string `json:"performanceLevel"`
+	// PVType can be Cloud Disk, NetWork Attached Storage(NAS) or Object Storage Service (OSS).
+	// Represents the way the PV was attached
+	PVType string `json:"pvType"`
+	// PVSubType represent the sub category of PVType. This is Data in case of Cloud Disk.
+	PVSubType string `json:"pvSubType"`
+	// Example for PVCategory with cloudDisk PVType are cloud, cloud_efficiency, cloud_ssd,
+	// ephemeral_ssd and cloud_essd. If not present returns empty.
+	PVCategory string `json:"pvCategory"`
+	// Example for PerformanceLevel with cloudDisk PVType are PL0,PL1,PL2 &PL3. If not present returns empty.
+	PVPerformanceLevel string `json:"performanceLevel"`
+	// The Size of the PV in terms of GiB
+	SizeInGiB string `json:"sizeInGiB"`
+}
+
+// TO-Do: next iteration of Alibaba provider support NetWork Attached Storage(NAS) and Object Storage Service (OSS type PVs).
+// Currently defaulting to cloudDisk with provision to add work in future.
+func NewAlibabaPVAttributes(disk *SlimK8sDisk) *AlibabaPVAttributes {
+	return &AlibabaPVAttributes{
+		PVType:             ALIBABA_PV_CLOUD_DISK_TYPE,
+		PVSubType:          disk.DiskType,
+		PVCategory:         disk.DiskCategory,
+		PVPerformanceLevel: disk.PerformanceLevel,
+		SizeInGiB:          disk.SizeInGiB,
+	}
 }
 
 // Stage 1 support will be Pay-As-You-Go with HourlyPrice equal to TradePrice with PriceUnit as Hour
@@ -279,6 +308,7 @@ func (alibaba *Alibaba) GetAlibabaAccessKey() (*credentials.AccessKeyCredential,
 	return alibaba.accessKey, nil
 }
 
+// DownloadPricingData satisfies the provider interface and downloads the price for node and PVs.
 func (alibaba *Alibaba) DownloadPricingData() error {
 	alibaba.DownloadPricingDataLock.Lock()
 	defer alibaba.DownloadPricingDataLock.Unlock()
@@ -306,13 +336,13 @@ func (alibaba *Alibaba) DownloadPricingData() error {
 	var client *sdk.Client
 	var signer *signers.AccessKeySigner
 	var ok bool
-	var pricingObj *AlibabaPricing
 	var lookupKey string
 	alibaba.clients = make(map[string]*sdk.Client)
 	alibaba.Pricing = make(map[string]*AlibabaPricing)
 
 	// TO-DO: Add disk price adjustment by parsing the local disk information and putting it as a param in describe Price function.
 	for _, node := range nodeList {
+		pricingObj := &AlibabaPricing{}
 		slimK8sNode := generateSlimK8sNodeFromV1Node(node)
 		lookupKey, err = determineKeyForPricing(slimK8sNode)
 		if _, ok := alibaba.Pricing[lookupKey]; ok {
@@ -336,49 +366,47 @@ func (alibaba *Alibaba) DownloadPricingData() error {
 		alibaba.Pricing[lookupKey] = pricingObj
 	}
 
-	// TO-DO: PV pricing
-	// //get pvList ultimately from Alibaba cloud provider and resemble data from the pvtype to
-	// // Hardcodedk8sNodeDiskStruct
-	// pvList := alibaba.Clientset.GetAllPersistentVolumes()
+	// set the first occurance of region from the node
+	i := 0
+	for alibaba.clusterRegion == "" && i < len(nodeList) {
+		regionID, ok := nodeList[i].Labels["topology.kubernetes.io/region"]
+		if ok {
+			alibaba.clusterRegion = regionID
+		} else {
+			i += 1
+		}
+	}
 
-	// pvList := []*Hardcodedk8sNodeDiskStruct{}
-	// pvList = append(pvList, &Hardcodedk8sNodeDiskStruct{
-	// 	DiskType:         "data",
-	// 	DiskCategory:     "cloud",
-	// 	PerformanceLevel: "",
-	// 	RegionID:         "cn-hangzhou",
-	// 	PriceUnit:        "Hour",
-	// 	SizeInGiB:        60,
-	// 	ProviderID:       "Ali-XXX-pv-01",
-	// }, &Hardcodedk8sNodeDiskStruct{
-	// 	DiskType:         "data",
-	// 	DiskCategory:     "cloud",
-	// 	PerformanceLevel: "P1",
-	// 	RegionID:         "cn-hangzhou",
-	// 	PriceUnit:        "Hour",
-	// 	SizeInGiB:        40,
-	// 	ProviderID:       "Ali-XXX-pv-01",
-	// })
+	// PV pricing for only Cloud Disk for now.
+	// TO-DO: Support both NAS(Network Attached storage) and OSS(Object Storage Service) type PVs
 
-	// for _, pv := range pvList {
-	// 	slimK8sNode := generateSlimK8sDiskFromV1PV(pv)
-	// 	if client, ok = alibaba.clients[pv.RegionID]; !ok {
-	// 		client, err = sdk.NewClientWithAccessKey(pv.RegionID, aak.AccessKeyId, aak.AccessKeySecret)
-	// 		if err != nil {
-	// 			return fmt.Errorf("access key provided does not have access to location %s", pv.RegionID)
-	// 		}
-	// 		alibaba.clients[pv.RegionID] = client
-	// 	}
-	// 	signer = signers.NewAccessKeySigner(aak)
-	// 	pricingObj, err = processDescribePriceAndCreateAlibabaPricing(client, pv, signer)
-	// 	lookupKey, err = determineKeyForPricing(pv)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	alibaba.Pricing[lookupKey] = pricingObj
-	// }
-	// log.Infof("Length of pricing is %d", len(alibaba.Pricing))
-	// log.Infof("random value is %v", alibaba.Pricing[lookupKey])
+	pvList := alibaba.Clientset.GetAllPersistentVolumes()
+
+	for _, pv := range pvList {
+		pricingObj := &AlibabaPricing{}
+		// Note for PR: Region ID defaulted to first occurance of node region for now, need to know the implication here!
+		// Can Pvs be in seperate Region than the Cluster? Is there ever a Multi Region k8s cluster?
+		slimK8sDisk := generateSlimK8sDiskFromV1PV(pv, alibaba.clusterRegion)
+		lookupKey, err = determineKeyForPricing(slimK8sDisk)
+		if _, ok := alibaba.Pricing[lookupKey]; ok {
+			log.Debugf("Pricing information for pv with same features %s already exists hence skipping", lookupKey)
+			continue
+		}
+		if client, ok = alibaba.clients[slimK8sDisk.RegionID]; !ok {
+			client, err = sdk.NewClientWithAccessKey(slimK8sDisk.RegionID, aak.AccessKeyId, aak.AccessKeySecret)
+			if err != nil {
+				return fmt.Errorf("unable to initiate alibaba cloud sdk client for region %s : %w", slimK8sDisk.RegionID, err)
+			}
+			alibaba.clients[slimK8sDisk.RegionID] = client
+		}
+		signer = signers.NewAccessKeySigner(aak)
+		pricingObj, err = processDescribePriceAndCreateAlibabaPricing(client, slimK8sDisk, signer, c)
+		if err != nil {
+			return fmt.Errorf("failed to create pricing information for pv with category %s with error: %w", slimK8sDisk.DiskCategory, err)
+		}
+		alibaba.Pricing[lookupKey] = pricingObj
+	}
+
 	return nil
 }
 
@@ -389,7 +417,7 @@ func (alibaba *Alibaba) AllNodePricing() (interface{}, error) {
 	return alibaba.Pricing, nil
 }
 
-// NodePricing gives a specific node for the key
+// NodePricing gives a specific node pricing information given by the key
 func (alibaba *Alibaba) NodePricing(key Key) (*Node, error) {
 	alibaba.DownloadPricingDataLock.RLock()
 	defer alibaba.DownloadPricingDataLock.RUnlock()
@@ -404,12 +432,8 @@ func (alibaba *Alibaba) NodePricing(key Key) (*Node, error) {
 	}
 
 	log.Debugf("returning the node price for the node with feature: %s", keyFeature)
-	// adjust the price of the node with local disk informatio
-	additionalLocalDiskPrice := applyAlibabaLocalDiskAdjustment(map[string]string{})
-
 	returnNode := pricing.Node
-	log.Debugf("Current Node price is %s and additionalPrice is: %f", returnNode.Cost, additionalLocalDiskPrice)
-	returnNode.adjustCost(additionalLocalDiskPrice)
+
 	return returnNode, nil
 }
 
@@ -602,19 +626,15 @@ type AlibabaNodeKey struct {
 	InstanceType     string
 	OSType           string
 	OptimizedKeyword string //If IsIoOptimized key will have optimize if not unoptimized the key for the node
-	LocalNodeDisks   map[string]string
 }
 
 func NewAlibabaNodeKey(node *SlimK8sNode, optimizedKeyword string) *AlibabaNodeKey {
-	//TO-DO: populate local disk via API
-	localNodeDisks := map[string]string{}
 	return &AlibabaNodeKey{
 		ProviderID:       node.ProviderID,
 		RegionID:         node.RegionID,
 		InstanceType:     node.InstanceType,
 		OSType:           node.OSType,
 		OptimizedKeyword: optimizedKeyword,
-		LocalNodeDisks:   localNodeDisks,
 	}
 }
 
@@ -635,10 +655,6 @@ func (alibabaNodeKey *AlibabaNodeKey) GPUCount() int {
 	return 0
 }
 
-func (alibabaNodeKey *AlibabaNodeKey) GetLocalDisks() map[string]string {
-	return alibabaNodeKey.LocalNodeDisks
-}
-
 // Get's the key for the k8s node input
 func (alibaba *Alibaba) GetKey(mapValue map[string]string, node *v1.Node) Key {
 	//Mostly parse the Node object and get the ProviderID, region, InstanceType, OSType and OptimizedKeyword(In if block)
@@ -655,16 +671,37 @@ func (alibaba *Alibaba) GetKey(mapValue map[string]string, node *v1.Node) Key {
 }
 
 type AlibabaPVKey struct {
-	ProviderID       string
-	RegionID         string
-	DiskType         string
-	DiskCategory     string
-	PerformaceLevel  string
-	StorageClassName string
+	ProviderID        string
+	RegionID          string
+	PVType            string
+	PVSubType         string
+	PVCategory        string
+	PVPerformaceLevel string
+	StorageClassName  string
+	SizeInGiB         string
+}
+
+func (alibaba *Alibaba) GetPVKey(pv *v1.PersistentVolume, parameters map[string]string, defaultRegion string) PVKey {
+	regionID := defaultRegion
+	// If default Region is not passed default it to cluster region ID.
+	if defaultRegion == "" {
+		regionID = alibaba.clusterRegion
+	}
+	slimK8sDisk := generateSlimK8sDiskFromV1PV(pv, defaultRegion)
+	return &AlibabaPVKey{
+		ProviderID:        slimK8sDisk.ProviderID,
+		RegionID:          regionID,
+		PVType:            ALIBABA_PV_CLOUD_DISK_TYPE,
+		PVSubType:         slimK8sDisk.DiskType,
+		PVCategory:        slimK8sDisk.DiskCategory,
+		PVPerformaceLevel: slimK8sDisk.PerformanceLevel,
+		StorageClassName:  pv.Spec.StorageClassName,
+		SizeInGiB:         slimK8sDisk.SizeInGiB,
+	}
 }
 
 func (alibabaPVKey *AlibabaPVKey) Features() string {
-	keyLookup := stringutil.DeleteEmptyStringsFromArray([]string{alibabaPVKey.RegionID, alibabaPVKey.DiskType, alibabaPVKey.DiskCategory, alibabaPVKey.PerformaceLevel})
+	keyLookup := stringutil.DeleteEmptyStringsFromArray([]string{alibabaPVKey.RegionID, alibabaPVKey.PVSubType, alibabaPVKey.PVCategory, alibabaPVKey.PVPerformaceLevel, alibabaPVKey.SizeInGiB})
 	return strings.Join(keyLookup, "::")
 }
 
@@ -710,10 +747,14 @@ func createDescribePriceACSRequest(i interface{}) (*requests.CommonRequest, erro
 	case *SlimK8sDisk:
 		disk := i.(*SlimK8sDisk)
 		request.QueryParams["RegionId"] = disk.RegionID
-		request.QueryParams["ResourceType"] = ALIBABA_DISK_RESOURCE_TYPE
-		request.QueryParams["DataDisk.1.Category"] = disk.DiskCategory
-		request.QueryParams["DataDisk.1.Size"] = fmt.Sprintf("%d", disk.SizeInGiB)
 		request.QueryParams["PriceUnit"] = disk.PriceUnit
+		request.QueryParams["ResourceType"] = ALIBABA_DISK_RESOURCE_TYPE
+		request.QueryParams[fmt.Sprintf("%s.%d.Size", ALIBABA_DATA_DISK_PREFIX, 1)] = disk.SizeInGiB
+		request.QueryParams[fmt.Sprintf("%s.%d.Category", ALIBABA_DATA_DISK_PREFIX, 1)] = disk.DiskCategory
+		// Performance level defaults to PL1 if not present in volume attribute.
+		if disk.PerformanceLevel != "" {
+			request.QueryParams[fmt.Sprintf("%s.%d.PerformanceLevel", ALIBABA_DATA_DISK_PREFIX, 1)] = disk.PerformanceLevel
+		}
 		request.TransToAcsRequest()
 		return request, nil
 	default:
@@ -721,7 +762,8 @@ func createDescribePriceACSRequest(i interface{}) (*requests.CommonRequest, erro
 	}
 }
 
-// determineKeyForPricing generate a unique key from SlimK8sNode object that is construct from v1.Node object.
+// determineKeyForPricing generate a unique key from SlimK8sNode object that is constructed from v1.Node object and
+// SlimK8sDisk that is constructed from v1.PersistentVolume.
 func determineKeyForPricing(i interface{}) (string, error) {
 	if i == nil {
 		return "", fmt.Errorf("nil component passed to determine key")
@@ -738,7 +780,7 @@ func determineKeyForPricing(i interface{}) (string, error) {
 		}
 	case *SlimK8sDisk:
 		disk := i.(*SlimK8sDisk)
-		keyLookup := stringutil.DeleteEmptyStringsFromArray([]string{disk.RegionID, disk.DiskCategory, disk.DiskType, disk.PerformanceLevel})
+		keyLookup := stringutil.DeleteEmptyStringsFromArray([]string{disk.RegionID, disk.DiskType, disk.DiskCategory, disk.PerformanceLevel, disk.SizeInGiB})
 		return strings.Join(keyLookup, "::"), nil
 	default:
 		return "", fmt.Errorf("unsupported ECS type (%T) at this time", i)
@@ -762,10 +804,11 @@ type DescribePriceResponse struct {
 	PriceInfo PriceInfo `json:"PriceInfo"`
 }
 
-// processDescribePriceAndCreateAlibabaPricing processes the DescribePrice API and generates the pricing information for alibaba node resource.
+// processDescribePriceAndCreateAlibabaPricing processes the DescribePrice API and generates the pricing information for alibaba node resource and alibaba pv resource that's backed by cloud disk.
 func processDescribePriceAndCreateAlibabaPricing(client *sdk.Client, i interface{}, signer *signers.AccessKeySigner, custom *CustomPricing) (pricing *AlibabaPricing, err error) {
 	pricing = &AlibabaPricing{}
 	var response DescribePriceResponse
+
 	if i == nil {
 		return nil, fmt.Errorf("nil component passed to process the pricing information")
 	}
@@ -804,19 +847,20 @@ func processDescribePriceAndCreateAlibabaPricing(client *sdk.Client, i interface
 			return nil, err
 		}
 		resp, err := client.ProcessCommonRequestWithSigner(req, signer)
-		if err != nil {
-			return nil, fmt.Errorf("unable to fetch information for disk with DiskType: %v", disk.DiskType)
+		if err != nil || resp.GetHttpStatus() != 200 {
+			return nil, fmt.Errorf("unable to fetch information for disk with DiskType: %v with err: %w", disk.DiskCategory, err)
 		} else {
 			// This is where population of Pricing happens
 			err = json.Unmarshal(resp.GetHttpContentBytes(), &response)
 			if err != nil {
 				return nil, fmt.Errorf("unable to unmarshall json response to custom struct with err: %w", err)
 			}
-			pricing.PVAttributes = &AlibabaPVAttributes{}
+			pricing.PVAttributes = NewAlibabaPVAttributes(disk)
 			pricing.PV = &PV{
 				Cost: fmt.Sprintf("%f", response.PriceInfo.Price.TradePrice),
 			}
-
+			// TO-DO : Disk has support for Hour and Month but pricing API is failing for month for disk(Research why?) and same challenge as node pricing no prepaid/postpaid distinction in v1.PersistentVolume object have to look at APIs for th information.
+			pricing.PricingTerms = NewAlibabaPricingTerms(ALIBABA_PAY_AS_YOU_GO_BILLING, NewAlibabaPricingDetails(response.PriceInfo.Price.TradePrice, ALIBABA_HOUR_PRICE_UNIT, response.PriceInfo.Price.TradePrice, response.PriceInfo.Price.Currency))
 		}
 	default:
 		return nil, fmt.Errorf("unsupported ECS Pricing component of type (%T) at this time", i)
@@ -842,7 +886,7 @@ func getInstanceFamilyFromType(instanceType string) string {
 	return splitinstanceType[1]
 }
 
-// function geenerates SlimK8sNode from v1.Node for better passing slimmed struct between functions
+// generateSlimK8sNodeFromV1Node generates SlimK8sNode struct from v1.Node to fetch pricing information.
 func generateSlimK8sNodeFromV1Node(node *v1.Node) *SlimK8sNode {
 	var regionID, osType, instanceType, providerID, priceUnit, instanceFamily string
 	var memorySizeInKiB string // TO-DO: try to convert it into float
@@ -872,12 +916,60 @@ func generateSlimK8sNodeFromV1Node(node *v1.Node) *SlimK8sNode {
 	return NewSlimK8sNode(instanceType, regionID, priceUnit, memorySizeInKiB, osType, providerID, instanceFamily, IsIoOptimized)
 }
 
-func generateSlimK8sDiskFromV1PV(pv v1.PersistentVolume) *SlimK8sDisk {
+// generateSlimK8sDiskFromV1PV function generates SlimK8sDisk from v1.PersistentVolume and DescribeDisk API(If required) of alibaba
+// to generate slim disk type that can be used to fetch pricing information.
+func generateSlimK8sDiskFromV1PV(pv *v1.PersistentVolume, regionID string) *SlimK8sDisk {
+	//Regular expression to get the GiB storage size for the API call
+	sizeRegEx := regexp.MustCompile("(.*?)Gi")
 
-}
+	// All PVs are data disks while local disk are categorized as system disk
+	diskType := ALIBABA_DATA_DISK_CATEGORY
 
-// applyAlibabaLocalDiskAdjustment will adjust the return node price with the loal disks that are attached
-// to a specific node.
-func applyAlibabaLocalDiskAdjustment(listOfDisks map[string]string) float32 {
-	return 0.0
+	//TO-DO: Disk supports month and hour prices , defaulting to hour
+	priceUnit := ALIBABA_HOUR_PRICE_UNIT
+
+	sizeQuantity := fmt.Sprintf("%s", pv.Spec.Capacity.Storage())
+
+	res := sizeRegEx.FindAllStringSubmatch(sizeQuantity, 1)
+
+	// This is the default value used for the DescribePrice DataDisk size, if any error occured defaulting it to 2000GiB's price
+	sizeInGiB := "2000"
+	if len(res) != 0 {
+		sizeInGiB = res[0][1]
+	}
+
+	providerID := ""
+	if pv.Spec.CSI != nil {
+		providerID = pv.Spec.CSI.VolumeHandle
+	} else {
+		providerID = pv.Name // Looks like pv name is same as providerID in Alibaba k8s cluster
+	}
+
+	// Performance level being empty string gets defaulted in describePrice to PL1.
+	performanceLevel := ""
+	diskCategory := ""
+	if pv.Spec.CSI != nil {
+		if val, ok := pv.Spec.CSI.VolumeAttributes["performanceLevel"]; ok {
+			performanceLevel = val
+		}
+		if val, ok := pv.Spec.CSI.VolumeAttributes["type"]; ok {
+			diskCategory = val
+		}
+	}
+
+	// Highly unlikely that label "csi.alibabacloud.com/disktype" doesn't exist but if occured default to cloud (most basic disk type)
+	if diskCategory == "" {
+		diskCategory = ALIBABA_DISK_CLOUD_CATEGORY
+	}
+
+	return &SlimK8sDisk{
+		DiskType:         diskType,
+		RegionID:         regionID,
+		PriceUnit:        priceUnit,
+		SizeInGiB:        sizeInGiB,
+		DiskCategory:     diskCategory,
+		PerformanceLevel: performanceLevel,
+		ProviderID:       providerID,
+		StorageClass:     pv.Spec.StorageClassName,
+	}
 }

--- a/pkg/cloud/aliyunprovider_test.go
+++ b/pkg/cloud/aliyunprovider_test.go
@@ -475,3 +475,40 @@ func TestGenerateSlimK8sDiskFromV1PV(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNumericalValueFromResourceQuantity(t *testing.T) {
+	cases := []struct {
+		name                 string
+		inputResourceQuanity string
+		expectedValue        string
+	}{
+		{
+			name:                 "positive scenario: when inputResourceQuantity is 10Gi",
+			inputResourceQuanity: "10Gi",
+			expectedValue:        "10",
+		},
+		{
+			name:                 "negative scenario: when inputResourceQuantity is Gi",
+			inputResourceQuanity: "Gi",
+			expectedValue:        ALIBABA_DEFAULT_DATADISK_SIZE,
+		},
+		{
+			name:                 "negative scenario: when inputResourceQuantity is 10",
+			inputResourceQuanity: "10",
+			expectedValue:        ALIBABA_DEFAULT_DATADISK_SIZE,
+		},
+		{
+			name:                 "negative scenario: when inputResourceQuantity is empty string",
+			inputResourceQuanity: "",
+			expectedValue:        ALIBABA_DEFAULT_DATADISK_SIZE,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			returnValue := getNumericalValueFromResourceQuantity(c.inputResourceQuanity)
+			if c.expectedValue != returnValue {
+				t.Fatalf("Case name %s: getNumericalValueFromResourceQuantity recieved %s but expected %s", c.name, returnValue, c.expectedValue)
+			}
+		})
+	}
+}

--- a/pkg/cloud/aliyunprovider_test.go
+++ b/pkg/cloud/aliyunprovider_test.go
@@ -22,9 +22,42 @@ func TestCreateDescribePriceACSRequest(t *testing.T) {
 		ProviderID:         "Ali-XXX-node-01",
 		InstanceTypeFamily: "g6",
 	}
-	_, err := createDescribePriceACSRequest(node)
-	if err != nil {
-		t.Errorf("Error converting to Alibaba cloud request")
+
+	disk := &SlimK8sDisk{
+		DiskType:         "data",
+		RegionID:         "cn-hangzhou",
+		PriceUnit:        "Hour",
+		SizeInGiB:        "20",
+		DiskCategory:     "diskCategory",
+		PerformanceLevel: "cloud_essd",
+		ProviderID:       "d-Ali-XXX-01",
+		StorageClass:     "testStorageClass",
+	}
+
+	cases := []struct {
+		name          string
+		testStruct    interface{}
+		expectedError error
+	}{
+		{
+			name:          "test CreateDescribePriceACSRequest with SlimK8sNode struct Object",
+			testStruct:    node,
+			expectedError: nil,
+		},
+		{
+			name:          "test CreateDescribePriceACSRequest with SlimK8sDisk struct Object",
+			testStruct:    disk,
+			expectedError: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := createDescribePriceACSRequest(c.testStruct)
+			if err != nil && c.expectedError == nil {
+				t.Fatalf("Case name %s: Error converting to Alibaba cloud request", c.name)
+			}
+		})
 	}
 }
 
@@ -47,12 +80,12 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		testNode      *SlimK8sNode
+		teststruct    interface{}
 		expectedError error
 	}{
 		{
 			name: "test Enhanced General Purpose Type g6e instance family",
-			testNode: &SlimK8sNode{
+			teststruct: &SlimK8sNode{
 				InstanceType:       "ecs.g6e.xlarge",
 				RegionID:           "cn-hangzhou",
 				PriceUnit:          "Hour",
@@ -66,7 +99,7 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 		},
 		{
 			name: "test General Purpose Type g6 instance family",
-			testNode: &SlimK8sNode{
+			teststruct: &SlimK8sNode{
 				InstanceType:       "ecs.g6.3xlarge",
 				RegionID:           "cn-hangzhou",
 				PriceUnit:          "Hour",
@@ -80,7 +113,7 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 		},
 		{
 			name: "test General Purpose Type g5 instance family",
-			testNode: &SlimK8sNode{
+			teststruct: &SlimK8sNode{
 				InstanceType:       "ecs.g5.2xlarge",
 				RegionID:           "cn-hangzhou",
 				PriceUnit:          "Hour",
@@ -94,7 +127,7 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 		},
 		{
 			name: "test General Purpose Type sn2 instance family",
-			testNode: &SlimK8sNode{
+			teststruct: &SlimK8sNode{
 				InstanceType:       "ecs.sn2.large",
 				RegionID:           "cn-hangzhou",
 				PriceUnit:          "Hour",
@@ -108,7 +141,7 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 		},
 		{
 			name: "test General Purpose Type with Enhanced Network Performance sn2ne instance family",
-			testNode: &SlimK8sNode{
+			teststruct: &SlimK8sNode{
 				InstanceType:       "ecs.sn2ne.2xlarge",
 				RegionID:           "cn-hangzhou",
 				PriceUnit:          "Hour",
@@ -122,21 +155,76 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 		},
 		{
 			name:          "test for a nil information",
-			testNode:      nil,
+			teststruct:    nil,
 			expectedError: fmt.Errorf("unsupported ECS pricing component at this time"),
+		},
+		{
+			name: "test Cloud Disk with Category cloud representing basic disk",
+			teststruct: &SlimK8sDisk{
+				DiskType:     "data",
+				RegionID:     "cn-hangzhou",
+				PriceUnit:    "Hour",
+				SizeInGiB:    "20",
+				DiskCategory: "cloud",
+				ProviderID:   "d-Ali-cloud-XXX-01",
+				StorageClass: "temp",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "test Cloud Disk with Category cloud_efficiency representing ultra disk",
+			teststruct: &SlimK8sDisk{
+				DiskType:     "data",
+				RegionID:     "cn-hangzhou",
+				PriceUnit:    "Hour",
+				SizeInGiB:    "40",
+				DiskCategory: "cloud_efficiency",
+				ProviderID:   "d-Ali-cloud-XXX-02",
+				StorageClass: "temp",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "test Cloud Disk with Category cloud_ssd representing standard SSD",
+			teststruct: &SlimK8sDisk{
+				DiskType:     "data",
+				RegionID:     "cn-hangzhou",
+				PriceUnit:    "Hour",
+				SizeInGiB:    "40",
+				DiskCategory: "cloud_efficiency",
+				ProviderID:   "d-Ali-cloud-XXX-02",
+				StorageClass: "temp",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "test Cloud Disk with Category cloud_essd representing Enhanced SSD with PL2 performance level",
+			teststruct: &SlimK8sDisk{
+				DiskType:         "data",
+				RegionID:         "cn-hangzhou",
+				PriceUnit:        "Hour",
+				SizeInGiB:        "80",
+				DiskCategory:     "cloud_ssd",
+				PerformanceLevel: "PL2",
+				ProviderID:       "d-Ali-cloud-XXX-04",
+				StorageClass:     "temp",
+			},
+			expectedError: nil,
 		},
 	}
 	custom := &CustomPricing{}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			pricingObj, err := processDescribePriceAndCreateAlibabaPricing(client, c.testNode, signer, custom)
+			pricingObj, err := processDescribePriceAndCreateAlibabaPricing(client, c.teststruct, signer, custom)
 			if err != nil && c.expectedError == nil {
 				t.Fatalf("Case name %s: got an error %s", c.name, err)
 			}
-			if pricingObj == nil {
-				t.Fatalf("Case name %s: got a nil pricing object", c.name)
+			if c.teststruct != nil {
+				if pricingObj == nil {
+					t.Fatalf("Case name %s: got a nil pricing object", c.name)
+				}
+				t.Logf("Case name %s: Pricing Information gathered for instanceType is %v", c.name, pricingObj.PricingTerms.PricingDetails.TradePrice)
 			}
-			t.Logf("Pricing Information gathered for instanceType %s is %v", c.name, pricingObj.PricingTerms.PricingDetails.TradePrice)
 		})
 	}
 }
@@ -185,7 +273,7 @@ func TestDetermineKeyForPricing(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name: "test when all RegionID, InstanceType, OSType & ALIBABA_OPTIMIZE_KEYWORD words are used to key",
+			name: "test when all RegionID, InstanceType, OSType & ALIBABA_OPTIMIZE_KEYWORD words are used in Node key",
 			testVar: &SlimK8sNode{
 				InstanceType:       "ecs.sn2.large",
 				RegionID:           "cn-hangzhou",
@@ -200,7 +288,7 @@ func TestDetermineKeyForPricing(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "test missing InstanceType to create key",
+			name: "test missing InstanceType to create Node key",
 			testVar: &SlimK8sNode{
 				RegionID:        "cn-hangzhou",
 				PriceUnit:       "Hour",
@@ -225,6 +313,35 @@ func TestDetermineKeyForPricing(t *testing.T) {
 			testVar:       nil,
 			expectedKey:   "",
 			expectedError: fmt.Errorf("unsupported ECS type randomK8sStruct for DescribePrice at this time"),
+		},
+		{
+			name: "test when all RegionID, InstanceType, OSType & ALIBABA_OPTIMIZE_KEYWORD words are used to key",
+			testVar: &SlimK8sDisk{
+				DiskType:     "data",
+				RegionID:     "cn-hangzhou",
+				PriceUnit:    "Hour",
+				SizeInGiB:    "40",
+				DiskCategory: "cloud_efficiency",
+				ProviderID:   "d-Ali-cloud-XXX-02",
+				StorageClass: "temp",
+			},
+			expectedKey:   "cn-hangzhou::data::cloud_efficiency::40",
+			expectedError: nil,
+		},
+		{
+			name: "test missing InstanceType to create key",
+			testVar: &SlimK8sDisk{
+				DiskType:         "data",
+				RegionID:         "cn-hangzhou",
+				PriceUnit:        "Hour",
+				SizeInGiB:        "80",
+				DiskCategory:     "cloud_ssd",
+				PerformanceLevel: "PL2",
+				ProviderID:       "d-Ali-cloud-XXX-04",
+				StorageClass:     "temp",
+			},
+			expectedKey:   "cn-hangzhou::data::cloud_ssd::PL2::80",
+			expectedError: nil,
 		},
 	}
 	for _, c := range cases {
@@ -260,7 +377,7 @@ func TestGenerateSlimK8sNodeFromV1Node(t *testing.T) {
 			expectedSlimNode: &SlimK8sNode{
 				InstanceType:       "ecs.sn2ne.2xlarge",
 				RegionID:           "us-east-1",
-				PriceUnit:          "Hour",
+				PriceUnit:          ALIBABA_HOUR_PRICE_UNIT,
 				MemorySizeInKiB:    "16",
 				IsIoOptimized:      true,
 				OSType:             "linux",
@@ -272,22 +389,88 @@ func TestGenerateSlimK8sNodeFromV1Node(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			returnSlimK8sNode := generateSlimK8sNodeFromV1Node(c.testNode)
 			if returnSlimK8sNode.InstanceType != c.expectedSlimNode.InstanceType {
-				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected InstanceType: %s , recieved Instance Type: %s", c.expectedSlimNode.InstanceType, returnSlimK8sNode.InstanceType)
+				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected InstanceType: %s , recieved InstanceType: %s", c.expectedSlimNode.InstanceType, returnSlimK8sNode.InstanceType)
 			}
 			if returnSlimK8sNode.RegionID != c.expectedSlimNode.RegionID {
-				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected RegionID: %s , recieved RegionID Type: %s", c.expectedSlimNode.RegionID, returnSlimK8sNode.RegionID)
+				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected RegionID: %s , recieved RegionID: %s", c.expectedSlimNode.RegionID, returnSlimK8sNode.RegionID)
 			}
 			if returnSlimK8sNode.PriceUnit != c.expectedSlimNode.PriceUnit {
-				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected PriceUnit: %s , recieved PriceUnit Type: %s", c.expectedSlimNode.PriceUnit, returnSlimK8sNode.PriceUnit)
+				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected PriceUnit: %s , recieved PriceUnit: %s", c.expectedSlimNode.PriceUnit, returnSlimK8sNode.PriceUnit)
 			}
 			if returnSlimK8sNode.MemorySizeInKiB != c.expectedSlimNode.MemorySizeInKiB {
-				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected MemorySizeInKiB: %s , recieved MemorySizeInKiB Type: %s", c.expectedSlimNode.MemorySizeInKiB, returnSlimK8sNode.MemorySizeInKiB)
+				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected MemorySizeInKiB: %s , recieved MemorySizeInKiB: %s", c.expectedSlimNode.MemorySizeInKiB, returnSlimK8sNode.MemorySizeInKiB)
 			}
 			if returnSlimK8sNode.OSType != c.expectedSlimNode.OSType {
-				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected OSType: %s , recieved OSType Type: %s", c.expectedSlimNode.OSType, returnSlimK8sNode.OSType)
+				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected OSType: %s , recieved OSType: %s", c.expectedSlimNode.OSType, returnSlimK8sNode.OSType)
 			}
 			if returnSlimK8sNode.InstanceTypeFamily != c.expectedSlimNode.InstanceTypeFamily {
-				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected InstanceTypeFamily: %s , recieved InstanceTypeFamily Type: %s", c.expectedSlimNode.InstanceTypeFamily, returnSlimK8sNode.InstanceTypeFamily)
+				t.Fatalf("unexpected conversion in function generateSlimK8sNodeFromV1Node expected InstanceTypeFamily: %s , recieved InstanceTypeFamily: %s", c.expectedSlimNode.InstanceTypeFamily, returnSlimK8sNode.InstanceTypeFamily)
+			}
+		})
+	}
+}
+
+func TestGenerateSlimK8sDiskFromV1PV(t *testing.T) {
+	testv1PV := &v1.PersistentVolume{}
+	testv1PV.Spec.Capacity = v1.ResourceList{
+		v1.ResourceStorage: *resource.NewQuantity(16*1024*1024*1024, resource.BinarySI),
+	}
+	testv1PV.Spec.CSI = &v1.CSIPersistentVolumeSource{}
+	testv1PV.Spec.CSI.VolumeHandle = "testPV"
+	testv1PV.Spec.CSI.VolumeAttributes = map[string]string{
+		"performanceLevel": "PL2",
+		"type":             "cloud_essd",
+	}
+	testv1PV.Spec.CSI.VolumeHandle = "testPV"
+	testv1PV.Spec.StorageClassName = "testStorageClass"
+	cases := []struct {
+		name             string
+		testPV           *v1.PersistentVolume
+		expectedSlimDisk *SlimK8sDisk
+		inpRegionID      string
+	}{
+		{
+			name:   "test a generic *v1.Node to *SlimK8sNode Conversion",
+			testPV: testv1PV,
+			expectedSlimDisk: &SlimK8sDisk{
+				DiskType:         ALIBABA_DATA_DISK_CATEGORY,
+				RegionID:         "us-east-1",
+				PriceUnit:        ALIBABA_HOUR_PRICE_UNIT,
+				SizeInGiB:        "16",
+				DiskCategory:     "cloud_essd",
+				PerformanceLevel: "PL2",
+				ProviderID:       "testPV",
+				StorageClass:     "testStorageClass",
+			},
+			inpRegionID: "us-east-1",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			returnSlimK8sDisk := generateSlimK8sDiskFromV1PV(c.testPV, c.inpRegionID)
+			if returnSlimK8sDisk.DiskType != c.expectedSlimDisk.DiskType {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected DiskType: %s , recieved DiskType: %s", c.expectedSlimDisk.DiskType, returnSlimK8sDisk.DiskType)
+			}
+			if returnSlimK8sDisk.RegionID != c.expectedSlimDisk.RegionID {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected RegionID: %s , recieved RegionID Type: %s", c.expectedSlimDisk.RegionID, returnSlimK8sDisk.RegionID)
+			}
+			if returnSlimK8sDisk.PriceUnit != c.expectedSlimDisk.PriceUnit {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected PriceUnit: %s , recieved PriceUnit Type: %s", c.expectedSlimDisk.PriceUnit, returnSlimK8sDisk.PriceUnit)
+			}
+			if returnSlimK8sDisk.SizeInGiB != c.expectedSlimDisk.SizeInGiB {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected SizeInGiB: %s , recieved SizeInGiB Type: %s", c.expectedSlimDisk.SizeInGiB, returnSlimK8sDisk.SizeInGiB)
+			}
+			if returnSlimK8sDisk.DiskCategory != c.expectedSlimDisk.DiskCategory {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected DiskCategory: %s , recieved DiskCategory Type: %s", c.expectedSlimDisk.DiskCategory, returnSlimK8sDisk.DiskCategory)
+			}
+			if returnSlimK8sDisk.PerformanceLevel != c.expectedSlimDisk.PerformanceLevel {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected PerformanceLevel: %s , recieved PerformanceLevel Type: %s", c.expectedSlimDisk.PerformanceLevel, returnSlimK8sDisk.PerformanceLevel)
+			}
+			if returnSlimK8sDisk.ProviderID != c.expectedSlimDisk.ProviderID {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected ProviderID: %s , recieved ProviderID Type: %s", c.expectedSlimDisk.ProviderID, returnSlimK8sDisk.ProviderID)
+			}
+			if returnSlimK8sDisk.StorageClass != c.expectedSlimDisk.StorageClass {
+				t.Fatalf("unexpected conversion in function generateSlimK8sDiskFromV1PV expected StorageClass: %s , recieved StorageClass Type: %s", c.expectedSlimDisk.StorageClass, returnSlimK8sDisk.StorageClass)
 			}
 		})
 	}

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -84,16 +84,6 @@ func (n *Node) IsSpot() bool {
 	}
 }
 
-// adjustCost adjust the cost of the Node, predominantly used in adjusting the cost with localDisk adjustment.
-// currently restricting to scope cloud package to be used in aliyunProvider.go can be made exported.
-func (n *Node) adjustCost(additionalPrice float32) {
-	currCost, err := strconv.ParseFloat(n.Cost, 32)
-	if err != nil {
-		log.Warnf("Skipping adjust node price with providerID %s ")
-	}
-	n.Cost = fmt.Sprintf("%f", float32(currCost)+additionalPrice)
-}
-
 // LoadBalancer is the interface by which the provider and cost model communicate LoadBalancer prices.
 // The provider will best-effort try to fill out this struct.
 type LoadBalancer struct {

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -84,6 +84,16 @@ func (n *Node) IsSpot() bool {
 	}
 }
 
+// adjustCost adjust the cost of the Node, predominantly used in adjusting the cost with localDisk adjustment.
+// currently restricting to scope cloud package to be used in aliyunProvider.go can be made exported.
+func (n *Node) adjustCost(additionalPrice float32) {
+	currCost, err := strconv.ParseFloat(n.Cost, 32)
+	if err != nil {
+		log.Warnf("Skipping adjust node price with providerID %s ")
+	}
+	n.Cost = fmt.Sprintf("%f", float32(currCost)+additionalPrice)
+}
+
 // LoadBalancer is the interface by which the provider and cost model communicate LoadBalancer prices.
 // The provider will best-effort try to fill out this struct.
 type LoadBalancer struct {


### PR DESCRIPTION
## What does this PR change?
* Gives insights into PV pricing for Physical volumes that are of type cloud disk.

## Does this PR relate to any other PRs?
* Continuation of work from [1488](https://github.com/opencost/opencost/pull/1488)

## How will this PR impact users?
* Gives them visibility into PV pricing.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Unit test
* creating PV and PVC with various combination of different available cloud disk options and seeing if results match with the actual Alibaba price.

Images listing the allNodePricing information = hourly price for the corresponding Alibaba's disk prices and the prometheus having the values in pv_hourly_cost
<img width="643" alt="Screen Shot 2022-11-23 at 9 10 43 AM" src="https://user-images.githubusercontent.com/11470561/203608046-328fd088-1555-40f7-8d70-c0b794a431fc.png">
<img width="657" alt="Screen Shot 2022-11-23 at 9 10 48 AM" src="https://user-images.githubusercontent.com/11470561/203608053-278f0aae-50d1-4130-9cf0-dae15c74067e.png">
<img width="1695" alt="Screen Shot 2022-11-23 at 9 07 50 AM" src="https://user-images.githubusercontent.com/11470561/203608115-e02a245d-f466-4563-a86f-b140a713c473.png">

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.99