### PR TITLE
Update ui dockerfile's base image not to use alpine. Reason being tha…

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as builder
+FROM node:18.3.0 as builder
 ADD package*.json /opt/ui/
 WORKDIR /opt/ui
 RUN npm install


### PR DESCRIPTION
## What does this PR change?
* Updates ui Dockerfile's base image not to use alpine. Reason being that building node-gyp bindings for ARM architectures requires Python, which the alpine box does not have

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Will allow the opencost UI image to build on ARM architectures

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Manually by building an image on the Kubecost ARM64 build box.

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.99
