### PR TITLE
fix: disabledMetrics cause panics

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -144,131 +144,131 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider model
 
 	metricsInit.Do(func() {
 
+		cpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "node_cpu_hourly_cost",
+			Help: "node_cpu_hourly_cost hourly cost for each cpu on this node",
+		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 		if _, disabled := disabledMetrics["node_cpu_hourly_cost"]; !disabled {
-			cpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "node_cpu_hourly_cost",
-				Help: "node_cpu_hourly_cost hourly cost for each cpu on this node",
-			}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 			toRegisterGV = append(toRegisterGV, cpuGv)
 		}
 
+		ramGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "node_ram_hourly_cost",
+			Help: "node_ram_hourly_cost hourly cost for each gb of ram on this node",
+		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 		if _, disabled := disabledMetrics["node_ram_hourly_cost"]; !disabled {
-			ramGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "node_ram_hourly_cost",
-				Help: "node_ram_hourly_cost hourly cost for each gb of ram on this node",
-			}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 			toRegisterGV = append(toRegisterGV, ramGv)
 		}
 
+		gpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "node_gpu_hourly_cost",
+			Help: "node_gpu_hourly_cost hourly cost for each gpu on this node",
+		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 		if _, disabled := disabledMetrics["node_gpu_hourly_cost"]; !disabled {
-			gpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "node_gpu_hourly_cost",
-				Help: "node_gpu_hourly_cost hourly cost for each gpu on this node",
-			}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 			toRegisterGV = append(toRegisterGV, gpuGv)
 		}
 
+		gpuCountGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "node_gpu_count",
+			Help: "node_gpu_count count of gpu on this node",
+		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 		if _, disabled := disabledMetrics["node_gpu_count"]; !disabled {
-			gpuCountGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "node_gpu_count",
-				Help: "node_gpu_count count of gpu on this node",
-			}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 			toRegisterGV = append(toRegisterGV, gpuCountGv)
 		}
 
+		pvGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "pv_hourly_cost",
+			Help: "pv_hourly_cost Cost per GB per hour on a persistent disk",
+		}, []string{"volumename", "persistentvolume", "provider_id"})
 		if _, disabled := disabledMetrics["pv_hourly_cost"]; !disabled {
-			pvGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "pv_hourly_cost",
-				Help: "pv_hourly_cost Cost per GB per hour on a persistent disk",
-			}, []string{"volumename", "persistentvolume", "provider_id"})
 			toRegisterGV = append(toRegisterGV, pvGv)
 		}
 
+		spotGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "kubecost_node_is_spot",
+			Help: "kubecost_node_is_spot Cloud provider info about node preemptibility",
+		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 		if _, disabled := disabledMetrics["kubecost_node_is_spot"]; !disabled {
-			spotGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "kubecost_node_is_spot",
-				Help: "kubecost_node_is_spot Cloud provider info about node preemptibility",
-			}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 			toRegisterGV = append(toRegisterGV, spotGv)
 		}
 
+		totalGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "node_total_hourly_cost",
+			Help: "node_total_hourly_cost Total node cost per hour",
+		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 		if _, disabled := disabledMetrics["node_total_hourly_cost"]; !disabled {
-			totalGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "node_total_hourly_cost",
-				Help: "node_total_hourly_cost Total node cost per hour",
-			}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 			toRegisterGV = append(toRegisterGV, totalGv)
 		}
 
+		ramAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "container_memory_allocation_bytes",
+			Help: "container_memory_allocation_bytes Bytes of RAM used",
+		}, []string{"namespace", "pod", "container", "instance", "node"})
 		if _, disabled := disabledMetrics["container_memory_allocation_bytes"]; !disabled {
-			ramAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "container_memory_allocation_bytes",
-				Help: "container_memory_allocation_bytes Bytes of RAM used",
-			}, []string{"namespace", "pod", "container", "instance", "node"})
 			toRegisterGV = append(toRegisterGV, ramAllocGv)
 		}
 
+		cpuAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "container_cpu_allocation",
+			Help: "container_cpu_allocation Percent of a single CPU used in a minute",
+		}, []string{"namespace", "pod", "container", "instance", "node"})
 		if _, disabled := disabledMetrics["container_cpu_allocation"]; !disabled {
-			cpuAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "container_cpu_allocation",
-				Help: "container_cpu_allocation Percent of a single CPU used in a minute",
-			}, []string{"namespace", "pod", "container", "instance", "node"})
 			toRegisterGV = append(toRegisterGV, cpuAllocGv)
 		}
 
+		gpuAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "container_gpu_allocation",
+			Help: "container_gpu_allocation GPU used",
+		}, []string{"namespace", "pod", "container", "instance", "node"})
 		if _, disabled := disabledMetrics["container_gpu_allocation"]; !disabled {
-			gpuAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "container_gpu_allocation",
-				Help: "container_gpu_allocation GPU used",
-			}, []string{"namespace", "pod", "container", "instance", "node"})
 			toRegisterGV = append(toRegisterGV, gpuAllocGv)
 		}
 
+		pvAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "pod_pvc_allocation",
+			Help: "pod_pvc_allocation Bytes used by a PVC attached to a pod",
+		}, []string{"namespace", "pod", "persistentvolumeclaim", "persistentvolume"})
 		if _, disabled := disabledMetrics["pod_pvc_allocation"]; !disabled {
-			pvAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "pod_pvc_allocation",
-				Help: "pod_pvc_allocation Bytes used by a PVC attached to a pod",
-			}, []string{"namespace", "pod", "persistentvolumeclaim", "persistentvolume"})
 			toRegisterGV = append(toRegisterGV, pvAllocGv)
 		}
 
