### PR TITLE
Cherry-pick intersection between cloud cost item aggregate properties for v1.100

### DIFF
--- a/pkg/kubecost/cloudcostaggregate.go
+++ b/pkg/kubecost/cloudcostaggregate.go
@@ -35,6 +35,33 @@ func (ccap CloudCostAggregateProperties) Equal(that CloudCostAggregateProperties
 		ccap.LabelValue == that.LabelValue
 }
 
+// Intersection ensure the values of two CloudCostAggregateProperties are maintain only if they are equal
+func (ccap CloudCostAggregateProperties) Intersection(that CloudCostAggregateProperties) CloudCostAggregateProperties {
+	if ccap.Equal(that) {
+		return ccap
+	}
+	intersectionCCAP := CloudCostAggregateProperties{}
+	if ccap == intersectionCCAP || that == intersectionCCAP {
+		return intersectionCCAP
+	}
+
+	if ccap.Provider == that.Provider {
+		intersectionCCAP.Provider = ccap.Provider
+	}
+	if ccap.WorkGroupID == that.WorkGroupID {
+		intersectionCCAP.WorkGroupID = ccap.WorkGroupID
+	}
+	if ccap.BillingID == that.BillingID {
+		intersectionCCAP.BillingID = ccap.BillingID
+	}
+	if ccap.Service == that.Service {
+		intersectionCCAP.Service = ccap.Service
+	}
+	if ccap.LabelValue == that.LabelValue {
+		intersectionCCAP.LabelValue = ccap.LabelValue
+	}
+	return intersectionCCAP
+}
 func (ccap CloudCostAggregateProperties) Key(props []string) string {
 	if len(props) == 0 {
 		return fmt.Sprintf("%s/%s/%s/%s/%s", ccap.Provider, ccap.BillingID, ccap.WorkGroupID, ccap.Service, ccap.LabelValue)
@@ -144,6 +171,9 @@ func (cca *CloudCostAggregate) add(that *CloudCostAggregate) {
 		log.Warnf("cannot add to nil CloudCostAggregate")
 		return
 	}
+
+	// Preserve string properties of cloud cost aggregates that are matching between the two CloudCostAggregate
+	cca.Properties = cca.Properties.Intersection(that.Properties)
 
 	// Compute KubernetesPercent for sum
 	k8sPct := 0.0

--- a/pkg/kubecost/cloudcostaggregate_test.go
+++ b/pkg/kubecost/cloudcostaggregate_test.go
@@ -1,9 +1,10 @@
 package kubecost
 
 import (
-	"github.com/opencost/opencost/pkg/util/timeutil"
 	"testing"
 	"time"
+
+	"github.com/opencost/opencost/pkg/util/timeutil"
 )
 
 var ccaProperties1 = CloudCostAggregateProperties{
@@ -12,6 +13,104 @@ var ccaProperties1 = CloudCostAggregateProperties{
 	BillingID:   "billing1",
 	Service:     "service1",
 	LabelValue:  "labelValue1",
+}
+
+func TestCloudCostAggregatePropertiesIntersection(t *testing.T) {
+	testCases := map[string]struct {
+		baseCCAP     CloudCostAggregateProperties
+		intCCAP      CloudCostAggregateProperties
+		expectedCCAP CloudCostAggregateProperties
+	}{
+		"When properties match between both CloudCostAggregateProperties": {
+			baseCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "Service1",
+				LabelValue:  "Label1",
+			},
+			intCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "Service1",
+				LabelValue:  "Label1",
+			},
+			expectedCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "Service1",
+				LabelValue:  "Label1",
+			},
+		},
+		"When one of the properties differ in the two CloudCostAggregateProperties": {
+			baseCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "Service1",
+				LabelValue:  "Label1",
+			},
+			intCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "Service2",
+				LabelValue:  "Label1",
+			},
+			expectedCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "",
+				LabelValue:  "Label1",
+			},
+		},
+		"When two of the properties differ in the two CloudCostAggregateProperties": {
+			baseCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID1",
+				BillingID:   "BillingID1",
+				Service:     "Service1",
+				LabelValue:  "Label1",
+			},
+			intCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "WorkGroupID2",
+				BillingID:   "BillingID1",
+				Service:     "Service2",
+				LabelValue:  "Label1",
+			},
+			expectedCCAP: CloudCostAggregateProperties{
+				Provider:    "CustomProvider",
+				WorkGroupID: "",
+				BillingID:   "BillingID1",
+				Service:     "",
+				LabelValue:  "Label1",
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actualCCAP := tc.baseCCAP.Intersection(tc.intCCAP)
+			if actualCCAP.Provider != tc.expectedCCAP.Provider {
+				t.Errorf("Case %s: Provider properties dont match with expected CloudCostAggregateProperties: %v actual %v", name, tc.expectedCCAP, actualCCAP)
+			}
+			if actualCCAP.WorkGroupID != tc.expectedCCAP.WorkGroupID {
+				t.Errorf("Case %s: WorkGroupID properties dont match with expected CloudCostAggregateProperties: %v actual %v", name, tc.expectedCCAP, actualCCAP)
+			}
+			if actualCCAP.BillingID != tc.expectedCCAP.BillingID {
+				t.Errorf("Case %s: BillingID properties dont match with expected CloudCostAggregateProperties: %v actual %v", name, tc.expectedCCAP, actualCCAP)
+			}
+			if actualCCAP.Service != tc.expectedCCAP.Service {
+				t.Errorf("Case %s: Service properties dont match with expected CloudCostAggregateProperties: %v actual %v", name, tc.expectedCCAP, actualCCAP)
+			}
+			if actualCCAP.LabelValue != tc.expectedCCAP.LabelValue {
+				t.Errorf("Case %s: LabelValue properties dont match with expected CloudCostAggregateProperties: %v actual %v", name, tc.expectedCCAP, actualCCAP)
+			}
+		})
+	}
 }
 
 // TestCloudCostAggregate_LoadCloudCostAggregate checks that loaded CloudCostAggregates end up in the correct set in the
@@ -240,9 +339,9 @@ func TestCloudCostAggregate_LoadCloudCostAggregate(t *testing.T) {
 					},
 				},
 				{
-					Integration: "integration",
-					LabelName:   "label",
-					Window:      dayWindows[2],
+					Integration:         "integration",
+					LabelName:           "label",
+					Window:              dayWindows[2],
 					CloudCostAggregates: map[string]*CloudCostAggregate{},
 				},
 			},


### PR DESCRIPTION
## What does this PR change?
* Cherry-pick PR for [PR](https://github.com/opencost/opencost/pull/1641)

## Does this PR relate to any other PRs?
* Nopes

## How will this PR impact users?
* This is need for Cloud cost aggregate properties to be deterministic when two properties are different between added cloud cost aggregate items.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Locally and on Cluster

## Does this PR require changes to documentation?
* Nopes

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.100 cherry-pick
