### PR TITLE
ensure /allocation response start and end are always in UTC format

### DIFF
--- a/pkg/kubecost/allocation_json.go
+++ b/pkg/kubecost/allocation_json.go
@@ -62,8 +62,8 @@ func (aj *AllocationJSON) BuildFromAllocation(a *Allocation) {
 	aj.Name = a.Name
 	aj.Properties = a.Properties
 	aj.Window = a.Window
-	aj.Start = a.Start.Format(time.RFC3339)
-	aj.End = a.End.Format(time.RFC3339)
+	aj.Start = a.Start.UTC().Format(time.RFC3339)
+	aj.End = a.End.UTC().Format(time.RFC3339)
 	aj.Minutes = formatFloat64ForResponse(a.Minutes())
 	aj.CPUCores = formatFloat64ForResponse(a.CPUCores())
 	aj.CPUCoreRequestAverage = formatFloat64ForResponse(a.CPUCoreRequestAverage)


### PR DESCRIPTION
## What does this PR change?
* `/allocation` is sometimes returning local time rather than UTC

## Does this PR relate to any other PRs?
* yes; https://github.com/opencost/opencost/pull/1666

## How will this PR impact users?
* user gets consistent timestamps

## Does this PR address any GitHub or Zendesk issues?
* no

## How was this PR tested?
* manually

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* no permissions
