### PR TITLE
allocation GenerateKey - remove sanitization for proper label matching

### DIFF
--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -852,6 +852,22 @@ func TestAllocationSet_AggregateBy(t *testing.T) {
 			windowEnd:   endYesterday,
 			expMinutes:  1440.0,
 		},
+		"1h-with-/": {
+			start:      start,
+			aggBy:      []string{"label:app/app"},
+			aggOpts:    nil,
+			numResults: numLabelApps + numIdle + numUnallocated,
+			totalCost:  activeTotalCost + idleTotalCost,
+			results: map[string]float64{
+				"app1":            16.00,
+				"app2":            24.00,
+				IdleSuffix:        30.00,
+				UnallocatedSuffix: 42.00,
+			},
+			windowStart: startYesterday,
+			windowEnd:   endYesterday,
+			expMinutes:  1440.0,
+		},
 		// 1i AggregationProperties=(deployment)
 		"1i": {
 			start:      start,
@@ -882,6 +898,23 @@ func TestAllocationSet_AggregateBy(t *testing.T) {
 				"team2":           6.00,
 				IdleSuffix:        30.00,
 				UnallocatedSuffix: 64.00,
+			},
+			windowStart: startYesterday,
+			windowEnd:   endYesterday,
+			expMinutes:  1440.0,
+		},
+		// 1j AggregationProperties=(Annotation:team/tags)
+		"1j-json-and-/": {
+			start:      start,
+			aggBy:      []string{"annotation:team/tags"},
+			aggOpts:    nil,
+			numResults: 2 + numIdle + numUnallocated,
+			totalCost:  activeTotalCost + idleTotalCost,
+			results: map[string]float64{
+				"{\"team\":\"team1\"}": 12.00,
+				"{\"team\":\"team2\"}": 6.00,
+				IdleSuffix:             30.00,
+				UnallocatedSuffix:      64.00,
 			},
 			windowStart: startYesterday,
 			windowEnd:   endYesterday,

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -296,7 +296,7 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.Sanitize(strings.TrimPrefix(agg, "label:"))
+				labelName := strings.TrimPrefix(agg, "label:")
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, fmt.Sprintf("%s", labelValue))
 				} else {
@@ -308,7 +308,7 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				annotationName := labelConfig.Sanitize(strings.TrimPrefix(agg, "annotation:"))
+				annotationName := strings.TrimPrefix(agg, "annotation:")
 				if annotationValue, ok := annotations[annotationName]; ok {
 					names = append(names, fmt.Sprintf("%s", annotationValue))
 				} else {

--- a/pkg/kubecost/mock.go
+++ b/pkg/kubecost/mock.go
@@ -293,16 +293,16 @@ func GenerateMockAllocationSet(start time.Time) *AllocationSet {
 
 	// Labels
 
-	a1111.Properties.Labels = map[string]string{"app": "app1", "env": "env1"}
-	a12ghi4.Properties.Labels = map[string]string{"app": "app2", "env": "env2"}
-	a12ghi5.Properties.Labels = map[string]string{"app": "app2", "env": "env2"}
-	a22mno4.Properties.Labels = map[string]string{"app": "app2"}
-	a22mno5.Properties.Labels = map[string]string{"app": "app2"}
+	a1111.Properties.Labels = map[string]string{"app": "app1", "env": "env1", "app/app": "app1"}
+	a12ghi4.Properties.Labels = map[string]string{"app": "app2", "env": "env2", "app/app": "app2"}
+	a12ghi5.Properties.Labels = map[string]string{"app": "app2", "env": "env2", "app/app": "app2"}
+	a22mno4.Properties.Labels = map[string]string{"app": "app2", "app/app": "app2"}
+	a22mno5.Properties.Labels = map[string]string{"app": "app2", "app/app": "app2"}
 
 	//Annotations
-	a23stu7.Properties.Annotations = map[string]string{"team": "team1"}
-	a23vwx8.Properties.Annotations = map[string]string{"team": "team2"}
-	a23vwx9.Properties.Annotations = map[string]string{"team": "team1"}
+	a23stu7.Properties.Annotations = map[string]string{"team": "team1", "team/tags": "{\"team\":\"team1\"}"}
+	a23vwx8.Properties.Annotations = map[string]string{"team": "team2", "team/tags": "{\"team\":\"team2\"}"}
+	a23vwx9.Properties.Annotations = map[string]string{"team": "team1", "team/tags": "{\"team\":\"team1\"}"}
 
 	// Services
 	a12jkl6.Properties.Services = []string{"service1"}
@@ -568,30 +568,44 @@ func GenerateMockAssetSets(start, end time.Time) []*AssetSet {
 //
 // | Asset                        | Cost |  Adj |
 // +------------------------------+------+------+
-//   cluster1:
-//     node1:                        6.00   1.00
-//     node2:                        4.00   1.50
-//     node3:                        7.00  -0.50
-//     disk1:                        2.50   0.00
-//     disk2:                        1.50   0.00
-//     clusterManagement1:           3.00   0.00
+//
+//	cluster1:
+//	  node1:                        6.00   1.00
+//	  node2:                        4.00   1.50
+//	  node3:                        7.00  -0.50
+//	  disk1:                        2.50   0.00
+//	  disk2:                        1.50   0.00
+//	  clusterManagement1:           3.00   0.00
+//
 // +------------------------------+------+------+
-//   cluster1 subtotal              24.00   2.00
+//
+//	cluster1 subtotal              24.00   2.00
+//
 // +------------------------------+------+------+
-//   cluster2:
-//     node4:                       12.00  -1.00
-//     disk3:                        2.50   0.00
-//     disk4:                        1.50   0.00
-//     clusterManagement2:           0.00   0.00
+//
+//	cluster2:
+//	  node4:                       12.00  -1.00
+//	  disk3:                        2.50   0.00
+//	  disk4:                        1.50   0.00
+//	  clusterManagement2:           0.00   0.00
+//
 // +------------------------------+------+------+
-//   cluster2 subtotal              16.00  -1.00
+//
+//	cluster2 subtotal              16.00  -1.00
+//
 // +------------------------------+------+------+
-//   cluster3:
-//     node5:                       17.00   2.00
+//
+//	cluster3:
+//	  node5:                       17.00   2.00
+//
 // +------------------------------+------+------+
-//   cluster3 subtotal              17.00   2.00
+//
+//	cluster3 subtotal              17.00   2.00
+//
 // +------------------------------+------+------+
-//   total                          57.00   3.00
+//
+//	total                          57.00   3.00
+//
 // +------------------------------+------+------+
 func GenerateMockAssetSet(start time.Time) *AssetSet {
 	end := start.Add(day)


### PR DESCRIPTION
## What does this PR change?
* AllocationProperties.GenerateKey

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* Annotation names and label names that contain a '/' or other sanitized character will have a key name that matches what is actually stored in the allocation set.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1750

## How was this PR tested?
* unit tests

## Does this PR require changes to documentation?
* yes, if there any special guidance around annotation names or label names containing un-sanitized characters

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* no permissions
