### PR TITLE
Update the NodeMap with default cost data on Failure

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -1642,7 +1642,10 @@ func (cm *CostModel) getNodePricing(nodeMap map[nodeKey]*nodePricing, nodeKey no
 		if nodeKey.Node != "" {
 			log.DedupedWarningf(5, "CostModel: failed to find node for %s", nodeKey)
 		}
-		return cm.getCustomNodePricing(false, "")
+		// since the node pricing data is not found, and this won't change for the duration of the allocation
+		// build process, we can update the node map with the defaults to prevent future failed lookups
+		nodeMap[nodeKey] = cm.getCustomNodePricing(false, "")
+		return nodeMap[nodeKey]
 	}
 
 	// If custom pricing is enabled and can be retrieved, override detected


### PR DESCRIPTION
## What does this PR change?
* On specific edge cases, cycling a node can sometimes leave the node pricing data out of alignment with allocation workloads. This small adjustment prevents further cache misses on the `nodeMap` (nodePricing) by storing the default costs on the first failure (preventing future failed lookups from having to rebuild default costs). 
* For the incubating allocation extension which passes back the node mapping, this allows uninterrupted calculation of idle by node calculation.  

## How will this PR impact users?
* Less spam logging when node data is missing from prometheus during edge case scenarios.

## How was this PR tested?
* Live environment via agent
