### PR TITLE
Add CPU/RAM idle to exported metrics.

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -128,6 +128,8 @@ var (
 	cpuAllocGv                 *prometheus.GaugeVec
 	gpuAllocGv                 *prometheus.GaugeVec
 	pvAllocGv                  *prometheus.GaugeVec
+	ramIdleGv                  *prometheus.GaugeVec
+	cpuIdleGv                  *prometheus.GaugeVec
 	networkZoneEgressCostG     prometheus.Gauge
 	networkRegionEgressCostG   prometheus.Gauge
 	networkInternetEgressCostG prometheus.Gauge
@@ -232,6 +234,22 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider model
 			toRegisterGV = append(toRegisterGV, pvAllocGv)
 		}
 
+		ramIdleGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "container_ram_idle",
+			Help: "container_ram_idle Ratio of idle RAM of containers",
+		}, []string{"namespace", "pod", "container", "instance", "node"})
+		if _, disabled := disabledMetrics["container_ram_idle"]; !disabled {
+			toRegisterGV = append(toRegisterGV, ramIdleGv)
+		}
+
+		cpuIdleGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "container_cpu_idle",
+			Help: "container_cpu_idle Ratio of CPU of containers",
+		}, []string{"namespace", "pod", "container", "instance", "node"})
+		if _, disabled := disabledMetrics["container_cpu_idle"]; !disabled {
+			toRegisterGV = append(toRegisterGV, cpuIdleGv)
+		}
+
 		networkZoneEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "kubecost_network_zone_egress_cost",
 			Help: "kubecost_network_zone_egress_cost Total cost per GB egress across zones",
