### PR TITLE
Fix panic in Asset/AllocSetRange NewAccumulation

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2103,6 +2103,14 @@ func (asr *AllocationSetRange) NewAccumulation() (*AllocationSet, error) {
 	var allocSet *AllocationSet
 	var err error
 
+	if asr == nil {
+		return nil, fmt.Errorf("nil AllocationSetRange in accumulation")
+	}
+
+	if len(asr.Allocations) == 0 {
+		return nil, fmt.Errorf("AllocationSetRange has empty AssetSet in accumulation")
+	}
+
 	for _, as := range asr.Allocations {
 		if allocSet == nil {
 			allocSet = as.Clone()

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -3249,6 +3249,14 @@ func (asr *AssetSetRange) NewAccumulation() (*AssetSet, error) {
 	var assetSet *AssetSet
 	var err error
 
+	if asr == nil {
+		return nil, fmt.Errorf("nil AssetSetRange in accumulation")
+	}
+
+	if len(asr.Assets) == 0 {
+		return nil, fmt.Errorf("AssetSetRange has empty AssetSet in accumulation")
+	}
+
 	for _, as := range asr.Assets {
 		if assetSet == nil {
 			assetSet = as.Clone()


### PR DESCRIPTION
## What does this PR change?
Fixes panic in NewAccumulation for AssetSetRange. Also applies fix to AllocationSetRange NewAccumulation.

## Does this PR relate to any other PRs?
* No.

## How will this PR impact users?
Fixes a nil panic while getting Assets

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1981

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
