### PR TITLE
Update DefaultPricing() with current GCP us-central1 prices

### DIFF
--- a/pkg/cloud/providerconfig.go
+++ b/pkg/cloud/providerconfig.go
@@ -211,16 +211,31 @@ func (pc *ProviderConfig) UpdateFromMap(a map[string]string) (*CustomPricing, er
 
 // DefaultPricing should be returned so we can do computation even if no file is supplied.
 func DefaultPricing() *CustomPricing {
+	// https://cloud.google.com/compute/all-pricing
 	return &CustomPricing{
-		Provider:              "base",
-		Description:           "Default prices based on GCP us-central1",
-		CPU:                   "0.031611",
-		SpotCPU:               "0.006655",
-		RAM:                   "0.004237",
-		SpotRAM:               "0.000892",
-		GPU:                   "0.95",
-		SpotGPU:               "0.308",
-		Storage:               "0.00005479452",
+		Provider:    "base",
+		Description: "Default prices based on GCP us-central1",
+
+		// E2 machine types in GCP us-central1 (Iowa)
+		CPU:     "0.021811", // per vCPU hour
+		SpotCPU: "0.006543", // per vCPU hour
+		RAM:     "0.002923", // per G(i?)B hour
+		SpotRAM: "0.000877", // per G(i?)B hour
+
+		// There are many GPU types. This serves as a reasonably-appropriate
+		// estimate within a broad range (0.35 up to 3.93)
+		GPU: "0.95", // per GPU hour
+		// Same story as above.
+		SpotGPU: "0.308", // per GPU hour
+
+		// This is the "Standard provision space" pricing in the "Disk pricing"
+		// table.
+		//
+		// (($.04 / month) per G(i?)B) *
+		//   month/730 hours =
+		//     0.00005479452054794521
+		Storage: "0.00005479452",
+
 		ZoneNetworkEgress:     "0.01",
 		RegionNetworkEgress:   "0.01",
 		InternetNetworkEgress: "0.12",


### PR DESCRIPTION
## What does this PR change?
See release note. This also affects default pricing for prediction in closed source.

## Does this PR relate to any other PRs?
* Not yet

## How will this PR impact users?
* Updated default resource pricing, which is used when a specific cloud provider cannot be found to query for public or private pricing data. Price update is drawn primarily from GCP's E2 family pricing in `us-central1` on 2023-03-13.

## How was this PR tested?
* N/A

## Does this PR require changes to documentation?
* N/A