### PR TITLE
Add "Container" to Breakdown options for OpenCost UI

### DIFF
--- a/ui/src/Reports.js
+++ b/ui/src/Reports.js
@@ -40,6 +40,7 @@ const aggregationOptions = [
   { name: 'Controller', value: 'controller' },
   { name: 'Service', value: 'service' },
   { name: 'Pod', value: 'pod' },
+  { name: 'Container', value: 'container' },
 ]
 
 const accumulateOptions = [
@@ -121,7 +122,7 @@ const ReportsPage = () => {
   const [fetch, setFetch] = useState(false)
   const [loading, setLoading] = useState(true)
   const [errors, setErrors] = useState([])
-  
+
   // Initialize once, then fetch report each time setFetch(true) is called
   useEffect(() => {
     if (!init) {


### PR DESCRIPTION
## What does this PR change?
* Adds "Container" to choices for Breakdown. This was in the API but not the UI, so I added it.

## Does this PR relate to any other PRs?
* nope

## How will this PR impact users?
* 1 more chocie

## Does this PR address any GitHub or Zendesk issues?
* n/a

## How was this PR tested?
* built the container, selected, screenshot:
<img width="1202" alt="Screenshot 2023-06-07 at 2 40 25 PM" src="https://github.com/opencost/opencost/assets/330023/98b8e0fb-9a44-4298-9c6c-fe560ec4478d">

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes, this is a new (minor) UI feature.
