### PR TITLE
fix: specify all resources use namespace opencost instead of the default

### DIFF
--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -13,6 +13,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: opencost
+  namespace: opencost
 ---
 
 # Cluster role giving opencost to get, list, watch required recources
@@ -21,6 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: opencost
+  namespace: opencost
 rules:
   - apiGroups:
       - ''
@@ -102,6 +104,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: opencost
+  namespace: opencost
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -120,6 +123,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: opencost
+  namespace: opencost
   labels:
     app: opencost
 spec:
@@ -178,6 +182,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: opencost
+  namespace: opencost
 spec:
   selector:
     app: opencost


### PR DESCRIPTION
Signed-off-by: Alex <hackcrack@126.com>

## What does this PR change?
* Specifies the namespace of the resource

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* when users use kubectl apply --namespace opencost -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/opencost.yaml    install opencost, pod and other resource will run in default namespace, but run in opencost namespace is right

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* yes, change https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/opencost.yaml content please
## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