+		networkZoneEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "kubecost_network_zone_egress_cost",
+			Help: "kubecost_network_zone_egress_cost Total cost per GB egress across zones",
+		})
 		if _, disabled := disabledMetrics["kubecost_network_zone_egress_cost"]; !disabled {
-			networkZoneEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: "kubecost_network_zone_egress_cost",
-				Help: "kubecost_network_zone_egress_cost Total cost per GB egress across zones",
-			})
 			toRegisterGauge = append(toRegisterGauge, networkZoneEgressCostG)
 		}
 
+		networkRegionEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "kubecost_network_region_egress_cost",
+			Help: "kubecost_network_region_egress_cost Total cost per GB egress across regions",
+		})
 		if _, disabled := disabledMetrics["kubecost_network_region_egress_cost"]; !disabled {
-			networkRegionEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: "kubecost_network_region_egress_cost",
-				Help: "kubecost_network_region_egress_cost Total cost per GB egress across regions",
-			})
 			toRegisterGauge = append(toRegisterGauge, networkRegionEgressCostG)
 		}
 
+		networkInternetEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "kubecost_network_internet_egress_cost",
+			Help: "kubecost_network_internet_egress_cost Total cost per GB of internet egress.",
+		})
 		if _, disabled := disabledMetrics["kubecost_network_internet_egress_cost"]; !disabled {
-			networkInternetEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
-				Name: "kubecost_network_internet_egress_cost",
-				Help: "kubecost_network_internet_egress_cost Total cost per GB of internet egress.",
-			})
 			toRegisterGauge = append(toRegisterGauge, networkInternetEgressCostG)
 		}
 
+		clusterManagementCostGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "kubecost_cluster_management_cost",
+			Help: "kubecost_cluster_management_cost Hourly cost paid as a cluster management fee.",
+		}, []string{"provisioner_name"})
 		if _, disabled := disabledMetrics["kubecost_cluster_management_cost"]; !disabled {
-			clusterManagementCostGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Name: "kubecost_cluster_management_cost",
-				Help: "kubecost_cluster_management_cost Hourly cost paid as a cluster management fee.",
-			}, []string{"provisioner_name"})
 			toRegisterGV = append(toRegisterGV, clusterManagementCostGv)
 		}
 
+		lbCostGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{ // no differentiation between ELB and ALB right now
+			Name: "kubecost_load_balancer_cost",
+			Help: "kubecost_load_balancer_cost Hourly cost of load balancer",
+		}, []string{"ingress_ip", "namespace", "service_name"}) // assumes one ingress IP per load balancer
 		if _, disabled := disabledMetrics["kubecost_load_balancer_cost"]; !disabled {
-			lbCostGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{ // no differentiation between ELB and ALB right now
-				Name: "kubecost_load_balancer_cost",
-				Help: "kubecost_load_balancer_cost Hourly cost of load balancer",
-			}, []string{"ingress_ip", "namespace", "service_name"}) // assumes one ingress IP per load balancer
 			toRegisterGV = append(toRegisterGV, lbCostGv)
 		}
 


### PR DESCRIPTION
## What does this PR change?
* Only skip metric registration when metrics are disabled, as the code doesn't nil check, and panics on nil pointers. Code loop could alternatively skip parts related to disabled metrics otherwise.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Prevent code panics when disabling any `*prometheus.GaugeVec` metrics from `CostModelMetricsEmitter`

## Does this PR address any GitHub or Zendesk issues?
* None found

## How was this PR tested?
* Locally, connecting to a remote cluster with the following metrics.json config:
```json
{"disabledMetrics":["service_selector_labels","statefulSet_match_labels","deployment_match_labels","kube_node_labels","kube_pod_labels","node_gpu_count","node_gpu_hourly_cost","container_cpu_allocation","container_gpu_allocation","container_memory_allocation_bytes"]}
```

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 


Attempting to disable `node_gpu_count` through disabledMetrics causes panic:
```
2023-05-03T19:18:33.926380026Z INF Panic: runtime error: invalid memory address or nil pointer dereference
StackTrace: goroutine 455 [running]:
github.com/opencost/opencost/pkg/errors.dispatch({0x324b0c0, 0x62befe0}, 0x0)
    /app/opencost/pkg/errors/panic.go:115 +0x4f
github.com/opencost/opencost/pkg/errors.HandlePanic()
    /app/opencost/pkg/errors/panic.go:91 +0x33
panic({0x324b0c0, 0x62befe0})
    /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/prometheus/client_golang/prometheus.(*GaugeVec).GetMetricWithLabelValues(0x3203c00?, {0xc000ad5d60?, 0xc001d5ac40?, 0xde?})
    /go/pkg/mod/github.com/prometheus/client_golang@v1.13.1/prometheus/gauge.go:183 +0x19
github.com/prometheus/client_golang/prometheus.(*GaugeVec).WithLabelValues(...)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.13.1/prometheus/gauge.go:215
github.com/opencost/opencost/pkg/costmodel.(*CostModelMetricsEmitter).Start.func1()
    /app/opencost/pkg/costmodel/metrics.go:531 +0x1369
created by github.com/opencost/opencost/pkg/costmodel.(*CostModelMetricsEmitter).Start
    /app/opencost/pkg/costmodel/metrics.go:401 +0x96
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 15 [running]:
github.com/opencost/opencost/pkg/errors.SetPanicHandler.func1()
    /app/opencost/pkg/errors/panic.go:63 +0xb3
created by github.com/opencost/opencost/pkg/errors.SetPanicHandler
    /app/opencost/pkg/errors/panic.go:57 +0x6b
```