### PR TITLE
Use localhost resolver to get host

### DIFF
--- a/ui/default.nginx.conf
+++ b/ui/default.nginx.conf
@@ -58,6 +58,7 @@ server {
     add_header ETag "1.96.0";
     listen 9090;
     listen [::]:9090;
+    resolver 127.0.0.1 valid=5s;
     location /healthz {
         return 200 'OK';
     }


### PR DESCRIPTION
Signed-off-by: Ajay Tripathy <ajay@kubecost.com>

## What does this PR change?
* Supports deployment on non kube-dns clusters

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Supports deployment on non kube-dns clusters

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/1587

## How was this PR tested?
* Deployed the opencost UI; however, it deployed for me in spite of #1587 so ymmv

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
