### PR TITLE
add url and description for providers

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1741,9 +1741,10 @@ func (aws *AWS) GetOrphanedResources() ([]OrphanedResource, error) {
 					continue
 				}
 				if tag.Value == nil {
-					continue
+					desc[*tag.Key] = ""
+				} else {
+					desc[*tag.Key] = *tag.Value
 				}
-				desc[*tag.Key] = *tag.Value
 			}
 
 			or := OrphanedResource{

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1706,7 +1706,10 @@ func (aws *AWS) GetOrphanedResources() ([]OrphanedResource, error) {
 			}
 
 			// This is turning us-east-1a into us-east-1
-			zone := *volume.AvailabilityZone
+			var zone string
+			if volume.AvailabilityZone != nil {
+				zone = *volume.AvailabilityZone
+			}
 			var region, url string
 			region = regionRx.FindString(zone)
 			if region != "" {
@@ -1734,6 +1737,12 @@ func (aws *AWS) GetOrphanedResources() ([]OrphanedResource, error) {
 
 			desc := map[string]string{}
 			for _, tag := range address.Tags {
+				if tag.Key == nil {
+					continue
+				}
+				if tag.Value == nil {
+					continue
+				}
 				desc[*tag.Key] = *tag.Value
 			}
 

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -65,6 +65,7 @@ var (
 	provIdRx      = regexp.MustCompile("aws:///([^/]+)/([^/]+)")
 	usageTypeRegx = regexp.MustCompile(".*(-|^)(EBS.+)")
 	versionRx     = regexp.MustCompile("^#Version: (\\d+)\\.\\d+$")
+	regionRx      = regexp.MustCompile("([a-z]+-[a-z]+-[0-9])")
 )
 
 func (aws *AWS) PricingSourceStatus() map[string]*PricingSource {
@@ -1704,11 +1705,22 @@ func (aws *AWS) GetOrphanedResources() ([]OrphanedResource, error) {
 				volumeSize = int64(*volume.Size)
 			}
 
+			// This is turning us-east-1a into us-east-1
+			zone := *volume.AvailabilityZone
+			var region, url string
+			region = regionRx.FindString(zone)
+			if region != "" {
+				url = "https://console.aws.amazon.com/ec2/home?region=" + region + "#Volumes:sort=desc:createTime"
+			} else {
+				url = "https://console.aws.amazon.com/ec2/home?#Volumes:sort=desc:createTime"
+			}
+
 			or := OrphanedResource{
 				Kind:        "disk",
-				Region:      *volume.AvailabilityZone,
+				Region:      zone,
 				Size:        &volumeSize,
 				DiskName:    *volume.VolumeId,
+				Url:         url,
 				MonthlyCost: cost,
 			}
 
@@ -1720,9 +1732,16 @@ func (aws *AWS) GetOrphanedResources() ([]OrphanedResource, error) {
 		if aws.isAddressOrphaned(address) {
 			cost := AWSHourlyPublicIPCost * timeutil.HoursPerMonth
 
+			desc := map[string]string{}
+			for _, tag := range address.Tags {
+				desc[*tag.Key] = *tag.Value
+			}
+
 			or := OrphanedResource{
 				Kind:        "address",
 				Address:     *address.PublicIp,
+				Description: desc,
+				Url:         "http://console.aws.amazon.com/ec2/home?#Addresses",
 				MonthlyCost: &cost,
 			}
 

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -1282,13 +1282,15 @@ func (az *Azure) GetOrphanedResources() ([]OrphanedResource, error) {
 				diskSize = int64(*d.DiskSizeGB)
 			}
 
+			desc := map[string]string{}
+			for k, v := range d.Tags {
+				desc[k] = *v
+			}
+
 			or := OrphanedResource{
-				Kind:   "disk",
-				Region: diskRegion,
-				Description: map[string]string{
-					"diskState":   string(d.DiskState),
-					"timeCreated": d.TimeCreated.String(),
-				},
+				Kind:        "disk",
+				Region:      diskRegion,
+				Description: desc,
 				Size:        &diskSize,
 				DiskName:    diskName,
 				MonthlyCost: &cost,

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -1284,6 +1284,9 @@ func (az *Azure) GetOrphanedResources() ([]OrphanedResource, error) {
 
 			desc := map[string]string{}
 			for k, v := range d.Tags {
+				if v == nil {
+					continue
+				}
 				desc[k] = *v
 			}
 

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -1285,9 +1285,10 @@ func (az *Azure) GetOrphanedResources() ([]OrphanedResource, error) {
 			desc := map[string]string{}
 			for k, v := range d.Tags {
 				if v == nil {
-					continue
+					desc[k] = ""
+				} else {
+					desc[k] = *v
 				}
-				desc[k] = *v
 			}
 
 			or := OrphanedResource{

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -468,12 +468,20 @@ func (gcp *GCP) GetOrphanedResources() ([]OrphanedResource, error) {
 					return nil, err
 				}
 
+				// GCP gives us description as a string formatted as a map[string]string, so we need to
+				// deconstruct it back into a map[string]string to match the OR struct
+				desc := map[string]string{}
+				if err := json.Unmarshal([]byte(disk.Description), &desc); err != nil {
+					return nil, err
+				}
+
 				or := OrphanedResource{
 					Kind:        "disk",
 					Region:      disk.Zone,
-					Description: map[string]string{},
+					Description: desc,
 					Size:        &disk.SizeGb,
 					DiskName:    disk.Name,
+					Url:         disk.SelfLink,
 					MonthlyCost: cost,
 				}
 				orphanedResources = append(orphanedResources, or)
@@ -498,6 +506,7 @@ func (gcp *GCP) GetOrphanedResources() ([]OrphanedResource, error) {
 						"type": address.AddressType,
 					},
 					Address:     address.Address,
+					Url:         address.SelfLink,
 					MonthlyCost: &cost,
 				}
 				orphanedResources = append(orphanedResources, or)

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -472,7 +472,7 @@ func (gcp *GCP) GetOrphanedResources() ([]OrphanedResource, error) {
 				// deconstruct it back into a map[string]string to match the OR struct
 				desc := map[string]string{}
 				if err := json.Unmarshal([]byte(disk.Description), &desc); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("error converting string to map: %s", err)
 				}
 
 				or := OrphanedResource{

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -110,6 +110,7 @@ type OrphanedResource struct {
 	Description map[string]string `json:"description"`
 	Size        *int64            `json:"diskSizeInGB,omitempty"`
 	DiskName    string            `json:"diskName,omitempty"`
+	Url         string            `json:"url"`
 	Address     string            `json:"ipAddress,omitempty"`
 	MonthlyCost *float64          `json:"monthlyCost"`
 }


### PR DESCRIPTION
## What does this PR change?
* Adds URL to AWS, GCP orphaned resources API

## Does this PR relate to any other PRs?
* Fixes https://github.com/opencost/opencost/pull/1597

## How will this PR impact users?
* Users can see the resource in their providers console easier

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Tested on GCP and AWS dev clusters

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.100
