### PR TITLE
Enable image to run as non-root

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -11,15 +11,15 @@ COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
-RUN adduser 101 -g 1000 -D
-RUN chown 101:1000 -R /var/www
-RUN chown 101:1000 -R /etc/nginx
+RUN adduser 1001 -g 1000 -D
+RUN chown 1001:1000 -R /var/www
+RUN chown 1001:1000 -R /etc/nginx
 
 ENV BASE_URL=/model
 
 COPY ./docker-entrypoint.sh /usr/local/bin/
 
-USER 101
+USER 1001
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,9 +9,17 @@ FROM nginx:alpine
 COPY --from=builder /opt/ui/dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
+RUN rm -rf /etc/nginx/conf.d/default.conf
+
+RUN adduser 101 -g 1000 -D
+RUN chown 101:1000 -R /var/www
+RUN chown 101:1000 -R /etc/nginx
 
 ENV BASE_URL=/model
 
 COPY ./docker-entrypoint.sh /usr/local/bin/
+
+USER 101
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## What does this PR change?
* This PR allows Opencost UI to run as non-root by creating a user and giving it ownership over the folders `/var/www` and `/etc/nginx`.
It also removes the file `/etc/nginx/conf.d/default.conf` which was exposing an unneeded endpoint in port 80, which is not allowed to bind as non-root.

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/1834

## How will this PR impact users?
* Existing users shouldn't be affected. Any user that wants to run the image as non-root must use user 1001.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/1824

## How was this PR tested?
* Build and run the image both locally and in a secured Kubernetes environment and it will get tested by CI / CD building the container

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.103
