### PR TITLE
Support high memory and high cpu n2d instances

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -1448,6 +1448,8 @@ func parseGCPInstanceTypeLabel(it string) string {
 			instanceType = "n2standard"
 		} else if instanceType == "e2highmem" || instanceType == "e2highcpu" {
 			instanceType = "e2standard"
+		} else if instanceType == "n2dhighmem" || instanceType == "n2dhighcpu" {
+			instanceType = "n2dstandard"
 		} else if strings.HasPrefix(instanceType, "custom") {
 			instanceType = "custom" // The suffix of custom does not matter
 		}

--- a/pkg/cloud/gcpprovider_test.go
+++ b/pkg/cloud/gcpprovider_test.go
@@ -25,6 +25,10 @@ func TestParseGCPInstanceTypeLabel(t *testing.T) {
 			input:    "custom-n1-standard-2",
 			expected: "custom",
 		},
+		{
+			input:    "n2d-highmem-8",
+			expected: "n2dstandard",
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
Update Node label parsing to support high memory and high cpu n2d instances.

## What does this PR change?
* Updates parsing of GCP instance type label to support n2d highmem and highcpu instances.

## Does this PR relate to any other PRs?
* #605

## How will this PR impact users?
* Pricing data will be found for highmem and highcpu n2d instances.

## How was this PR tested?
* Adds a new test case to parseGCPInstanceTypeLabel for n2d instance type.

## Does this PR require changes to documentation?
* No 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
