### PR TITLE
Add mimir API support with X-Scope-OrgID

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1535,6 +1535,7 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 		},
 		QueryConcurrency: queryConcurrency,
 		QueryLogFile:     "",
+		MimirHeaderOrgId: env.GetMimirHeaderOrgId(),
 	})
 	if err != nil {
 		log.Fatalf("Failed to create prometheus client, Error: %v", err)

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -90,6 +90,8 @@ const (
 	PrometheusRetryOnRateLimitMaxRetriesEnvVar  = "PROMETHEUS_RETRY_ON_RATE_LIMIT_MAX_RETRIES"
 	PrometheusRetryOnRateLimitDefaultWaitEnvVar = "PROMETHEUS_RETRY_ON_RATE_LIMIT_DEFAULT_WAIT"
 
+	MimirHeaderOrgIdEnvVar = "MIMIR_HEADER_ORG_ID"
+
 	IngestPodUIDEnvVar = "INGEST_POD_UID"
 
 	ETLReadOnlyMode = "ETL_READ_ONLY"
@@ -158,6 +160,11 @@ func GetPrometheusRetryOnRateLimitMaxRetries() int {
 // Retry-After header.
 func GetPrometheusRetryOnRateLimitDefaultWait() time.Duration {
 	return GetDuration(PrometheusRetryOnRateLimitDefaultWaitEnvVar, 100*time.Millisecond)
+}
+
+// GetMimirOrgIdHeader returns the default value for X-Scope-OrgID header used for requests in Mimir API.
+func GetMimirHeaderOrgId() string {
+	return Get(MimirHeaderOrgIdEnvVar, "")
 }
 
 // GetPrometheusQueryOffset returns the time.Duration to offset all prometheus queries by. NOTE: This env var is applied

--- a/pkg/prom/ratelimitedclient_test.go
+++ b/pkg/prom/ratelimitedclient_test.go
@@ -142,6 +142,7 @@ func TestRateLimitedOnceAndSuccess(t *testing.T) {
 		nil,
 		newTestRetryOpts(),
 		"",
+		"",
 	)
 
 	if err != nil {
@@ -182,6 +183,7 @@ func TestRateLimitedOnceAndFail(t *testing.T) {
 		nil,
 		nil,
 		newTestRetryOpts(),
+		"",
 		"",
 	)
 
@@ -228,6 +230,7 @@ func TestRateLimitedResponses(t *testing.T) {
 		nil,
 		nil,
 		newTestRetryOpts(),
+		"",
 		"",
 	)
 
@@ -341,6 +344,7 @@ func TestConcurrentRateLimiting(t *testing.T) {
 		nil,
 		nil,
 		newTestRetryOpts(),
+		"",
 		"",
 	)
 

--- a/pkg/thanos/thanos.go
+++ b/pkg/thanos/thanos.go
@@ -104,5 +104,6 @@ func NewThanosClient(address string, config *prom.PrometheusClientConfig) (prome
 		maxSourceDecorator,
 		config.RateLimitRetryOpts,
 		config.QueryLogFile,
+		"",
 	)
 }


### PR DESCRIPTION
## What does this PR change?
Add required by Mimir header X-Scope-OrgID in http Prometheus client.

To use Mimir instead of Prometheus add variable:
    "MIMIR_HEADER_ORG_ID": "my-cluster-name"

Then set Prometheus URL to Mimir endpoint:
    "PROMETHEUS_SERVER_ENDPOINT": "http://mimir-url/prometheus/"

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
Adds ability to use Mimir storage instead of Prometheus

## Does this PR address any GitHub or Zendesk issues?
No

## How was this PR tested?
Manual

## Does this PR require changes to documentation?
Yes

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
Required release 
