### PR TITLE
Core 140 attempt iii

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2250,7 +2250,10 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// IncludeProportionalAssetResourceCosts, if true,
 	includeProportionalAssetResourceCosts := qp.GetBool("includeProportionalAssetResourceCosts", false)
 
-	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts)
+	// include aggregated labels/annotations if true
+	includeAggregatedMetadata := qp.GetBool("includeAggregatedMetadata", true)
+
+	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "bad request") {
 			WriteError(w, BadRequest(err.Error()))

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2295,7 +2295,7 @@ func measureTimeAsync(start time.Time, threshold time.Duration, name string, ch 
 	}
 }
 
-func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts bool) (*kubecost.AllocationSetRange, error) {
+func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeNamespaceLabels bool) (*kubecost.AllocationSetRange, error) {
 	// Validate window is legal
 	if window.IsOpen() || window.IsNegative() {
 		return nil, fmt.Errorf("illegal window: %s", window)
@@ -2347,6 +2347,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 	opts := &kubecost.AllocationAggregationOptions{
 		IncludeProportionalAssetResourceCosts: includeProportionalAssetResourceCosts,
 		IdleByNode:                            idleByNode,
+		IncludeNamespaceLabels:                includeNamespaceLabels,
 	}
 
 	// Aggregate

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2295,7 +2295,7 @@ func measureTimeAsync(start time.Time, threshold time.Duration, name string, ch 
 	}
 }
 
-func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeNamespaceLabels bool) (*kubecost.AllocationSetRange, error) {
+func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata bool) (*kubecost.AllocationSetRange, error) {
 	// Validate window is legal
 	if window.IsOpen() || window.IsNegative() {
 		return nil, fmt.Errorf("illegal window: %s", window)
@@ -2347,7 +2347,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 	opts := &kubecost.AllocationAggregationOptions{
 		IncludeProportionalAssetResourceCosts: includeProportionalAssetResourceCosts,
 		IdleByNode:                            idleByNode,
-		IncludeNamespaceLabels:                includeNamespaceLabels,
+		IncludeAggregatedMetadata:             includeAggregatedMetadata,
 	}
 
 	// Aggregate

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -921,6 +921,7 @@ type AllocationAggregationOptions struct {
 	ShareSplit                            string
 	SharedHourlyCosts                     map[string]float64
 	SplitIdle                             bool
+	IncludeNamespaceLabels                bool
 }
 
 // AggregateBy aggregates the Allocations in the given AllocationSet by the given

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1043,11 +1043,9 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 	// to aggregate.
 	for _, alloc := range as.Allocations {
 		// if the user does not want any aggregated labels/annotations returned
-		// set the
-		if !options.IncludeAggregatedMetadata {
-			alloc.Properties.Annotations = nil
-			alloc.Properties.Labels = nil
-		}
+		// set the properties accordingly
+		alloc.Properties.AggregatedMetadata = options.IncludeAggregatedMetadata
+
 		// External allocations get aggregated post-hoc (see step 6) and do
 		// not necessarily contain complete sets of properties, so they are
 		// moved to a separate AllocationSet.

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -921,7 +921,7 @@ type AllocationAggregationOptions struct {
 	ShareSplit                            string
 	SharedHourlyCosts                     map[string]float64
 	SplitIdle                             bool
-	IncludeNamespaceLabels                bool
+	IncludeAggregatedMetadata             bool
 }
 
 // AggregateBy aggregates the Allocations in the given AllocationSet by the given
@@ -1042,6 +1042,12 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 	// them to their respective sets, removing them from the set of allocations
 	// to aggregate.
 	for _, alloc := range as.Allocations {
+		// if the user does not want any aggregated labels/annotations returned
+		// set the
+		if !options.IncludeAggregatedMetadata {
+			alloc.Properties.Annotations = nil
+			alloc.Properties.Labels = nil
+		}
 		// External allocations get aggregated post-hoc (see step 6) and do
 		// not necessarily contain complete sets of properties, so they are
 		// moved to a separate AllocationSet.

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -456,10 +456,10 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 			// This logic is designed to effectively ignore the unmounted/unallocated objects
 			// and just copy over the labels from the other object - we only take the intersection
 			// of 'legitimate' allocations.
-			if p.Container == UnmountedSuffix || p.Container == UnallocatedSuffix {
+			if p.Container == UnmountedSuffix {
 				intersectionProps.Annotations = that.Annotations
 				intersectionProps.Labels = that.Labels
-			} else if that.Container == UnmountedSuffix || that.Container == UnallocatedSuffix {
+			} else if that.Container == UnmountedSuffix {
 				intersectionProps.Annotations = p.Annotations
 				intersectionProps.Labels = p.Labels
 			} else {

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -440,6 +440,9 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 	}
 	if p.Namespace == that.Namespace {
 		intersectionProps.Namespace = p.Namespace
+
+		intersectionProps.Annotations = mapIntersection(p.Annotations, that.Annotations)
+		intersectionProps.Labels = mapIntersection(p.Labels, that.Labels)
 	}
 	if p.Pod == that.Pod {
 		intersectionProps.Pod = p.Pod
@@ -448,6 +451,20 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 		intersectionProps.ProviderID = p.ProviderID
 	}
 	return intersectionProps
+}
+
+func mapIntersection(map1, map2 map[string]string) map[string]string {
+	result := make(map[string]string)
+	for key, value := range map1 {
+		if value2, ok := map2[key]; ok {
+			if value2 == value {
+				result[key] = value
+			}
+		}
+
+	}
+
+	return result
 }
 
 func (p *AllocationProperties) String() string {

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -439,10 +439,20 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 		intersectionProps.ControllerKind = p.ControllerKind
 	}
 	if p.Namespace == that.Namespace {
-		intersectionProps.Namespace = p.Namespace
 
-		intersectionProps.Annotations = mapIntersection(p.Annotations, that.Annotations)
-		intersectionProps.Labels = mapIntersection(p.Labels, that.Labels)
+		// ignore the incoming labels from unallocated or unmounted special case pods
+		intersectionProps.Namespace = p.Namespace
+		if p.Container == UnmountedSuffix || p.Container == UnallocatedSuffix {
+			intersectionProps.Annotations = that.Annotations
+			intersectionProps.Labels = that.Labels
+		} else if that.Container == UnmountedSuffix || that.Container == UnallocatedSuffix {
+			intersectionProps.Annotations = p.Annotations
+			intersectionProps.Labels = p.Labels
+		} else {
+			intersectionProps.Annotations = mapIntersection(p.Annotations, that.Annotations)
+			intersectionProps.Labels = mapIntersection(p.Labels, that.Labels)
+		}
+
 	}
 	if p.Pod == that.Pod {
 		intersectionProps.Pod = p.Pod

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -76,7 +76,7 @@ func TestAllocationPropsIntersection(t *testing.T) {
 		"intersection, with labels/annotations, special case container": {
 			allocationProps1: &AllocationProperties{
 				AggregatedMetadata: false,
-				Container:          UnallocatedSuffix,
+				Container:          UnmountedSuffix,
 				Namespace:          "ns1",
 				Labels:             map[string]string{},
 				Annotations:        map[string]string{},

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -5,6 +5,110 @@ import (
 	"testing"
 )
 
+func TestAllocationPropsIntersection(t *testing.T) {
+	cases := map[string]struct {
+		allocationProps1 *AllocationProperties
+		allocationProps2 *AllocationProperties
+		expected         *AllocationProperties
+	}{
+		"intersection two allocation properties with empty labels/annotations": {
+			allocationProps1: &AllocationProperties{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			allocationProps2: &AllocationProperties{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			expected: &AllocationProperties{
+				Labels:      nil,
+				Annotations: nil,
+			},
+		},
+		"nil intersection": {
+			allocationProps1: nil,
+			allocationProps2: nil,
+			expected:         nil,
+		},
+		"intersection, with labels/annotations, no aggregated metdata": {
+			allocationProps1: &AllocationProperties{
+				AggregatedMetadata: false,
+				Node:               "node1",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+			allocationProps2: &AllocationProperties{
+				AggregatedMetadata: false,
+				Node:               "node1",
+				Labels:             map[string]string{"key3": "val3"},
+				Annotations:        map[string]string{"key4": "val4"},
+			},
+			expected: &AllocationProperties{
+				AggregatedMetadata: false,
+				Node:               "node1",
+				Labels:             nil,
+				Annotations:        nil,
+			},
+		},
+		"intersection, with labels/annotations, with aggregated metdata": {
+			allocationProps1: &AllocationProperties{
+				AggregatedMetadata: false,
+				ControllerKind:     "controller1",
+				Namespace:          "ns1",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+			allocationProps2: &AllocationProperties{
+				AggregatedMetadata: true,
+				ControllerKind:     "controller2",
+				Namespace:          "ns1",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+			expected: &AllocationProperties{
+				AggregatedMetadata: true,
+				Namespace:          "ns1",
+				ControllerKind:     "",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+		},
+		"intersection, with labels/annotations, special case container": {
+			allocationProps1: &AllocationProperties{
+				AggregatedMetadata: false,
+				Container:          UnallocatedSuffix,
+				Namespace:          "ns1",
+				Labels:             map[string]string{},
+				Annotations:        map[string]string{},
+			},
+			allocationProps2: &AllocationProperties{
+				AggregatedMetadata: true,
+				Container:          "container3",
+				Namespace:          "ns1",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+			expected: &AllocationProperties{
+				AggregatedMetadata: true,
+				Namespace:          "ns1",
+				ControllerKind:     "",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			actual := tc.allocationProps1.Intersection(tc.allocationProps2)
+
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Fatalf("test case %s: expected %+v; got %+v", name, tc.expected, actual)
+			}
+		})
+	}
+}
 func TestGenerateKey(t *testing.T) {
 
 	customOwnerLabelConfig := NewLabelConfig()


### PR DESCRIPTION
## What does this PR change?
* Updates label logic to be governed by a query param, and returns aggregated annotations/labels 

## Does this PR relate to any other PRs?
* a non-rebased iteration of https://github.com/opencost/opencost/pull/1829

## How will this PR impact users?
* This adds a new query param, includeAggregatedMeta, that governs the behavior

## Does this PR address any GitHub or Zendesk issues?
* Closes CORE-140, closes #1223 

## How was this PR tested?
* tested locally, confirmed expected labels and annotations were returned 

## Does this PR require changes to documentation?
* yes, an additional query param 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
