### PR TITLE
Removed IsThanosEnabled check

### DIFF
--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -477,6 +477,7 @@ func GetETLMaxPrometheusQueryDuration() time.Duration {
 	dayMins := 60 * 24
 	mins := time.Duration(GetInt64(ETLMaxPrometheusQueryDurationMinutes, int64(dayMins)))
 	return mins * time.Minute
+}
 
 // GetETLResolution determines the resolution of ETL queries. The smaller the
 // duration, the higher the resolution; the higher the resolution, the more
@@ -486,8 +487,6 @@ func GetETLResolution() time.Duration {
 	// 5m (i.e. 300s)
 	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
 	return secs * time.Second
-}
-
 }
  
 func LegacyExternalCostsAPIDisabled() bool {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -478,9 +478,19 @@ func GetETLMaxPrometheusQueryDuration() time.Duration {
 	mins := time.Duration(GetInt64(ETLMaxPrometheusQueryDurationMinutes, int64(dayMins)))
 	return mins * time.Minute
 }
-
+ 
 func LegacyExternalCostsAPIDisabled() bool {
 	return GetBool(LegacyExternalAPIDisabledVar, false)
+}
+
+// GetETLResolution determines the resolution of ETL queries. The smaller the
+// duration, the higher the resolution; the higher the resolution, the more
+// accurate the query results, but the more computationally expensive.
+func GetETLResolution() time.Duration {
+	// Use the configured ETL resolution, or default to
+	// 5m (i.e. 300s)
+	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
+	return secs * time.Second
 }
 
 // GetPromClusterLabel returns the environemnt variable value for PromClusterIDLabel

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -479,22 +479,6 @@ func GetETLMaxPrometheusQueryDuration() time.Duration {
 	return mins * time.Minute
 }
 
-// GetETLResolution determines the resolution of ETL queries. The smaller the
-// duration, the higher the resolution; the higher the resolution, the more
-// accurate the query results, but the more computationally expensive. This
-// value is always 1m for Prometheus, but is configurable for Thanos.
-func GetETLResolution() time.Duration {
-	// If Thanos is not enabled, hard-code to 1m resolution
-	if !IsThanosEnabled() {
-		return 60 * time.Second
-	}
-
-	// Thanos is enabled, so use the configured ETL resolution, or default to
-	// 5m (i.e. 300s)
-	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
-	return secs * time.Second
-}
-
 func LegacyExternalCostsAPIDisabled() bool {
 	return GetBool(LegacyExternalAPIDisabledVar, false)
 }

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -488,7 +488,7 @@ func GetETLResolution() time.Duration {
 	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
 	return secs * time.Second
 }
- 
+
 func LegacyExternalCostsAPIDisabled() bool {
 	return GetBool(LegacyExternalAPIDisabledVar, false)
 }

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -477,11 +477,6 @@ func GetETLMaxPrometheusQueryDuration() time.Duration {
 	dayMins := 60 * 24
 	mins := time.Duration(GetInt64(ETLMaxPrometheusQueryDurationMinutes, int64(dayMins)))
 	return mins * time.Minute
-}
- 
-func LegacyExternalCostsAPIDisabled() bool {
-	return GetBool(LegacyExternalAPIDisabledVar, false)
-}
 
 // GetETLResolution determines the resolution of ETL queries. The smaller the
 // duration, the higher the resolution; the higher the resolution, the more
@@ -491,6 +486,12 @@ func GetETLResolution() time.Duration {
 	// 5m (i.e. 300s)
 	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
 	return secs * time.Second
+}
+
+}
+ 
+func LegacyExternalCostsAPIDisabled() bool {
+	return GetBool(LegacyExternalAPIDisabledVar, false)
 }
 
 // GetPromClusterLabel returns the environemnt variable value for PromClusterIDLabel


### PR DESCRIPTION
Removed 'IsThanosEnabled' check as it is not required and possibly causing issues for some users.

Signed-off-by: Jason Charcalla <jason@kubecost.com>

## What does this PR change?
* It removes code that checks if thanos is enabled, and if not sets ETLResolutionSeconds to 1 min.

## Does this PR address any GitHub or Zendesk issues?
* [ZD: 3246](https://kubecost.zendesk.com/agent/tickets/3246)

## How was this PR tested?
* It was not tested
