### PR TITLE
Allow ui to run from non privileged

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,3 +9,4 @@ RUN npx parcel build src/index.html
 FROM nginx:alpine
 COPY --from=builder /opt/ui/dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/

--- a/ui/default.nginx.conf
+++ b/ui/default.nginx.conf
@@ -31,6 +31,13 @@ gzip_types
     text/xml
     text/x-component
     text/x-cross-domain-policy;
+
+upstream model {
+    # Update to the cost model endpoint
+    # Example: host.docker.internal:9003;
+    server 0.0.0.0:9003;
+}
+
 server {
     server_name _;
     root /var/www;
@@ -51,7 +58,6 @@ server {
     add_header ETag "1.96.0";
     listen 9090;
     listen [::]:9090;
-    resolver kube-dns.kube-system.svc.cluster.local valid=5s;
     location /healthz {
         return 200 'OK';
     }
@@ -59,8 +65,7 @@ server {
         proxy_connect_timeout       180;
         proxy_send_timeout          180;
         proxy_read_timeout          180;
-        set $server http://opencost.opencost.svc.cluster.local.:9003;
-        proxy_pass $server;
+        proxy_pass http://model/;
         proxy_redirect off;
         proxy_http_version 1.1;
         proxy_set_header Connection "";

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,0 +1,36 @@
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## What does this PR change?
**Fix this issue**

> [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
> [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)

```
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: can not modify /etc/nginx/conf.d/default.conf (read-only file system?)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2022/12/16 12:45:34 [warn] 1#1: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
2022/12/16 12:45:34 [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Fix the frontend ui so that it can be run on non privileged k8s cluster

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Tested on a private cluster which run on non privileged mode

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.99.1
