### PR TITLE
Cherry Pick: Access warnings on AssetSetRange

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -3410,6 +3410,28 @@ func (asr *AssetSetRange) InsertRange(that *AssetSetRange) error {
 	return err
 }
 
+func (asr *AssetSetRange) GetWarnings() []string {
+	warnings := []string{}
+
+	for _, as := range asr.Assets {
+		if len(as.Warnings) > 0 {
+			warnings = append(warnings, as.Warnings...)
+		}
+	}
+
+	return warnings
+}
+
+func (asr *AssetSetRange) HasWarnings() bool {
+	for _, as := range asr.Assets {
+		if len(as.Warnings) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsEmpty returns false if AssetSetRange contains a single AssetSet that is not empty
 func (asr *AssetSetRange) IsEmpty() bool {
 	if asr == nil || asr.Length() == 0 {


### PR DESCRIPTION
## What does this PR change?
* Cherry Picks https://github.com/opencost/opencost/pull/1717 into v1.101

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
