### PR TITLE
Fix panic calling IsEmpty() on a nil CoverageSet

### DIFF
--- a/pkg/kubecost/coverage.go
+++ b/pkg/kubecost/coverage.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/opencost/opencost/pkg/filter"
+	"github.com/opencost/opencost/pkg/log"
 )
 
 // Coverage This is a placeholder struct which can be replaced by a more specific implementation later
@@ -67,6 +68,10 @@ func (cs *CoverageSet) GetWindow() Window {
 }
 
 func (cs *CoverageSet) IsEmpty() bool {
+	if cs == nil {
+		log.Warnf("calling IsEmpty() on a nil CoverageSet")
+		return true
+	}
 	for _, item := range cs.Items {
 		if !item.IsEmpty() {
 			return false


### PR DESCRIPTION
## What does this PR change?
* Fix panic calling IsEmpty() on a nil CoverageSet

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Fix panic calling IsEmpty() on a nil CoverageSet

## Does this PR address any GitHub or Zendesk issues?
* Addresses https://kubecost.atlassian.net/browse/CORE-124

## How was this PR tested?
* Fixes panics on nightly integration test instance
