### PR TITLE
Fix ListDirectories for GCS not working properly

### DIFF
--- a/pkg/storage/gcsstorage.go
+++ b/pkg/storage/gcsstorage.go
@@ -270,10 +270,11 @@ func (gs *GCSStorage) ListDirectories(path string) ([]*StorageInfo, error) {
 			continue
 		}
 
-		// If trim removes the entire name, it's a directory, ergo we list it
-		if trimName(attrs.Name) == "" {
+		// We filter directories using DirDelim, so a nameless entry is a dir
+		// See gcs.ObjectAttrs Prefix property
+		if attrs.Name == "" {
 			stats = append(stats, &StorageInfo{
-				Name:    attrs.Name,
+				Name:    attrs.Prefix,
 				Size:    attrs.Size,
 				ModTime: attrs.Updated,
 			})


### PR DESCRIPTION
Signed-off-by: Kaelan Patel <kaelanspatel@gmail.com>

## What does this PR change?
Fix `ListDirectories` for GCS storage type not properly returning the name of the directory.

## Does this PR relate to any other PRs?
No.

## How will this PR impact users?
Fixes an issue where Federator would fail to find changed files when using GCS.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
Tested on cluster using GCS for Federated ETL Federator: cluster was able to federate files on combined storage after change was made.

## Does this PR require changes to documentation?
No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
Yes.
