### PR TITLE
Make "/var/configs" a const and create new env helper called GetCostAnalyzerVolumeMountPath

### DIFF
--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -181,7 +181,7 @@ func Execute(opts *AgentOpts) error {
 
 	clusterCache.SetConfigMapUpdateFunc(watchConfigFunc)
 
-	configPrefix := env.GetConfigPathWithDefault("/var/configs/")
+	configPrefix := env.GetConfigPathWithDefault(env.DefaultConfigMountPath)
 
 	// Initialize cluster exporting if it's enabled
 	if env.IsExportClusterCacheEnabled() {

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1363,7 +1363,7 @@ func (a *Accesses) AddServiceKey(w http.ResponseWriter, r *http.Request, ps http
 
 	key := r.PostForm.Get("key")
 	k := []byte(key)
-	err := os.WriteFile(path.Join(env.GetConfigPathWithDefault("/var/configs/"), "key.json"), k, 0644)
+	err := os.WriteFile(path.Join(env.GetConfigPathWithDefault(env.DefaultConfigMountPath), "key.json"), k, 0644)
 	if err != nil {
 		fmt.Fprintf(w, "Error writing service key: "+err.Error())
 	}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -99,6 +99,8 @@ const (
 	regionOverrideList = "REGION_OVERRIDE_LIST"
 )
 
+const DefaultConfigMountPath = "/var/configs"
+
 var offsetRegex = regexp.MustCompile(`^(\+|-)(\d\d):(\d\d)$`)
 
 func IsETLReadOnlyMode() bool {
@@ -314,10 +316,10 @@ func GetCSVPath() string {
 	return Get(CSVPathEnvVar, "")
 }
 
-// GetConfigPath returns the environment variable value for ConfigPathEnvVar which represents the cost
-// model configuration path
-func GetConfigPath() string {
-	return Get(ConfigPathEnvVar, "")
+// GetCostAnalyzerVolumeMountPath is an alias of GetConfigPath, which returns the mount path for the
+// Cost Analyzer volume, which stores configs, persistent data, etc.
+func GetCostAnalyzerVolumeMountPath() string {
+	return GetConfigPathWithDefault(DefaultConfigMountPath)
 }
 
 // GetConfigPath returns the environment variable value for ConfigPathEnvVar which represents the cost

--- a/pkg/metrics/metricsconfig.go
+++ b/pkg/metrics/metricsconfig.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	metricsConfigLock = new(sync.Mutex)
-	metricsFilePath   = path.Join(env.GetConfigPathWithDefault("/var/configs/"), "metrics.json")
+	metricsFilePath   = path.Join(env.GetCostAnalyzerVolumeMountPath(), "metrics.json")
 )
 
 type MetricsConfig struct {

--- a/pkg/services/clusterservice.go
+++ b/pkg/services/clusterservice.go
@@ -15,7 +15,7 @@ func NewClusterManagerService() HTTPService {
 
 // newClusterManager creates a new cluster manager instance for use in the service
 func newClusterManager() *clusters.ClusterManager {
-	clustersConfigFile := path.Join(env.GetConfigPathWithDefault("/var/configs/"), "clusters/default-clusters.yaml")
+	clustersConfigFile := path.Join(env.GetCostAnalyzerVolumeMountPath(), "clusters/default-clusters.yaml")
 
 	// Return a memory-backed cluster manager populated by configmap
 	return clusters.NewConfiguredClusterManager(clusters.NewMapDBClusterStorage(), clustersConfigFile)


### PR DESCRIPTION
## What does this PR change?
* Makes `"/var/configs"` a const that is exported by the `env` package to unify implementations and prevent typos
* Adds a more clear helper function for those seeking to get the mount path for the cost analyzer volume: `GetCostAnalyzerVolumeMountPath`

## Does this PR relate to any other PRs?
* Required for https://github.com/kubecost/kubecost-cost-model/pull/1303

## How was this PR tested?
* Builds work
* Unit tests pass
* Manually, everything looks right in cluster logs

## Does this PR require changes to documentation?
* No
