### PR TITLE
remove some deprecated methods

### DIFF
--- a/pkg/cloud/aliyunprovider.go
+++ b/pkg/cloud/aliyunprovider.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -591,7 +591,7 @@ func (alibaba *Alibaba) loadAlibabaAuthSecretAndSetEnv(force bool) error {
 		return fmt.Errorf("failed to locate service account file: %s with err: %w", authSecretPath, err)
 	}
 
-	result, err := ioutil.ReadFile(authSecretPath)
+	result, err := os.ReadFile(authSecretPath)
 	if err != nil {
 		return fmt.Errorf("failed to read service account file: %s with err: %w", authSecretPath, err)
 	}
@@ -676,7 +676,7 @@ func (alibaba *Alibaba) UpdateConfig(r io.Reader, updateType string) (*CustomPri
 				return err
 			}
 			for k, v := range a {
-				kUpper := strings.Title(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
+				kUpper := toTitle.String(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
 				vstr, ok := v.(string)
 				if ok {
 					err := SetCustomPricingField(c, kUpper, vstr)

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -591,7 +591,7 @@ func (aws *AWS) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 				return err
 			}
 			for k, v := range a {
-				kUpper := strings.Title(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
+				kUpper := toTitle.String(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
 				vstr, ok := v.(string)
 				if ok {
 					err := SetCustomPricingField(c, kUpper, vstr)

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -15,16 +15,6 @@ import (
 
 	"github.com/opencost/opencost/pkg/kubecost"
 
-	"github.com/opencost/opencost/pkg/clustercache"
-	"github.com/opencost/opencost/pkg/env"
-	"github.com/opencost/opencost/pkg/log"
-	"github.com/opencost/opencost/pkg/util"
-	"github.com/opencost/opencost/pkg/util/fileutil"
-	"github.com/opencost/opencost/pkg/util/json"
-	"github.com/opencost/opencost/pkg/util/timeutil"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/preview/commerce/mgmt/2015-06-01-preview/commerce"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-06-01/subscriptions"
@@ -32,6 +22,13 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/opencost/opencost/pkg/clustercache"
+	"github.com/opencost/opencost/pkg/env"
+	"github.com/opencost/opencost/pkg/log"
+	"github.com/opencost/opencost/pkg/util"
+	"github.com/opencost/opencost/pkg/util/fileutil"
+	"github.com/opencost/opencost/pkg/util/json"
+	"github.com/opencost/opencost/pkg/util/timeutil"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -45,8 +42,6 @@ const (
 	defaultSpotLabelValue            = "spot"
 	AzureStorageUpdateType           = "AzureStorage"
 )
-
-var toTitle = cases.Title(language.Und, cases.NoLower)
 
 var (
 	regionCodeMappings = map[string]string{
@@ -1238,7 +1233,7 @@ func (az *Azure) getDisks() ([]*compute.Disk, error) {
 			d := d
 			disks = append(disks, &d)
 		}
-		err := diskPage.Next()
+		err := diskPage.NextWithContext(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("error getting next page: %v", err)
 		}

--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opencost/opencost/pkg/kubecost"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -77,7 +76,7 @@ func (cp *CustomProvider) UpdateConfig(r io.Reader, updateType string) (*CustomP
 	// Update Config
 	c, err := cp.Config.Update(func(c *CustomPricing) error {
 		for k, v := range a {
-			kUpper := strings.Title(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
+			kUpper := toTitle.String(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
 			vstr, ok := v.(string)
 			if ok {
 				err := SetCustomPricingField(c, kUpper, vstr)

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -27,7 +27,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/compute/metadata"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
@@ -285,7 +284,7 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 				return err
 			}
 			for k, v := range a {
-				kUpper := strings.Title(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
+				kUpper := toTitle.String(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
 				vstr, ok := v.(string)
 				if ok {
 					err := SetCustomPricingField(c, kUpper, vstr)
@@ -352,7 +351,7 @@ func (gcp *GCP) getAllAddresses() (*compute.AddressAggregatedList, error) {
 		return nil, err
 	}
 
-	client, err := google.DefaultClient(oauth2.NoContext,
+	client, err := google.DefaultClient(context.TODO(),
 		"https://www.googleapis.com/auth/compute.readonly")
 	if err != nil {
 		return nil, err
@@ -392,7 +391,7 @@ func (gcp *GCP) getAllDisks() (*compute.DiskAggregatedList, error) {
 		return nil, err
 	}
 
-	client, err := google.DefaultClient(oauth2.NoContext,
+	client, err := google.DefaultClient(context.TODO(),
 		"https://www.googleapis.com/auth/compute.readonly")
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"io"
 	"net/http"
 	"regexp"
@@ -34,6 +36,8 @@ const defaultShareTenancyCost = "true"
 
 const KarpenterCapacityTypeLabel = "karpenter.sh/capacity-type"
 const KarpenterCapacitySpotTypeValue = "spot"
+
+var toTitle = cases.Title(language.Und, cases.NoLower)
 
 var createTableStatements = []string{
 	`CREATE TABLE IF NOT EXISTS names (

--- a/pkg/cloud/providerconfig.go
+++ b/pkg/cloud/providerconfig.go
@@ -5,7 +5,6 @@ import (
 	gopath "path"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/microcosm-cc/bluemonday"
@@ -191,7 +190,7 @@ func (pc *ProviderConfig) UpdateFromMap(a map[string]string) (*CustomPricing, er
 	return pc.Update(func(c *CustomPricing) error {
 		for k, v := range a {
 			// Just so we consistently supply / receive the same values, uppercase the first letter.
-			kUpper := strings.Title(k)
+			kUpper := toTitle.String(k)
 			if kUpper == "CPU" || kUpper == "SpotCPU" || kUpper == "RAM" || kUpper == "SpotRAM" || kUpper == "GPU" || kUpper == "Storage" {
 				val, err := strconv.ParseFloat(v, 64)
 				if err != nil {

--- a/pkg/cloud/scalewayprovider.go
+++ b/pkg/cloud/scalewayprovider.go
@@ -289,7 +289,7 @@ func (c *Scaleway) UpdateConfig(r io.Reader, updateType string) (*CustomPricing,
 			return err
 		}
 		for k, v := range a {
-			kUpper := strings.Title(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
+			kUpper := toTitle.String(k) // Just so we consistently supply / receive the same values, uppercase the first letter.
 			vstr, ok := v.(string)
 			if ok {
 				err := SetCustomPricingField(c, kUpper, vstr)

--- a/pkg/util/mathutil/mathutil.go
+++ b/pkg/util/mathutil/mathutil.go
@@ -7,7 +7,7 @@ func Approximately(exp, act float64) bool {
 }
 
 func ApproximatelyPct(exp, act, pct float64) bool {
-	delta := (exp * pct)
+	delta := exp * pct
 	if delta < 0.00001 {
 		delta = 0.00001
 	}


### PR DESCRIPTION
## What does this PR change?

- use `cases.Title` instead of `strings.Title`
- use  `os.ReadFile` instead of  `ioutil.ReadFile`
- use `diskPage.NextWithContext(context.Background())` instead of `diskPage.Next()`
- use `context.TODO` instead of `oauth2.NoContext`

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
No

## Does this PR address any GitHub or Zendesk issues?
No

## How was this PR tested?
* 

## Does this PR require changes to documentation?
NO

