### PR TITLE
Apply node labels to allocation data

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -244,6 +244,7 @@ func applyCPUCoresAllocated(podMap map[podKey]*pod, resCPUCoresAllocated []*prom
 				continue
 			}
 			thisPod.Allocations[container].Properties.Node = node
+			thisPod.Node = node
 		}
 	}
 }
@@ -301,6 +302,7 @@ func applyCPUCoresRequested(podMap map[podKey]*pod, resCPUCoresRequested []*prom
 				continue
 			}
 			thisPod.Allocations[container].Properties.Node = node
+			thisPod.Node = node
 		}
 	}
 }
@@ -449,6 +451,7 @@ func applyRAMBytesAllocated(podMap map[podKey]*pod, resRAMBytesAllocated []*prom
 				continue
 			}
 			thisPod.Allocations[container].Properties.Node = node
+			thisPod.Node = node
 		}
 	}
 }
@@ -503,6 +506,7 @@ func applyRAMBytesRequested(podMap map[podKey]*pod, resRAMBytesRequested []*prom
 				continue
 			}
 			pod.Allocations[container].Properties.Node = node
+			pod.Node = node
 		}
 	}
 }
@@ -766,6 +770,42 @@ func applyNetworkAllocation(podMap map[podKey]*pod, resNetworkGiB []*prom.QueryR
 	}
 }
 
