### PR TITLE
Fix upstream nginx to access cost-model API. Update README in /ui.

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,7 @@ ADD package*.json /opt/ui/
 WORKDIR /opt/ui
 RUN npm install
 ADD src /opt/ui/src
-ENV BASE_URL=/allocation
+ENV BASE_URL=/model
 RUN npx parcel build src/index.html
 
 FROM nginx:alpine

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,31 +1,22 @@
 # OpenCost UI
-The preferred install path for OpenCost is via Helm chart, and is available explained [here](http://github.com/opencost/opencost-helm-chart)
 
-To manually run the OpenCost UI, follow the steps below.
+## Installing
 
-## Requirements
-
-* `nodejs >= 18.3.0`
-* `npm >= 8.11.0`
-
-## Installation & Running
-To run the UI, open a terminal to the `opencost/ui/` directory (where this README is located) and run
+See https://www.opencost.io/docs/install for the full instructions.
 
 ```
-npm install
+helm install my-prometheus --repo https://prometheus-community.github.io/helm-charts prometheus \
+  --namespace prometheus --create-namespace \
+  --set pushgateway.enabled=false \
+  --set alertmanager.enabled=false \
+  -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml
+
+kubectl apply --namespace opencost -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/opencost.yaml
 ```
 
-This will install required dependencies and build tools. To launch the UI, run
+## Using
 
+After following the installation instructions, access the UI by port forwarding:
 ```
-npx parcel src/index.html
+kubectl port-forward --namespace opencost service/opencost 9090
 ```
-
-This will launch a development server, serving the UI at `http://localhost:1234` and targeting the data for an instance of
-OpenCost running at `http://localhost:9090`. To access an arbitrary OpenCost install, you can use
-
-```
-kubectl port-forward deployment/opencost 9090:9003
-```
-
-for your choice of namespace and cloud context.

--- a/ui/default.nginx.conf
+++ b/ui/default.nginx.conf
@@ -62,7 +62,7 @@ server {
     location /healthz {
         return 200 'OK';
     }
-    location /allocation {
+    location /model/ {
         proxy_connect_timeout       180;
         proxy_send_timeout          180;
         proxy_read_timeout          180;

--- a/ui/src/services/allocation.js
+++ b/ui/src/services/allocation.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 class AllocationService {
-  BASE_URL = process.env.BASE_URL || 'http://localhost:9090/allocation';
+  BASE_URL = process.env.BASE_URL || 'http://localhost:9090/model';
 
   async fetchAllocation(win, aggregate, options) {
     const { accumulate, filters, } = options;
@@ -13,7 +13,7 @@ class AllocationService {
     if (typeof accumulate === 'boolean') {
       params.accumulate = accumulate;
     }
-    const result = await axios.get(`${this.BASE_URL}/compute`, { params });
+    const result = await axios.get(`${this.BASE_URL}/allocation/compute`, { params });
     return result.data;
   }
 }


### PR DESCRIPTION
Previous PR broke the nginx config. This fixes that. Also updated the README in the ui folder.

### Testing
Did a basic install and it now works, whereas it previously 404'd and errored.

![Screenshot from 2023-02-09 12-46-35](https://user-images.githubusercontent.com/8070055/217941975-fa07bd45-ef97-4a32-9ef0-933014de0cb1.png)
