### PR TITLE
License documentation under the CC BY 4.0.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,3 @@
-The docs are available at <https://www.opencost.io/docs/> and the source is at <https://github.com/opencost/opencost-website/>
+The docs are available at <https://www.opencost.io/docs/> with additional source at <https://github.com/opencost/opencost-website/>.
+
+All documentation in this repository is made available by the CNCF under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Following guidance from the CNCF's IP policy https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy

The OpenCost code already has the Apache v2 License, this is for the documentation included in the repository.