### PR TITLE
Remove AppVersion for Version

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1482,7 +1482,7 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 
 	var err error
 	if errorReportingEnabled {
-		err = sentry.Init(sentry.ClientOptions{Release: env.GetAppVersion()})
+		err = sentry.Init(sentry.ClientOptions{Release: version.FriendlyVersion()})
 		if err != nil {
 			log.Infof("Failed to initialize sentry for error reporting")
 		} else {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -10,8 +10,6 @@ import (
 )
 
 const (
-	AppVersionEnvVar = "APP_VERSION"
-
 	AWSAccessKeyIDEnvVar     = "AWS_ACCESS_KEY_ID"
 	AWSAccessKeySecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	AWSClusterIDEnvVar       = "AWS_CLUSTER_ID"
@@ -169,12 +167,6 @@ func GetPricingConfigmapName() string {
 
 func GetMetricsConfigmapName() string {
 	return Get(MetricsConfigmapName, "metrics-config")
-}
-
-// GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents
-// the AWS access key for authentication
-func GetAppVersion() string {
-	return Get(AppVersionEnvVar, "1.91.0-rc.0")
 }
 
 // IsEmitNamespaceAnnotationsMetric returns true if cost-model is configured to emit the kube_namespace_annotations metric


### PR DESCRIPTION
## What does this PR change?
* Removes the APP_VERSION env var usage, replaces with `version.Version` for up to date error reporting.