### PR TITLE
Node-GYP dockerfile,upgreade nodejs to 18.13

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.3.0 as builder
+FROM node:18.13.0 as builder
 ADD package*.json /opt/ui/
 WORKDIR /opt/ui
 RUN npm install

--- a/ui/README.md
+++ b/ui/README.md
@@ -5,8 +5,8 @@ To manually run the OpenCost UI, follow the steps below.
 
 ## Requirements
 
-* `nodejs >= 18.3.0`
-* `npm >= 8.11.0`
+* `nodejs >= 18.13.0`
+* `npm >= 8.19.3`
 
 ## Installation & Running
 To run the UI, open a terminal to the `opencost/ui/` directory (where this README is located) and run


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

## What does this PR change?
update the ui image to the latest nodejs 18's version.
[18.13 releaed](https://github.com/nodejs/node/releases/tag/v18.13.0)
[18.13 docker image](https://hub.docker.com/layers/library/node/18.13.0/images/sha256-d9061fd0205c20cd47f70bdc879a7a84fb472b822d3ad3158aeef40698d2ce36?context=explore).

and match npm version  [8.19.3](https://nodejs.org/en/download/releases/)
