### PR TITLE
add omitempty to filters to clean up group report responses

### DIFF
--- a/pkg/filter/util/cloudcost.go
+++ b/pkg/filter/util/cloudcost.go
@@ -11,13 +11,13 @@ import (
 )
 
 type CloudCostFilter struct {
-	AccountIDs       []string `json:"accountIDs"`
-	Categories       []string `json:"categories"`
-	InvoiceEntityIDs []string `json:"invoiceEntityIDs"`
-	Labels           []string `json:"labels"`
-	Providers        []string `json:"providers"`
-	ProviderIDs      []string `json:"providerIDs"`
-	Services         []string `json:"services"`
+	AccountIDs       []string `json:"accountIDs,omitempty"`
+	Categories       []string `json:"categories,omitempty"`
+	InvoiceEntityIDs []string `json:"invoiceEntityIDs,omitempty"`
+	Labels           []string `json:"labels,omitempty"`
+	Providers        []string `json:"providers,omitempty"`
+	ProviderIDs      []string `json:"providerIDs,omitempty"`
+	Services         []string `json:"services,omitempty"`
 }
 
 func (g *CloudCostFilter) Equals(that CloudCostFilter) bool {

--- a/pkg/util/allocationfilterutil/queryfilters.go
+++ b/pkg/util/allocationfilterutil/queryfilters.go
@@ -83,21 +83,21 @@ func AllHTTPParamKeys() []string {
 }
 
 type FilterV1 struct {
-	Annotations     []string `json:"annotations"`
-	Containers      []string `json:"containers"`
-	Controllers     []string `json:"controllers"`
-	ControllerKinds []string `json:"controllerKinds"`
-	Clusters        []string `json:"clusters"`
-	Departments     []string `json:"departments"`
-	Environments    []string `json:"environments"`
-	Labels          []string `json:"labels"`
-	Namespaces      []string `json:"namespaces"`
-	Nodes           []string `json:"nodes"`
-	Owners          []string `json:"owners"`
-	Pods            []string `json:"pods"`
-	Products        []string `json:"products"`
-	Services        []string `json:"services"`
-	Teams           []string `json:"teams"`
+	Annotations     []string `json:"annotations,omitempty"`
+	Containers      []string `json:"containers,omitempty"`
+	Controllers     []string `json:"controllers,omitempty"`
+	ControllerKinds []string `json:"controllerKinds,omitempty"`
+	Clusters        []string `json:"clusters,omitempty"`
+	Departments     []string `json:"departments,omitempty"`
+	Environments    []string `json:"environments,omitempty"`
+	Labels          []string `json:"labels,omitempty"`
+	Namespaces      []string `json:"namespaces,omitempty"`
+	Nodes           []string `json:"nodes,omitempty"`
+	Owners          []string `json:"owners,omitempty"`
+	Pods            []string `json:"pods,omitempty"`
+	Products        []string `json:"products,omitempty"`
+	Services        []string `json:"services,omitempty"`
+	Teams           []string `json:"teams,omitempty"`
 }
 
 func (f FilterV1) Equals(that FilterV1) bool {


### PR DESCRIPTION
## What does this PR change?
* adds omitempty to types primarily for group reports

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/1942

## How will this PR impact users?
* remove empty fields from group report responses

## Does this PR address any GitHub or Zendesk issues?
* no

## How was this PR tested?
* manually

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next Opencost release? If not, why not?
* can't
