### PR TITLE
Taking into account Summary Allocation not run for entire duration of SAS set window for RAM and CPU efficiency calculation 

### DIFF
--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -1179,23 +1179,23 @@ func (sas *SummaryAllocationSet) RAMEfficiency() float64 {
 	sas.RLock()
 	defer sas.RUnlock()
 
-	totalRAMBytesUsage := 0.0
-	totalRAMBytesRequest := 0.0
+	totalRAMBytesMinutesUsage := 0.0
+	totalRAMBytesMinutesRequest := 0.0
 	totalRAMCost := 0.0
 	for _, sa := range sas.SummaryAllocations {
 		if sa.IsIdle() {
 			continue
 		}
-		totalRAMBytesUsage += sa.RAMBytesUsageAverage
-		totalRAMBytesRequest += sa.RAMBytesRequestAverage
+		totalRAMBytesMinutesUsage += sa.RAMBytesUsageAverage * sa.Minutes()
+		totalRAMBytesMinutesRequest += sa.RAMBytesRequestAverage * sa.Minutes()
 		totalRAMCost += sa.RAMCost
 	}
 
-	if totalRAMBytesRequest > 0 {
-		return totalRAMBytesUsage / totalRAMBytesRequest
+	if totalRAMBytesMinutesRequest > 0 {
+		return totalRAMBytesMinutesUsage / totalRAMBytesMinutesRequest
 	}
 
-	if totalRAMBytesUsage == 0.0 || totalRAMCost == 0.0 {
+	if totalRAMBytesMinutesUsage == 0.0 || totalRAMCost == 0.0 {
 		return 0.0
 	}
 
@@ -1211,23 +1211,23 @@ func (sas *SummaryAllocationSet) CPUEfficiency() float64 {
 	sas.RLock()
 	defer sas.RUnlock()
 
-	totalCPUCoreUsage := 0.0
-	totalCPUCoreRequest := 0.0
+	totalCPUCoreMinutesUsage := 0.0
+	totalCPUCoreMinutesRequest := 0.0
 	totalCPUCost := 0.0
 	for _, sa := range sas.SummaryAllocations {
 		if sa.IsIdle() {
 			continue
 		}
-		totalCPUCoreUsage += sa.CPUCoreUsageAverage
-		totalCPUCoreRequest += sa.CPUCoreRequestAverage
+		totalCPUCoreMinutesUsage += sa.CPUCoreUsageAverage * sa.Minutes()
+		totalCPUCoreMinutesRequest += sa.CPUCoreRequestAverage * sa.Minutes()
 		totalCPUCost += sa.CPUCost
 	}
 
-	if totalCPUCoreRequest > 0 {
-		return totalCPUCoreUsage / totalCPUCoreRequest
+	if totalCPUCoreMinutesRequest > 0 {
+		return totalCPUCoreMinutesUsage / totalCPUCoreMinutesRequest
 	}
 
-	if totalCPUCoreUsage == 0.0 || totalCPUCost == 0.0 {
+	if totalCPUCoreMinutesUsage == 0.0 || totalCPUCost == 0.0 {
 		return 0.0
 	}
 

--- a/pkg/kubecost/summaryallocation_test.go
+++ b/pkg/kubecost/summaryallocation_test.go
@@ -421,7 +421,7 @@ func TestSummaryAllocationSet_RAMEfficiency(t *testing.T) {
 			expectedEfficiency: 0.65,
 		},
 		{
-			name:               "Check RAMEfficiency in presense of n idle allocation",
+			name:               "Check RAMEfficiency in presense of an idle allocation",
 			testsas:            sas6,
 			expectedEfficiency: 0.25,
 		},
@@ -648,7 +648,7 @@ func TestSummaryAllocationSet_CPUEfficiency(t *testing.T) {
 			expectedEfficiency: 0.50,
 		},
 		{
-			name:               "Check CPUEfficiency in presence of idle allocation",
+			name:               "Check CPUEfficiency in presence of an idle allocation",
 			testsas:            sas6,
 			expectedEfficiency: 0.30,
 		},


### PR DESCRIPTION
## What does this PR change?
* Fixing UI mismatch between old UI and new UI resulting from the impact of calculating RAM and CPU efficiency of allocations not active for entire duration of the requested window.

## Does this PR relate to any other PRs?
* Enhancement to #1523 after investigation

## How will this PR impact users?
* Absolute concurrency between old UI and new UI to the decimal place

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/kubecost-cost-model/issues/1057

## How was this PR tested?
* Uploading to my instance and testing old and new UI along with drilldowns

## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v.199 
