### PR TITLE
Revert "Add both amd64 and arm64 support for docker image"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,5 +29,4 @@ jobs:
         with:
           context: ${{ matrix.location }}/
           file: ${{ matrix.location }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
           push: false


### PR DESCRIPTION
Reverts opencost/opencost#1799 due to huge increases in CI time (10 minutes -> 1 hour). Ref: https://github.com/opencost/opencost/issues/1820