### PR TITLE
Add Matt Ray to the maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,3 +14,4 @@ Please keep the below list sorted in ascending order.
 | Niko Kovacevic | @nikovacevic | Kubecost | <niko@kubecost.com> |
 | Sean Holcomb | @Sean-Holcomb | Kubecost | <Sean@kubecost.com> |
 | Thomas Evans | @teevans | Kubecost | <thomas@kubecost.com> |
+| Matt Ray | @mattray | Kubecost | <mattray@kubecost.com> |


### PR DESCRIPTION
This is referenced at https://github.com/cncf/foundation/blob/main/project-maintainers.csv#L1107 and I want to ensure I'm looped in for CNCF-related messaging if it comes through this channel.

As a CNCF Sandbox project, we should be invited to host a booth a KubeCon and I suspect I'm the most inclined to want to coordinate efforts around this.
https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/project-benefits/

Signed-off-by: Matt Ray <github@mattray.dev>