+func resToNodeLabels(resNodeLabels []*prom.QueryResult) map[nodeKey]map[string]string {
+	nodeLabels := map[nodeKey]map[string]string{}
+
+	for _, res := range resNodeLabels {
+		nodeKey, err := resultNodeKey(res, env.GetPromClusterLabel(), "node")
+		if err != nil {
+			continue
+		}
+
+		if _, ok := nodeLabels[nodeKey]; !ok {
+			nodeLabels[nodeKey] = map[string]string{}
+		}
+
+		for _, rawK := range env.GetAllocationNodeLabelsIncludeList() {
+			labels := res.GetLabels()
+
+			// Sanitize the given label name to match Prometheus formatting
+			// e.g. topology.kubernetes.io/zone => topology_kubernetes_io_zone
+			k := prom.SanitizeLabelName(rawK)
+			if v, ok := labels[k]; ok {
+				nodeLabels[nodeKey][k] = v
+				continue
+			}
+
+			// Try with the "label_" prefix, if not found
+			// e.g. topology_kubernetes_io_zone => label_topology_kubernetes_io_zone
+			k = fmt.Sprintf("label_%s", k)
+			if v, ok := labels[k]; ok {
+				nodeLabels[nodeKey][k] = v
+			}
+		}
+	}
+
+	return nodeLabels
+}
+
 func resToNamespaceLabels(resNamespaceLabels []*prom.QueryResult) map[namespaceKey]map[string]string {
 	namespaceLabels := map[namespaceKey]map[string]string{}
 
@@ -878,21 +918,34 @@ func resToPodAnnotations(resPodAnnotations []*prom.QueryResult, podUIDKeyMap map
 	return podAnnotations
 }
 
-func applyLabels(podMap map[podKey]*pod, namespaceLabels map[namespaceKey]map[string]string, podLabels map[podKey]map[string]string) {
+func applyLabels(podMap map[podKey]*pod, nodeLabels map[nodeKey]map[string]string, namespaceLabels map[namespaceKey]map[string]string, podLabels map[podKey]map[string]string) {
 	for podKey, pod := range podMap {
 		for _, alloc := range pod.Allocations {
 			allocLabels := alloc.Properties.Labels
 			if allocLabels == nil {
 				allocLabels = make(map[string]string)
 			}
-			// Apply namespace labels first, then pod labels so that pod labels
-			// overwrite namespace labels.
-			nsKey := podKey.namespaceKey // newNamespaceKey(podKey.Cluster, podKey.Namespace)
+
+			// Apply node labels first, then namespace labels, then pod labels
+			// so that pod labels overwrite namespace labels, which overwrite
+			// node labels.
+
+			if nodeLabels != nil {
+				nodeKey := newNodeKey(pod.Key.Cluster, pod.Node)
+				if labels, ok := nodeLabels[nodeKey]; ok {
+					for k, v := range labels {
+						allocLabels[k] = v
+					}
+				}
+			}
+
+			nsKey := podKey.namespaceKey
 			if labels, ok := namespaceLabels[nsKey]; ok {
 				for k, v := range labels {
 					allocLabels[k] = v
 				}
 			}
+
 			if labels, ok := podLabels[podKey]; ok {
 				for k, v := range labels {
 					allocLabels[k] = v
@@ -2008,6 +2061,8 @@ func getUnmountedPodForCluster(window kubecost.Window, podMap map[podKey]*pod, c
 		thisPod.Allocations[container].Properties.Pod = podName
 		thisPod.Allocations[container].Properties.Container = container
 
+		thisPod.Node = node
+
 		podMap[thisPodKey] = thisPod
 	}
 	return thisPod
@@ -2038,6 +2093,8 @@ func getUnmountedPodForNamespace(window kubecost.Window, podMap map[podKey]*pod,
 		thisPod.Allocations[container].Properties.Namespace = namespace
 		thisPod.Allocations[container].Properties.Pod = podName
 		thisPod.Allocations[container].Properties.Container = container
+
+		thisPod.Node = node
 
 		podMap[thisPodKey] = thisPod
 	}

--- a/pkg/costmodel/allocation_types.go
+++ b/pkg/costmodel/allocation_types.go
@@ -2,8 +2,9 @@ package costmodel
 
 import (
 	"fmt"
-	"github.com/opencost/opencost/pkg/kubecost"
 	"time"
+
+	"github.com/opencost/opencost/pkg/kubecost"
 )
 
 // pod describes a running pod's start and end time within a Window and
@@ -13,6 +14,7 @@ type pod struct {
 	Start       time.Time
 	End         time.Time
 	Key         podKey
+	Node        string
 	Allocations map[string]*kubecost.Allocation
 }
 

--- a/pkg/costmodel/key.go
+++ b/pkg/costmodel/key.go
@@ -2,9 +2,9 @@ package costmodel
 
 import (
 	"fmt"
-	"github.com/opencost/opencost/pkg/kubecost"
 
 	"github.com/opencost/opencost/pkg/env"
+	"github.com/opencost/opencost/pkg/kubecost"
 	"github.com/opencost/opencost/pkg/prom"
 )
 

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -92,6 +92,9 @@ const (
 	IngestPodUIDEnvVar = "INGEST_POD_UID"
 
 	ETLReadOnlyMode = "ETL_READ_ONLY"
+
+	AllocationNodeLabelsEnabled     = "ALLOCATION_NODE_LABELS_ENABLED"
+	AllocationNodeLabelsIncludeList = "ALLOCATION_NODE_LABELS_INCLUDE_LIST"
 )
 
 var offsetRegex = regexp.MustCompile(`^(\+|-)(\d\d):(\d\d)$`)
@@ -502,4 +505,33 @@ func GetPromClusterLabel() string {
 // contents of podKeys in Allocation
 func IsIngestingPodUID() bool {
 	return GetBool(IngestPodUIDEnvVar, false)
+}
+
+func GetAllocationNodeLabelsEnabled() bool {
+	return GetBool(AllocationNodeLabelsEnabled, true)
+}
+
+var defaultAllocationNodeLabelsIncludeList []string = []string{
+	"cloud.google.com/gke-nodepool",
+	"eks.amazonaws.com/nodegroup",
+	"kubernetes.azure.com/agentpool",
+	"node.kubernetes.io/instance-type",
+	"topology.kubernetes.io/region",
+	"topology.kubernetes.io/zone",
+}
+
+func GetAllocationNodeLabelsIncludeList() []string {
+	// If node labels are not enabled, return an empty list.
+	if !GetAllocationNodeLabelsEnabled() {
+		return []string{}
+	}
+
+	list := GetList(AllocationNodeLabelsIncludeList, ",")
+
+	// If node labels are enabled, but the white list is empty, use defaults.
+	if len(list) == 0 {
+		return defaultAllocationNodeLabelsIncludeList
+	}
+
+	return list
 }


### PR DESCRIPTION
## What does this PR change?
* Applies node labels to allocation data. Note: labels may conflict! The order of precedence is pod labels supersede namespace labels, which supersede node labels. 

## How will this PR impact users?
* Users will have access to node labels from the Allocation APIs (as long as namespace and pod labels do not overwrite them)

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/1609
* Relates to https://github.com/kubecost/cost-analyzer-helm-chart/issues/1656

## Does this PR relate to other PRs?
* Ideally requires https://github.com/kubecost/cost-analyzer-helm-chart/pull/1925

## Does this PR require changes to documentation?
* Added "documentation" to the helm chart. Is more needed? Defer to product. I think that is fine?

## How was this PR tested?
Tested on an EKS cluster. Tested three states:
1. default, i.e. enabled with default includeList
2. enabled with custom includeList
3. disabled

### Default (enabled)

Tested without actively setting `enabled` to `true` and verified that the feature works, with the default labels.

```yaml
kubecostModel:
  allocation:
    # nodeLabels:
    #   enabled: true
    #   includeList: "node.kubernetes.io/instance-type,topology.kubernetes.io/region,topology.kubernetes.io/zone"
```

```
INF [node-labels] using defaults
INF [node-labels] successfully applying node_kubernetes_io_instance_type=m5.large for node aws-dev-1-niko/ip-192-168-49-107.us-east-2.compute.internal
INF [node-labels] successfully applying topology_kubernetes_io_region=us-east-2 for node aws-dev-1-niko/ip-192-168-49-107.us-east-2.compute.internal
INF [node-labels] successfully applying topology_kubernetes_io_zone=us-east-2b for node aws-dev-1-niko/ip-192-168-49-107.us-east-2.compute.internal
INF [node-labels] using defaults
INF [node-labels] successfully applying node_kubernetes_io_instance_type=m5.large for node aws-dev-1-niko/ip-192-168-7-143.us-east-2.compute.internal
INF [node-labels] successfully applying topology_kubernetes_io_region=us-east-2 for node aws-dev-1-niko/ip-192-168-7-143.us-east-2.compute.internal
INF [node-labels] successfully applying topology_kubernetes_io_zone=us-east-2a for node aws-dev-1-niko/ip-192-168-7-143.us-east-2.compute.internal
INF [node-labels] using defaults
INF [node-labels] successfully applying node_kubernetes_io_instance_type=m5.large for node aws-dev-1-niko/ip-192-168-92-251.us-east-2.compute.internal
INF [node-labels] successfully applying topology_kubernetes_io_region=us-east-2 for node aws-dev-1-niko/ip-192-168-92-251.us-east-2.compute.internal
INF [node-labels] successfully applying topology_kubernetes_io_zone=us-east-2c for node aws-dev-1-niko/ip-192-168-92-251.us-east-2.compute.internal
```

![Screenshot from 2023-01-26 17-10-05](https://user-images.githubusercontent.com/8070055/214979724-d32f7418-ebf8-4bcc-b572-b40be4a5201b.png)

### Enabled, custom include list

```yaml
kubecostModel:
  allocation:
    nodeLabels:
      enabled: true
      includeList: "node.kubernetes.io/instance-type"
```

```
INF [node-labels] successfully applying node_kubernetes_io_instance_type=m5.large for node aws-dev-1-niko/ip-192-168-7-143.us-east-2.compute.internal
INF [node-labels] successfully applying node_kubernetes_io_instance_type=m5.large for node aws-dev-1-niko/ip-192-168-92-251.us-east-2.compute.internal
INF [node-labels] successfully applying node_kubernetes_io_instance_type=m5.large for node aws-dev-1-niko/ip-192-168-3-17.us-east-2.compute.internal
```

![Screenshot from 2023-01-26 17-24-31](https://user-images.githubusercontent.com/8070055/214979999-8316030b-2989-4fa3-8a21-f85299fd6114.png)

### Disabled

```yaml
kubecostModel:
  allocation:
    nodeLabels:
      enabled: false
```

```
INF [node-labels] allocation node labels disabled
INF [node-labels] allocation node labels disabled
INF [node-labels] allocation node labels disabled
```

![Screenshot from 2023-01-26 17-15-10](https://user-images.githubusercontent.com/8070055/214979813-51daecef-2823-44e2-b88d-8c2b2ed9eb86.png)

