### PR TITLE
Map of allocation property to filter property for easy lookup 

### DIFF
--- a/pkg/util/allocationfilterutil/queryfilters.go
+++ b/pkg/util/allocationfilterutil/queryfilters.go
@@ -1,6 +1,7 @@
 package allocationfilterutil
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/opencost/opencost/pkg/costmodel/clusters"
@@ -29,6 +30,31 @@ const (
 	ParamFilterLabels      = "filterLabels"
 	ParamFilterServices    = "filterServices"
 )
+
+var allocationFilterFieldMap = map[string]string{
+	kubecost.AllocationClusterProp:        ParamFilterClusters,
+	kubecost.FilterNode:                   ParamFilterNodes,
+	kubecost.AllocationNamespaceProp:      ParamFilterNamespaces,
+	kubecost.AllocationControllerKindProp: ParamFilterControllerKinds,
+	kubecost.AllocationControllerProp:     ParamFilterControllers,
+	kubecost.AllocationPodProp:            ParamFilterPods,
+	kubecost.AllocationContainerProp:      ParamFilterContainers,
+	kubecost.AllocationDepartmentProp:     ParamFilterDepartments,
+	kubecost.AllocationEnvironmentProp:    ParamFilterEnvironments,
+	kubecost.AllocationOwnerProp:          ParamFilterOwners,
+	kubecost.AllocationProductProp:        ParamFilterProducts,
+	kubecost.AllocationTeamProp:           ParamFilterTeams,
+	kubecost.AllocationAnnotationProp:     ParamFilterAnnotations,
+	kubecost.AllocationLabelProp:          ParamFilterLabels,
+	kubecost.AllocationServiceProp:        ParamFilterServices,
+}
+
+func GetAllocationFilterForTheAllocationProperty(allocationProp string) (string, error) {
+	if _, ok := allocationFilterFieldMap[allocationProp]; !ok {
+		return "", fmt.Errorf("unknown allocation property %s", allocationProp)
+	}
+	return allocationFilterFieldMap[allocationProp], nil
+}
 
 // AllHTTPParamKeys returns all HTTP GET parameters used for v1 filters. It is
 // intended to help validate HTTP queries in handlers to help avoid e.g.


### PR DESCRIPTION
## What does this PR change?
* Helps in avoiding several places to initialize a map of allocation property to filterProperty for allocation 

## Does this PR relate to any other PRs?
* Describe in ClosedSource the usage

## How will this PR impact users?
* None

## Does this PR address any GitHub or Zendesk issues?
* Closes ... CORE-249

## How was this PR tested?
* More testing commentary in closed source

## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* v1.104
