### PR TITLE
Set up Karpenter capacity type label

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -55,9 +55,11 @@ const (
 	InUseState    = "in-use"
 	AttachedState = "attached"
 
-	AWSHourlyPublicIPCost    = 0.005
-	EKSCapacityTypeLabel     = "eks.amazonaws.com/capacityType"
-	EKSCapacitySpotTypeValue = "SPOT"
+	AWSHourlyPublicIPCost          = 0.005
+	EKSCapacityTypeLabel           = "eks.amazonaws.com/capacityType"
+	EKSCapacitySpotTypeValue       = "SPOT"
+	KarpenterCapacityTypeLabel     = "karpenter.sh/capacity-type"
+	KarpenterCapacitySpotTypeValue = "spot"
 )
 
 var (
@@ -667,8 +669,11 @@ func (k *awsKey) Features() string {
 // If the instance is a spot instance, it will return PreemptibleType
 // Otherwise returns an empty string
 func (k *awsKey) getUsageType(labels map[string]string) string {
-	if label, ok := labels[EKSCapacityTypeLabel]; ok && label == EKSCapacitySpotTypeValue {
+	if eksLabel, ok := labels[EKSCapacityTypeLabel]; ok && eksLabel == EKSCapacitySpotTypeValue {
 		// We currently write out spot instances as "preemptible" in the pricing data, so these need to match
+		return PreemptibleType
+	}
+	if kLabel, ok := labels[KarpenterCapacityTypeLabel]; ok && kLabel == KarpenterCapacitySpotTypeValue {
 		return PreemptibleType
 	}
 	return ""

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -55,11 +55,9 @@ const (
 	InUseState    = "in-use"
 	AttachedState = "attached"
 
-	AWSHourlyPublicIPCost          = 0.005
-	EKSCapacityTypeLabel           = "eks.amazonaws.com/capacityType"
-	EKSCapacitySpotTypeValue       = "SPOT"
-	KarpenterCapacityTypeLabel     = "karpenter.sh/capacity-type"
-	KarpenterCapacitySpotTypeValue = "spot"
+	AWSHourlyPublicIPCost    = 0.005
+	EKSCapacityTypeLabel     = "eks.amazonaws.com/capacityType"
+	EKSCapacitySpotTypeValue = "SPOT"
 )
 
 var (

--- a/pkg/cloud/awsprovider_test.go
+++ b/pkg/cloud/awsprovider_test.go
@@ -25,7 +25,7 @@ func Test_awsKey_getUsageType(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "label with a capacityType set to empty string should return empty string",
+			name: "EKS label with a capacityType set to empty string should return empty string",
 			args: args{
 				labels: map[string]string{
 					EKSCapacityTypeLabel: "",
@@ -34,7 +34,7 @@ func Test_awsKey_getUsageType(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "label with capacityType set to a random value should return empty string",
+			name: "EKS label with capacityType set to a random value should return empty string",
 			args: args{
 				labels: map[string]string{
 					EKSCapacityTypeLabel: "TEST_ME",
@@ -43,10 +43,37 @@ func Test_awsKey_getUsageType(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "label with capacityType set to spot should return spot",
+			name: "EKS label with capacityType set to spot should return spot",
 			args: args{
 				labels: map[string]string{
 					EKSCapacityTypeLabel: EKSCapacitySpotTypeValue,
+				},
+			},
+			want: PreemptibleType,
+		},
+		{
+			name: "Karpenter label with a capacityType set to empty string should return empty string",
+			args: args{
+				labels: map[string]string{
+					KarpenterCapacityTypeLabel: "",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "Karpenter label with capacityType set to a random value should return empty string",
+			args: args{
+				labels: map[string]string{
+					KarpenterCapacityTypeLabel: "TEST_ME",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "Karpenter label with capacityType set to spot should return spot",
+			args: args{
+				labels: map[string]string{
+					KarpenterCapacityTypeLabel: KarpenterCapacitySpotTypeValue,
 				},
 			},
 			want: PreemptibleType,

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -42,6 +42,9 @@ const (
 	GCPMonthlyBasicDiskCost = 0.04
 	GCPMonthlySSDDiskCost   = 0.17
 	GCPMonthlyGP2DiskCost   = 0.1
+
+	GKEPreemptibleLabel = "cloud.google.com/gke-preemptible"
+	GKESpotLabel        = "cloud.google.com/gke-spot"
 )
 
 // List obtained by installing the `gcloud` CLI tool,
@@ -1563,10 +1566,12 @@ func parseGCPProjectID(id string) string {
 }
 
 func getUsageType(labels map[string]string) string {
-	if t, ok := labels["cloud.google.com/gke-preemptible"]; ok && t == "true" {
+	if t, ok := labels[GKEPreemptibleLabel]; ok && t == "true" {
 		return "preemptible"
-	} else if t, ok := labels["cloud.google.com/gke-spot"]; ok && t == "true" {
+	} else if t, ok := labels[GKESpotLabel]; ok && t == "true" {
 		// https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms
+		return "preemptible"
+	} else if t, ok := labels[KarpenterCapacityTypeLabel]; ok && t == KarpenterCapacitySpotTypeValue {
 		return "preemptible"
 	}
 	return "ondemand"

--- a/pkg/cloud/gcpprovider_test.go
+++ b/pkg/cloud/gcpprovider_test.go
@@ -73,13 +73,19 @@ func TestGetUsageType(t *testing.T) {
 	}{
 		{
 			input: map[string]string{
-				"cloud.google.com/gke-preemptible": "true",
+				GKEPreemptibleLabel: "true",
 			},
 			expected: "preemptible",
 		},
 		{
 			input: map[string]string{
-				"cloud.google.com/gke-spot": "true",
+				GKESpotLabel: "true",
+			},
+			expected: "preemptible",
+		},
+		{
+			input: map[string]string{
+				KarpenterCapacityTypeLabel: KarpenterCapacitySpotTypeValue,
 			},
 			expected: "preemptible",
 		},

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -32,6 +32,9 @@ const authSecretPath = "/var/secrets/service-key.json"
 const storageConfigSecretPath = "/var/azure-storage-config/azure-storage-config.json"
 const defaultShareTenancyCost = "true"
 
+const KarpenterCapacityTypeLabel = "karpenter.sh/capacity-type"
+const KarpenterCapacitySpotTypeValue = "spot"
+
 var createTableStatements = []string{
 	`CREATE TABLE IF NOT EXISTS names (
 		cluster_id VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## What does this PR change?
This PR updates the instance label parser to correctly detect the Karpenter capacity type label `karpenter.sh/capacity-type` as an alternative to:
- the EKS capacity label `eks.amazonaws.com/capacityType` (for AWS)
- the GKE preemptible and spot labels `cloud.google.com/gke-preemptible` `cloud.google.com/gke-spot` (for GCP)

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
Karpenter users will note correct identification of spot vs on-demand nodes given labels. 

## Does this PR address any GitHub or Zendesk issues?
Closes https://github.com/opencost/opencost/issues/1621

## How was this PR tested?
Unit test

## Does this PR require changes to documentation?
TBD

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
v1.100
