### PR TITLE
Add endpoints to set and get log levels

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -49,6 +49,22 @@ func InitLogging(showLogLevelSetMessage bool) {
 
 }
 
+func GetLogLevel() string {
+	return zerolog.GlobalLevel().String()
+}
+
+func SetLogLevel(l string) error {
+
+	level, err := zerolog.ParseLevel(l)
+	if err != nil {
+		return err
+	}
+
+	zerolog.SetGlobalLevel(level)
+	log.Info().Msg(fmt.Sprintf("log level set to %s.", l))
+	return nil
+}
+
 func Errorf(format string, a ...interface{}) {
 	log.Error().Msgf(format, a...)
 }


### PR DESCRIPTION
Signed-off-by: saweber <saweber@gmail.com>

## What does this PR change?
* addition of GET /logs/level and POST /logs/level endpoints

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* ability to get and set log levels without restarting application

## Does this PR address any GitHub or Zendesk issues?
* Closes issue in private repo

## How was this PR tested?
* manually

## Does this PR require changes to documentation?
* yes - addition of GET /logs/level and POST /logs/level endpoints

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* I can't.
