### PR TITLE
Avoid panic in AWS findCostForDisk

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1779,7 +1779,17 @@ func (aws *AWS) findCostForDisk(disk *ec2Types.Volume) (*float64, error) {
 
 	key := "us-east-2" + "," + class
 
-	priceStr := aws.Pricing[key].PV.Cost
+	pricing, ok := aws.Pricing[key]
+	if !ok {
+		return nil, fmt.Errorf("no pricing data for key '%s'", key)
+	}
+	if pricing == nil {
+		return nil, fmt.Errorf("nil pricing data for key '%s'", key)
+	}
+	if pricing.PV == nil {
+		return nil, fmt.Errorf("pricing for key '%s' has nil PV", key)
+	}
+	priceStr := pricing.PV.Cost
 
 	price, err := strconv.ParseFloat(priceStr, 64)
 	if err != nil {


### PR DESCRIPTION
## What does this PR change?
* Adds missing nilness checks

The original trace:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x21e52bc]

goroutine 607 [running]:
github.com/opencost/opencost/pkg/cloud/aws.(*AWS).findCostForDisk(0xc000878000, 0xc000b4b980)
	/home/delta/devel/costmodel-parent/opencost/pkg/cloud/aws/provider.go:1782 +0x9c
github.com/opencost/opencost/pkg/cloud/aws.(*AWS).GetOrphanedResources(0x0?)
	/home/delta/devel/costmodel-parent/opencost/pkg/cloud/aws/provider.go:1703 +0x136
github.com/kubecost/kubecost-cost-model/pkg/savings.(*Optimizer).SummarizeOrphanedResources(0xb?, 0x1e?)
	/home/delta/devel/costmodel-parent/kubecost-cost-model/pkg/savings/savings.go:407 +0x3b
github.com/kubecost/kubecost-cost-model/pkg/savings.(*Optimizer).refreshSummaryCache.func7()
	/home/delta/devel/costmodel-parent/kubecost-cost-model/pkg/savings/savings.go:361 +0x25
github.com/kubecost/kubecost-cost-model/pkg/savings.(*Optimizer).refreshIndividualMetric(0xc001fc2000, {0xc001dd4840, 0x1e}, 0xc0027c5f10)
	/home/delta/devel/costmodel-parent/kubecost-cost-model/pkg/savings/savings.go:240 +0x1ee
github.com/kubecost/kubecost-cost-model/pkg/savings.(*Optimizer).refreshSummaryCache(0xc001fc2000)
	/home/delta/devel/costmodel-parent/kubecost-cost-model/pkg/savings/savings.go:363 +0x519
github.com/kubecost/kubecost-cost-model/pkg/savings.NewOptimizer.func1()
	/home/delta/devel/costmodel-parent/kubecost-cost-model/pkg/savings/savings.go:169 +0x1d
created by github.com/kubecost/kubecost-cost-model/pkg/savings.NewOptimizer
	/home/delta/devel/costmodel-parent/kubecost-cost-model/pkg/savings/savings.go:168 +0x60c
exit status 2
```

Now I just see error logs:
```
832:2023-05-17T14:26:43.864001244-07:00 ERR error parsing window: no pricing data for key 'us-east-2,EBS:VolumeUsage.gp2'
833:2023-05-17T14:26:43.864041704-07:00 WRN got error no pricing data for key 'us-east-2,EBS:VolumeUsage.gp2' for metric orphanedResources%%Development, not adding to cache
911:2023-05-17T14:26:46.713174861-07:00 ERR error parsing window: no pricing data for key 'us-east-2,EBS:VolumeUsage.gp2'
912:2023-05-17T14:26:46.713204371-07:00 WRN got error no pricing data for key 'us-east-2,EBS:VolumeUsage.gp2' for metric orphanedResources%%Production, not adding to cache
1010:2023-05-17T14:26:49.834950366-07:00 ERR error parsing window: no pricing data for key 'us-east-2,EBS:VolumeUsage.gp2'
1011:2023-05-17T14:26:49.834973746-07:00 WRN got error no pricing data for key 'us-east-2,EBS:VolumeUsage.gp2' for metric orphanedResources%%High-Availability, not adding to cache
```

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* https://kubecost.atlassian.net/browse/CORE-260

## How was this PR tested?
* Local run of KCM. Panic used to occur shortly after startup, no longer occurs. Local run targets an EKS cluster in `us-west-2`, which may be the underlying source, given that the key appears to be `us-east-2`. WRN/ERR logs now show up in appropriate places.