### PR TITLE
Added critical Prometheus diagnostic metrics.

### DIFF
--- a/pkg/prom/diagnostics.go
+++ b/pkg/prom/diagnostics.go
@@ -40,6 +40,18 @@ const (
 	// KubecostRecordingRuleCPUUsageID is the identifier for the query used to
 	// determine of the CPU usage recording rule is set up correctly.
 	KubecostRecordingRuleCPUUsageID = "kubecostRecordingRuleCPUUsage"
+
+	// CAdvisorWorkingSetBytesMetricID is the identifier for the query used to determine
+	// if cAdvisor working set bytes data is being scraped
+	CAdvisorWorkingSetBytesMetricID = "cadvisorWorkingSetBytesMetric"
+
+	// KSMCPUCapacityMetricID is the identifier for the query used to determine if
+	// KSM CPU capacity data is being scraped
+	KSMCPUCapacityMetricID = "ksmCpuCapacityMetric"
+
+	// KSMAllocatableCPUCoresMetricID is the identifier for the query used to determine
+	// if KSM allocatable CPU core data is being scraped
+	KSMAllocatableCPUCoresMetricID = "ksmAllocatableCpuCoresMetric"
 )
 
 const DocumentationBaseURL = "https://github.com/kubecost/docs/blob/master/diagnostics.md"
@@ -106,6 +118,24 @@ var diagnosticDefinitions map[string]*diagnosticDefinition = map[string]*diagnos
 		Label:       "Kubecost's CPU usage recording rule is set up",
 		Description: "If the 'kubecost_container_cpu_usage_irate' recording rule is not set up, Allocation pipeline build may put pressure on your Prometheus due to the use of a subquery.",
 		DocLink:     "https://docs.kubecost.com/install-and-configure/install/custom-prom",
+	},
+	CAdvisorWorkingSetBytesMetricID: {
+		ID:          CAdvisorWorkingSetBytesMetricID,
+		QueryFmt:    `absent_over_time(container_memory_working_set_bytes{container="cost-model", container!="POD", instance!=""}[5m] %s)`,
+		Label:       "cAdvsior working set bytes metrics available",
+		Description: "Determine if cAdvisor working set bytes metrics are available during last 5 minutes.",
+	},
+	KSMCPUCapacityMetricID: {
+		ID:          KSMCPUCapacityMetricID,
+		QueryFmt:    `avg_over_time(kube_node_status_capacity_cpu_cores[5m] %s) == 0`,
+		Label:       "KSM had CPU capacity during the last 5 minutes",
+		Description: "Determine if KSM had CPU capacity during the last 5 minutes",
+	},
+	KSMAllocatableCPUCoresMetricID: {
+		ID:          KSMAllocatableCPUCoresMetricID,
+		QueryFmt:    `avg_over_time(kube_node_status_allocatable_cpu_cores[5m] %s) == 0`,
+		Label:       "KSM had allocatable CPU cores during the last 5 minutes",
+		Description: "Determine if KSM had allocatable CPU cores during the last 5 minutes",
 	},
 }
 

--- a/pkg/prom/diagnostics.go
+++ b/pkg/prom/diagnostics.go
@@ -127,13 +127,13 @@ var diagnosticDefinitions map[string]*diagnosticDefinition = map[string]*diagnos
 	},
 	KSMCPUCapacityMetricID: {
 		ID:          KSMCPUCapacityMetricID,
-		QueryFmt:    `avg_over_time(kube_node_status_capacity_cpu_cores[5m] %s) == 0`,
+		QueryFmt:    `absent_over_time(kube_node_status_capacity_cpu_cores[5m] %s)`,
 		Label:       "KSM had CPU capacity during the last 5 minutes",
 		Description: "Determine if KSM had CPU capacity during the last 5 minutes",
 	},
 	KSMAllocatableCPUCoresMetricID: {
 		ID:          KSMAllocatableCPUCoresMetricID,
-		QueryFmt:    `avg_over_time(kube_node_status_allocatable_cpu_cores[5m] %s) == 0`,
+		QueryFmt:    `absent_over_time(kube_node_status_allocatable_cpu_cores[5m] %s)`,
 		Label:       "KSM had allocatable CPU cores during the last 5 minutes",
 		Description: "Determine if KSM had allocatable CPU cores during the last 5 minutes",
 	},


### PR DESCRIPTION
## What does this PR change?
* Exposes a few cAdvisor and KSM metrics for the /diagnostics page

## Does this PR relate to any other PRs?
* Nope

## How will this PR impact users?
* Will give more visibility into configuration issues

## Does this PR address any GitHub or Zendesk issues?
* [cost-analyzer-helm-chart #2066](https://github.com/kubecost/cost-analyzer-helm-chart/issues/2066)

## How was this PR tested?
* Tested locally, confirmed metrics appeared on /diagnostics page

## Does this PR require changes to documentation?
* May require additional documentation [here](https://github.com/kubecost/docs/blob/master/diagnostics.md)

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 

<img width="1218" alt="metrics" src="https://user-images.githubusercontent.com/127428785/230138000-4271fff6-7dbd-4f38-b6b5-6b4b9d7b94ec.png">
