### PR TITLE
use region instead of region url

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -475,9 +476,15 @@ func (gcp *GCP) GetOrphanedResources() ([]OrphanedResource, error) {
 					return nil, fmt.Errorf("error converting string to map: %s", err)
 				}
 
+				// Converts https://www.googleapis.com/compute/v1/projects/xxxxx/zones/us-central1-c to us-central1-c
+				zone := path.Base(disk.Zone)
+				if zone == "." {
+					zone = ""
+				}
+
 				or := OrphanedResource{
 					Kind:        "disk",
-					Region:      disk.Zone,
+					Region:      zone,
 					Description: desc,
 					Size:        &disk.SizeGb,
 					DiskName:    disk.Name,
@@ -499,9 +506,15 @@ func (gcp *GCP) GetOrphanedResources() ([]OrphanedResource, error) {
 				//todo: use GCP pricing
 				cost := GCPHourlyPublicIPCost * timeutil.HoursPerMonth
 
+				// Converts https://www.googleapis.com/compute/v1/projects/xxxxx/regions/us-central1 to us-central1
+				region := path.Base(address.Region)
+				if region == "." {
+					region = ""
+				}
+
 				or := OrphanedResource{
 					Kind:   "address",
-					Region: address.Region,
+					Region: region,
 					Description: map[string]string{
 						"type": address.AddressType,
 					},


### PR DESCRIPTION
## What does this PR change?
* Orphaned Resources endpoint returns region rather than GCP's region url

## Does this PR relate to any other PRs?
* Original endpoint PR here: https://github.com/opencost/opencost/pull/1597

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Tested on GCP dev-1

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.100
