### PR TITLE
Set up opencost UI deployment

### DIFF
--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -157,6 +157,16 @@ spec:
             - name: CLUSTER_ID
               value: "cluster-one" # Default cluster ID to use if cluster_id is not set in Prometheus metrics.
           imagePullPolicy: Always
+        - image: quay.io/kubecost1/opencost-ui:latest
+          name: opencost-ui
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "55M"
+            limits:
+              cpu: "999m"
+              memory: "1G"
+          imagePullPolicy: Always
 ---
 
 # Expose the cost model with a service
@@ -176,4 +186,7 @@ spec:
     - name: opencost
       port: 9003
       targetPort: 9003
+    - name: opencost-ui
+      port: 9090
+      targetPort: 9090
 ---


### PR DESCRIPTION
## What does this PR change?
This PR introduces the `opencost-ui` container at port `9090` referencing the `quay.io/kubecost1/opencost-ui:latest` image. 

## Does this PR relate to any other PRs?
https://github.com/kubecost/release-scripts/pull/31

## How will this PR impact users?
Users will be able to port-forward to port 9090 to access the opencost UI.

## Does this PR address any GitHub or Zendesk issues?


## How was this PR tested?
Verify that updated spec deploys the service and new container in the opencost pod correctly.

## Does this PR require changes to documentation?
Yes: https://github.com/opencost/opencost-website/pull/64

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
Next release
