### PR TITLE
Fix CPU max query by using already-existing irate recording rule

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -22,7 +22,7 @@ const (
 	queryFmtCPUCoresAllocated        = `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", node!=""}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtCPURequests              = `avg(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!="", container!="POD", node!=""}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtCPUUsageAvg              = `avg(rate(container_cpu_usage_seconds_total{container!="", container_name!="POD", container!="POD"}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
-	queryFmtCPUUsageMax              = `max(rate(container_cpu_usage_seconds_total{container!="", container_name!="POD", container!="POD"}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
+	queryFmtCPUUsageMax              = `max(max_over_time(kubecost_container_cpu_usage_irate{}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
 	queryFmtGPUsRequested            = `avg(avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!=""}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtGPUsAllocated            = `avg(avg_over_time(container_gpu_allocation{container!="", container!="POD", node!=""}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtNodeCostPerCPUHr         = `avg(avg_over_time(node_cpu_hourly_cost[%s])) by (node, %s, instance_type, provider_id)`

--- a/pkg/prom/diagnostics.go
+++ b/pkg/prom/diagnostics.go
@@ -36,6 +36,10 @@ const (
 	// CPUThrottlingDiagnosticMetricID is the identifier for the metric used to determine if CPU throttling is being applied to the
 	// cost-model container.
 	CPUThrottlingDiagnosticMetricID = "cpuThrottling"
+
+	// KubecostRecordingRuleCPUUsageID is the identifier for the query used to
+	// determine of the CPU usage recording rule is set up correctly.
+	KubecostRecordingRuleCPUUsageID = "kubecostRecordingRuleCPUUsage"
 )
 
 const DocumentationBaseURL = "https://github.com/kubecost/docs/blob/master/diagnostics.md"
@@ -95,6 +99,13 @@ var diagnosticDefinitions map[string]*diagnosticDefinition = map[string]*diagnos
 	/ avg(increase(container_cpu_cfs_periods_total{container="cost-model"}[10m] %s)) by (container_name, pod_name, namespace) > 0.2`,
 		Label:       "Kubecost is not CPU throttled",
 		Description: "Kubecost loading slowly? A kubecost component might be CPU throttled",
+	},
+	KubecostRecordingRuleCPUUsageID: {
+		ID:          KubecostRecordingRuleCPUUsageID,
+		QueryFmt:    `absent_over_time(kubecost_container_cpu_usage_irate[5m] %s)`,
+		Label:       "Kubecost's CPU usage recording rule is set up",
+		Description: "If the 'kubecost_container_cpu_usage_irate' recording rule is not set up, Allocation pipeline build may put pressure on your Prometheus due to the use of a subquery.",
+		DocLink:     "https://docs.kubecost.com/install-and-configure/install/custom-prom",
 	},
 }
 


### PR DESCRIPTION
## What does this PR change?
The query before this commit is broken; it looks like a max but is actually an average (or very close to) due to the usage of "rate" before maxing. The rate reduces the resolution to the first and last datapoint.

The recording rule handles this for us. At the time of this commit, the recording rule is set in the Helm values:

```
- expr: avg(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!=""}[5m])) by (container_name,pod_name,namespace)
  record: kubecost_container_cpu_usage_irate
```

https://github.com/kubecost/cost-analyzer-helm-chart/blob/b04da589a5a8b469fe13f8b25cd21023601ecca9/cost-analyzer/values.yaml#L609-L610

Design doc discussing this problem in more depth and proposing alternative solutions: https://docs.google.com/document/d/1j36iYFWXsG7CsU3H-jODBKL76RkRA5g4Rnu7BRogmSs/edit

## Does this PR address any GitHub or Zendesk issues?
https://kubecost.atlassian.net/browse/CORE-126

## How was this PR tested?
Create a Pod like described in Jesse's original bug report:
```
read -r -d '' WL << EOM
apiVersion: v1
kind: Pod
metadata:
  name: stress-ng2
  labels:
    app: stress-ng2
spec:
  containers:
  - image: litmuschaos/stress-ng
    args:
      - -c 1
    imagePullPolicy: IfNotPresent
    name: stress-ng2
    resources:
      requests:
        cpu: 50m
        memory: 40Mi
      limits:
        cpu: 50m
        memory: 40Mi
EOM

echo "${WL}" | kubectl apply -f -
date
```

```
: pod/stress-ng2 created
: Tue Mar 28 01:24:57 PM PDT 2023
```

Wait 10 min

Query APIs, check maxes in request sizing and allocation

```
date
curl -G 'localhost:9090/model/savings/requestSizingV2' \
    -L -s \
    --data-urlencode 'filter=namespace:"default"+container:"stress-ng2"' \
    -d 'window=today' \
    -d 'targetCPUUtilization=1' \
    -d 'targetRAMUtilization=1' \
    | jq '.Recommendations[]' \
    | jq 'del(.monthlySavings, .currentEfficiency)'

Tue Mar 28 02:41:16 PM PDT 2023
{
  "clusterID": "cluster-one",
  "namespace": "default",
  "controllerKind": "pod",
  "controllerName": "stress-ng2",
  "containerName": "stress-ng2",
  "recommendedRequest": {
    "cpu": "51m",
    "memory": "20Mi"
  },
  "latestKnownRequest": {
    "cpu": "50m",
    "memory": "40Mi"
  }
}
```

```
date
curl -G 'localhost:9090/model/allocation' \
    -L -s \
    --data-urlencode 'filter=namespace:"default"+container:"stress-ng2"' \
    -d 'window=today' \
    -d 'accumulate=false' \
    -d 'step=1h' \
    -d 'idle=false' \
    | jq '.data[] | select(. != null) | to_entries[].value' \
    | jq 'del(.properties.labels, .properties.annotations, .properties.providerID, .properties.node)' \
    | jq 'with_entries(select([.key] | inside(["properties", "window", "start", "end", "cpuCoreUsageAverage", "ramByteUsageAverage", "rawAllocationOnly"])))'

Tue Mar 28 02:41:22 PM PDT 2023
{
  "properties": {
    "cluster": "cluster-one",
    "container": "stress-ng2",
    "namespace": "default",
    "pod": "stress-ng2"
  },
  "window": {
    "start": "2023-03-28T20:00:00Z",
    "end": "2023-03-28T21:00:00Z"
  },
  "start": "2023-03-28T20:25:00Z",
  "end": "2023-03-28T21:00:00Z",
  "cpuCoreUsageAverage": 0.02918,
  "ramByteUsageAverage": 8896512,
  "rawAllocationOnly": {
    "cpuCoreUsageMax": 0.05006192877884747,
    "ramByteUsageMax": 8896512
  }
}
{
  "properties": {
    "cluster": "cluster-one",
    "container": "stress-ng2",
    "namespace": "default",
    "pod": "stress-ng2"
  },
  "window": {
    "start": "2023-03-28T21:00:00Z",
    "end": "2023-03-28T22:00:00Z"
  },
  "start": "2023-03-28T21:00:00Z",
  "end": "2023-03-28T21:35:00Z",
  "cpuCoreUsageAverage": 0.02906,
  "ramByteUsageAverage": 8896512,
  "rawAllocationOnly": {
    "cpuCoreUsageMax": 0.05011191291833002,
    "ramByteUsageMax": 8896512
  }
}
```

Prior to this change, the first hourly Allocation block would have a <0.05 max.

## Does this PR require changes to documentation?
* https://app.gitbook.com/o/MQuX6uFwV0j7vIHtR15E/s/cjJbIkEBCZifkHo05tVh/~/changes/159/install-and-configure/install/custom-prom/~/comments/JyuJPE3SHR6Cfg59OiJI
