### PR TITLE
code clean for log-format variable.

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -71,7 +71,7 @@ func newRootCommand(costModelCmd *cobra.Command, cmds ...*cobra.Command) *cobra.
 
 	// Add our persistent flags, these are global and available anywhere
 	cmd.PersistentFlags().String("log-level", "info", "Set the log level")
-	cmd.PersistentFlags().String("log-format", "pretty", "Set the log format - Can be either 'JSON' or 'pretty'")
+	cmd.PersistentFlags().String("log-format", "pretty", "Set the log format - Can be either 'json' or 'pretty'")
 	cmd.PersistentFlags().Bool("disable-log-color", false, "Disable coloring of log output")
 
 	viper.BindPFlag("log-level", cmd.PersistentFlags().Lookup("log-level"))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -3,7 +3,6 @@ package log
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -30,7 +29,7 @@ const (
 func InitLogging(showLogLevelSetMessage bool) {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	// Default to using pretty formatting
-	if strings.ToLower(viper.GetString(flagFormat)) != "json" {
+	if viper.GetString(flagFormat) != "json" {
 		disableColor := viper.GetBool(flagDisableColor)
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano, NoColor: disableColor})
 	}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

## What does this PR change?
Through cobra flag variable hint the user to input 'json' or 'pretty'.
 We should reduce the programe cost for the string match . 

like 
```
strings.ToLower(
```
.
maybe these purpose is transfer 'JSON' to 'json'.:grinning::grinning: