### PR TITLE
[CORE-207] provide a function that returns the undiscounted cost of a node

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1835,6 +1835,10 @@ func (n *Node) TotalCost() float64 {
 	return ((n.CPUCost + n.RAMCost) * (1.0 - n.Discount)) + n.GPUCost + n.Adjustment
 }
 
+func (n *Node) UndiscountedCost() float64 {
+	return n.CPUCost + n.RAMCost + n.GPUCost + n.Adjustment
+}
+
 // Start returns the precise start time of the Asset within the window
 func (n *Node) GetStart() time.Time {
 	return n.Start


### PR DESCRIPTION


## What does this PR change?
* adds a function to return the undiscounted cost of a node 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* no impact. 

## Does this PR address any GitHub or Zendesk issues?
* Closes CORE-207

## How was this PR tested?
* tested these changes out against kc-integration test cluster. Confirmed monthly cost within ~2% of what the GCP cost calculator said it should be. 

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
