### PR TITLE
Disable kube_pod_owner when emitting only KSM v1 metrics

### DIFF
--- a/pkg/metrics/podlabelmetrics.go
+++ b/pkg/metrics/podlabelmetrics.go
@@ -54,9 +54,6 @@ func (kpmc KubePodLabelsCollector) Describe(ch chan<- *prometheus.Desc) {
 	if _, disabled := disabledMetrics["kube_pod_labels"]; !disabled {
 		ch <- prometheus.NewDesc("kube_pod_labels", "All labels for each pod prefixed with label_", []string{}, nil)
 	}
-	if _, disabled := disabledMetrics["kube_pod_owner"]; !disabled {
-		ch <- prometheus.NewDesc("kube_pod_owner", "Information about the Pod's owner", []string{}, nil)
-	}
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
@@ -75,11 +72,5 @@ func (kpmc KubePodLabelsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- newKubePodLabelsMetric("kube_pod_labels", podNS, podName, podUID, labelNames, labelValues)
 		}
 
-		// Owner References
-		if _, disabled := disabledMetrics["kube_pod_owner"]; !disabled {
-			for _, owner := range pod.OwnerReferences {
-				ch <- newKubePodOwnerMetric("kube_pod_owner", podNS, podName, owner.Name, owner.Kind, owner.Controller != nil)
-			}
-		}
 	}
 }


### PR DESCRIPTION
## What does this PR change?
Minimal change to solve https://github.com/opencost/opencost/issues/1571. Stops Kubecost from emitting the `kube_pod_owner` duplicated KSM metric when `EMIT_KSM_V1_METRICS_ONLY` is true.

As we recommend users with KSM v2.X to enable `EMIT_KSM_V1_METRICS_ONLY` and disable `EMIT_KSM_V1_METRICS`, we expect the minimal set of metrics not present in KSM v2 that Kubecost requires to be emitted. As `kube_pod_owner` exists in KSM v2, this PR allows the recommended behavior without that metric being duplicated. 

## Does this PR relate to any other PRs?
No.

## How will this PR impact users?
* Kubecost will no longer emit `kube_pod_owner` when EMIT_KSM_V1_METRICS_ONLY` is true.

## Does this PR address any GitHub or Zendesk issues?
* https://github.com/opencost/opencost/issues/1571

## How was this PR tested?
Tested manually by observing proper emission behavior.

## Does this PR require changes to documentation?
No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
Yes.
