### PR TITLE
Interfaces needed in Kubecost Asset and CloudCost item for mapping monitored to billed resources

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -3179,18 +3179,17 @@ func (as *AssetSet) accumulate(that *AssetSet) (*AssetSet, error) {
 	return acc, nil
 }
 
-func (as *AssetSet) MonitoredPropsOfCloudCostItem(cci *CloudCostItem) (time.Time, string, string) {
+func (as *AssetSet) MonitoredNodeForCloudCostItem(cci *CloudCostItem) *Node {
 	for _, node := range as.Nodes {
 		if node.MonitoringKey() == cci.MonitoringKey() {
 			props := node.GetProperties()
 			if props == nil {
 				continue
 			}
-			// To-DO: No match between cluster ID and Node here?
-			return node.End, props.Cluster, ""
+			return node
 		}
 	}
-	return time.Time{}, "", ""
+	return nil
 }
 
 type DiffKind string

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2157,6 +2157,22 @@ func (n *Node) GPUs() float64 {
 	return n.GPUHours * (60.0 / n.Minutes())
 }
 
+func (n *Node) MonitoringKey() string {
+	nodeProps := n.GetProperties()
+	if nodeProps == nil {
+		return ""
+	}
+	//TO-DO: For Alibaba investigate why cloudCost ProviderID doesnt match Kubecost ProviderID via Kubernetes API
+	if nodeProps.Provider == AlibabaProvider {
+		aliProviderID := strings.Split(nodeProps.ProviderID, ".")
+		if len(aliProviderID) != 2 {
+			return ""
+		}
+		return nodeProps.Provider + "/" + nodeProps.Account + "/" + aliProviderID[1]
+	}
+	return nodeProps.Provider + "/" + nodeProps.Account + "/" + nodeProps.ProviderID
+}
+
 // LoadBalancer is an Asset representing a single load balancer in a cluster
 // TODO: add GB of ingress processed, numForwardingRules once we start recording those to prometheus metric
 type LoadBalancer struct {
@@ -3161,6 +3177,20 @@ func (as *AssetSet) accumulate(that *AssetSet) (*AssetSet, error) {
 	}
 
 	return acc, nil
+}
+
+func (as *AssetSet) MonitoredPropsOfCloudCostItem(cci *CloudCostItem) (time.Time, string, string) {
+	for _, node := range as.Nodes {
+		if node.MonitoringKey() == cci.MonitoringKey() {
+			props := node.GetProperties()
+			if props == nil {
+				continue
+			}
+			// To-DO: No match between cluster ID and Node here?
+			return node.End, props.Cluster, ""
+		}
+	}
+	return time.Time{}, "", ""
 }
 
 type DiffKind string

--- a/pkg/kubecost/mock.go
+++ b/pkg/kubecost/mock.go
@@ -2,6 +2,7 @@ package kubecost
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -568,30 +569,44 @@ func GenerateMockAssetSets(start, end time.Time) []*AssetSet {
 //
 // | Asset                        | Cost |  Adj |
 // +------------------------------+------+------+
-//   cluster1:
-//     node1:                        6.00   1.00
-//     node2:                        4.00   1.50
-//     node3:                        7.00  -0.50
-//     disk1:                        2.50   0.00
-//     disk2:                        1.50   0.00
-//     clusterManagement1:           3.00   0.00
+//
+//	cluster1:
+//	  node1:                        6.00   1.00
+//	  node2:                        4.00   1.50
+//	  node3:                        7.00  -0.50
+//	  disk1:                        2.50   0.00
+//	  disk2:                        1.50   0.00
+//	  clusterManagement1:           3.00   0.00
+//
 // +------------------------------+------+------+
-//   cluster1 subtotal              24.00   2.00
+//
+//	cluster1 subtotal              24.00   2.00
+//
 // +------------------------------+------+------+
-//   cluster2:
-//     node4:                       12.00  -1.00
-//     disk3:                        2.50   0.00
-//     disk4:                        1.50   0.00
-//     clusterManagement2:           0.00   0.00
+//
+//	cluster2:
+//	  node4:                       12.00  -1.00
+//	  disk3:                        2.50   0.00
+//	  disk4:                        1.50   0.00
+//	  clusterManagement2:           0.00   0.00
+//
 // +------------------------------+------+------+
-//   cluster2 subtotal              16.00  -1.00
+//
+//	cluster2 subtotal              16.00  -1.00
+//
 // +------------------------------+------+------+
-//   cluster3:
-//     node5:                       17.00   2.00
+//
+//	cluster3:
+//	  node5:                       17.00   2.00
+//
 // +------------------------------+------+------+
-//   cluster3 subtotal              17.00   2.00
+//
+//	cluster3 subtotal              17.00   2.00
+//
 // +------------------------------+------+------+
-//   total                          57.00   3.00
+//
+//	total                          57.00   3.00
+//
 // +------------------------------+------+------+
 func GenerateMockAssetSet(start time.Time) *AssetSet {
 	end := start.Add(day)
@@ -681,4 +696,51 @@ func GenerateMockAssetSet(start time.Time) *AssetSet {
 		// cluster 3
 		node5,
 	)
+}
+
+func GenerateKubecostNodeAndPID(mockProviderIDInt int, provider string, mockClusterID int, setEndTime time.Time) (*Node, string) {
+	providerID := "PID" + strconv.FormatInt(int64(mockProviderIDInt), 10)
+	return &Node{
+		Properties: &AssetProperties{
+			Provider:   provider,
+			ProviderID: providerID,
+			Cluster:    "cluster" + strconv.FormatInt(int64(mockClusterID), 10),
+		},
+		End: setEndTime,
+	}, providerID
+}
+func GenerateAWSMockCCIAndPID(mockProviderIDInt int, mockCloudIDInt int, labelKey string, resourceCategory string) (*CloudCostItem, string) {
+	return &CloudCostItem{
+		Properties: CloudCostItemProperties{
+			ProviderID: "PID" + strconv.FormatInt(int64(mockProviderIDInt), 10),
+			Provider:   AWSProvider,
+			Category:   resourceCategory,
+			Labels: map[string]string{
+				labelKey: "cluster" + strconv.FormatInt(int64(mockCloudIDInt), 10),
+			},
+		},
+	}, "cluster" + strconv.FormatInt(int64(mockCloudIDInt), 10)
+}
+
+func GenerateAlibabaMockCCIAndPID(mockProviderIDInt int, mockCloudIDInt int, labelKey string, resourceCategory string) (*CloudCostItem, string) {
+	return &CloudCostItem{
+		Properties: CloudCostItemProperties{
+			ProviderID: "PID" + strconv.FormatInt(int64(mockProviderIDInt), 10),
+			Provider:   AlibabaProvider,
+			Category:   resourceCategory,
+			Labels: map[string]string{
+				labelKey: "cluster" + strconv.FormatInt(int64(mockCloudIDInt), 10),
+			},
+		},
+	}, "cluster" + strconv.FormatInt(int64(mockCloudIDInt), 10)
+}
+
+func GenerateGCPMockCCIAndPID(mockProviderIDInt int, mockCloudIDInt int, labelKey string, resourceCategory string) (*CloudCostItem, string) {
+	return &CloudCostItem{
+		Properties: CloudCostItemProperties{
+			ProviderID: "PID" + strconv.FormatInt(int64(mockProviderIDInt), 10),
+			Provider:   GCPProvider,
+			Category:   resourceCategory,
+		},
+	}, ""
 }


### PR DESCRIPTION
## What does this PR change?
* Few functions needed to match billed to monitored resources such as
 monitoring key with provider/account/providerID in both asset and cloud cost items and accumulate in cloudcostItemset

## Does this PR relate to any other PRs?
* KCM PR link soon

## How will this PR impact users?
* No Impact

## Does this PR address any GitHub or Zendesk issues?
* Closes ... Or JIRA Issue to get unmonitored Clusters 

## How was this PR tested?
* On all 4 providers in conjunction with KCM PR

## Does this PR require changes to documentation?
* Not now

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* Dont have permission can some opencosters do it for me!