@@ -312,6 +330,8 @@ type CostModelMetricsEmitter struct {
 	RAMAllocationRecorder         *prometheus.GaugeVec
 	CPUAllocationRecorder         *prometheus.GaugeVec
 	GPUAllocationRecorder         *prometheus.GaugeVec
+	CPUIdleRecorder               *prometheus.GaugeVec
+	RAMIdleRecorder               *prometheus.GaugeVec
 	ClusterManagementCostRecorder *prometheus.GaugeVec
 	LBCostRecorder                *prometheus.GaugeVec
 	NetworkZoneEgressRecorder     prometheus.Gauge
@@ -364,6 +384,8 @@ func NewCostModelMetricsEmitter(promClient promclient.Client, clusterCache clust
 		CPUAllocationRecorder:         cpuAllocGv,
 		GPUAllocationRecorder:         gpuAllocGv,
 		PVAllocationRecorder:          pvAllocGv,
+		RAMIdleRecorder:               ramIdleGv,
+		CPUIdleRecorder:               cpuIdleGv,
 		NetworkZoneEgressRecorder:     networkZoneEgressCostG,
 		NetworkRegionEgressRecorder:   networkRegionEgressCostG,
 		NetworkInternetEgressRecorder: networkInternetEgressCostG,
@@ -607,10 +629,39 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				}
 
 				if len(costs.RAMAllocation) > 0 {
-					cmme.RAMAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(costs.RAMAllocation[0].Value)
+					allocation := costs.RAMAllocation[0].Value
+					cmme.RAMAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(allocation)
+
+					if allocation > 0 {
+						usage := 0.0
+						if len(costs.RAMUsed) > 0 {
+							usage = costs.RAMUsed[0].Value
+						}
+						idle := (allocation - usage) / allocation
+						if idle < 0 {
+							idle = 0
+						}
+
+						cmme.RAMIdleRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(idle)
+					}
 				}
+
 				if len(costs.CPUAllocation) > 0 {
-					cmme.CPUAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(costs.CPUAllocation[0].Value)
+					allocation := costs.CPUAllocation[0].Value
+					cmme.CPUAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(allocation)
+
+					if allocation > 0 {
+						usage := 0.0
+						if len(costs.CPUUsed) > 0 {
+							usage = costs.CPUUsed[0].Value
+						}
+						idle := (allocation - usage) / allocation
+						if idle < 0 {
+							idle = 0
+						}
+
+						cmme.CPUIdleRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(idle)
+					}
 				}
 				if len(costs.GPUReq) > 0 {
 					// allocation here is set to the request because shared GPU usage not yet supported.
@@ -730,7 +781,9 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				if !seen {
 					labels := getLabelStringsFromKey(labelString)
 					cmme.RAMAllocationRecorder.DeleteLabelValues(labels...)
+					cmme.RAMIdleRecorder.DeleteLabelValues(labels...)
 					cmme.CPUAllocationRecorder.DeleteLabelValues(labels...)
+					cmme.CPUIdleRecorder.DeleteLabelValues(labels...)
 					cmme.GPUAllocationRecorder.DeleteLabelValues(labels...)
 					delete(containerSeen, labelString)
 				} else {


### PR DESCRIPTION
## What does this PR change?
* Adds `container_cpu_idle` and `container_ram_idle` to the metrics emitter. They represent the idle % for a container ie. `(request - usage)/request`

I'm not 100% sure this is the correct metric to export but it seemed most convenient with the available data. The intention is to allow users to determine the historical efficiency of workloads at a glance. It seems reasonable to limit this to containers with explicit requests, if instead we used max(usage, request) similar to allocations those without a request would consistently have 0% idle as the it would be equal to the usage.

## How will this PR impact users?
* Users that scrape the metrics endpoint will be able to view historical idle values similar to allocations.

## How was this PR tested?
* Built locally using minikube and podman.

```
# HELP container_cpu_idle container_cpu_idle Ratio of CPU of containers
# TYPE container_cpu_idle gauge
container_cpu_idle{container="coredns",instance="minipod",namespace="kube-system",node="minipod",pod="coredns-787d4945fb-vznrv"} 0.09678320090805903
container_cpu_idle{container="etcd",instance="minipod",namespace="kube-system",node="minipod",pod="etcd-minipod"} 0.082127348502672
container_cpu_idle{container="kindnet-cni",instance="minipod",namespace="kube-system",node="minipod",pod="kindnet-n7gkh"} 0.09901240555918292
container_cpu_idle{container="kube-apiserver",instance="minipod",namespace="kube-system",node="minipod",pod="kube-apiserver-minipod"} 0.21464884710724458
container_cpu_idle{container="kube-controller-manager",instance="minipod",namespace="kube-system",node="minipod",pod="kube-controller-manager-minipod"} 0.18833326821991758
container_cpu_idle{container="kube-scheduler",instance="minipod",namespace="kube-system",node="minipod",pod="kube-scheduler-minipod"} 0.09697293807641634
container_cpu_idle{container="opencost",instance="minipod",namespace="opencost",node="minipod",pod="opencost-646b557747-66lff"} 0.008518372009752938
container_cpu_idle{container="opencost-ui",instance="minipod",namespace="opencost",node="minipod",pod="opencost-646b557747-66lff"} 0.01


....

# HELP container_ram_idle container_ram_idle Ratio of idle RAM of containers
# TYPE container_ram_idle gauge
container_ram_idle{container="coredns",instance="minipod",namespace="kube-system",node="minipod",pod="coredns-787d4945fb-vznrv"} 0.48306361607142856
container_ram_idle{container="etcd",instance="minipod",namespace="kube-system",node="minipod",pod="etcd-minipod"} 0.5233984375
container_ram_idle{container="kindnet-cni",instance="minipod",namespace="kube-system",node="minipod",pod="kindnet-n7gkh"} 0.5557421875
container_ram_idle{container="opencost",instance="minipod",namespace="opencost",node="minipod",pod="opencost-587c654bf-w2fqg"} 0.51872
container_ram_idle{container="opencost-ui",instance="minipod",namespace="opencost",node="minipod",pod="opencost-587c654bf-w2fqg"} 0.9263464727272728
```

## Does this PR require changes to documentation?
* Potentially as this metric could be excluded via `disabledMetrics`.
* It also assumes a container has a cpu or ram request to record an idle metric.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* Not sure the process for this, so didn't. :)
