### PR TITLE
orphaned resources: prevent error if description is empty

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -472,8 +472,10 @@ func (gcp *GCP) GetOrphanedResources() ([]OrphanedResource, error) {
 				// GCP gives us description as a string formatted as a map[string]string, so we need to
 				// deconstruct it back into a map[string]string to match the OR struct
 				desc := map[string]string{}
-				if err := json.Unmarshal([]byte(disk.Description), &desc); err != nil {
-					return nil, fmt.Errorf("error converting string to map: %s", err)
+				if disk.Description != "" {
+					if err := json.Unmarshal([]byte(disk.Description), &desc); err != nil {
+						return nil, fmt.Errorf("error converting string to map: %s", err)
+					}
 				}
 
 				// Converts https://www.googleapis.com/compute/v1/projects/xxxxx/zones/us-central1-c to us-central1-c


### PR DESCRIPTION
## What does this PR change?
* Fix bug that causes `savings/orphanedResources` to error when disks on GCP have no description

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* See "What does this PR change?"

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Tested on dev-1, no errors for disks with no description

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.100
