### PR TITLE
V1.103 nick unmounted allocation bugfix

### DIFF
--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2760,12 +2760,12 @@ func TestAllocationSet_Accumulate_Equals_AllocationSetRange_Accumulate(t *testin
 	}
 }
 
-func Test_AggregateBy(t *testing.T) {
+func Test_AggregateByService_UnmountedLBs(t *testing.T) {
 	end := time.Now().UTC().Truncate(day)
 	start := end.Add(-day)
 
 	normalProps := &AllocationProperties{
-		Cluster:        "kc-demo-stage",
+		Cluster:        "cluster-one",
 		Container:      "nginx-plus-nginx-ingress",
 		Controller:     "nginx-plus-nginx-ingress",
 		ControllerKind: "deployment",
@@ -2778,8 +2778,8 @@ func Test_AggregateBy(t *testing.T) {
 		},
 	}
 
-	weirdProps := &AllocationProperties{
-		Cluster:    "kc-demo-stage",
+	problematicProps := &AllocationProperties{
+		Cluster:    "cluster-one",
 		Container:  UnmountedSuffix,
 		Namespace:  UnmountedSuffix,
 		Pod:        UnmountedSuffix,
@@ -2792,19 +2792,21 @@ func Test_AggregateBy(t *testing.T) {
 		},
 	}
 
-	idle := NewMockUnitAllocation(fmt.Sprintf("kc-demo-stage/%s", IdleSuffix), start, day, &AllocationProperties{
-		Cluster: "kc-demo-stage",
+	idle := NewMockUnitAllocation(fmt.Sprintf("cluster-one/%s", IdleSuffix), start, day, &AllocationProperties{
+		Cluster: "cluster-one",
 	})
-	one := NewMockUnitAllocation("kc-demo-stage//__unmounted__/__unmounted__/__unmounted__", start, day, weirdProps)
-	two := NewMockUnitAllocation("kc-demo-stage//nginx-plus/nginx-plus-nginx-ingress-123a4b5678-ab12c/nginx-plus-nginx-ingress", start, day, normalProps)
-	three := NewMockUnitAllocation("kc-demo-stage//nginx-plus/nginx-plus-nginx-ingress-123a4b5678-ab12c/nginx-plus-nginx-ingress", start, day, normalProps)
-	four := NewMockUnitAllocation("kc-demo-stage//nginx-plus/nginx-plus-nginx-ingress-123a4b5678-ab12c/nginx-plus-nginx-ingress", start, day, normalProps)
+	// this allocation is the main point of the test; an unmounted LB that has services
+	problematicAllocation := NewMockUnitAllocation("cluster-one//__unmounted__/__unmounted__/__unmounted__", start, day, problematicProps)
 
-	one.ExternalCost = 2.35
+	two := NewMockUnitAllocation("cluster-one//nginx-plus/nginx-plus-nginx-ingress-123a4b5678-ab12c/nginx-plus-nginx-ingress", start, day, normalProps)
+	three := NewMockUnitAllocation("cluster-one//nginx-plus/nginx-plus-nginx-ingress-123a4b5678-ab12c/nginx-plus-nginx-ingress", start, day, normalProps)
+	four := NewMockUnitAllocation("cluster-one//nginx-plus/nginx-plus-nginx-ingress-123a4b5678-ab12c/nginx-plus-nginx-ingress", start, day, normalProps)
+
+	problematicAllocation.ExternalCost = 2.35
 	two.ExternalCost = 1.35
 	three.ExternalCost = 2.60
 	four.ExternalCost = 4.30
-	set := NewAllocationSet(start, start.Add(day), one, two, three, four)
+	set := NewAllocationSet(start, start.Add(day), problematicAllocation, two, three, four)
 
 	set.Insert(idle)
 
@@ -2834,5 +2836,5 @@ func Test_AggregateBy(t *testing.T) {
 	}
 
 	spew.Config.DisableMethods = true
-	fmt.Printf("%s", spew.Sdump(set.Allocations))
+	t.Logf("%s", spew.Sdump(set.Allocations))
 }

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opencost/opencost/pkg/util"
 	"github.com/opencost/opencost/pkg/util/json"
 )
@@ -2756,4 +2758,68 @@ func TestAllocationSet_Accumulate_Equals_AllocationSetRange_Accumulate(t *testin
 			}
 		}
 	}
+}
+
+func Test_AggregateBy(t *testing.T) {
+	end := time.Now().UTC().Truncate(day)
+	start := end.Add(-day)
+
+	normalProps := &AllocationProperties{
+		Cluster:        "kc-demo-stage",
+		Container:      "nginx-plus-nginx-ingress",
+		Controller:     "nginx-plus-nginx-ingress",
+		ControllerKind: "deployment",
+		Namespace:      "nginx-plus",
+		Pod:            "nginx-plus-nginx-ingress-123a4b5678-ab12c",
+		Services: []string{
+			"nginx-plus-nginx-ingress",
+		},
+	}
+
+	weirdProps := &AllocationProperties{
+		Cluster:   "kc-demo-stage",
+		Container: UnmountedSuffix,
+		Namespace: UnmountedSuffix,
+		Pod:       UnmountedSuffix,
+		Services: []string{
+			"nginx-plus-nginx-ingress",
+			"ingress-nginx-controller",
+			"pacman",
+		},
+	}
+
+	idle := NewMockUnitAllocation(fmt.Sprintf("kc-demo-stage/%s", IdleSuffix), start, day, &AllocationProperties{
+		Cluster: "kc-demo-stage",
+	})
+	one := NewMockUnitAllocation("kc-demo-stage//__unmounted__/__unmounted__/__unmounted__", start, day, weirdProps)
+	two := NewMockUnitAllocation("kc-demo-stage/gke-kc-demo-stage-pool-2-70aa2479-k41y/nginx-plus/nginx-plus-nginx-ingress-676f9b6674-nv78q/nginx-plus-nginx-ingress", start, day, normalProps)
+	four := NewMockUnitAllocation("kc-demo-stage/gke-kc-demo-stage-pool-2-70aa2479-k41y/nginx-plus/nginx-plus-nginx-ingress-676f9b6674-nv78q/nginx-plus-nginx-ingress", start, day, normalProps)
+	three := NewMockUnitAllocation("kc-demo-stage/gke-kc-demo-stage-pool-2-70aa2479-k41y/nginx-plus/nginx-plus-nginx-ingress-676f9b6674-nv78q/nginx-plus-nginx-ingress", start, day, normalProps)
+
+	set := NewAllocationSet(start, start.Add(day), one, two, three, four)
+
+	set.Insert(idle)
+
+	set.AggregateBy([]string{AllocationServiceProp}, &AllocationAggregationOptions{
+		Filter: AllocationFilterCondition{Field: FilterServices, Op: FilterEquals, Value: "nginx-plus-nginx-ingress"},
+	})
+
+	for _, alloc := range set.Allocations {
+		if strings.Contains(UnmountedSuffix, alloc.Name) {
+			props := alloc.Properties
+			if props.Cluster == UnmountedSuffix {
+				t.Fatalf("cluster unmounted")
+			} else if props.Container == UnmountedSuffix {
+				t.Fatalf("container unmounted")
+			} else if props.Namespace == UnmountedSuffix {
+				t.Fatalf("namespace unmounted")
+			} else if props.Pod == UnmountedSuffix {
+				t.Fatalf("pod unmounted")
+			} else if props.Controller == UnmountedSuffix {
+				t.Fatalf("controller unmounted")
+			}
+		}
+	}
+
+	fmt.Printf("%s", spew.Sdump(set.Allocations))
 }

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -288,11 +288,17 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 				// Indicate that allocation has no services
 				names = append(names, UnallocatedSuffix)
 			} else {
+				// sometimes load balancers will retain their services when unmounted
+				// so if we have an unmounted pod, make sure the key shows unmounted
+				// if p.Pod == UnmountedSuffix {
+				// 	names = append(names, UnmountedSuffix)
+				// } else {
 				// This just uses the first service
 				for _, service := range services {
 					names = append(names, service)
 					break
 				}
+				// }
 			}
 		case strings.HasPrefix(agg, "label:"):
 			labels := p.Labels

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -288,9 +288,11 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 				// Indicate that allocation has no services
 				names = append(names, UnallocatedSuffix)
 			} else {
-				// sometimes load balancers will retain their services when unmounted
-				// so if we have an unmounted pod, make sure the key shows unmounted
-				if p.Pod == UnmountedSuffix {
+				// Unmounted load balancers lead to __unmounted__ Allocations whose
+				// services field is populated. If we don't have a special case, the
+				// __unmounted__ Allocation will be transformed into a regular Allocation,
+				// causing issues with AggregateBy and drilldown
+				if p.Pod == UnmountedSuffix || p.Namespace == UnmountedSuffix || p.Container == UnmountedSuffix {
 					names = append(names, UnmountedSuffix)
 				} else {
 					// This just uses the first service

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -290,15 +290,15 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			} else {
 				// sometimes load balancers will retain their services when unmounted
 				// so if we have an unmounted pod, make sure the key shows unmounted
-				// if p.Pod == UnmountedSuffix {
-				// 	names = append(names, UnmountedSuffix)
-				// } else {
-				// This just uses the first service
-				for _, service := range services {
-					names = append(names, service)
-					break
+				if p.Pod == UnmountedSuffix {
+					names = append(names, UnmountedSuffix)
+				} else {
+					// This just uses the first service
+					for _, service := range services {
+						names = append(names, service)
+						break
+					}
 				}
-				// }
 			}
 		case strings.HasPrefix(agg, "label:"):
 			labels := p.Labels

--- a/pkg/kubecost/allocationprops_test.go
+++ b/pkg/kubecost/allocationprops_test.go
@@ -96,6 +96,32 @@ func TestAllocationPropsIntersection(t *testing.T) {
 				Annotations:        map[string]string{"key2": "val2"},
 			},
 		},
+		"test services are nulled when intersecting": {
+			allocationProps1: &AllocationProperties{
+				AggregatedMetadata: false,
+				Container:          UnmountedSuffix,
+				Namespace:          "ns1",
+				Services: []string{
+					"cool",
+				},
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			allocationProps2: &AllocationProperties{
+				AggregatedMetadata: true,
+				Container:          "container3",
+				Namespace:          "ns1",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+			expected: &AllocationProperties{
+				AggregatedMetadata: true,
+				Namespace:          "ns1",
+				ControllerKind:     "",
+				Labels:             map[string]string{"key1": "val1"},
+				Annotations:        map[string]string{"key2": "val2"},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## What does this PR change?
* Prevent allocations with services, but other unmounted properties from being listed separately than __unmounted__ allocation

## Does this PR relate to any other PRs?
* Cherry pick of https://github.com/opencost/opencost/pull/1876

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/BURNDOWN-80

## How was this PR tested?
* Unit tests

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.103
