### PR TITLE
feature: Add support to query allocation with namepsace filter

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2226,6 +2226,9 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// resolution.
 	resolution := qp.GetDuration("resolution", env.GetETLResolution())
 
+	// Namespace is an optional parameter, defaulting to all the namespaces
+	namespace := qp.Get("namespace", "")
+
 	// Step is an optional parameter that defines the duration per-set, i.e.
 	// the window for an AllocationSet, of the AllocationSetRange to be
 	// computed. Defaults to the window size, making one set.
@@ -2267,7 +2270,8 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// include aggregated labels/annotations if true
 	includeAggregatedMetadata := qp.GetBool("includeAggregatedMetadata", false)
 
-	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, accumulateBy)
+	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, namespace,
+		includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, accumulateBy)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "bad request") {
 			WriteError(w, BadRequest(err.Error()))

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opencost/opencost/pkg/clustercache"
 	"github.com/opencost/opencost/pkg/costmodel/clusters"
 	"github.com/opencost/opencost/pkg/env"
+	afilter "github.com/opencost/opencost/pkg/filter21/allocation"
+	"github.com/opencost/opencost/pkg/filter21/ops"
 	"github.com/opencost/opencost/pkg/kubecost"
 	"github.com/opencost/opencost/pkg/log"
 	"github.com/opencost/opencost/pkg/prom"
@@ -2438,8 +2440,10 @@ func (cm *CostModel) QueryAllocation(
 	opts := &kubecost.AllocationAggregationOptions{
 		IncludeProportionalAssetResourceCosts: includeProportionalAssetResourceCosts,
 		IdleByNode:                            idleByNode,
-		Namespace:                             namespace,
 		IncludeAggregatedMetadata:             includeAggregatedMetadata,
+	}
+	if namespace != "" {
+		opts.Filter = ops.Eq(afilter.FieldNamespace, namespace)
 	}
 
 	// Aggregate

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2361,7 +2361,10 @@ func measureTimeAsync(start time.Time, threshold time.Duration, name string, ch 
 	}
 }
 
-func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata bool, accumulateBy kubecost.AccumulateOption) (*kubecost.AllocationSetRange, error) {
+func (cm *CostModel) QueryAllocation(
+	window kubecost.Window, resolution, step time.Duration, aggregate []string, namespace string,
+	includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata bool,
+	accumulateBy kubecost.AccumulateOption) (*kubecost.AllocationSetRange, error) {
 	// Validate window is legal
 	if window.IsOpen() || window.IsNegative() {
 		return nil, fmt.Errorf("illegal window: %s", window)
@@ -2435,6 +2438,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 	opts := &kubecost.AllocationAggregationOptions{
 		IncludeProportionalAssetResourceCosts: includeProportionalAssetResourceCosts,
 		IdleByNode:                            idleByNode,
+		Namespace:                             namespace,
 		IncludeAggregatedMetadata:             includeAggregatedMetadata,
 	}
 

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1106,6 +1106,7 @@ type AllocationAggregationOptions struct {
 	AllocationTotalsStore                 AllocationTotalsStore
 	Filter                                filter21.Filter
 	IdleByNode                            bool
+	Namespace                             string
 	IncludeProportionalAssetResourceCosts bool
 	LabelConfig                           *LabelConfig
 	MergeUnallocated                      bool
@@ -1256,7 +1257,6 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 	// them to their respective sets, removing them from the set of allocations
 	// to aggregate.
 	for _, alloc := range as.Allocations {
-
 		alloc.Properties.AggregatedMetadata = options.IncludeAggregatedMetadata
 		// build a parallel set of allocations to only be used
 		// for computing PARCs
@@ -1441,6 +1441,12 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 
 		// (3) If the allocation does not match the filter, immediately skip the
 		// allocation.
+		if options.Namespace != "" &&
+			alloc.Properties != nil &&
+			alloc.Properties.Namespace != options.Namespace {
+			log.Debugf("Do not match the namespace filter, expect:%s, but get %s", options.Namespace, alloc.Properties.Namespace)
+			continue
+		}
 		if !filter.Matches(alloc) {
 			// If we are tracking idle filtration coefficients, delete the
 			// entry corresponding to the filtered allocation. (Deleting the

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1106,7 +1106,6 @@ type AllocationAggregationOptions struct {
 	AllocationTotalsStore                 AllocationTotalsStore
 	Filter                                filter21.Filter
 	IdleByNode                            bool
-	Namespace                             string
 	IncludeProportionalAssetResourceCosts bool
 	LabelConfig                           *LabelConfig
 	MergeUnallocated                      bool
@@ -1257,6 +1256,7 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 	// them to their respective sets, removing them from the set of allocations
 	// to aggregate.
 	for _, alloc := range as.Allocations {
+
 		alloc.Properties.AggregatedMetadata = options.IncludeAggregatedMetadata
 		// build a parallel set of allocations to only be used
 		// for computing PARCs
@@ -1441,12 +1441,6 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 
 		// (3) If the allocation does not match the filter, immediately skip the
 		// allocation.
-		if options.Namespace != "" &&
-			alloc.Properties != nil &&
-			alloc.Properties.Namespace != options.Namespace {
-			log.Debugf("Do not match the namespace filter, expect:%s, but get %s", options.Namespace, alloc.Properties.Namespace)
-			continue
-		}
 		if !filter.Matches(alloc) {
 			// If we are tracking idle filtration coefficients, delete the
 			// entry corresponding to the filtered allocation. (Deleting the


### PR DESCRIPTION
## What does this PR change?
* Add support to query allocation with namepsace filter

## Does this PR relate to any other PRs?
* none

## How will this PR impact users?
* Users now can query allocation with namespace filter

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/1964

## How was this PR tested?
* with namespace parameter:
```sh
root@cesign [~]
-> # curl http://localhost:9003/allocation/compute -d namespace=opencost \
  -d window=60m \
  -d resolution=1m \
  -d aggregate=controller \
  -d accumulate=true \
  -G | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1342  100  1342    0     0  59908      0 --:--:-- --:--:-- --:--:-- 61000
{
  "code": 200,
  "status": "success",
  "data": [
    {
      "deployment:opencost": {
        "name": "deployment:opencost",
        "properties": {
          "cluster": "cluster-one",
          "node": "opencost-control-plane",
          "controller": "opencost",
          "controllerKind": "deployment",
          "namespace": "opencost",
          "pod": "opencost-55957677fc-p4rbr",
          "namespaceLabels": {
            "kubernetes_io_metadata_name": "opencost"
          }
        },
        "window": {
          "start": "2023-06-26T12:52:47Z",
          "end": "2023-06-26T13:52:47Z"
        },
        "start": "2023-06-26T13:46:00Z",
        "end": "2023-06-26T13:52:00Z",
        "minutes": 6,
        "cpuCores": 0.02,
        "cpuCoreRequestAverage": 0.02,
        "cpuCoreUsageAverage": 0.0001,
        "cpuCoreHours": 0.002,
        "cpuCost": 4e-05,
        "cpuCostAdjustment": 0,
        "cpuEfficiency": 0.00499,
        "gpuCount": 0,
        "gpuHours": 0,
        "gpuCost": 0,
        "gpuCostAdjustment": 0,
        "networkTransferBytes": 139564.8,
        "networkReceiveBytes": 130008,
        "networkCost": 0,
        "networkCrossZoneCost": 0,
        "networkCrossRegionCost": 0,
        "networkInternetCost": 0,
        "networkCostAdjustment": 0,
        "loadBalancerCost": 0,
        "loadBalancerCostAdjustment": 0,
        "pvBytes": 0,
        "pvByteHours": 0,
        "pvCost": 0,
        "pvs": null,
        "pvCostAdjustment": 0,
        "ramBytes": 110000000,
        "ramByteRequestAverage": 110000000,
        "ramByteUsageAverage": 34514261.33333,
        "ramByteHours": 11000000,
        "ramCost": 3e-05,
        "ramCostAdjustment": 0,
        "ramEfficiency": 0.31377,
        "externalCost": 0,
        "sharedCost": 0,
        "totalCost": 7e-05,
        "totalEfficiency": 0.13067,
        "proportionalAssetResourceCosts": {},
        "lbAllocations": null,
        "sharedCostBreakdown": {}
      }
    }
  ]
}
```

* Withou namespace parameter:

```sh
root@cesign [~]
-> # curl http://localhost:9003/allocation/compute \
  -d window=60m \
  -d resolution=1m \
  -d aggregate=controller \
  -d accumulate=true \
  -G | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13919    0 13919    0     0  1109k      0 --:--:-- --:--:-- --:--:-- 1132k
{
  "code": 200,
  "status": "success",
  "data": [
    {
      "__unallocated__": {
        "name": "__unallocated__",
        "properties": {
          "cluster": "cluster-one",
          "node": "opencost-control-plane"
        },
        "window": {
          "start": "2023-06-26T12:53:26Z",
          "end": "2023-06-26T13:53:26Z"
        },
        "start": "2023-06-26T13:44:00Z",
        "end": "2023-06-26T13:53:00Z",
        "minutes": 9,
        "cpuCores": 0.65111,
        "cpuCoreRequestAverage": 0.65111,
        "cpuCoreUsageAverage": 0.00657,
        "cpuCoreHours": 0.09767,
        "cpuCost": 0.00213,
        "cpuCostAdjustment": 0,
        "cpuEfficiency": 0.01009,
        "gpuCount": 0,
        "gpuHours": 0,
...
}
```

## Does this PR require changes to documentation?
* Yes, we need to update the official docs

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
