### PR TITLE
Export v1 Allocation filter params to support validation logic in handlers

### DIFF
--- a/pkg/util/allocationfilterutil/queryfilters.go
+++ b/pkg/util/allocationfilterutil/queryfilters.go
@@ -10,6 +10,51 @@ import (
 	"github.com/opencost/opencost/pkg/util/mapper"
 )
 
+const (
+	ParamFilterClusters        = "filterClusters"
+	ParamFilterNodes           = "filterNodes"
+	ParamFilterNamespaces      = "filterNamespaces"
+	ParamFilterControllerKinds = "filterControllerKinds"
+	ParamFilterControllers     = "filterControllers"
+	ParamFilterPods            = "filterPods"
+	ParamFilterContainers      = "filterContainers"
+
+	ParamFilterDepartments  = "filterDepartments"
+	ParamFilterEnvironments = "filterEnvironments"
+	ParamFilterOwners       = "filterOwners"
+	ParamFilterProducts     = "filterProducts"
+	ParamFilterTeams        = "filterTeams"
+
+	ParamFilterAnnotations = "filterAnnotations"
+	ParamFilterLabels      = "filterLabels"
+	ParamFilterServices    = "filterServices"
+)
+
+// AllHTTPParamKeys returns all HTTP GET parameters used for v1 filters. It is
+// intended to help validate HTTP queries in handlers to help avoid e.g.
+// spelling errors.
+func AllHTTPParamKeys() []string {
+	return []string{
+		ParamFilterClusters,
+		ParamFilterNodes,
+		ParamFilterNamespaces,
+		ParamFilterControllerKinds,
+		ParamFilterControllers,
+		ParamFilterPods,
+		ParamFilterContainers,
+
+		ParamFilterDepartments,
+		ParamFilterEnvironments,
+		ParamFilterOwners,
+		ParamFilterProducts,
+		ParamFilterTeams,
+
+		ParamFilterAnnotations,
+		ParamFilterLabels,
+		ParamFilterServices,
+	}
+}
+
 // ============================================================================
 // This file contains:
 // Parsing (HTTP query params -> AllocationFilter) for V1 of filters
@@ -83,7 +128,7 @@ func AllocationFilterFromParamsV1(
 	// filter structs (they evaluate to true always) there could be overhead
 	// when calling Matches() repeatedly for no purpose.
 
-	if filterClusters := qp.GetList("filterClusters", ","); len(filterClusters) > 0 {
+	if filterClusters := qp.GetList(ParamFilterClusters, ","); len(filterClusters) > 0 {
 		clustersOr := kubecost.AllocationFilterOr{
 			Filters: []kubecost.AllocationFilter{},
 		}
@@ -116,15 +161,15 @@ func AllocationFilterFromParamsV1(
 		filter.Filters = append(filter.Filters, clustersOr)
 	}
 
-	if raw := qp.GetList("filterNodes", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterNodes, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1SingleValueFromList(raw, kubecost.FilterNode))
 	}
 
-	if raw := qp.GetList("filterNamespaces", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterNamespaces, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1SingleValueFromList(raw, kubecost.FilterNamespace))
 	}
 
-	if raw := qp.GetList("filterControllerKinds", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterControllerKinds, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1SingleValueFromList(raw, kubecost.FilterControllerKind))
 	}
 
@@ -132,7 +177,7 @@ func AllocationFilterFromParamsV1(
 	// "deployment:kubecost-cost-analyzer"
 	//
 	// Thus, we have to make a custom OR filter for this condition.
-	if filterControllers := qp.GetList("filterControllers", ","); len(filterControllers) > 0 {
+	if filterControllers := qp.GetList(ParamFilterControllers, ","); len(filterControllers) > 0 {
 		controllersOr := kubecost.AllocationFilterOr{
 			Filters: []kubecost.AllocationFilter{},
 		}
@@ -183,44 +228,44 @@ func AllocationFilterFromParamsV1(
 		}
 	}
 
-	if raw := qp.GetList("filterPods", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterPods, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1SingleValueFromList(raw, kubecost.FilterPod))
 	}
 
-	if raw := qp.GetList("filterContainers", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterContainers, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1SingleValueFromList(raw, kubecost.FilterContainer))
 	}
 
 	// Label-mapped queries require a label config to be present.
 	if labelConfig != nil {
-		if raw := qp.GetList("filterDepartments", ","); len(raw) > 0 {
+		if raw := qp.GetList(ParamFilterDepartments, ","); len(raw) > 0 {
 			filter.Filters = append(filter.Filters, filterV1LabelAliasMappedFromList(raw, labelConfig.DepartmentLabel))
 		}
-		if raw := qp.GetList("filterEnvironments", ","); len(raw) > 0 {
+		if raw := qp.GetList(ParamFilterEnvironments, ","); len(raw) > 0 {
 			filter.Filters = append(filter.Filters, filterV1LabelAliasMappedFromList(raw, labelConfig.EnvironmentLabel))
 		}
-		if raw := qp.GetList("filterOwners", ","); len(raw) > 0 {
+		if raw := qp.GetList(ParamFilterOwners, ","); len(raw) > 0 {
 			filter.Filters = append(filter.Filters, filterV1LabelAliasMappedFromList(raw, labelConfig.OwnerLabel))
 		}
-		if raw := qp.GetList("filterProducts", ","); len(raw) > 0 {
+		if raw := qp.GetList(ParamFilterProducts, ","); len(raw) > 0 {
 			filter.Filters = append(filter.Filters, filterV1LabelAliasMappedFromList(raw, labelConfig.ProductLabel))
 		}
-		if raw := qp.GetList("filterTeams", ","); len(raw) > 0 {
+		if raw := qp.GetList(ParamFilterTeams, ","); len(raw) > 0 {
 			filter.Filters = append(filter.Filters, filterV1LabelAliasMappedFromList(raw, labelConfig.TeamLabel))
 		}
 	} else {
 		log.Debugf("No label config is available. Not creating filters for label-mapped 'fields'.")
 	}
 
-	if raw := qp.GetList("filterAnnotations", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterAnnotations, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1DoubleValueFromList(raw, kubecost.FilterAnnotation))
 	}
 
-	if raw := qp.GetList("filterLabels", ","); len(raw) > 0 {
+	if raw := qp.GetList(ParamFilterLabels, ","); len(raw) > 0 {
 		filter.Filters = append(filter.Filters, filterV1DoubleValueFromList(raw, kubecost.FilterLabel))
 	}
 
-	if filterServices := qp.GetList("filterServices", ","); len(filterServices) > 0 {
+	if filterServices := qp.GetList(ParamFilterServices, ","); len(filterServices) > 0 {
 		// filterServices= is the only filter that uses the "contains" operator.
 		servicesFilter := kubecost.AllocationFilterOr{
 			Filters: []kubecost.AllocationFilter{},


### PR DESCRIPTION
## What does this PR change?
* Exports the string names of filterV1 parameters so they can be used in validation. See https://github.com/kubecost/kubecost-cost-model/pull/1218 for example usage.

## Does this PR relate to any other PRs?
* Pairs with https://github.com/opencost/opencost/pull/1682
* Required for https://github.com/kubecost/kubecost-cost-model/pull/1218

## How will this PR impact users?
* N/A

## How was this PR tested?
* In the KCM PR