### PR TITLE
Support opt-out from alibaba cloud provider

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -563,7 +563,7 @@ func getClusterProperties(node *v1.Node) clusterProperties {
 	} else if strings.HasPrefix(providerID, "scaleway") { // the scaleway provider ID looks like scaleway://instance/<instance_id>
 		cp.provider = kubecost.ScalewayProvider
 		cp.configFileName = "scaleway.json"
-	} else if strings.Contains(node.Status.NodeInfo.KubeletVersion, "aliyun") { // provider ID is not prefix with any distinct keyword like other providers
+	} else if !env.IsAlibabaProviderDisabled() && strings.Contains(node.Status.NodeInfo.KubeletVersion, "aliyun") { // provider ID is not prefix with any distinct keyword like other providers
 		cp.provider = kubecost.AlibabaProvider
 		cp.configFileName = "alibaba.json"
 	}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -19,6 +19,7 @@ const (
 
 	AlibabaAccessKeyIDEnvVar     = "ALIBABA_ACCESS_KEY_ID"
 	AlibabaAccessKeySecretEnvVar = "ALIBABA_SECRET_ACCESS_KEY"
+	AlibabaDisableEnvVar         = "ALIBABA_PROVIDER_DISABLE"
 
 	KubecostNamespaceEnvVar        = "KUBECOST_NAMESPACE"
 	PodNameEnvVar                  = "POD_NAME"
@@ -228,6 +229,12 @@ func GetAlibabaAccessKeyID() string {
 // the Alibaba access key secret for authentication
 func GetAlibabaAccessKeySecret() string {
 	return Get(AlibabaAccessKeySecretEnvVar, "")
+}
+
+// IsAlibabaProviderDisabled returns whether Alibaba Cloud provider is explicitly disabled. This is used to opt-out
+// from the provider implementation.
+func IsAlibabaProviderDisabled() bool {
+	return GetBool(AlibabaDisableEnvVar, false)
 }
 
 // GetKubecostNamespace returns the environment variable value for KubecostNamespaceEnvVar which
@@ -511,7 +518,7 @@ func GetAllocationNodeLabelsEnabled() bool {
 	return GetBool(AllocationNodeLabelsEnabled, true)
 }
 
-var defaultAllocationNodeLabelsIncludeList []string = []string{
+var defaultAllocationNodeLabelsIncludeList = []string{
 	"cloud.google.com/gke-nodepool",
 	"eks.amazonaws.com/nodegroup",
 	"kubernetes.azure.com/agentpool",


### PR DESCRIPTION
## What does this PR change?
* adding an env var for opt-out from the default Alibaba cloud provider implementation. This is useful for offline Alibaba cloud clusters of which the cost computing model is different/conflicting with the current one. these offline clusters are also using kubelet images suffixed `-aliyun-` platform version, this makes opencost agents not working in offline environment (because the provider detection logic for Alibaba cloud is based on kubelet version). I'm raising this pull because I'm currently working for alibaba cloud-native kubernetes related product and it looks fine for me to keep the current provider as default alibaba provider but just leaving an option to custom provider would be great.
