### PR TITLE
add namespace to kubernetes resources (updated)

### DIFF
--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -13,6 +13,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: opencost
+  namespace: opencost
 ---
 
 # Cluster role giving OpenCost to get, list, watch required resources
@@ -21,6 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: opencost
+  namespace: opencost
 rules:
   - apiGroups:
       - ''
@@ -102,6 +104,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: opencost
+  namespace: opencost
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -120,6 +123,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: opencost
+  namespace: opencost
   labels:
     app: opencost
 spec:
@@ -178,6 +182,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: opencost
+  namespace: opencost
 spec:
   selector:
     app: opencost

--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -22,7 +22,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: opencost
-  namespace: opencost
 rules:
   - apiGroups:
       - ''
@@ -104,7 +103,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: opencost
-  namespace: opencost
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This is https://github.com/opencost/opencost/pull/1511 rebased on the latest code with the ClusterRole and ClusterRoleBinding namespace removed