### PR TITLE
Fix for Opencost’s cpu & mem allocation metrics

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -152,10 +152,22 @@ const (
 	) by (namespace,container_name,pod_name,node,%s)`
 	queryRAMUsageStr = `sort_desc(
 		avg(
-			label_replace(count_over_time(container_memory_working_set_bytes{container_name!="",container_name!="POD", instance!=""}[%s] %s), "node", "$1", "instance","(.+)")
+			label_replace(
+				label_replace(
+					label_replace(
+						count_over_time(container_memory_working_set_bytes{container!="", container!="POD", instance!=""}[%s] %s), "node", "$1", "instance", "(.+)"
+					), "container_name", "$1", "container", "(.+)"
+				), "pod_name", "$1", "pod", "(.+)"
+			)
 			*
-			label_replace(avg_over_time(container_memory_working_set_bytes{container_name!="",container_name!="POD", instance!=""}[%s] %s), "node", "$1", "instance","(.+)")
-		) by (namespace,container_name,pod_name,node,%s)
+			label_replace(
+				label_replace(
+					label_replace(
+						avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", instance!=""}[%s] %s), "node", "$1", "instance", "(.+)"
+					), "container_name", "$1", "container", "(.+)"
+				), "pod_name", "$1", "pod", "(.+)"
+			)
+		) by (namespace, container_name, pod_name, node, %s)
 	)`
 	queryCPURequestsStr = `avg(
 		label_replace(
@@ -170,11 +182,15 @@ const (
 	) by (namespace,container_name,pod_name,node,%s)`
 	queryCPUUsageStr = `avg(
 		label_replace(
-		rate(
-			container_cpu_usage_seconds_total{container_name!="",container_name!="POD",instance!=""}[%s] %s
-		) , "node", "$1", "instance", "(.+)"
+			label_replace(
+				label_replace(
+					rate(
+						container_cpu_usage_seconds_total{container!="", container!="POD", instance!=""}[%s] %s
+					), "node", "$1", "instance", "(.+)"
+				), "container_name", "$1", "container", "(.+)"
+			), "pod_name", "$1", "pod", "(.+)"
 		)
-	) by (namespace,container_name,pod_name,node,%s)`
+	) by (namespace, container_name, pod_name, node, %s)`
 	queryGPURequestsStr = `avg(
 		label_replace(
 			label_replace(


### PR DESCRIPTION
Resubmission of PR: https://github.com/opencost/opencost/pull/1715

## What does this PR change?

- Previously, OpenCost’s `container_cpu_allocation` and `container_memory_allocation` were only reporting on requests, and not usage. This was due to OpenCost querying cAdvisor container usage metrics, and getting empty responses.
- This PR fixes those queries by now filtering for `container` instead of `container_name`
- This change also required additional metric relabeling in the query for compatibility reasons. (`container` -> `container_name`, `pod` -> `pod_name`)

Todo (probably for a future PR):

- [ ] Audit other cAdvisor metrics used by OpenCost to see which are also affected

## Does this PR relate to any other PRs?

- No

## How will this PR impact users?

- **Backwards Compatibility:** We are now filtering on the `container` metric label, instead of `container_name`. Kubernetes clusters before v1.14 will be impacted, because the kubelet cAdvisor would still be emitting `container_name`. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md?plain=1#L985

## Does this PR address any GitHub or Zendesk issues?

- Closes https://github.com/opencost/opencost/issues/1702

## How was this PR tested?

- Ran OpenCost locally and now see that OpenCost’s metrics (http://localhost:9003/metrics) for `container_cpu_allocation` and `container_memory_allocation` correctly return non-zero values for containers which do not have requests set.

## Does this PR require changes to documentation?

- No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?

- 