### PR TITLE
provide proportional PV costs via PARCs

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -156,7 +156,7 @@ func applyPodResults(window kubecost.Window, resolution time.Duration, podMap ma
 
 		}
 
-		allocStart, allocEnd := calculateStartEndFromIsRunning(res, resolution, window)
+		allocStart, allocEnd := calculateStartAndEnd(res, resolution, true)
 		if allocStart.IsZero() || allocEnd.IsZero() {
 			continue
 		}
@@ -1955,7 +1955,9 @@ func applyPVCsToPods(window kubecost.Window, podMap map[podKey]*pod, podPVCMap m
 	pvcPodWindowMap := make(map[pvcKey]map[podKey]kubecost.Window)
 
 	for thisPodKey, thisPod := range podMap {
+
 		if pvcs, ok := podPVCMap[thisPodKey]; ok {
+
 			for _, thisPVC := range pvcs {
 
 				// Determine the (start, end) of the relationship between the
@@ -2185,92 +2187,4 @@ func calculateStartAndEnd(result *prom.QueryResult, resolution time.Duration, of
 	}
 	e := time.Unix(int64(result.Values[len(result.Values)-1].Timestamp), 0).UTC()
 	return s, e
-}
-
-// calculateStartEndFromIsRunning Calculates the start and end of a prom result when the values of the datum are 0 for not running and 1 for running
-// the coeffs are used to adjust the start and end when the value is not equal to 1 or 0, which means that pod came up or went down in that window.
-func calculateStartEndFromIsRunning(result *prom.QueryResult, resolution time.Duration, window kubecost.Window) (time.Time, time.Time) {
-	// start and end are the timestamps of the first and last
-	// minutes the pod was running, respectively. We subtract one resolution
-	// from start because this point will actually represent the end
-	// of the first minute. We don't subtract from end because it
-	// already represents the end of the last minute.
-	var start, end time.Time
-	startAdjustmentCoeff, endAdjustmentCoeff := 1.0, 1.0
-	for _, datum := range result.Values {
-		t := time.Unix(int64(datum.Timestamp), 0)
-
-		if start.IsZero() && datum.Value > 0 && window.Contains(t) {
-			// Set the start timestamp to the earliest non-zero timestamp
-			start = t
-
-			// Record adjustment coefficient, i.e. the portion of the start
-			// timestamp to "ignore". That is, sometimes the value will be
-			// 0.5, meaning that we should discount the time running by
-			// half of the resolution the timestamp stands for.
-			startAdjustmentCoeff = (1.0 - datum.Value)
-		}
-
-		if datum.Value > 0 && window.Contains(t) {
-			// Set the end timestamp to the latest non-zero timestamp
-			end = t
-
-			// Record adjustment coefficient, i.e. the portion of the end
-			// timestamp to "ignore". (See explanation above for start.)
-			endAdjustmentCoeff = (1.0 - datum.Value)
-		}
-	}
-
-	// Do not attempt to adjust start if it is zero
-	if !start.IsZero() {
-		// Adjust timestamps according to the resolution and the adjustment
-		// coefficients, as described above. That is, count the start timestamp
-		// from the beginning of the resolution, not the end. Then "reduce" the
-		// start and end by the correct amount, in the case that the "running"
-		// value of the first or last timestamp was not a full 1.0.
-		start = start.Add(-resolution)
-		// Note: the *100 and /100 are necessary because Duration is an int, so
-		// 0.5, for instance, will be truncated, resulting in no adjustment.
-		start = start.Add(time.Duration(startAdjustmentCoeff*100) * resolution / time.Duration(100))
-		end = end.Add(-time.Duration(endAdjustmentCoeff*100) * resolution / time.Duration(100))
-
-		// Ensure that the start is always within the window, adjusting
-		// for the occasions where start falls 1m before the query window.
-		// NOTE: window here will always be closed (so no need to nil check
-		// "start").
-		// TODO:CLEANUP revisit query methodology to figure out why this is
-		// happening on occasion
-		if start.Before(*window.Start()) {
-			start = *window.Start()
-		}
-	}
-
-	// do not attempt to adjust end if it is zero
-	if !end.IsZero() {
-		// If there is only one point with a value <= 0.5 that the start and
-		// end timestamps both share, then we will enter this case because at
-		// least half of a resolution will be subtracted from both the start
-		// and the end. If that is the case, then add back half of each side
-		// so that the pod is said to run for half a resolution total.
-		// e.g. For resolution 1m and a value of 0.5 at one timestamp, we'll
-		//      end up with end == start and each coeff == 0.5. In
-		//      that case, add 0.25m to each side, resulting in 0.5m duration.
-		if !end.After(start) {
-			start = start.Add(-time.Duration(50*startAdjustmentCoeff) * resolution / time.Duration(100))
-			end = end.Add(time.Duration(50*endAdjustmentCoeff) * resolution / time.Duration(100))
-		}
-
-		// Ensure that the allocEnf is always within the window, adjusting
-		// for the occasions where end falls 1m after the query window. This
-		// has not ever happened, but is symmetrical with the start check
-		// above.
-		// NOTE: window here will always be closed (so no need to nil check
-		// "end").
-		// TODO:CLEANUP revisit query methodology to figure out why this is
-		// happening on occasion
-		if end.After(*window.End()) {
-			end = *window.End()
-		}
-	}
-	return start, end
 }

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -555,8 +555,7 @@ func buildActiveDataMap(resActiveMins []*prom.QueryResult, resolution time.Durat
 			continue
 		}
 
-		s := time.Unix(int64(result.Values[0].Timestamp), 0)
-		e := time.Unix(int64(result.Values[len(result.Values)-1].Timestamp), 0)
+		s, e := calculateStartAndEnd(result, resolution, true)
 		mins := e.Sub(s).Minutes()
 
 		// TODO niko/assets if mins >= threshold, interpolate for missing data?

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2520,6 +2520,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 					parc.CPUTotalCost = totals.CPUCost
 					parc.GPUTotalCost = totals.GPUCost
 					parc.RAMTotalCost = totals.RAMCost
+					parc.PVTotalCost = totals.PersistentVolumeCost
 					if !isAzure {
 						parc.LoadBalancerTotalCost = totals.LoadBalancerCost
 					} else if len(alloc.LoadBalancers) > 0 {

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -280,12 +280,13 @@ func (pva *PVAllocation) Equal(that *PVAllocation) bool {
 type ProportionalAssetResourceCost struct {
 	Cluster                string  `json:"cluster"`
 	Name                   string  `json:"name,omitempty"`
-	Type                   string  `json:"name,omitempty"`
+	Type                   string  `json:"type,omitempty"`
 	ProviderID             string  `json:"providerID,omitempty"`
 	CPUPercentage          float64 `json:"cpuPercentage"`
 	GPUPercentage          float64 `json:"gpuPercentage"`
 	RAMPercentage          float64 `json:"ramPercentage"`
 	LoadBalancerPercentage float64 `json:"loadBalancerPercentage"`
+	PVPercentage           float64 `json:"pvPercentage"`
 
 	NodeResourceCostPercentage   float64 `json:"nodeResourceCostPercentage"`
 	GPUTotalCost                 float64 `json:"-"`
@@ -296,6 +297,8 @@ type ProportionalAssetResourceCost struct {
 	RAMProportionalCost          float64 `json:"-"`
 	LoadBalancerProportionalCost float64 `json:"-"`
 	LoadBalancerTotalCost        float64 `json:"-"`
+	PVProportionalCost           float64 `json:"-"`
+	PVTotalCost                  float64 `json:"-"`
 }
 
 func (parc ProportionalAssetResourceCost) Key(insertByName bool) string {
@@ -334,6 +337,7 @@ func (parcs ProportionalAssetResourceCosts) Insert(parc ProportionalAssetResourc
 			CPUProportionalCost:          curr.CPUProportionalCost + parc.CPUProportionalCost,
 			RAMProportionalCost:          curr.RAMProportionalCost + parc.RAMProportionalCost,
 			GPUProportionalCost:          curr.GPUProportionalCost + parc.GPUProportionalCost,
+			PVProportionalCost:           curr.PVProportionalCost + parc.PVProportionalCost,
 			LoadBalancerProportionalCost: curr.LoadBalancerProportionalCost + parc.LoadBalancerProportionalCost,
 		}
 
@@ -363,6 +367,10 @@ func ComputePercentages(toInsert *ProportionalAssetResourceCost) {
 
 	if toInsert.RAMTotalCost > 0 {
 		toInsert.RAMPercentage = toInsert.RAMProportionalCost / toInsert.RAMTotalCost
+	}
+
+	if toInsert.PVTotalCost > 0 {
+		toInsert.PVPercentage = toInsert.PVProportionalCost / toInsert.PVTotalCost
 	}
 
 	ramFraction := toInsert.RAMTotalCost / totalNodeCost
@@ -2098,6 +2106,15 @@ func deriveProportionalAssetResourceCosts(options *AllocationAggregationOptions,
 					LoadBalancerProportionalCost: coeffs[key][alloc.Name]["loadbalancer"],
 				}, options.IdleByNode)
 			}
+		}
+		for name, pvAlloc := range alloc.PVs {
+			// insert a separate PARC for each PV attached
+			alloc.ProportionalAssetResourceCosts.Insert(ProportionalAssetResourceCost{
+				Cluster:            name.Cluster,
+				Name:               name.Name,
+				Type:               "PV",
+				PVProportionalCost: pvAlloc.Cost,
+			}, options.IdleByNode)
 		}
 
 	}

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -478,10 +478,9 @@ func ComputeAssetTotals(as *AssetSet, byAsset bool) map[string]*AssetTotals {
 			arts[key].Count++
 			arts[key].AttachedVolumeCost += disk.Cost
 			arts[key].AttachedVolumeCostAdjustment += disk.Adjustment
-		} else if !byAsset {
+		} else {
 			// Here, we're looking at a PersistentVolume because we're not
-			// looking at an AttachedVolume. Only record PersistentVolume data
-			// at the cluster level (i.e. prop == AssetClusterProp).
+			// looking at an AttachedVolume.
 			arts[key].Count++
 			arts[key].PersistentVolumeCost += disk.Cost
 			arts[key].PersistentVolumeCostAdjustment += disk.Adjustment


### PR DESCRIPTION
## What does this PR change?
* adds PV support to PARCs

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* This is response to a specific ask from the Azure team to provide a proportion of a PV used by a given allocation in the specified window. 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* tested on an AKS cluster. Deleted pods and observed the PV parc percentage matched the relative lifetime of the pods within the window

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 

