### PR TITLE
Nick/azure orphaned resources disknames

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"github.com/opencost/opencost/pkg/kubecost"
 	"io"
 	"net/http"
 	"net/url"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/opencost/opencost/pkg/kubecost"
 
 	"github.com/opencost/opencost/pkg/clustercache"
 	"github.com/opencost/opencost/pkg/env"
@@ -1266,14 +1267,25 @@ func (az *Azure) GetOrphanedResources() ([]OrphanedResource, error) {
 				return nil, err
 			}
 
+			diskName := ""
+			if d.Name != nil {
+				diskName = *d.Name
+			}
+
+			diskRegion := ""
+			if d.Location != nil {
+				diskRegion = *d.Location
+			}
+
 			or := OrphanedResource{
 				Kind:   "disk",
-				Region: *d.Location,
+				Region: diskRegion,
 				Description: map[string]string{
 					"diskState":   string(d.DiskState),
 					"timeCreated": d.TimeCreated.String(),
 				},
 				Size:        d.DiskSizeGB,
+				DiskName:    diskName,
 				MonthlyCost: &cost,
 			}
 			orphanedResources = append(orphanedResources, or)

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -109,6 +109,7 @@ type OrphanedResource struct {
 	Region      string            `json:"region"`
 	Description map[string]string `json:"description"`
 	Size        *int32            `json:"diskSizeInGB,omitempty"`
+	DiskName    string            `json:"diskName,omitempty"`
 	Address     string            `json:"ipAddress,omitempty"`
 	MonthlyCost *float64          `json:"monthlyCost"`
 }


### PR DESCRIPTION
## What does this PR change?
* Adds disk names to Azure's orphaned resources

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/1489

## How will this PR impact users?
* Users will see disk names

## Does this PR address any GitHub or Zendesk issues?
* 

## How was this PR tested?
* On Azure cluster

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.99
