### PR TITLE
[OPENCOST-1753] Derive Default Cluster Name from CLUSTER_ID var

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1355,9 +1355,10 @@ func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 		if awsClusterID != "" {
 			log.Infof("Returning \"%s\" as ClusterName", awsClusterID)
 			clusterName = awsClusterID
+			log.Warnf("Warning - %s will be deprecated in a future release. Use %f instead", env.AWSClusterIDEnvVar, env.ClusterIDEnvVar)
 		} else {
-			log.Infof("Unable to sniff out cluster ID, perhaps set $%s to force one", env.AWSClusterIDEnvVar)
-			clusterName = "AWS Cluster #1"
+			clusterName = env.GetClusterID()
+			log.Infof("Setting cluster name to %s from %s ", clusterName, env.ClusterIDEnvVar)
 		}
 	}
 

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1356,7 +1356,7 @@ func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 		if awsClusterID != "" {
 			log.Infof("Returning \"%s\" as ClusterName", awsClusterID)
 			clusterName = awsClusterID
-			log.Warnf("Warning - %s will be deprecated in a future release. Use %f instead", env.AWSClusterIDEnvVar, env.ClusterIDEnvVar)
+			log.Warnf("Warning - %s will be deprecated in a future release. Use %s instead", env.AWSClusterIDEnvVar, env.ClusterIDEnvVar)
 		} else if clusterName = env.GetClusterID(); clusterName != "" {
 			log.Infof("Setting cluster name to %s from %s ", clusterName, env.ClusterIDEnvVar)
 		} else {

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1348,6 +1348,7 @@ func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 		return nil, err
 	}
 
+	const defaultClusterName = "AWS Cluster #1"
 	// Determine cluster name
 	clusterName := c.ClusterName
 	if clusterName == "" {
@@ -1356,10 +1357,14 @@ func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 			log.Infof("Returning \"%s\" as ClusterName", awsClusterID)
 			clusterName = awsClusterID
 			log.Warnf("Warning - %s will be deprecated in a future release. Use %f instead", env.AWSClusterIDEnvVar, env.ClusterIDEnvVar)
-		} else {
-			clusterName = env.GetClusterID()
+		} else if clusterName = env.GetClusterID(); clusterName != "" {
 			log.Infof("Setting cluster name to %s from %s ", clusterName, env.ClusterIDEnvVar)
+		} else {
+			clusterName = defaultClusterName
+			log.Warnf("Unable to detect cluster name - using default of %s", defaultClusterName)
+			log.Warnf("Please set cluster name through configmap or via %s env var", env.ClusterIDEnvVar)
 		}
+
 	}
 
 	// this value requires configuration but is unavailable else where


### PR DESCRIPTION
## What does this PR change?
* Utilizes the CLUSTER_ID env var to set an AWS cluster name if the AWS_CLUSTER_ID var is not set.

## Does this PR relate to any other PRs?
* None 

## How will this PR impact users?
* Users will now be able to use the CLUSTER_ID var to end their cluster name. This opens the door for the eventual deprecation of the AWS_CLUSTER_ID variable 

## Does this PR address any GitHub or Zendesk issues?
* Closes #1753 

## How was this PR tested?
* A local build was run, and cluster name was checked when the pricing-config configmap did not have any cluster name set. 

## Does this PR require changes to documentation?
* AWS_CLUSTER_ID was not documented, so it is not likely

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* Release 102
