### PR TITLE
feat: watch metrics-config in agent mode

### DIFF
--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -164,6 +164,8 @@ func Execute(opts *AgentOpts) error {
 
 	// Append the pricing config watcher
 	configWatchers.AddWatcher(provider.ConfigWatcherFor(cloudProvider))
+	configWatchers.AddWatcher(metrics.GetMetricsConfigWatcher())
+
 	watchConfigFunc := configWatchers.ToWatchFunc()
 	watchedConfigs := configWatchers.GetWatchedConfigs()
 


### PR DESCRIPTION
## What does this PR change?
* Allows agent mode to watch the metrics-config ConfigMap, this was unexpected as the costmodel execution behaves correctly. Documentation doesn't mention agent mode missing that feature.

## Does this PR relate to any other PRs?
* #1897 indirectly, we're trying to disable a few metrics in agent mode and having issues

## How will this PR impact users?
* Enables disabledMetrics support in agent mode

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
Running locally port-forwarded to a remote cluster and Prometheus, with a provisioned metrics-config configmap.
* Log outputs:
   ```
   INF Starting metrics init with disabled metrics: [service_selector_labels statefulSet_match_labels 
   deployment_match_labels kube_namespace_labels kube_node_labels kube_pod_labels]
   ```
* `curl localhost:9005/metrics` output doesn't contain the above metrics once this PR is applied.


## Does this PR require changes to documentation?
* No, there are no mentions of the missing feature in agent mode.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* 
