### PR TITLE
Ignoring Idle Summary allocation in total efficiency computation of Summary allocation set 

### DIFF
--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -1183,6 +1183,9 @@ func (sas *SummaryAllocationSet) RAMEfficiency() float64 {
 	totalRAMBytesRequest := 0.0
 	totalRAMCost := 0.0
 	for _, sa := range sas.SummaryAllocations {
+		if sa.IsIdle() {
+			continue
+		}
 		totalRAMBytesUsage += sa.RAMBytesUsageAverage
 		totalRAMBytesRequest += sa.RAMBytesRequestAverage
 		totalRAMCost += sa.RAMCost
@@ -1212,6 +1215,9 @@ func (sas *SummaryAllocationSet) CPUEfficiency() float64 {
 	totalCPUCoreRequest := 0.0
 	totalCPUCost := 0.0
 	for _, sa := range sas.SummaryAllocations {
+		if sa.IsIdle() {
+			continue
+		}
 		totalCPUCoreUsage += sa.CPUCoreUsageAverage
 		totalCPUCoreRequest += sa.CPUCoreRequestAverage
 		totalCPUCost += sa.CPUCost
@@ -1237,19 +1243,18 @@ func (sas *SummaryAllocationSet) TotalEfficiency() float64 {
 	sas.RLock()
 	defer sas.RUnlock()
 
-	totalRAMCostEff := 0.0
-	totalCPUCostEff := 0.0
 	totalRAMCost := 0.0
 	totalCPUCost := 0.0
 	for _, sa := range sas.SummaryAllocations {
-		totalRAMCostEff += sa.RAMEfficiency() * sa.RAMCost
-		totalCPUCostEff += sa.CPUEfficiency() * sa.CPUCost
+		if sa.IsIdle() {
+			continue
+		}
 		totalRAMCost += sa.RAMCost
 		totalCPUCost += sa.CPUCost
 	}
 
 	if totalRAMCost+totalCPUCost > 0 {
-		return (totalRAMCostEff + totalCPUCostEff) / (totalRAMCost + totalCPUCost)
+		return (totalRAMCost*sas.RAMEfficiency() + totalCPUCost*sas.CPUEfficiency()) / (totalRAMCost + totalCPUCost)
 	}
 
 	return 0.0

--- a/pkg/kubecost/summaryallocation_test.go
+++ b/pkg/kubecost/summaryallocation_test.go
@@ -213,10 +213,10 @@ func TestSummaryAllocation_Add(t *testing.T) {
 
 func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 	// Generating 6 sample summary allocations for testing
-	var sa1, sa2, sa3, sa4, sa5, sa6 *SummaryAllocation
+	var sa1, sa2, sa3, sa4, sa5, sa6, idlesa *SummaryAllocation
 
 	// Generating accumulated summary allocation sets for testing
-	var sas1, sas2, sas3, sas4, sas5 *SummaryAllocationSet
+	var sas1, sas2, sas3, sas4, sas5, sas6 *SummaryAllocationSet
 
 	window, _ := ParseWindowUTC("7d")
 
@@ -314,6 +314,20 @@ func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 		RAMCost:                0.10,
 	}
 
+	idlesa = &SummaryAllocation{
+		Name: IdleSuffix,
+		Properties: &AllocationProperties{
+			Cluster:   "cluster1",
+			Namespace: "namespace1",
+			Pod:       "pod1",
+			Container: "container7",
+		},
+		Start:   saStart,
+		End:     saEnd,
+		CPUCost: 1.0,
+		RAMCost: 1.0,
+	}
+
 	testcase1Map := map[string]*SummaryAllocation{
 		"cluster1/namespace1/pod1/container1": sa1,
 		"cluster1/namespace1/pod1/container2": sa2,
@@ -340,6 +354,12 @@ func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 		"cluster1/namespace1/pod1/container6": sa6,
 	}
 
+	testcase6Map := map[string]*SummaryAllocation{
+		"cluster1/namespace1/pod1/container1": sa1,
+		"cluster1/namespace1/pod1/container2": sa2,
+		"cluster1/__idle__":                   idlesa,
+	}
+
 	sas1 = &SummaryAllocationSet{
 		SummaryAllocations: testcase1Map,
 		Window:             window,
@@ -362,6 +382,11 @@ func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 
 	sas5 = &SummaryAllocationSet{
 		SummaryAllocations: testcase5Map,
+		Window:             window,
+	}
+
+	sas6 = &SummaryAllocationSet{
+		SummaryAllocations: testcase6Map,
 		Window:             window,
 	}
 
@@ -395,6 +420,11 @@ func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 			testsas:            sas5,
 			expectedEfficiency: 0.65,
 		},
+		{
+			name:               "Check RAMEfficiency in presense of n idle allocation",
+			testsas:            sas6,
+			expectedEfficiency: 0.25,
+		},
 	}
 
 	for _, c := range cases {
@@ -410,10 +440,10 @@ func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 
 func TestSummaryAllocationSet_CPUEfficiency(t *testing.T) {
 	// Generating 6 sample summary allocations for testing
-	var sa1, sa2, sa3, sa4, sa5, sa6 *SummaryAllocation
+	var sa1, sa2, sa3, sa4, sa5, sa6, idlesa *SummaryAllocation
 
 	// Generating accumulated summary allocation sets for testing
-	var sas1, sas2, sas3, sas4, sas5 *SummaryAllocationSet
+	var sas1, sas2, sas3, sas4, sas5, sas6 *SummaryAllocationSet
 
 	window, _ := ParseWindowUTC("7d")
 
@@ -511,6 +541,20 @@ func TestSummaryAllocationSet_CPUEfficiency(t *testing.T) {
 		CPUCost:               0.2,
 	}
 
+	idlesa = &SummaryAllocation{
+		Name: IdleSuffix,
+		Properties: &AllocationProperties{
+			Cluster:   "cluster1",
+			Namespace: "namespace1",
+			Pod:       "pod1",
+			Container: "container7",
+		},
+		Start:   saStart,
+		End:     saEnd,
+		CPUCost: 1.0,
+		RAMCost: 1.0,
+	}
+
 	testcase1Map := map[string]*SummaryAllocation{
 		"cluster1/namespace1/pod1/container1": sa1,
 		"cluster1/namespace1/pod1/container2": sa2,
@@ -537,6 +581,12 @@ func TestSummaryAllocationSet_CPUEfficiency(t *testing.T) {
 		"cluster1/namespace1/pod1/container6": sa6,
 	}
 
+	testcase6Map := map[string]*SummaryAllocation{
+		"cluster1/namespace1/pod1/container1": sa1,
+		"cluster1/namespace1/pod1/container2": sa2,
+		"cluster1/__idle__":                   idlesa,
+	}
+
 	sas1 = &SummaryAllocationSet{
 		SummaryAllocations: testcase1Map,
 		Window:             window,
@@ -559,6 +609,11 @@ func TestSummaryAllocationSet_CPUEfficiency(t *testing.T) {
 
 	sas5 = &SummaryAllocationSet{
 		SummaryAllocations: testcase5Map,
+		Window:             window,
+	}
+
+	sas6 = &SummaryAllocationSet{
+		SummaryAllocations: testcase6Map,
 		Window:             window,
 	}
 
@@ -591,6 +646,11 @@ func TestSummaryAllocationSet_CPUEfficiency(t *testing.T) {
 			name:               "Check CPUEfficiency over combination of all allocation summaries",
 			testsas:            sas5,
 			expectedEfficiency: 0.50,
+		},
+		{
+			name:               "Check CPUEfficiency in presence of idle allocation",
+			testsas:            sas6,
+			expectedEfficiency: 0.30,
 		},
 	}
 
@@ -803,7 +863,7 @@ func TestSummaryAllocationSet_TotalEfficiency(t *testing.T) {
 		{
 			name:               "Check TotalEfficiency with idle cost",
 			testsas:            sas4,
-			expectedEfficiency: 0.20,
+			expectedEfficiency: 0.30,
 		},
 	}
 


### PR DESCRIPTION
## What does this PR change?
* Parity between old UI and new UI of Kubecost calling the Opencost package 

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* Consistency between efficiency between old UI and New UI

Old UI with Idle not impacting the total efficiency
![Screen Shot 2022-12-05 at 3 30 57 PM](https://user-images.githubusercontent.com/11470561/205771046-3cb2cba1-0968-4939-8842-a45309611c09.png)
![Screen Shot 2022-12-05 at 3 31 25 PM](https://user-images.githubusercontent.com/11470561/205771048-b209b547-9b25-450a-83d1-877ef71f3cd4.png)


New UI without the above fix where total efficiency is impacted with idle true
<img width="1448" alt="Screen Shot 2022-12-05 at 3 30 52 PM" src="https://user-images.githubusercontent.com/11470561/205771103-137649a1-3976-46b3-b759-9846db1266c7.png">
<img width="1391" alt="Screen Shot 2022-12-05 at 3 31 20 PM" src="https://user-images.githubusercontent.com/11470561/205771105-97f456ed-7851-4f80-a054-01e9aa82bdcf.png">


## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/kubecost-cost-model/issues/1057

## How was this PR tested?
* Unit tests

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.99 (Can maintainer label it please)
