### PR TITLE
removing account from key matching between kubecost and cloudcost

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2168,9 +2168,9 @@ func (n *Node) MonitoringKey() string {
 		if len(aliProviderID) != 2 {
 			return ""
 		}
-		return nodeProps.Provider + "/" + nodeProps.Account + "/" + aliProviderID[1]
+		return nodeProps.Provider + "/" + aliProviderID[1]
 	}
-	return nodeProps.Provider + "/" + nodeProps.Account + "/" + nodeProps.ProviderID
+	return nodeProps.Provider + "/" + nodeProps.ProviderID
 }
 
 // LoadBalancer is an Asset representing a single load balancer in a cluster

--- a/pkg/kubecost/cloudcostitem.go
+++ b/pkg/kubecost/cloudcostitem.go
@@ -81,7 +81,7 @@ func (ccip CloudCostItemProperties) Key() string {
 }
 
 func (ccip CloudCostItemProperties) MonitoringKey() string {
-	return fmt.Sprintf("%s/%s/%s", ccip.Provider, ccip.WorkGroupID, ccip.ProviderID)
+	return fmt.Sprintf("%s/%s", ccip.Provider, ccip.ProviderID)
 }
 
 // CloudCostItem represents a CUR line item, identifying a cloud resource and


### PR DESCRIPTION
## What does this PR change?
* Sometimes account is not populated in node properties and match between kubecost and cloudcost fail in those scenarios

## Does this PR relate to any other PRs?
* Enhancement to [1695](https://github.com/opencost/opencost/pull/1695)

## How will this PR impact users?
* Nothing unless u r on latest rc for KCM

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* When account wasnt given!

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.101
