### PR TITLE
[next release] recognize additional storage types and catch additional Azure naming …

### DIFF
--- a/pkg/cloud/azureprovider_test.go
+++ b/pkg/cloud/azureprovider_test.go
@@ -70,7 +70,7 @@ func TestConvertMeterToPricings(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := map[string]*AzurePricing{
-			"useast,premium_ssd": {
+			"useast,Premium_LRS": {
 				PV: &PV{Cost: "0.085616", Region: "useast"},
 			},
 		}


### PR DESCRIPTION

## What does this PR change?
* Catches an inconsistency in Azure pricing where node names may use a mix of "_" and " " as separators by replacing all " " in names with "_", not just the first instance.   Matches additional PV types including ZRS (multi-region) types.  Matches inconsistent PV attribute naming when the "skuName" attribute appears as "skuname"
 
## Does this PR relate to any other PRs?
* No
 
## How will this PR impact users?
* Enables cost tracking for additional aks objects that were previously overlooked because of naming/matching issues
 
## Does this PR address any GitHub or Zendesk issues?
* We didn't open a related issue
 
## How was this PR tested?
* Against an aks cluster containing NC8as T4 v3 nodes, StandardSSD ZRS PVs
* Ran test suite per instructions.
     PASS
     ok      github.com/opencost/opencost/test       0.443s
 
## Does this PR require changes to documentation?
* No
 
## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* Yes