### PR TITLE
Sanitize old nil sample AWS access key value

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -534,6 +534,12 @@ func (aws *AWS) UpdateConfig(r io.Reader, updateType string) (*models.CustomPric
 				return err
 			}
 
+			// If the sample nil service key name is set, zero it out so that it is not
+			// misinterpreted as a real service key.
+			if asfi.ServiceKeyName == "AKIXXX" {
+				asfi.ServiceKeyName = ""
+			}
+
 			c.ServiceKeyName = asfi.ServiceKeyName
 			if asfi.ServiceKeySecret != "" {
 				c.ServiceKeySecret = asfi.ServiceKeySecret
@@ -551,6 +557,13 @@ func (aws *AWS) UpdateConfig(r io.Reader, updateType string) (*models.CustomPric
 			if err != nil {
 				return err
 			}
+
+			// If the sample nil service key name is set, zero it out so that it is not
+			// misinterpreted as a real service key.
+			if aai.ServiceKeyName == "AKIXXX" {
+				aai.ServiceKeyName = ""
+			}
+
 			c.AthenaBucketName = aai.AthenaBucketName
 			c.AthenaRegion = aai.AthenaRegion
 			c.AthenaDatabase = aai.AthenaDatabase
@@ -1401,7 +1414,6 @@ func (aws *AWS) ConfigureAuthWith(config *models.CustomPricing) error {
 
 // Gets the aws key id and secret
 func (aws *AWS) getAWSAuth(forceReload bool, cp *models.CustomPricing) (string, string) {
-
 	// 1. Check config values first (set from frontend UI)
 	if cp.ServiceKeyName != "" && cp.ServiceKeySecret != "" {
 		aws.ServiceAccountChecks.Set("hasKey", &models.ServiceAccountCheck{
@@ -1459,6 +1471,12 @@ func (aws *AWS) loadAWSAuthSecret(force bool) (*AWSAccessKey, error) {
 	err = json.Unmarshal(result, &ak)
 	if err != nil {
 		return nil, err
+	}
+
+	// If the sample nil service key name is set, zero it out so that it is not
+	// misinterpreted as a real service key.
+	if ak.AccessKeyID == "AKIXXX" {
+		ak.AccessKeyID = ""
 	}
 
 	awsSecret = &ak

--- a/pkg/cloud/provider/provider.go
+++ b/pkg/cloud/provider/provider.go
@@ -162,6 +162,13 @@ func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.
 		cp.accountID = providerConfig.customPricing.ClusterAccountID
 	}
 
+	providerConfig.Update(func(cp *models.CustomPricing) error {
+		if cp.ServiceKeyName == "AKIXXX" {
+			cp.ServiceKeyName = ""
+		}
+		return nil
+	})
+
 	switch cp.provider {
 	case kubecost.CSVProvider:
 		log.Infof("Using CSV Provider with CSV at %s", env.GetCSVPath())

--- a/pkg/cloud/provider/providerconfig.go
+++ b/pkg/cloud/provider/providerconfig.go
@@ -143,6 +143,12 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*models.CustomPrici
 		pc.customPricing.ShareTenancyCosts = models.DefaultShareTenancyCost
 	}
 
+	// If the sample nil service key name is set, zero it out so that it is not
+	// misinterpreted as a real service key.
+	if pc.customPricing.ServiceKeyName == "AKIXXX" {
+		pc.customPricing.ServiceKeyName = ""
+	}
+
 	return pc.customPricing, nil
 }
 

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -215,7 +215,13 @@ func IsEmitKsmV1MetricsOnly() bool {
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents
 // the AWS access key for authentication
 func GetAWSAccessKeyID() string {
-	return Get(AWSAccessKeyIDEnvVar, "")
+	awsAccessKeyID := Get(AWSAccessKeyIDEnvVar, "")
+	// If the sample nil service key name is set, zero it out so that it is not
+	// misinterpreted as a real service key.
+	if awsAccessKeyID == "AKIXXX" {
+		awsAccessKeyID = ""
+	}
+	return awsAccessKeyID
 }
 
 // GetAWSAccessKeySecret returns the environment variable value for AWSAccessKeySecretEnvVar which represents


### PR DESCRIPTION
## What does this PR change?
* Sanitizes any possible occurrences of an old sample AWS access key value, which should be considered a "nil" value. If it does not get sanitized (i.e. set to `""`), we will sometimes treat it as a real value and make erroneous calls with it.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/1561

## How will this PR impact users?
* It should fix AWS funny business related to 

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/BURNDOWN-144

## How was this PR tested?
* Not tested

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes

## Notes

Ultimately, there ended up being 4 functions it seemed worthwhile to patch here.

Sanitizing AWS service keys from:
1. environment variable (`env.GetAWSAccessKeyID()`)
2. config file (`(pc *ProviderConfig) loadConfig(writeIfNotExists bool)`)
3. secret (`(aws *AWS) loadAWSAuthSecret`)
4. manual config update (`(aws *AWS) UpdateConfig`)

Functions potentially affected:
- [x] env.GetAWSAccessKeyID()
  - [x] **PATCHED**
- [x] (pc *ProviderConfig) loadConfig(writeIfNotExists bool)
  - [x] **PATCHED**
  - [x] DefaultPricing()
- [x] (aws *AWS) loadAWSAuthSecret
  - [x] **PATCHED**
- [x] (aws *AWS) UpdateConfig (when is this called??)
  - [x] **PATCHED** (x2)
  - [ ] models.SetCustomPricingField (ugh why...)
- [x] (pc *ProviderConfig) GetCustomPricingData()
  - [x] pc.loadConfig(true)
- [x] aws.GetConfig()
  - [x] aws.Config.GetCustomPricingData()
- [x] aws.ConfigureAuthWith(config)  ()
  - [x] aws.getAWSAuth(false, config)
    - [x] config always comes from GetCustomPricingData or GetConfig, so no need to patch this function
    - [x] loadAWSAuthSecret()
    - [x] env.GetAWSAccessKeyID()
- [x] aws.GetAWSAccessKey()
  - [x] aws.GetConfig()
  - [x] aws.ConfigureAuthWith(config)
  - [x] env.GetAWSAccessKeyID()
- [x] GetAWSAthenaInfo()
  - [x] aws.GetAWSAccessKey()
- [x] aws.getCloudConfig
  - [x] awsProvider.GetAWSAthenaInfo()
- [x] (cfw *ConfigFileWatcher) GetConfigs()
  - [x] pc.GetCustomPricingData()
- [x] GetComputeReservationsForRegion
  - [x] aws.getCloudConfig()
- [x] GetOrganizationAccountIDs()
  - [x] aws.getCloudConfig()
- [x] (cfw *ConfigFileWatcher) GetConfigs()
  - [x] GetCustomPricingData()
