### PR TITLE
get labels/annotations intersection

### DIFF
--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -148,7 +148,9 @@ func (p *AllocationProperties) Clone() *AllocationProperties {
 }
 
 func (p *AllocationProperties) Equal(that *AllocationProperties) bool {
-	if p == nil || that == nil {
+	if p == nil && that == nil {
+		return true
+	} else if p == nil || that == nil {
 		return false
 	}
 
@@ -422,7 +424,10 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 	if p == nil || that == nil {
 		return nil
 	}
-	intersectionProps := &AllocationProperties{}
+	intersectionProps := &AllocationProperties{
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
 	if p.Cluster == that.Cluster {
 		intersectionProps.Cluster = p.Cluster
 	}
@@ -446,6 +451,16 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 	}
 	if p.ProviderID == that.ProviderID {
 		intersectionProps.ProviderID = p.ProviderID
+	}
+	for k1, v1 := range p.Labels {
+		if that.Labels[k1] == v1 {
+			intersectionProps.Labels[k1] = v1
+		}
+	}
+	for k1, v1 := range p.Annotations {
+		if that.Annotations[k1] == v1 {
+			intersectionProps.Annotations[k1] = v1
+		}
 	}
 	return intersectionProps
 }

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -107,3 +107,80 @@ func TestGenerateKey(t *testing.T) {
 		})
 	}
 }
+
+func TestAllocationPropsIntersection(t *testing.T) {
+	cases := []struct {
+		name                     string
+		leftProps                *AllocationProperties
+		rightProps               *AllocationProperties
+		expectedIntersectedProps *AllocationProperties
+	}{
+		{
+			name:                     "nil props should work #1",
+			leftProps:                nil,
+			rightProps:               nil,
+			expectedIntersectedProps: nil,
+		},
+		{
+			name: "basic information should work #1",
+			leftProps: &AllocationProperties{
+				Cluster:    "foo",
+				Node:       "bar",
+				Container:  "baz",
+				Controller: "bak",
+			},
+			rightProps: &AllocationProperties{
+				Cluster:    "foo",
+				Node:       "bar",
+				Container:  "baz",
+				Controller: "bal",
+			},
+			expectedIntersectedProps: &AllocationProperties{
+				Cluster:   "foo",
+				Node:      "bar",
+				Container: "baz",
+			},
+		},
+		{
+			name: "labels/annotations intersection should work #1",
+			leftProps: &AllocationProperties{
+				Labels: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar2",
+					"foo3": "foo3",
+				},
+				Annotations: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar2",
+					"foo3": "foo3",
+				},
+			},
+			rightProps: &AllocationProperties{
+				Labels: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar_wrong",
+				},
+				Annotations: map[string]string{
+					"foo1": "bar1",
+					"foo2": "bar_wrong",
+				},
+			},
+			expectedIntersectedProps: &AllocationProperties{
+				Labels: map[string]string{
+					"foo1": "bar1",
+				},
+				Annotations: map[string]string{
+					"foo1": "bar1",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.leftProps.Intersection(c.rightProps)
+			if !actual.Equal(c.expectedIntersectedProps) {
+				t.Errorf("expected %#v, but received %#v", c.expectedIntersectedProps, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* currently `AllocationProperties#Intersection()` function doesnt process the intersection of labels/annotations which may contain useful information either inherited from belonging namespace or the pod per se. for my case, i'm managing workloads under namespaces controlled by [hierarchical-namespace-controller](https://github.com/kubernetes-sigs/hierarchical-namespaces), those namespaces has some additional metadata in labels

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* No, totally backward compatible

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* Yes

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
