### PR TITLE
example results from betteralign apply

### DIFF
--- a/pkg/cloud/alibaba/boaconfiguration.go
+++ b/pkg/cloud/alibaba/boaconfiguration.go
@@ -9,9 +9,9 @@ import (
 
 // BOAConfiguration is the BSS open API configuration for Alibaba's Billing information
 type BOAConfiguration struct {
+	Authorizer Authorizer `json:"authorizer"`
 	Account    string     `json:"account"`
 	Region     string     `json:"region"`
-	Authorizer Authorizer `json:"authorizer"`
 }
 
 func (bc *BOAConfiguration) Validate() error {

--- a/pkg/cloud/aws/athenaconfiguration.go
+++ b/pkg/cloud/aws/athenaconfiguration.go
@@ -9,13 +9,13 @@ import (
 
 // AthenaConfiguration
 type AthenaConfiguration struct {
+	Authorizer Authorizer `json:"authorizer"`
 	Bucket     string     `json:"bucket"`
 	Region     string     `json:"region"`
 	Database   string     `json:"database"`
 	Table      string     `json:"table"`
 	Workgroup  string     `json:"workgroup"`
 	Account    string     `json:"account"`
-	Authorizer Authorizer `json:"authorizer"`
 }
 
 func (ac *AthenaConfiguration) Validate() error {

--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -48,19 +48,19 @@ const AthenaWhereUsage = "(line_item_line_item_type = 'Usage' OR line_item_line_
 
 // AthenaQueryIndexes is a struct for holding the context of a query
 type AthenaQueryIndexes struct {
-	Query                     string
 	ColumnIndexes             map[string]int
-	TagColumns                []string
+	NetK8sCostColumn          string
 	ListCostColumn            string
 	ListK8sCostColumn         string
 	NetCostColumn             string
-	NetK8sCostColumn          string
+	Query                     string
 	AmortizedNetCostColumn    string
 	AmortizedNetK8sCostColumn string
 	AmortizedCostColumn       string
 	AmortizedK8sCostColumn    string
 	InvoicedCostColumn        string
 	InvoicedK8sCostColumn     string
+	TagColumns                []string
 }
 
 type AthenaIntegration struct {

--- a/pkg/cloud/aws/s3configuration.go
+++ b/pkg/cloud/aws/s3configuration.go
@@ -9,10 +9,10 @@ import (
 )
 
 type S3Configuration struct {
+	Authorizer Authorizer `json:"authorizer"`
 	Bucket     string     `json:"bucket"`
 	Region     string     `json:"region"`
 	Account    string     `json:"account"`
-	Authorizer Authorizer `json:"authorizer"`
 }
 
 func (s3c *S3Configuration) Validate() error {

--- a/pkg/cloud/azure/billingexportparser.go
+++ b/pkg/cloud/azure/billingexportparser.go
@@ -20,13 +20,13 @@ var groupRegex = regexp.MustCompile("(/[^/]+)")
 // BillingRowValues holder for Azure Billing Values
 type BillingRowValues struct {
 	Date            time.Time
+	Tags            map[string]string
+	AdditionalInfo  map[string]any
 	MeterCategory   string
 	SubscriptionID  string
 	InvoiceEntityID string
 	InstanceID      string
 	Service         string
-	Tags            map[string]string
-	AdditionalInfo  map[string]any
 	Cost            float64
 	NetCost         float64
 }
@@ -49,6 +49,7 @@ func (brv *BillingRowValues) IsCompute(category string) bool {
 
 // BillingExportParser holds indexes of relevent fields in Azure Billing CSV in addition to the correct data format
 type BillingExportParser struct {
+	DateFormat      string
 	Date            int
 	MeterCategory   int
 	InvoiceEntityID int
@@ -59,7 +60,6 @@ type BillingExportParser struct {
 	AdditionalInfo  int
 	Cost            int
 	NetCost         int
-	DateFormat      string
 }
 
 // match "SubscriptionGuid" in "Abonnement-GUID (SubscriptionGuid)"

--- a/pkg/cloud/azure/pricesheetdownloader.go
+++ b/pkg/cloud/azure/pricesheetdownloader.go
@@ -21,12 +21,12 @@ import (
 )
 
 type PriceSheetDownloader struct {
+	ConvertMeterInfo func(info commerce.MeterInfo) (map[string]*AzurePricing, error)
 	TenantID         string
 	ClientID         string
 	ClientSecret     string
 	BillingAccount   string
 	OfferID          string
-	ConvertMeterInfo func(info commerce.MeterInfo) (map[string]*AzurePricing, error)
 }
 
 func (d *PriceSheetDownloader) GetPricing(ctx context.Context) (map[string]*AzurePricing, error) {
@@ -272,8 +272,8 @@ func ptr[T any](v T) *T {
 // prices we're interested in with factors to the corresponding units
 // in the rate card.
 var conversions = map[string]struct {
-	divisor float64
 	unit    string
+	divisor float64
 }{
 	"1 /Month":       {divisor: 1, unit: "1 /Month"},
 	"1 Hour":         {divisor: 1, unit: "1 Hour"},

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -356,34 +356,34 @@ type AzureRetailPricing struct {
 	BillingCurrency    string                         `json:"BillingCurrency"`
 	CustomerEntityId   string                         `json:"CustomerEntityId"`
 	CustomerEntityType string                         `json:"CustomerEntityType"`
-	Items              []AzureRetailPricingAttributes `json:"Items"`
 	NextPageLink       string                         `json:"NextPageLink"`
+	Items              []AzureRetailPricingAttributes `json:"Items"`
 	Count              int                            `json:"Count"`
 }
 
 // AzureRetailPricingAttributes struct for unmarshalling Azure Retail pricing api JSON response
 type AzureRetailPricingAttributes struct {
-	CurrencyCode         string     `json:"currencyCode"`
-	TierMinimumUnits     float32    `json:"tierMinimumUnits"`
-	RetailPrice          float32    `json:"retailPrice"`
-	UnitPrice            float32    `json:"unitPrice"`
-	ArmRegionName        string     `json:"armRegionName"`
-	Location             string     `json:"location"`
 	EffectiveStartDate   *time.Time `json:"effectiveStartDate"`
 	EffectiveEndDate     *time.Time `json:"effectiveEndDate"`
+	ProductId            string     `json:"productId"`
+	ServiceId            string     `json:"serviceId"`
+	ArmRegionName        string     `json:"armRegionName"`
+	Location             string     `json:"location"`
+	ArmSkuName           string     `json:"armSkuName"`
+	Type                 string     `json:"type"`
 	MeterId              string     `json:"meterId"`
 	MeterName            string     `json:"meterName"`
-	ProductId            string     `json:"productId"`
+	CurrencyCode         string     `json:"currencyCode"`
 	SkuId                string     `json:"skuId"`
 	ProductName          string     `json:"productName"`
 	SkuName              string     `json:"skuName"`
 	ServiceName          string     `json:"serviceName"`
-	ServiceId            string     `json:"serviceId"`
-	ServiceFamily        string     `json:"serviceFamily"`
 	UnitOfMeasure        string     `json:"unitOfMeasure"`
-	Type                 string     `json:"type"`
+	ServiceFamily        string     `json:"serviceFamily"`
+	UnitPrice            float32    `json:"unitPrice"`
+	TierMinimumUnits     float32    `json:"tierMinimumUnits"`
+	RetailPrice          float32    `json:"retailPrice"`
 	IsPrimaryMeterRegion bool       `json:"isPrimaryMeterRegion"`
-	ArmSkuName           string     `json:"armSkuName"`
 }
 
 // AzurePricing either contains a Node or PV
@@ -393,21 +393,21 @@ type AzurePricing struct {
 }
 
 type Azure struct {
-	Pricing                 map[string]*AzurePricing
-	DownloadPricingDataLock sync.RWMutex
-	Clientset               clustercache.ClusterCache
-	Config                  models.ProviderConfig
-	ServiceAccountChecks    *models.ServiceAccountChecks
-	ClusterAccountID        string
-	ClusterRegion           string
+	priceSheetPricingError error
+	rateCardPricingError   error
+	Clientset              clustercache.ClusterCache
+	Config                 models.ProviderConfig
+	ServiceAccountChecks   *models.ServiceAccountChecks
+	Pricing                map[string]*AzurePricing
+	azureSecret            *AzureServiceKey
+	azureStorageConfig     *AzureStorageConfig
+	ClusterAccountID       string
+	ClusterRegion          string
 
 	pricingSource                  string
-	rateCardPricingError           error
-	priceSheetPricingError         error
+	DownloadPricingDataLock        sync.RWMutex
 	loadedAzureSecret              bool
-	azureSecret                    *AzureServiceKey
 	loadedAzureStorageConfigSecret bool
-	azureStorageConfig             *AzureStorageConfig
 }
 
 // PricingSourceSummary returns the pricing source summary for the provider.
@@ -521,8 +521,8 @@ type AzureAppKey struct {
 // AzureServiceKey service key for a specific subscription
 // Deprecated: v1.104 Use ServiceKey instead
 type AzureServiceKey struct {
-	SubscriptionID string       `json:"subscriptionId"`
 	ServiceKey     *AzureAppKey `json:"serviceKey"`
+	SubscriptionID string       `json:"subscriptionId"`
 }
 
 // Validity check on service key

--- a/pkg/cloud/azure/storageconfiguration.go
+++ b/pkg/cloud/azure/storageconfiguration.go
@@ -8,12 +8,12 @@ import (
 )
 
 type StorageConfiguration struct {
+	Authorizer     Authorizer `json:"authorizer"`
 	SubscriptionID string     `json:"subscriptionID"`
 	Account        string     `json:"account"`
 	Container      string     `json:"container"`
 	Path           string     `json:"path"`
 	Cloud          string     `json:"cloud"`
-	Authorizer     Authorizer `json:"authorizer"`
 }
 
 // Check ensures that all required fields are set, and throws an error if they are not

--- a/pkg/cloud/gcp/bigqueryconfiguration.go
+++ b/pkg/cloud/gcp/bigqueryconfiguration.go
@@ -11,10 +11,10 @@ import (
 )
 
 type BigQueryConfiguration struct {
+	Authorizer Authorizer `json:"authorizer"`
 	ProjectID  string     `json:"projectID"`
 	Dataset    string     `json:"dataset"`
 	Table      string     `json:"table"`
-	Authorizer Authorizer `json:"authorizer"`
 }
 
 func (bqc *BigQueryConfiguration) Validate() error {

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -39,28 +39,28 @@ type ReservedInstanceData struct {
 // Node is the interface by which the provider and cost model communicate Node prices.
 // The provider will best-effort try to fill out this struct.
 type Node struct {
-	Cost             string                `json:"hourlyCost"`
-	VCPU             string                `json:"CPU"`
-	VCPUCost         string                `json:"CPUHourlyCost"`
-	RAM              string                `json:"RAM"`
-	RAMBytes         string                `json:"RAMBytes"`
+	Reserved         *ReservedInstanceData `json:"reserved,omitempty"`
+	BaseRAMPrice     string                `json:"baseRAMPrice"` // Used to compute an implicit RAM GB/Hr price when RAM pricing is not provided.
 	RAMCost          string                `json:"RAMGBHourlyCost"`
+	BaseGPUPrice     string                `json:"baseGPUPrice"`
+	GPU              string                `json:"gpu"` // GPU represents the number of GPU on the instance
+	UsageType        string                `json:"usageType"`
 	Storage          string                `json:"storage"`
 	StorageCost      string                `json:"storageHourlyCost"`
-	UsesBaseCPUPrice bool                  `json:"usesDefaultPrice"`
+	ArchType         string                `json:"archType,omitempty"`
 	BaseCPUPrice     string                `json:"baseCPUPrice"` // Used to compute an implicit RAM GB/Hr price when RAM pricing is not provided.
-	BaseRAMPrice     string                `json:"baseRAMPrice"` // Used to compute an implicit RAM GB/Hr price when RAM pricing is not provided.
-	BaseGPUPrice     string                `json:"baseGPUPrice"`
-	UsageType        string                `json:"usageType"`
-	GPU              string                `json:"gpu"` // GPU represents the number of GPU on the instance
+	Cost             string                `json:"hourlyCost"`
+	RAM              string                `json:"RAM"`
+	VCPUCost         string                `json:"CPUHourlyCost"`
+	RAMBytes         string                `json:"RAMBytes"`
 	GPUName          string                `json:"gpuName"`
 	GPUCost          string                `json:"gpuCost"`
 	InstanceType     string                `json:"instanceType,omitempty"`
 	Region           string                `json:"region,omitempty"`
-	Reserved         *ReservedInstanceData `json:"reserved,omitempty"`
+	VCPU             string                `json:"CPU"`
 	ProviderID       string                `json:"providerID,omitempty"`
 	PricingType      PricingType           `json:"pricingType,omitempty"`
-	ArchType         string                `json:"archType,omitempty"`
+	UsesBaseCPUPrice bool                  `json:"usesDefaultPrice"`
 }
 
 // IsSpot determines whether or not a Node uses spot by usage type
@@ -73,26 +73,26 @@ func (n *Node) IsSpot() bool {
 }
 
 type OrphanedResource struct {
-	Kind        string            `json:"resourceKind"`
-	Region      string            `json:"region"`
 	Description map[string]string `json:"description"`
 	Size        *int64            `json:"diskSizeInGB,omitempty"`
+	MonthlyCost *float64          `json:"monthlyCost"`
+	Kind        string            `json:"resourceKind"`
+	Region      string            `json:"region"`
 	DiskName    string            `json:"diskName,omitempty"`
 	Url         string            `json:"url"`
 	Address     string            `json:"ipAddress,omitempty"`
-	MonthlyCost *float64          `json:"monthlyCost"`
 }
 
 // PV is the interface by which the provider and cost model communicate PV prices.
 // The provider will best-effort try to fill out this struct.
 type PV struct {
+	Parameters map[string]string `json:"parameters"`
 	Cost       string            `json:"hourlyCost"`
 	CostPerIO  string            `json:"costPerIOOperation"`
 	Class      string            `json:"storageClass"`
 	Size       string            `json:"size"`
 	Region     string            `json:"region"`
 	ProviderID string            `json:"providerID,omitempty"`
-	Parameters map[string]string `json:"parameters"`
 }
 
 // Key represents a way for nodes to match between the k8s API and a pricing API
@@ -114,8 +114,8 @@ type OutOfClusterAllocation struct {
 	Aggregator  string  `json:"aggregator"`
 	Environment string  `json:"environment"`
 	Service     string  `json:"service"`
-	Cost        float64 `json:"cost"`
 	Cluster     string  `json:"cluster"`
+	Cost        float64 `json:"cost"`
 }
 
 type CustomPricing struct {
@@ -245,9 +245,9 @@ type PricingSources struct {
 
 type PricingSource struct {
 	Name      string `json:"name"`
+	Error     string `json:"error"`
 	Enabled   bool   `json:"enabled"`
 	Available bool   `json:"available"`
-	Error     string `json:"error"`
 }
 
 type PricingType string
@@ -263,8 +263,8 @@ const (
 )
 
 type PricingMatchMetadata struct {
-	TotalNodes        int                 `json:"TotalNodes"`
 	PricingTypeCounts map[PricingType]int `json:"PricingType"`
+	TotalNodes        int                 `json:"TotalNodes"`
 }
 
 // Provider represents a k8s provider.

--- a/pkg/cloud/models/serviceaccounts.go
+++ b/pkg/cloud/models/serviceaccounts.go
@@ -8,8 +8,8 @@ type ServiceAccountStatus struct {
 
 // ServiceAccountChecks is a thread safe map for holding ServiceAccountCheck objects
 type ServiceAccountChecks struct {
-	sync.RWMutex
 	serviceAccountChecks map[string]*ServiceAccountCheck
+	sync.RWMutex
 }
 
 // NewServiceAccountChecks initialize ServiceAccountChecks
@@ -40,6 +40,6 @@ func (sac *ServiceAccountChecks) GetStatus() *ServiceAccountStatus {
 
 type ServiceAccountCheck struct {
 	Message        string `json:"message"`
-	Status         bool   `json:"status"`
 	AdditionalInfo string `json:"additionalInfo"`
+	Status         bool   `json:"status"`
 }

--- a/pkg/cloud/provider/customprovider.go
+++ b/pkg/cloud/provider/customprovider.go
@@ -28,6 +28,7 @@ type NodePrice struct {
 
 type CustomProvider struct {
 	Clientset               clustercache.ClusterCache
+	Config                  models.ProviderConfig
 	Pricing                 map[string]*NodePrice
 	SpotLabel               string
 	SpotLabelValue          string
@@ -36,7 +37,6 @@ type CustomProvider struct {
 	ClusterRegion           string
 	ClusterAccountID        string
 	DownloadPricingDataLock sync.RWMutex
-	Config                  models.ProviderConfig
 }
 
 var volTypes = map[string]string{
@@ -72,11 +72,11 @@ func (cp *CustomProvider) PricingSourceSummary() interface{} {
 }
 
 type customProviderKey struct {
+	Labels         map[string]string
 	SpotLabel      string
 	SpotLabelValue string
 	GPULabel       string
 	GPULabelValue  string
-	Labels         map[string]string
 }
 
 func (*CustomProvider) ClusterManagementPricing() (string, float64, error) {

--- a/pkg/clustercache/clusterexporter.go
+++ b/pkg/clustercache/clusterexporter.go
@@ -35,10 +35,10 @@ type clusterEncoding struct {
 
 // ClusterExporter manages and runs an file export process which dumps the local kubernetes cluster to a target location.
 type ClusterExporter struct {
+	runState atomic.AtomicRunState
 	cluster  ClusterCache
 	target   *config.ConfigFile
 	interval time.Duration
-	runState atomic.AtomicRunState
 }
 
 // NewClusterExporter creates a new ClusterExporter instance for exporting the kubernetes cluster.

--- a/pkg/clustercache/clusterimporter.go
+++ b/pkg/clustercache/clusterimporter.go
@@ -17,9 +17,9 @@ import (
 // as it's source of the cluster data.
 type ClusterImporter struct {
 	source          *config.ConfigFile
-	sourceHandlerID config.HandlerID
 	dataLock        *sync.Mutex
 	data            *clusterEncoding
+	sourceHandlerID config.HandlerID
 }
 
 // Creates a new ClusterCache implementation which uses an import process to provide cluster data

--- a/pkg/clustercache/watchcontroller.go
+++ b/pkg/clustercache/watchcontroller.go
@@ -45,11 +45,11 @@ type CachingWatchController struct {
 	queue    workqueue.RateLimitingInterface
 	informer cache.Controller
 
-	resource     string
-	resourceType string
-
 	updateHandler WatchHandler
 	removeHandler WatchHandler
+
+	resource     string
+	resourceType string
 }
 
 func NewCachingWatcher(restClient rest.Interface, resource string, resourceType rt.Object, namespace string, fieldSelector fields.Selector) WatchController {

--- a/pkg/collections/blockingqueue.go
+++ b/pkg/collections/blockingqueue.go
@@ -37,9 +37,9 @@ type BlockingQueue[T any] interface {
 
 // blockingSliceQueue is an implementation of BlockingQueue which uses a slice for storage.
 type blockingSliceQueue[T any] struct {
-	q        []T
 	l        *sync.Mutex
 	nonEmpty *sync.Cond
+	q        []T
 }
 
 // NewBlockingQueue returns a new BlockingQueue implementation

--- a/pkg/config/configfile.go
+++ b/pkg/config/configfile.go
@@ -53,14 +53,14 @@ var NoBackingStore error = errors.New("Backing storage does not exist.")
 // ConfigFile is representation of a configuration file that can be written to, read, and watched
 // for updates
 type ConfigFile struct {
-	store      storage.Storage
-	file       string
-	dataLock   *sync.Mutex
-	data       []byte
-	watchLock  *sync.Mutex
-	watchers   []*pHandler
 	runState   atomic.AtomicRunState
 	lastChange time.Time
+	store      storage.Storage
+	dataLock   *sync.Mutex
+	watchLock  *sync.Mutex
+	file       string
+	data       []byte
+	watchers   []*pHandler
 }
 
 // NewConfigFile creates a new ConfigFile instance using a specific storage.Storage and path relative
@@ -358,7 +358,7 @@ func (cf *ConfigFile) onFileChange(changeType ChangeType, newData []byte) {
 
 // pHandler is a wrapper type used to assign a ConfigChangedHandler a unique identifier and priority.
 type pHandler struct {
-	id       HandlerID
 	handler  ConfigChangedHandler
+	id       HandlerID
 	priority int
 }

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -45,45 +45,45 @@ const (
 // allocation data per resource, vectors of rate data per resource, efficiency
 // data, and metadata describing the type of aggregation operation.
 type Aggregation struct {
+	End                        time.Time                      `json:"-"`
+	Start                      time.Time                      `json:"-"`
+	Properties                 *kubecost.AllocationProperties `json:"-"`
 	Aggregator                 string                         `json:"aggregation"`
-	Subfields                  []string                       `json:"subfields,omitempty"`
 	Environment                string                         `json:"environment"`
 	Cluster                    string                         `json:"cluster,omitempty"`
-	Properties                 *kubecost.AllocationProperties `json:"-"`
-	Start                      time.Time                      `json:"-"`
-	End                        time.Time                      `json:"-"`
-	CPUAllocationHourlyAverage float64                        `json:"cpuAllocationAverage"`
-	CPUAllocationVectors       []*util.Vector                 `json:"-"`
-	CPUAllocationTotal         float64                        `json:"-"`
-	CPUCost                    float64                        `json:"cpuCost"`
-	CPUCostVector              []*util.Vector                 `json:"cpuCostVector,omitempty"`
-	CPUEfficiency              float64                        `json:"cpuEfficiency"`
+	NetworkCostVector          []*util.Vector                 `json:"networkCostVector,omitempty"`
 	CPURequestedVectors        []*util.Vector                 `json:"-"`
-	CPUUsedVectors             []*util.Vector                 `json:"-"`
-	Efficiency                 float64                        `json:"efficiency"`
-	GPUAllocationHourlyAverage float64                        `json:"gpuAllocationAverage"`
-	GPUAllocationVectors       []*util.Vector                 `json:"-"`
-	GPUCost                    float64                        `json:"gpuCost"`
-	GPUCostVector              []*util.Vector                 `json:"gpuCostVector,omitempty"`
-	GPUAllocationTotal         float64                        `json:"-"`
-	RAMAllocationHourlyAverage float64                        `json:"ramAllocationAverage"`
+	CPUAllocationVectors       []*util.Vector                 `json:"-"`
+	Subfields                  []string                       `json:"subfields,omitempty"`
 	RAMAllocationVectors       []*util.Vector                 `json:"-"`
+	CPUCostVector              []*util.Vector                 `json:"cpuCostVector,omitempty"`
+	PVCostVector               []*util.Vector                 `json:"pvCostVector,omitempty"`
+	TotalCostVector            []*util.Vector                 `json:"totalCostVector,omitempty"`
+	CPUUsedVectors             []*util.Vector                 `json:"-"`
+	PVAllocationVectors        []*util.Vector                 `json:"-"`
+	RAMUsedVectors             []*util.Vector                 `json:"-"`
+	GPUAllocationVectors       []*util.Vector                 `json:"-"`
+	RAMRequestedVectors        []*util.Vector                 `json:"-"`
+	GPUCostVector              []*util.Vector                 `json:"gpuCostVector,omitempty"`
+	RAMCostVector              []*util.Vector                 `json:"ramCostVector,omitempty"`
+	CPUAllocationTotal         float64                        `json:"-"`
+	RAMAllocationHourlyAverage float64                        `json:"ramAllocationAverage"`
 	RAMAllocationTotal         float64                        `json:"-"`
 	RAMCost                    float64                        `json:"ramCost"`
-	RAMCostVector              []*util.Vector                 `json:"ramCostVector,omitempty"`
+	GPUAllocationTotal         float64                        `json:"-"`
 	RAMEfficiency              float64                        `json:"ramEfficiency"`
-	RAMRequestedVectors        []*util.Vector                 `json:"-"`
-	RAMUsedVectors             []*util.Vector                 `json:"-"`
+	GPUCost                    float64                        `json:"gpuCost"`
+	GPUAllocationHourlyAverage float64                        `json:"gpuAllocationAverage"`
 	PVAllocationHourlyAverage  float64                        `json:"pvAllocationAverage"`
-	PVAllocationVectors        []*util.Vector                 `json:"-"`
+	Efficiency                 float64                        `json:"efficiency"`
 	PVAllocationTotal          float64                        `json:"-"`
 	PVCost                     float64                        `json:"pvCost"`
-	PVCostVector               []*util.Vector                 `json:"pvCostVector,omitempty"`
+	CPUEfficiency              float64                        `json:"cpuEfficiency"`
 	NetworkCost                float64                        `json:"networkCost"`
-	NetworkCostVector          []*util.Vector                 `json:"networkCostVector,omitempty"`
+	CPUCost                    float64                        `json:"cpuCost"`
 	SharedCost                 float64                        `json:"sharedCost"`
 	TotalCost                  float64                        `json:"totalCost"`
-	TotalCostVector            []*util.Vector                 `json:"totalCostVector,omitempty"`
+	CPUAllocationHourlyAverage float64                        `json:"cpuAllocationAverage"`
 }
 
 // TotalHours determines the amount of hours the Aggregation covers, as a
@@ -130,15 +130,15 @@ func (a *Aggregation) RateCoefficient(rateStr string, resolutionHours float64) f
 }
 
 type SharedResourceInfo struct {
-	ShareResources  bool
 	SharedNamespace map[string]bool
 	LabelSelectors  map[string]map[string]bool
+	ShareResources  bool
 }
 
 type SharedCostInfo struct {
 	Name      string
-	Cost      float64
 	ShareType string
+	Cost      float64
 }
 
 func (s *SharedResourceInfo) IsSharedResource(costDatum *CostData) bool {
@@ -252,19 +252,19 @@ func (a *Accesses) ComputeIdleCoefficient(costData map[string]*CostData, cli pro
 
 // AggregationOptions provides optional parameters to AggregateCostData, allowing callers to perform more complex operations
 type AggregationOptions struct {
-	Discount               float64            // percent by which to discount CPU, RAM, and GPU cost
-	CustomDiscount         float64            // additional custom discount applied to all prices
-	IdleCoefficients       map[string]float64 // scales costs by amount of idle resources on a per-cluster basis
-	IncludeEfficiency      bool               // set to true to receive efficiency/usage data
-	IncludeTimeSeries      bool               // set to true to receive time series data
-	Rate                   string             // set to "hourly", "daily", or "monthly" to receive cost rate, rather than cumulative cost
-	ResolutionHours        float64
 	SharedResourceInfo     *SharedResourceInfo
-	SharedCosts            map[string]*SharedCostInfo
-	FilteredContainerCount int
+	IdleCoefficients       map[string]float64 // scales costs by amount of idle resources on a per-cluster basis
 	FilteredEnvironments   map[string]int
+	SharedCosts            map[string]*SharedCostInfo
 	SharedSplit            string
+	Rate                   string // set to "hourly", "daily", or "monthly" to receive cost rate, rather than cumulative cost
+	FilteredContainerCount int
+	ResolutionHours        float64
+	Discount               float64 // percent by which to discount CPU, RAM, and GPU cost
+	CustomDiscount         float64 // additional custom discount applied to all prices
 	TotalContainerCost     float64
+	IncludeTimeSeries      bool // set to true to receive time series data
+	IncludeEfficiency      bool // set to true to receive efficiency/usage data
 }
 
 // Helper method to test request/usgae values against allocation averages for efficiency scores. Generate a warning log if
@@ -1605,14 +1605,14 @@ func (s *SharedResourceInfo) String() string {
 }
 
 type aggKeyParams struct {
+	filters    map[string]string
+	sri        *SharedResourceInfo
 	duration   string
 	offset     string
-	filters    map[string]string
 	field      string
-	subfields  []string
 	rate       string
-	sri        *SharedResourceInfo
 	shareType  string
+	subfields  []string
 	idle       bool
 	timeSeries bool
 	efficiency bool
@@ -2286,8 +2286,8 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 // TODO move to util and/or standardize everything
 
 type Error struct {
-	StatusCode int
 	Body       string
+	StatusCode int
 }
 
 func WriteError(w http.ResponseWriter, err Error) {

--- a/pkg/costmodel/allocation_types.go
+++ b/pkg/costmodel/allocation_types.go
@@ -10,12 +10,12 @@ import (
 // pod describes a running pod's start and end time within a Window and
 // all the Allocations (i.e. containers) contained within it.
 type pod struct {
-	Window      kubecost.Window
 	Start       time.Time
 	End         time.Time
+	Window      kubecost.Window
+	Allocations map[string]*kubecost.Allocation
 	Key         podKey
 	Node        string
-	Allocations map[string]*kubecost.Allocation
 }
 
 func (p *pod) equal(that *pod) bool {
@@ -79,14 +79,14 @@ func (p *pod) appendContainer(container string) {
 // TODO:CLEANUP move to pkg/kubecost?
 // TODO:CLEANUP add PersistentVolumeClaims field to type Allocation?
 type pvc struct {
-	Bytes     float64   `json:"bytes"`
+	Start     time.Time `json:"start"`
+	End       time.Time `json:"end"`
+	Volume    *pv       `json:"persistentVolume"`
 	Name      string    `json:"name"`
 	Cluster   string    `json:"cluster"`
 	Namespace string    `json:"namespace"`
-	Volume    *pv       `json:"persistentVolume"`
+	Bytes     float64   `json:"bytes"`
 	Mounted   bool      `json:"mounted"`
-	Start     time.Time `json:"start"`
-	End       time.Time `json:"end"`
 }
 
 // Cost computes the cumulative cost of the pvc
@@ -127,11 +127,11 @@ func (p *pvc) key() pvcKey {
 type pv struct {
 	Start          time.Time `json:"start"`
 	End            time.Time `json:"end"`
-	Bytes          float64   `json:"bytes"`
-	CostPerGiBHour float64   `json:"costPerGiBHour"`
 	Cluster        string    `json:"cluster"`
 	Name           string    `json:"name"`
 	StorageClass   string    `json:"storageClass"`
+	Bytes          float64   `json:"bytes"`
+	CostPerGiBHour float64   `json:"costPerGiBHour"`
 }
 
 func (p *pv) clone() *pv {
@@ -208,8 +208,8 @@ func (p *pv) key() pvKey {
 
 // lbCost describes the start and end time of a Load Balancer along with cost
 type lbCost struct {
-	TotalCost float64
 	Start     time.Time
 	End       time.Time
+	TotalCost float64
 	Private   bool
 }

--- a/pkg/costmodel/allocationnode.go
+++ b/pkg/costmodel/allocationnode.go
@@ -37,10 +37,10 @@ type nodePricing struct {
 	Name            string
 	NodeType        string
 	ProviderID      string
-	Preemptible     bool
+	Source          string
 	CostPerCPUHr    float64
 	CostPerRAMGiBHr float64
 	CostPerGPUHr    float64
 	Discount        float64
-	Source          string
+	Preemptible     bool
 }

--- a/pkg/costmodel/clusters/clustermap.go
+++ b/pkg/costmodel/clusters/clustermap.go
@@ -102,11 +102,11 @@ type ClusterInfoProvider interface {
 
 // ClusterMap keeps records of all known cost-model clusters.
 type PrometheusClusterMap struct {
-	lock        sync.RWMutex
 	client      prometheus.Client
-	clusters    map[string]*ClusterInfo
 	clusterInfo ClusterInfoProvider
+	clusters    map[string]*ClusterInfo
 	stop        chan struct{}
+	lock        sync.RWMutex
 }
 
 // NewClusterMap creates a new ClusterMap implementation using a prometheus or thanos client

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -53,12 +53,12 @@ var isCron = regexp.MustCompile(`^(.+)-(\d{10}|\d{8})$`)
 type CostModel struct {
 	Cache                      clustercache.ClusterCache
 	ClusterMap                 clusters.ClusterMap
-	MaxPrometheusQueryDuration time.Duration
-	RequestGroup               *singleflight.Group
-	ScrapeInterval             time.Duration
 	PrometheusClient           prometheus.Client
 	Provider                   costAnalyzerCloud.Provider
+	RequestGroup               *singleflight.Group
 	pricingMetadata            *costAnalyzerCloud.PricingMatchMetadata
+	MaxPrometheusQueryDuration time.Duration
+	ScrapeInterval             time.Duration
 }
 
 func NewCostModel(client prometheus.Client, provider costAnalyzerCloud.Provider, cache clustercache.ClusterCache, clusterMap clusters.ClusterMap, scrapeInterval time.Duration) *CostModel {
@@ -77,30 +77,30 @@ func NewCostModel(client prometheus.Client, provider costAnalyzerCloud.Provider,
 }
 
 type CostData struct {
+	NodeData        *costAnalyzerCloud.Node      `json:"node,omitempty"`
+	NamespaceLabels map[string]string            `json:"namespaceLabels,omitempty"`
+	Labels          map[string]string            `json:"labels,omitempty"`
+	Annotations     map[string]string            `json:"annotations,omitempty"`
 	Name            string                       `json:"name,omitempty"`
 	PodName         string                       `json:"podName,omitempty"`
 	NodeName        string                       `json:"nodeName,omitempty"`
-	NodeData        *costAnalyzerCloud.Node      `json:"node,omitempty"`
 	Namespace       string                       `json:"namespace,omitempty"`
-	Deployments     []string                     `json:"deployments,omitempty"`
-	Services        []string                     `json:"services,omitempty"`
-	Daemonsets      []string                     `json:"daemonsets,omitempty"`
-	Statefulsets    []string                     `json:"statefulsets,omitempty"`
-	Jobs            []string                     `json:"jobs,omitempty"`
-	RAMReq          []*util.Vector               `json:"ramreq,omitempty"`
-	RAMUsed         []*util.Vector               `json:"ramused,omitempty"`
+	ClusterName     string                       `json:"clusterName"`
+	ClusterID       string                       `json:"clusterId"`
 	RAMAllocation   []*util.Vector               `json:"ramallocated,omitempty"`
+	PVCData         []*PersistentVolumeClaimData `json:"pvcData,omitempty"`
+	RAMReq          []*util.Vector               `json:"ramreq,omitempty"`
 	CPUReq          []*util.Vector               `json:"cpureq,omitempty"`
 	CPUUsed         []*util.Vector               `json:"cpuused,omitempty"`
 	CPUAllocation   []*util.Vector               `json:"cpuallocated,omitempty"`
 	GPUReq          []*util.Vector               `json:"gpureq,omitempty"`
-	PVCData         []*PersistentVolumeClaimData `json:"pvcData,omitempty"`
+	RAMUsed         []*util.Vector               `json:"ramused,omitempty"`
 	NetworkData     []*util.Vector               `json:"network,omitempty"`
-	Annotations     map[string]string            `json:"annotations,omitempty"`
-	Labels          map[string]string            `json:"labels,omitempty"`
-	NamespaceLabels map[string]string            `json:"namespaceLabels,omitempty"`
-	ClusterID       string                       `json:"clusterId"`
-	ClusterName     string                       `json:"clusterName"`
+	Jobs            []string                     `json:"jobs,omitempty"`
+	Statefulsets    []string                     `json:"statefulsets,omitempty"`
+	Daemonsets      []string                     `json:"daemonsets,omitempty"`
+	Services        []string                     `json:"services,omitempty"`
+	Deployments     []string                     `json:"deployments,omitempty"`
 }
 
 func (cd *CostData) String() string {
@@ -2337,14 +2337,14 @@ func getAllocatableVGPUs(cache clustercache.ClusterCache) (float64, error) {
 }
 
 type PersistentVolumeClaimData struct {
+	Volume       *costAnalyzerCloud.PV `json:"persistentVolume"`
 	Class        string                `json:"class"`
 	Claim        string                `json:"claim"`
 	Namespace    string                `json:"namespace"`
 	ClusterID    string                `json:"clusterId"`
-	TimesClaimed int                   `json:"timesClaimed"`
 	VolumeName   string                `json:"volumeName"`
-	Volume       *costAnalyzerCloud.PV `json:"persistentVolume"`
 	Values       []*util.Vector        `json:"values"`
+	TimesClaimed int                   `json:"timesClaimed"`
 }
 
 func measureTime(start time.Time, threshold time.Duration, name string) {

--- a/pkg/costmodel/csv_export.go
+++ b/pkg/costmodel/csv_export.go
@@ -165,8 +165,8 @@ func (e *csvExporter) writeCSVToWriter(ctx context.Context, w io.Writer, dates [
 	}
 
 	type columnDef struct {
-		column string
 		value  func(data rowData) string
+		column string
 	}
 
 	csvDef := []columnDef{

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -67,9 +67,9 @@ func (cic ClusterInfoCollector) Collect(ch chan<- prometheus.Metric) {
 
 // ClusterInfoMetric is a prometheus.Metric used to encode the local cluster info
 type ClusterInfoMetric struct {
+	labels map[string]string
 	fqName string
 	help   string
-	labels map[string]string
 }
 
 // Creates a new ClusterInfoMetric, implementation of prometheus.Metric

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -82,31 +82,31 @@ var (
 // Accesses defines a singleton application instance, providing access to
 // Prometheus, Kubernetes, the cloud provider, and caches.
 type Accesses struct {
-	Router              *httprouter.Router
-	PrometheusClient    prometheus.Client
-	ThanosClient        prometheus.Client
-	KubeClientSet       kubernetes.Interface
-	ClusterCache        clustercache.ClusterCache
-	ClusterMap          clusters.ClusterMap
-	CloudProvider       models.Provider
-	ConfigFileManager   *config.ConfigFileManager
+	AggAPI           Aggregator
+	PrometheusClient prometheus.Client
+	ThanosClient     prometheus.Client
+	KubeClientSet    kubernetes.Interface
+	ClusterCache     clustercache.ClusterCache
+	ClusterMap       clusters.ClusterMap
+	CloudProvider    models.Provider
+	// registered http service instances
+	httpServices        services.HTTPServices
 	ClusterInfoProvider clusters.ClusterInfoProvider
-	Model               *CostModel
 	MetricsEmitter      *CostModelMetricsEmitter
+	Router              *httprouter.Router
 	OutOfClusterCache   *cache.Cache
 	AggregateCache      *cache.Cache
 	CostDataCache       *cache.Cache
 	ClusterCostsCache   *cache.Cache
 	CacheExpiration     map[time.Duration]time.Duration
-	AggAPI              Aggregator
+	Model               *CostModel
 	// SettingsCache stores current state of app settings
 	SettingsCache *cache.Cache
 	// settingsSubscribers tracks channels through which changes to different
 	// settings will be published in a pub/sub model
 	settingsSubscribers map[string][]chan string
+	ConfigFileManager   *config.ConfigFileManager
 	settingsMutex       sync.Mutex
-	// registered http service instances
-	httpServices services.HTTPServices
 }
 
 // GetPrometheusClient decides whether the default Prometheus client or the Thanos client
@@ -166,11 +166,11 @@ func (a *Accesses) ClusterCostsFromCacheHandler(w http.ResponseWriter, r *http.R
 }
 
 type Response struct {
-	Code    int         `json:"code"`
-	Status  string      `json:"status"`
 	Data    interface{} `json:"data"`
+	Status  string      `json:"status"`
 	Message string      `json:"message,omitempty"`
 	Warning string      `json:"warning,omitempty"`
+	Code    int         `json:"code"`
 }
 
 // FilterFunc is a filter that returns true iff the given CostData should be filtered out, and the environment that was used as the filter criteria, if it was an aggregate
@@ -1187,9 +1187,9 @@ func (a *Accesses) GetInstallNamespace(w http.ResponseWriter, r *http.Request, _
 }
 
 type InstallInfo struct {
-	Containers  []ContainerInfo   `json:"containers"`
 	ClusterInfo map[string]string `json:"clusterInfo"`
 	Version     string            `json:"version"`
+	Containers  []ContainerInfo   `json:"containers"`
 }
 
 type ContainerInfo struct {

--- a/pkg/filemanager/filemanager.go
+++ b/pkg/filemanager/filemanager.go
@@ -135,9 +135,9 @@ func (c *S3File) Upload(ctx context.Context, f *os.File) error {
 }
 
 type GCSStorageFile struct {
+	client *storage.Client
 	bucket string
 	key    string
-	client *storage.Client
 }
 
 func NewGCSStorageFile(path string) (*GCSStorageFile, error) {

--- a/pkg/filter21/ast/lexer.go
+++ b/pkg/filter21/ast/lexer.go
@@ -95,8 +95,8 @@ func (tk tokenKind) String() string {
 // ============================================================================
 
 type token struct {
-	kind tokenKind
 	s    string
+	kind tokenKind
 }
 
 func (t token) String() string {
@@ -104,12 +104,12 @@ func (t token) String() string {
 }
 
 type scanner struct {
+	fields    map[string]*Field
+	mapFields map[string]*Field
+
 	source string
 	tokens []token
 	errors []error
-
-	fields    map[string]*Field
-	mapFields map[string]*Field
 
 	lexemeStartByte int
 	nextByte        int

--- a/pkg/filter21/ast/parser.go
+++ b/pkg/filter21/ast/parser.go
@@ -42,11 +42,10 @@ func parseError(t token, message string) error {
 }
 
 type parser struct {
-	tokens  []token
-	current int
-
 	fields    map[string]*Field
 	mapFields map[string]*Field
+	tokens    []token
+	current   int
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/filter21/matcher/stringmapmatcher.go
+++ b/pkg/filter21/matcher/stringmapmatcher.go
@@ -33,11 +33,10 @@ func (smmf *StringMapMatcherFactory[T]) NewStringMapMatcher(op ast.FilterOp, ide
 
 // // StringMapMatcher matches properties of a T instance which are map[string]string
 type StringMapMatcher[T any] struct {
-	Op         ast.FilterOp
-	Identifier ast.Identifier
-	Key        string
-
 	fieldMapper MapFieldMapper[T]
+	Identifier  ast.Identifier
+	Op          ast.FilterOp
+	Key         string
 }
 
 func (smm *StringMapMatcher[T]) String() string {

--- a/pkg/filter21/matcher/stringmatcher.go
+++ b/pkg/filter21/matcher/stringmatcher.go
@@ -33,11 +33,10 @@ func (smf *StringMatcherFactory[T]) NewStringMatcher(op ast.FilterOp, ident ast.
 
 // StringMatcher matches properties of a T instance which are string.
 type StringMatcher[T any] struct {
-	Op         ast.FilterOp
-	Identifier ast.Identifier
-	Value      string
-
 	fieldMapper StringFieldMapper[T]
+	Identifier  ast.Identifier
+	Op          ast.FilterOp
+	Value       string
 }
 
 func (sm *StringMatcher[T]) String() string {

--- a/pkg/filter21/matcher/stringslicematcher.go
+++ b/pkg/filter21/matcher/stringslicematcher.go
@@ -34,11 +34,10 @@ func (smf *StringSliceMatcherFactory[T]) NewStringSliceMatcher(op ast.FilterOp, 
 // StringSliceProperty is the lowest-level type of filter. It represents
 // a filter operation (equality, inequality, etc.) on a property that contains a string slice
 type StringSliceMatcher[T any] struct {
-	Op         ast.FilterOp
-	Identifier ast.Identifier
-	Value      string
-
 	fieldMapper SliceFieldMapper[T]
+	Identifier  ast.Identifier
+	Op          ast.FilterOp
+	Value       string
 }
 
 func (ssp *StringSliceMatcher[T]) String() string {

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -52,48 +52,48 @@ const ShareNone = "__none__"
 // TODO:CLEANUP consider dropping name in favor of just Allocation and an
 // Assets-style key() function for AllocationSet.
 type Allocation struct {
-	Name                       string                `json:"name"`
-	Properties                 *AllocationProperties `json:"properties,omitempty"`
-	Window                     Window                `json:"window"`
-	Start                      time.Time             `json:"start"`
-	End                        time.Time             `json:"end"`
-	CPUCoreHours               float64               `json:"cpuCoreHours"`
-	CPUCoreRequestAverage      float64               `json:"cpuCoreRequestAverage"`
-	CPUCoreUsageAverage        float64               `json:"cpuCoreUsageAverage"`
-	CPUCost                    float64               `json:"cpuCost"`
-	CPUCostAdjustment          float64               `json:"cpuCostAdjustment"`
-	GPUHours                   float64               `json:"gpuHours"`
-	GPUCost                    float64               `json:"gpuCost"`
-	GPUCostAdjustment          float64               `json:"gpuCostAdjustment"`
-	NetworkTransferBytes       float64               `json:"networkTransferBytes"`
-	NetworkReceiveBytes        float64               `json:"networkReceiveBytes"`
-	NetworkCost                float64               `json:"networkCost"`
-	NetworkCrossZoneCost       float64               `json:"networkCrossZoneCost"`   // @bingen:field[version=16]
-	NetworkCrossRegionCost     float64               `json:"networkCrossRegionCost"` // @bingen:field[version=16]
-	NetworkInternetCost        float64               `json:"networkInternetCost"`    // @bingen:field[version=16]
-	NetworkCostAdjustment      float64               `json:"networkCostAdjustment"`
-	LoadBalancerCost           float64               `json:"loadBalancerCost"`
-	LoadBalancerCostAdjustment float64               `json:"loadBalancerCostAdjustment"`
-	PVs                        PVAllocations         `json:"pvs"`
-	PVCostAdjustment           float64               `json:"pvCostAdjustment"`
-	RAMByteHours               float64               `json:"ramByteHours"`
-	RAMBytesRequestAverage     float64               `json:"ramByteRequestAverage"`
-	RAMBytesUsageAverage       float64               `json:"ramByteUsageAverage"`
-	RAMCost                    float64               `json:"ramCost"`
-	RAMCostAdjustment          float64               `json:"ramCostAdjustment"`
-	SharedCost                 float64               `json:"sharedCost"`
-	ExternalCost               float64               `json:"externalCost"`
-	// RawAllocationOnly is a pointer so if it is not present it will be
-	// marshalled as null rather than as an object with Go default values.
-	RawAllocationOnly *RawAllocationOnlyData `json:"rawAllocationOnly"`
+	Start         time.Time             `json:"start"`
+	End           time.Time             `json:"end"`
+	Window        Window                `json:"window"`
+	Properties    *AllocationProperties `json:"properties,omitempty"`
+	LoadBalancers LbAllocations         `json:"LoadBalancers"` // @bingen:field[version=17]
+
+	SharedCostBreakdown SharedCostBreakdowns `json:"sharedCostBreakdown"` //@bingen:field[ignore]
 	// ProportionalAssetResourceCost represents the per-resource costs of the
 	// allocation as a percentage of the per-resource total cost of the
 	// asset on which the allocation was run. It is optionally computed
 	// and appended to an Allocation, and so by default is is nil.
 	ProportionalAssetResourceCosts ProportionalAssetResourceCosts `json:"proportionalAssetResourceCosts"` //@bingen:field[ignore]
-	SharedCostBreakdown            SharedCostBreakdowns           `json:"sharedCostBreakdown"`            //@bingen:field[ignore]
-	LoadBalancers                  LbAllocations                  `json:"LoadBalancers"`                  // @bingen:field[version=17]
-
+	// RawAllocationOnly is a pointer so if it is not present it will be
+	// marshalled as null rather than as an object with Go default values.
+	RawAllocationOnly          *RawAllocationOnlyData `json:"rawAllocationOnly"`
+	PVs                        PVAllocations          `json:"pvs"`
+	Name                       string                 `json:"name"`
+	NetworkCrossZoneCost       float64                `json:"networkCrossZoneCost"` // @bingen:field[version=16]
+	PVCostAdjustment           float64                `json:"pvCostAdjustment"`
+	GPUCostAdjustment          float64                `json:"gpuCostAdjustment"`
+	NetworkTransferBytes       float64                `json:"networkTransferBytes"`
+	NetworkReceiveBytes        float64                `json:"networkReceiveBytes"`
+	NetworkCost                float64                `json:"networkCost"`
+	GPUHours                   float64                `json:"gpuHours"`
+	NetworkCrossRegionCost     float64                `json:"networkCrossRegionCost"` // @bingen:field[version=16]
+	NetworkInternetCost        float64                `json:"networkInternetCost"`    // @bingen:field[version=16]
+	NetworkCostAdjustment      float64                `json:"networkCostAdjustment"`
+	LoadBalancerCost           float64                `json:"loadBalancerCost"`
+	LoadBalancerCostAdjustment float64                `json:"loadBalancerCostAdjustment"`
+	CPUCostAdjustment          float64                `json:"cpuCostAdjustment"`
+	GPUCost                    float64                `json:"gpuCost"`
+	RAMByteHours               float64                `json:"ramByteHours"`
+	RAMBytesRequestAverage     float64                `json:"ramByteRequestAverage"`
+	RAMBytesUsageAverage       float64                `json:"ramByteUsageAverage"`
+	RAMCost                    float64                `json:"ramCost"`
+	RAMCostAdjustment          float64                `json:"ramCostAdjustment"`
+	SharedCost                 float64                `json:"sharedCost"`
+	ExternalCost               float64                `json:"externalCost"`
+	CPUCost                    float64                `json:"cpuCost"`
+	CPUCoreUsageAverage        float64                `json:"cpuCoreUsageAverage"`
+	CPUCoreRequestAverage      float64                `json:"cpuCoreRequestAverage"`
+	CPUCoreHours               float64                `json:"cpuCoreHours"`
 }
 
 type LbAllocations map[string]*LbAllocation
@@ -1103,20 +1103,20 @@ func NewAllocationSet(start, end time.Time, allocs ...*Allocation) *AllocationSe
 // succeeds, the allocation is marked as a shared resource. ShareIdle is a
 // simple flag for sharing idle resources.
 type AllocationAggregationOptions struct {
-	AllocationTotalsStore                 AllocationTotalsStore
 	Filter                                filter21.Filter
-	IdleByNode                            bool
-	IncludeProportionalAssetResourceCosts bool
+	AllocationTotalsStore                 AllocationTotalsStore
+	SharedLabels                          map[string][]string
+	SharedHourlyCosts                     map[string]float64
 	LabelConfig                           *LabelConfig
-	MergeUnallocated                      bool
-	Reconcile                             bool
-	ReconcileNetwork                      bool
+	ShareSplit                            string
+	ShareIdle                             string
 	ShareFuncs                            []AllocationMatchFunc
 	SharedNamespaces                      []string
-	SharedLabels                          map[string][]string
-	ShareIdle                             string
-	ShareSplit                            string
-	SharedHourlyCosts                     map[string]float64
+	Reconcile                             bool
+	ReconcileNetwork                      bool
+	MergeUnallocated                      bool
+	IncludeProportionalAssetResourceCosts bool
+	IdleByNode                            bool
 	IncludeSharedCostBreakdown            bool
 	SplitIdle                             bool
 	IncludeAggregatedMetadata             bool
@@ -2601,8 +2601,8 @@ func (as *AllocationSet) Accumulate(that *AllocationSet) (*AllocationSet, error)
 // respect to using the same aggregation properties, UTC offset, and
 // resolution. However these rules are not necessarily enforced, so use wisely.
 type AllocationSetRange struct {
-	Allocations []*AllocationSet
 	FromStore   string // stores the name of the store used to retrieve the data
+	Allocations []*AllocationSet
 }
 
 // NewAllocationSetRange instantiates a new range composed of the given

--- a/pkg/kubecost/allocation_json.go
+++ b/pkg/kubecost/allocation_json.go
@@ -11,11 +11,11 @@ import (
 // AllocationJSON  exists because there are expected JSON response fields
 // that are calculated values from methods on an annotation
 type AllocationJSON struct {
-	Name                           string                          `json:"name"`
-	Properties                     *AllocationProperties           `json:"properties"`
 	Window                         Window                          `json:"window"`
-	Start                          string                          `json:"start"`
-	End                            string                          `json:"end"`
+	NetworkInternetCost            *float64                        `json:"networkInternetCost"`
+	LoadBalancers                  LbAllocations                   `json:"lbAllocations"`
+	SharedCostBreakdown            *SharedCostBreakdowns           `json:"sharedCostBreakdown,omitempty"`
+	NetworkCostAdjustment          *float64                        `json:"networkCostAdjustment"`
 	Minutes                        *float64                        `json:"minutes"`
 	CPUCores                       *float64                        `json:"cpuCores"`
 	CPUCoreRequestAverage          *float64                        `json:"cpuCoreRequestAverage"`
@@ -29,14 +29,14 @@ type AllocationJSON struct {
 	GPUCost                        *float64                        `json:"gpuCost"`
 	GPUCostAdjustment              *float64                        `json:"gpuCostAdjustment"`
 	NetworkTransferBytes           *float64                        `json:"networkTransferBytes"`
-	NetworkReceiveBytes            *float64                        `json:"networkReceiveBytes"`
+	LoadBalancerCostAdjustment     *float64                        `json:"loadBalancerCostAdjustment"`
 	NetworkCost                    *float64                        `json:"networkCost"`
 	NetworkCrossZoneCost           *float64                        `json:"networkCrossZoneCost"`
 	NetworkCrossRegionCost         *float64                        `json:"networkCrossRegionCost"`
-	NetworkInternetCost            *float64                        `json:"networkInternetCost"`
-	NetworkCostAdjustment          *float64                        `json:"networkCostAdjustment"`
 	LoadBalancerCost               *float64                        `json:"loadBalancerCost"`
-	LoadBalancerCostAdjustment     *float64                        `json:"loadBalancerCostAdjustment"`
+	ProportionalAssetResourceCosts *ProportionalAssetResourceCosts `json:"proportionalAssetResourceCosts,omitempty"`
+	Properties                     *AllocationProperties           `json:"properties"`
+	NetworkReceiveBytes            *float64                        `json:"networkReceiveBytes"`
 	PVBytes                        *float64                        `json:"pvBytes"`
 	PVByteHours                    *float64                        `json:"pvByteHours"`
 	PVCost                         *float64                        `json:"pvCost"`
@@ -54,9 +54,9 @@ type AllocationJSON struct {
 	TotalCost                      *float64                        `json:"totalCost"`
 	TotalEfficiency                *float64                        `json:"totalEfficiency"`
 	RawAllocationOnly              *RawAllocationOnlyData          `json:"rawAllocationOnly,omitempty"`
-	ProportionalAssetResourceCosts *ProportionalAssetResourceCosts `json:"proportionalAssetResourceCosts,omitempty"`
-	LoadBalancers                  LbAllocations                   `json:"lbAllocations"`
-	SharedCostBreakdown            *SharedCostBreakdowns           `json:"sharedCostBreakdown,omitempty"`
+	End                            string                          `json:"end"`
+	Name                           string                          `json:"name"`
+	Start                          string                          `json:"start"`
 }
 
 func (aj *AllocationJSON) BuildFromAllocation(a *Allocation) {

--- a/pkg/kubecost/allocationmatcher.go
+++ b/pkg/kubecost/allocationmatcher.go
@@ -100,8 +100,8 @@ func allocationMapFieldMap(a *Allocation, identifier ast.Identifier) (map[string
 // a pass which converts alias nodes to logically-equivalent label/annotation
 // filter nodes based on the label config.
 type allocationAliasPass struct {
-	Config              LabelConfig
 	AliasNameToAliasKey map[afilter.AllocationAlias]string
+	Config              LabelConfig
 }
 
 // NewAliasPass creates a compiler pass that converts alias nodes to

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -92,19 +92,19 @@ func ParseProperty(text string) (string, error) {
 
 // AllocationProperties describes a set of Kubernetes objects.
 type AllocationProperties struct {
-	Cluster              string                `json:"cluster,omitempty"`
-	Node                 string                `json:"node,omitempty"`
-	Container            string                `json:"container,omitempty"`
+	Labels               AllocationLabels      `json:"labels,omitempty"`
+	NamespaceAnnotations AllocationAnnotations `json:"namespaceAnnotations,omitempty"` // @bingen:field[version=17]
+	NamespaceLabels      AllocationLabels      `json:"namespaceLabels,omitempty"`      // @bingen:field[version=17]
+	Annotations          AllocationAnnotations `json:"annotations,omitempty"`
 	Controller           string                `json:"controller,omitempty"`
-	ControllerKind       string                `json:"controllerKind,omitempty"`
 	Namespace            string                `json:"namespace,omitempty"`
 	Pod                  string                `json:"pod,omitempty"`
-	Services             []string              `json:"services,omitempty"`
 	ProviderID           string                `json:"providerID,omitempty"`
-	Labels               AllocationLabels      `json:"labels,omitempty"`
-	Annotations          AllocationAnnotations `json:"annotations,omitempty"`
-	NamespaceLabels      AllocationLabels      `json:"namespaceLabels,omitempty"`      // @bingen:field[version=17]
-	NamespaceAnnotations AllocationAnnotations `json:"namespaceAnnotations,omitempty"` // @bingen:field[version=17]
+	ControllerKind       string                `json:"controllerKind,omitempty"`
+	Cluster              string                `json:"cluster,omitempty"`
+	Container            string                `json:"container,omitempty"`
+	Node                 string                `json:"node,omitempty"`
+	Services             []string              `json:"services,omitempty"`
 	// When set to true, maintain the intersection of all labels + annotations
 	// in the aggregated AllocationProperties object
 	AggregatedMetadata bool `json:"-"` //@bingen:field[ignore]

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1098,22 +1098,22 @@ func (cm *ClusterManagement) String() string {
 
 // Disk represents an in-cluster disk Asset
 type Disk struct {
-	Labels         AssetLabels
-	Properties     *AssetProperties
-	Start          time.Time
 	End            time.Time
+	Start          time.Time
 	Window         Window
+	ByteUsageMax   *float64 // @bingen:field[version=18]
+	Properties     *AssetProperties
+	Breakdown      *Breakdown
+	ByteHoursUsed  *float64 // @bingen:field[version=18]
+	Labels         AssetLabels
+	StorageClass   string // @bingen:field[version=17]
+	VolumeName     string // @bingen:field[version=18]
+	ClaimName      string // @bingen:field[version=18]
+	ClaimNamespace string // @bingen:field[version=18]
 	Adjustment     float64
 	Cost           float64
 	ByteHours      float64
 	Local          float64
-	Breakdown      *Breakdown
-	StorageClass   string   // @bingen:field[version=17]
-	ByteHoursUsed  *float64 // @bingen:field[version=18]
-	ByteUsageMax   *float64 // @bingen:field[version=18]
-	VolumeName     string   // @bingen:field[version=18]
-	ClaimName      string   // @bingen:field[version=18]
-	ClaimNamespace string   // @bingen:field[version=18]
 }
 
 // NewDisk creates and returns a new Disk Asset
@@ -1762,25 +1762,25 @@ type NodeOverhead struct {
 
 // Node is an Asset representing a single node in a cluster
 type Node struct {
-	Properties   *AssetProperties
-	Labels       AssetLabels
 	Start        time.Time
 	End          time.Time
 	Window       Window
-	Adjustment   float64
+	CPUBreakdown *Breakdown
+	Labels       AssetLabels
+	Overhead     *NodeOverhead // @bingen:field[version=19]
+	RAMBreakdown *Breakdown
+	Properties   *AssetProperties
 	NodeType     string
-	CPUCoreHours float64
 	RAMByteHours float64
 	GPUHours     float64
-	CPUBreakdown *Breakdown
-	RAMBreakdown *Breakdown
+	CPUCoreHours float64
 	CPUCost      float64
 	GPUCost      float64
 	GPUCount     float64
 	RAMCost      float64
 	Discount     float64
 	Preemptible  float64
-	Overhead     *NodeOverhead // @bingen:field[version=19]
+	Adjustment   float64
 }
 
 // NewNode creates and returns a new Node Asset
@@ -3240,8 +3240,8 @@ func DiffAsset(before, after *AssetSet, ratioCostChange float64) (map[string]Dif
 // respect to using the same aggregation Properties, UTC offset, and
 // resolution. However these rules are not necessarily enforced, so use wisely.
 type AssetSetRange struct {
-	Assets    []*AssetSet
 	FromStore string // stores the name of the store used to retrieve the data
+	Assets    []*AssetSet
 }
 
 // NewAssetSetRange instantiates a new range composed of the given
@@ -3791,8 +3791,8 @@ func (asr *AssetSetRange) clone() *AssetSetRange {
 // DESERIALIZATION LOGIC DEFINED IN asset_json.go can unmarshal a json directly
 // from an Assets API query
 type AssetAPIResponse struct {
-	Code int                   `json:"code"`
 	Data AssetSetRangeResponse `json:"data"`
+	Code int                   `json:"code"`
 }
 
 // Returns true if string slices a and b contain all of the same strings, in any order.

--- a/pkg/kubecost/audit.go
+++ b/pkg/kubecost/audit.go
@@ -265,14 +265,14 @@ func (ac *AuditCoverage) Update(as *AuditSet) {
 
 // AuditSet is a ETLSet which contains all kind of Audits for a given Window
 type AuditSet struct {
-	sync.RWMutex
+	Window                   Window                         `json:"window"`
 	AllocationReconciliation *AllocationReconciliationAudit `json:"allocationReconciliation"`
 	AllocationAgg            *AggAudit                      `json:"allocationAgg"`
 	AllocationTotal          *TotalAudit                    `json:"allocationTotal"`
 	AssetTotal               *TotalAudit                    `json:"assetTotal"`
 	AssetReconciliation      *AssetReconciliationAudit      `json:"assetReconciliation"`
 	ClusterEquality          *EqualityAudit                 `json:"clusterEquality"`
-	Window                   Window                         `json:"window"`
+	sync.RWMutex
 }
 
 // NewAuditSet creates an empty AuditSet with the given window

--- a/pkg/kubecost/cloudcost.go
+++ b/pkg/kubecost/cloudcost.go
@@ -395,8 +395,8 @@ func (ccs *CloudCostSet) Merge(that *CloudCostSet) (*CloudCostSet, error) {
 }
 
 type CloudCostSetRange struct {
-	CloudCostSets []*CloudCostSet `json:"sets"`
 	Window        Window          `json:"window"`
+	CloudCostSets []*CloudCostSet `json:"sets"`
 }
 
 // NewCloudCostSetRange create a CloudCostSetRange containing CloudCostSets with windows of equal duration

--- a/pkg/kubecost/cloudcostprops.go
+++ b/pkg/kubecost/cloudcostprops.go
@@ -88,13 +88,13 @@ func (ccl CloudCostLabels) Intersection(that CloudCostLabels) CloudCostLabels {
 }
 
 type CloudCostProperties struct {
+	Labels          CloudCostLabels `json:"labels,omitempty"`
 	ProviderID      string          `json:"providerID,omitempty"`
 	Provider        string          `json:"provider,omitempty"`
 	AccountID       string          `json:"accountID,omitempty"`
 	InvoiceEntityID string          `json:"invoiceEntityID,omitempty"`
 	Service         string          `json:"service,omitempty"`
 	Category        string          `json:"category,omitempty"`
-	Labels          CloudCostLabels `json:"labels,omitempty"`
 }
 
 func (ccp *CloudCostProperties) Equal(that *CloudCostProperties) bool {

--- a/pkg/kubecost/coverage.go
+++ b/pkg/kubecost/coverage.go
@@ -9,12 +9,12 @@ import (
 
 // Coverage This is a placeholder struct which can be replaced by a more specific implementation later
 type Coverage struct {
+	Updated  time.Time `json:"updated"`
 	Window   Window    `json:"window"`
 	Type     string    `json:"type"`
-	Count    int       `json:"count"`
-	Updated  time.Time `json:"updated"`
 	Errors   []string  `json:"errors"`
 	Warnings []string  `json:"warnings"`
+	Count    int       `json:"count"`
 }
 
 func (c *Coverage) GetWindow() Window {

--- a/pkg/kubecost/etlrange.go
+++ b/pkg/kubecost/etlrange.go
@@ -10,8 +10,8 @@ import (
 // SetRange is a generic implementation of the SetRanges that act as containers. It covers the basic functionality that
 // is shared by the basic types but is meant to be extended by each implementation.
 type SetRange[T ETLSet] struct {
-	lock sync.RWMutex
 	sets []T
+	lock sync.RWMutex
 }
 
 // Append attaches the given ETLSet to the end of the sets slice.

--- a/pkg/kubecost/query.go
+++ b/pkg/kubecost/query.go
@@ -36,25 +36,25 @@ type CloudUsageQuerier interface {
 
 // AllocationQueryOptions defines optional parameters for querying an Allocation Store
 type AllocationQueryOptions struct {
-	Accumulate              AccumulateOption
-	AggregateBy             []string
-	Compute                 bool
-	DisableAggregatedStores bool
 	Filter                  filter21.Filter
-	IdleByNode              bool
-	IncludeExternal         bool
-	IncludeIdle             bool
 	LabelConfig             *LabelConfig
-	MergeUnallocated        bool
-	Reconcile               bool
-	ReconcileNetwork        bool
-	ShareFuncs              []AllocationMatchFunc
 	SharedHourlyCosts       map[string]float64
-	ShareIdle               string
 	ShareSplit              string
+	ShareIdle               string
+	Accumulate              AccumulateOption
+	ShareFuncs              []AllocationMatchFunc
+	AggregateBy             []string
+	Step                    time.Duration
+	IncludeExternal         bool
+	DisableAggregatedStores bool
+	IncludeIdle             bool
+	Compute                 bool
+	IdleByNode              bool
+	ReconcileNetwork        bool
+	Reconcile               bool
 	ShareTenancyCosts       bool
 	SplitIdle               bool
-	Step                    time.Duration
+	MergeUnallocated        bool
 }
 
 type AccumulateOption string
@@ -70,36 +70,36 @@ const (
 
 // AssetQueryOptions defines optional parameters for querying an Asset Store
 type AssetQueryOptions struct {
-	Accumulate              bool
+	Filter                  filter21.Filter
+	SharedHourlyCosts       map[string]float64
+	LabelConfig             *LabelConfig
 	AggregateBy             []string
+	Step                    time.Duration
+	Accumulate              bool
 	Compute                 bool
 	DisableAdjustments      bool
 	DisableAggregatedStores bool
-	Filter                  filter21.Filter
 	IncludeCloud            bool
-	SharedHourlyCosts       map[string]float64
-	Step                    time.Duration
-	LabelConfig             *LabelConfig
 }
 
 // CloudUsageQueryOptions define optional parameters for querying a Store
 type CloudUsageQueryOptions struct {
-	Accumulate   bool
-	AggregateBy  []string
-	Compute      bool
-	Filter       filter21.Filter
 	FilterValues CloudUsageFilter
+	Filter       filter21.Filter
 	LabelConfig  *LabelConfig
+	AggregateBy  []string
+	Accumulate   bool
+	Compute      bool
 }
 
 type CloudUsageFilter struct {
+	Labels      map[string][]string `json:"labels"`
 	Categories  []string            `json:"categories"`
 	Providers   []string            `json:"providers"`
 	ProviderIDs []string            `json:"providerIDs"`
 	Accounts    []string            `json:"accounts"`
 	Projects    []string            `json:"projects"`
 	Services    []string            `json:"services"`
-	Labels      map[string][]string `json:"labels"`
 }
 
 // QueryAllocationAsync provide a functions for retrieving results from any AllocationQuerier Asynchronously

--- a/pkg/kubecost/status.go
+++ b/pkg/kubecost/status.go
@@ -4,63 +4,63 @@ import "time"
 
 // ETLStatus describes ETL metadata
 type ETLStatus struct {
-	Coverage                   Window           `json:"coverage"`
 	LastRun                    time.Time        `json:"lastRun"`
-	Progress                   float64          `json:"progress"`
+	StartTime                  time.Time        `json:"startTime"`
+	Coverage                   Window           `json:"coverage"`
+	Backup                     *DirectoryStatus `json:"backup,omitempty"`
 	RefreshRate                string           `json:"refreshRate"`
 	Resolution                 string           `json:"resolution"`
 	MaxPrometheusQueryDuration string           `json:"maxPrometheusQueryDuration"`
-	StartTime                  time.Time        `json:"startTime"`
 	UTCOffset                  string           `json:"utcOffset"`
-	Backup                     *DirectoryStatus `json:"backup,omitempty"`
+	Progress                   float64          `json:"progress"`
 }
 
 // DirectoryStatus describes metadata of a directory of files
 type DirectoryStatus struct {
+	LastModified time.Time    `json:"lastModified"`
 	Path         string       `json:"path"`
 	Size         string       `json:"size"`
-	LastModified time.Time    `json:"lastModified"`
-	FileCount    int          `json:"fileCount"`
 	Files        []FileStatus `json:"files"`
+	FileCount    int          `json:"fileCount"`
 }
 
 // FileStatus describes the metadata of a single file
 type FileStatus struct {
+	LastModified time.Time         `json:"lastModified"`
+	Details      map[string]string `json:"details,omitempty"`
 	Name         string            `json:"name"`
 	Size         string            `json:"size"`
-	LastModified time.Time         `json:"lastModified"`
-	IsRepairing  bool              `json:"isRepairing"`
-	Details      map[string]string `json:"details,omitempty"`
 	Errors       []string          `json:"errors,omitempty"`
 	Warnings     []string          `json:"warnings,omitempty"`
+	IsRepairing  bool              `json:"isRepairing"`
 }
 
 // CloudStatus describes CloudStore metadata
 type CloudStatus struct {
-	ConnectionStatus string                `json:"cloudConnectionStatus"`
-	ProviderType     string                `json:"providerType"`
 	CloudUsage       *CloudAssetStatus     `json:"cloudUsage,omitempty"`
 	Reconciliation   *ReconciliationStatus `json:"reconciliation,omitempty"`
+	ConnectionStatus string                `json:"cloudConnectionStatus"`
+	ProviderType     string                `json:"providerType"`
 }
 
 // CloudAssetStatus describes CloudAsset metadata of a CloudStore
 type CloudAssetStatus struct {
-	Coverage    Window    `json:"coverage"`
 	LastRun     time.Time `json:"lastRun"`
 	NextRun     time.Time `json:"nextRun"`
-	Progress    float64   `json:"progress"`
+	StartTime   time.Time `json:"startTime"`
+	Coverage    Window    `json:"coverage"`
 	RefreshRate string    `json:"refreshRate"`
 	Resolution  string    `json:"resolution"`
-	StartTime   time.Time `json:"startTime"`
+	Progress    float64   `json:"progress"`
 }
 
 // ReconciliationStatus describes Reconciliation metadata of a CloudStore
 type ReconciliationStatus struct {
-	Coverage    Window    `json:"coverage"`
 	LastRun     time.Time `json:"lastRun"`
 	NextRun     time.Time `json:"nextRun"`
-	Progress    float64   `json:"progress"`
+	StartTime   time.Time `json:"startTime"`
+	Coverage    Window    `json:"coverage"`
 	RefreshRate string    `json:"refreshRate"`
 	Resolution  string    `json:"resolution"`
-	StartTime   time.Time `json:"startTime"`
+	Progress    float64   `json:"progress"`
 }

--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -22,15 +22,15 @@ import (
 // within which it is defined, as opposed to the Start and End times). That
 // context must be provided by a SummaryAllocationSet.
 type SummaryAllocation struct {
-	Name                   string                `json:"name"`
-	Properties             *AllocationProperties `json:"-"`
 	Start                  time.Time             `json:"start"`
 	End                    time.Time             `json:"end"`
-	CPUCoreRequestAverage  float64               `json:"cpuCoreRequestAverage"`
+	Properties             *AllocationProperties `json:"-"`
+	Name                   string                `json:"name"`
+	NetworkCost            float64               `json:"networkCost"`
 	CPUCoreUsageAverage    float64               `json:"cpuCoreUsageAverage"`
 	CPUCost                float64               `json:"cpuCost"`
 	GPUCost                float64               `json:"gpuCost"`
-	NetworkCost            float64               `json:"networkCost"`
+	CPUCoreRequestAverage  float64               `json:"cpuCoreRequestAverage"`
 	LoadBalancerCost       float64               `json:"loadBalancerCost"`
 	PVCost                 float64               `json:"pvCost"`
 	RAMBytesRequestAverage float64               `json:"ramByteRequestAverage"`
@@ -360,11 +360,11 @@ func (sa *SummaryAllocation) TotalEfficiency() float64 {
 // name, that share a window. An AllocationSet is mutable, so treat it like a
 // threadsafe map.
 type SummaryAllocationSet struct {
-	sync.RWMutex
+	Window             Window `json:"window"`
 	externalKeys       map[string]bool
 	idleKeys           map[string]bool
 	SummaryAllocations map[string]*SummaryAllocation `json:"allocations"`
-	Window             Window                        `json:"window"`
+	sync.RWMutex
 }
 
 // NewSummaryAllocationSet converts an AllocationSet to a SummaryAllocationSet.
@@ -1360,11 +1360,11 @@ func (sas *SummaryAllocationSet) TotalEfficiency() float64 {
 
 // SummaryAllocationSetRange is a thread-safe slice of SummaryAllocationSets.
 type SummaryAllocationSetRange struct {
-	sync.RWMutex
-	Step                  time.Duration           `json:"step"`
-	SummaryAllocationSets []*SummaryAllocationSet `json:"sets"`
 	Window                Window                  `json:"window"`
 	Message               string                  `json:"-"`
+	SummaryAllocationSets []*SummaryAllocationSet `json:"sets"`
+	Step                  time.Duration           `json:"step"`
+	sync.RWMutex
 }
 
 // NewSummaryAllocationSetRange instantiates a new range composed of the given

--- a/pkg/kubecost/summaryallocation_json.go
+++ b/pkg/kubecost/summaryallocation_json.go
@@ -9,13 +9,12 @@ import (
 // SummaryAllocationResponse is a sanitized version of SummaryAllocation, which
 // formats fields and protects against issues like mashaling NaNs.
 type SummaryAllocationResponse struct {
-	Name                   string    `json:"name"`
-	Start                  time.Time `json:"start"`
 	End                    time.Time `json:"end"`
+	Start                  time.Time `json:"start"`
+	GPUCost                *float64  `json:"gpuCost"`
 	CPUCoreRequestAverage  *float64  `json:"cpuCoreRequestAverage"`
 	CPUCoreUsageAverage    *float64  `json:"cpuCoreUsageAverage"`
 	CPUCost                *float64  `json:"cpuCost"`
-	GPUCost                *float64  `json:"gpuCost"`
 	NetworkCost            *float64  `json:"networkCost"`
 	LoadBalancerCost       *float64  `json:"loadBalancerCost"`
 	PVCost                 *float64  `json:"pvCost"`
@@ -24,6 +23,7 @@ type SummaryAllocationResponse struct {
 	RAMCost                *float64  `json:"ramCost"`
 	SharedCost             *float64  `json:"sharedCost"`
 	ExternalCost           *float64  `json:"externalCost"`
+	Name                   string    `json:"name"`
 }
 
 // ToResponse converts a SummaryAllocation to a SummaryAllocationResponse,
@@ -80,9 +80,9 @@ func (sas *SummaryAllocationSet) ToResponse() *SummaryAllocationSetResponse {
 // SummaryAllocationSetRangeResponse is a sanitized version of SummaryAllocationSetRange,
 // which formats fields and protects against issues like marshaling NaNs.
 type SummaryAllocationSetRangeResponse struct {
-	Step                  time.Duration                   `json:"step"`
-	SummaryAllocationSets []*SummaryAllocationSetResponse `json:"sets"`
 	Window                Window                          `json:"window"`
+	SummaryAllocationSets []*SummaryAllocationSetResponse `json:"sets"`
+	Step                  time.Duration                   `json:"step"`
 }
 
 // ToResponse converts a SummaryAllocationSet to a SummaryAllocationSetResponse,

--- a/pkg/log/counter.go
+++ b/pkg/log/counter.go
@@ -3,8 +3,8 @@ package log
 import "sync"
 
 type counter struct {
-	mu   sync.RWMutex
 	seen map[string]int
+	mu   sync.RWMutex
 }
 
 func newCounter() *counter {

--- a/pkg/metrics/deploymentmetrics.go
+++ b/pkg/metrics/deploymentmetrics.go
@@ -59,10 +59,10 @@ func (kdc KubecostDeploymentCollector) Collect(ch chan<- prometheus.Metric) {
 type DeploymentMatchLabelsMetric struct {
 	fqName         string
 	help           string
-	labelNames     []string
-	labelValues    []string
 	deploymentName string
 	namespace      string
+	labelNames     []string
+	labelValues    []string
 }
 
 // Creates a new DeploymentMatchLabelsMetric, implementation of prometheus.Metric

--- a/pkg/metrics/events.go
+++ b/pkg/metrics/events.go
@@ -5,8 +5,8 @@ import "time"
 // HttpHandlerMetricEvent contains http handler response metrics.
 type HttpHandlerMetricEvent struct {
 	Handler      string
-	Code         int
 	Method       string
+	Code         int
 	ResponseTime time.Duration
 	ResponseSize uint64
 }

--- a/pkg/metrics/nodemetrics.go
+++ b/pkg/metrics/nodemetrics.go
@@ -208,8 +208,8 @@ func (kpcrr KubeNodeStatusCapacityMetric) Write(m *dto.Metric) error {
 type KubeNodeStatusCapacityMemoryBytesMetric struct {
 	fqName string
 	help   string
-	bytes  float64
 	node   string
+	bytes  float64
 }
 
 // Creates a new KubeNodeStatusCapacityMemoryBytesMetric, implementation of prometheus.Metric
@@ -254,8 +254,8 @@ func (nam KubeNodeStatusCapacityMemoryBytesMetric) Write(m *dto.Metric) error {
 type KubeNodeStatusCapacityCPUCoresMetric struct {
 	fqName string
 	help   string
-	cores  float64
 	node   string
+	cores  float64
 }
 
 // Creates a new KubeNodeStatusCapacityCPUCoresMetric, implementation of prometheus.Metric
@@ -300,9 +300,9 @@ func (nam KubeNodeStatusCapacityCPUCoresMetric) Write(m *dto.Metric) error {
 type KubeNodeLabelsMetric struct {
 	fqName      string
 	help        string
+	node        string
 	labelNames  []string
 	labelValues []string
-	node        string
 }
 
 // Creates a new KubeNodeLabelsMetric, implementation of prometheus.Metric

--- a/pkg/metrics/podmetrics.go
+++ b/pkg/metrics/podmetrics.go
@@ -117,8 +117,8 @@ func (kpmc KubePodCollector) Collect(ch chan<- prometheus.Metric) {
 		if _, disabled := disabledMetrics["kube_pod_status_phase"]; !disabled {
 			if phase != "" {
 				phases := []struct {
-					v bool
 					n string
+					v bool
 				}{
 					{phase == v1.PodPending, string(v1.PodPending)},
 					{phase == v1.PodSucceeded, string(v1.PodSucceeded)},
@@ -1009,9 +1009,9 @@ type KubePodOwnerMetric struct {
 	help              string
 	namespace         string
 	pod               string
-	ownerIsController bool
 	ownerName         string
 	ownerKind         string
+	ownerIsController bool
 }
 
 // Creates a new KubePodOwnerMetric, implementation of prometheus.Metric

--- a/pkg/metrics/pvmetrics.go
+++ b/pkg/metrics/pvmetrics.go
@@ -43,8 +43,8 @@ func (kpvcb KubePVCollector) Collect(ch chan<- prometheus.Metric) {
 			phase := pv.Status.Phase
 			if phase != "" {
 				phases := []struct {
-					v bool
 					n string
+					v bool
 				}{
 					{phase == v1.VolumePending, string(v1.VolumePending)},
 					{phase == v1.VolumeAvailable, string(v1.VolumeAvailable)},

--- a/pkg/metrics/servicemetrics.go
+++ b/pkg/metrics/servicemetrics.go
@@ -59,10 +59,10 @@ func (sc KubecostServiceCollector) Collect(ch chan<- prometheus.Metric) {
 type ServiceSelectorLabelsMetric struct {
 	fqName      string
 	help        string
-	labelNames  []string
-	labelValues []string
 	serviceName string
 	namespace   string
+	labelNames  []string
+	labelValues []string
 }
 
 // Creates a new ServiceMetric, implementation of prometheus.Metric

--- a/pkg/metrics/statefulsetmetrics.go
+++ b/pkg/metrics/statefulsetmetrics.go
@@ -58,10 +58,10 @@ func (sc KubecostStatefulsetCollector) Collect(ch chan<- prometheus.Metric) {
 type StatefulsetMatchLabelsMetric struct {
 	fqName          string
 	help            string
-	labelNames      []string
-	labelValues     []string
 	statefulsetName string
 	namespace       string
+	labelNames      []string
+	labelValues     []string
 }
 
 // Creates a new StatefulsetMetric, implementation of prometheus.Metric

--- a/pkg/prom/error.go
+++ b/pkg/prom/error.go
@@ -27,9 +27,9 @@ func IsNoStoreAPIWarning(warning string) bool {
 //--------------------------------------------------------------------------
 
 type QueryError struct {
-	Query      string `json:"query"`
 	Error      error  `json:"error"`
 	ParseError error  `json:"parseError"`
+	Query      string `json:"query"`
 }
 
 // String returns a string representation of the QueryError
@@ -84,9 +84,9 @@ type ErrorsAndWarningStrings struct {
 // QueryErrorCollector is used to collect prometheus query errors and warnings, and also meets the
 // Error interface
 type QueryErrorCollector struct {
-	m        sync.RWMutex
 	errors   []*QueryError
 	warnings []*QueryWarning
+	m        sync.RWMutex
 }
 
 // Reports an error to the collector. Ignores if the error is nil and the warnings

--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -31,8 +31,8 @@ var promQueryOffset time.Duration = env.GetPrometheusQueryOffset()
 // parsing query responses and errors.
 type Context struct {
 	Client         prometheus.Client
-	name           string
 	errorCollector *QueryErrorCollector
+	name           string
 }
 
 // NewContext creates a new Prometheus querying context from the given client

--- a/pkg/services/clusters/boltdbstorage.go
+++ b/pkg/services/clusters/boltdbstorage.go
@@ -6,8 +6,8 @@ import (
 
 // BoltDBClusterStorage is a boltdb implementation of a database used to store cluster definitions
 type BoltDBClusterStorage struct {
-	bucket []byte
 	db     *bolt.DB
+	bucket []byte
 }
 
 // NewBoltDBClusterStorage creates a new boltdb backed ClusterStorage implementation

--- a/pkg/services/clusters/clustermanager.go
+++ b/pkg/services/clusters/clustermanager.go
@@ -36,18 +36,18 @@ type ClusterConfigEntryAuth struct {
 
 // Cluster definition from a configuration yaml
 type ClusterConfigEntry struct {
-	Name    string                  `yaml:"name"`
-	Address string                  `yaml:"address"`
 	Auth    *ClusterConfigEntryAuth `yaml:"auth,omitempty"`
 	Details map[string]interface{}  `yaml:"details,omitempty"`
+	Name    string                  `yaml:"name"`
+	Address string                  `yaml:"address"`
 }
 
 // ClusterDefinition
 type ClusterDefinition struct {
+	Details map[string]interface{} `json:"details,omitempty"`
 	ID      string                 `json:"id,omitempty"`
 	Name    string                 `json:"name"`
 	Address string                 `json:"address"`
-	Details map[string]interface{} `json:"details,omitempty"`
 }
 
 // ClusterStorage interface defines an implementation prototype for a storage responsible

--- a/pkg/services/clusters/clustersendpoints.go
+++ b/pkg/services/clusters/clustersendpoints.go
@@ -13,9 +13,9 @@ import (
 
 // DataEnvelope is a generic wrapper struct for http response data
 type DataEnvelope struct {
-	Code   int         `json:"code"`
-	Status string      `json:"status"`
 	Data   interface{} `json:"data"`
+	Status string      `json:"status"`
+	Code   int         `json:"code"`
 }
 
 // ClusterManagerHTTPService is an implementation of HTTPService which provides

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -25,8 +25,8 @@ type HTTPServices interface {
 }
 
 type defaultHTTPServices struct {
-	sync.Mutex
 	services []HTTPService
+	sync.Mutex
 }
 
 // Add a HTTPService implementation for

--- a/pkg/storage/azurestorage.go
+++ b/pkg/storage/azurestorage.go
@@ -71,12 +71,12 @@ type AzureConfig struct {
 	StorageAccountKey  string          `yaml:"storage_account_key"`
 	ContainerName      string          `yaml:"container"`
 	Endpoint           string          `yaml:"endpoint"`
-	MaxRetries         int             `yaml:"max_retries"`
 	MSIResource        string          `yaml:"msi_resource"`
 	UserAssignedID     string          `yaml:"user_assigned_id"`
-	PipelineConfig     PipelineConfig  `yaml:"pipeline_config"`
-	ReaderConfig       ReaderConfig    `yaml:"reader_config"`
 	HTTPConfig         AzureHTTPConfig `yaml:"http_config"`
+	PipelineConfig     PipelineConfig  `yaml:"pipeline_config"`
+	MaxRetries         int             `yaml:"max_retries"`
+	ReaderConfig       ReaderConfig    `yaml:"reader_config"`
 }
 
 type ReaderConfig struct {
@@ -91,25 +91,25 @@ type PipelineConfig struct {
 }
 
 type AzureHTTPConfig struct {
+	TLSConfig             TLSConfig      `yaml:"tls_config"`
 	IdleConnTimeout       model.Duration `yaml:"idle_conn_timeout"`
 	ResponseHeaderTimeout model.Duration `yaml:"response_header_timeout"`
-	InsecureSkipVerify    bool           `yaml:"insecure_skip_verify"`
 
 	TLSHandshakeTimeout   model.Duration `yaml:"tls_handshake_timeout"`
 	ExpectContinueTimeout model.Duration `yaml:"expect_continue_timeout"`
 	MaxIdleConns          int            `yaml:"max_idle_conns"`
 	MaxIdleConnsPerHost   int            `yaml:"max_idle_conns_per_host"`
 	MaxConnsPerHost       int            `yaml:"max_conns_per_host"`
-	DisableCompression    bool           `yaml:"disable_compression"`
+	InsecureSkipVerify    bool           `yaml:"insecure_skip_verify"`
 
-	TLSConfig TLSConfig `yaml:"tls_config"`
+	DisableCompression bool `yaml:"disable_compression"`
 }
 
 // AzureStorage implements the storage.Storage interface against Azure APIs.
 type AzureStorage struct {
-	name         string
 	containerURL blob.ContainerURL
 	config       *AzureConfig
+	name         string
 }
 
 // Validate checks to see if any of the config options are set.

--- a/pkg/storage/gcsstorage.go
+++ b/pkg/storage/gcsstorage.go
@@ -26,9 +26,9 @@ type GCSConfig struct {
 
 // GCSStorage is a storage.Storage implementation for Google Cloud Storage.
 type GCSStorage struct {
-	name   string
 	bucket *gcs.BucketHandle
 	client *gcs.Client
+	name   string
 }
 
 // NewGCSStorage creates a new GCSStorage instance using the provided GCS configuration.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,9 +16,9 @@ var DoesNotExistError = os.ErrNotExist
 
 // StorageInfo is a data object containing basic information about the path in storage.
 type StorageInfo struct {
+	ModTime time.Time // modification time
 	Name    string    // base name of the file
 	Size    int64     // length in bytes for regular files
-	ModTime time.Time // modification time
 }
 
 // Storage provides an API for storing binary data

--- a/pkg/util/atomic/atomicrunstate.go
+++ b/pkg/util/atomic/atomicrunstate.go
@@ -7,10 +7,10 @@ import (
 // AtomicRunState can be used to provide thread-safe start/stop functionality to internal run-loops
 // inside a goroutine.
 type AtomicRunState struct {
-	lock     sync.Mutex
-	stopping bool
 	stop     chan struct{}
 	reset    chan struct{}
+	lock     sync.Mutex
+	stopping bool
 }
 
 // Start checks for an existing run state and returns false if the run state has already started. If

--- a/pkg/util/cache/cachegroup.go
+++ b/pkg/util/cache/cachegroup.go
@@ -18,13 +18,13 @@ type cacheEntry[T comparable] struct {
 // CacheGroup provides single flighting for grouping repeated calls for the same workload, as well
 // as a cache that extends the lifetime of the returned result by a specific duration.
 type CacheGroup[T comparable] struct {
-	lock             sync.Mutex
-	cache            map[string]*cacheEntry[T]
 	group            singleflight.Group
-	expirationLock   sync.Mutex
+	cache            map[string]*cacheEntry[T]
 	expirationRunner *interval.IntervalRunner
 	expiry           time.Duration
 	max              int
+	lock             sync.Mutex
+	expirationLock   sync.Mutex
 }
 
 // NewCacheGroup[T] creates a new cache group instance given the max number of keys to cache.

--- a/pkg/util/httputil/roundtrip.go
+++ b/pkg/util/httputil/roundtrip.go
@@ -3,8 +3,8 @@ package httputil
 import "net/http"
 
 type userAgentTransport struct {
-	userAgent string
 	base      http.RoundTripper
+	userAgent string
 }
 
 // NewUserAgentTransport creates a RoundTripper that attaches the configured user agent.

--- a/pkg/util/stringutil/stringutil.go
+++ b/pkg/util/stringutil/stringutil.go
@@ -24,8 +24,8 @@ var alpha = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 var alphanumeric = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 type stringBank struct {
-	lock sync.Mutex
 	m    map[string]string
+	lock sync.Mutex
 }
 
 func newStringBank() *stringBank {

--- a/pkg/util/timeutil/profile.go
+++ b/pkg/util/timeutil/profile.go
@@ -54,6 +54,6 @@ func (pds *ProfileDataSeries) String() string {
 }
 
 type ProfileDatum struct {
-	Name string
 	Time time.Time
+	Name string
 }

--- a/pkg/util/watcher/configwatchers.go
+++ b/pkg/util/watcher/configwatchers.go
@@ -7,8 +7,8 @@ import (
 
 // ConfigMapWatcher represents a single configmap watcher
 type ConfigMapWatcher struct {
-	ConfigMapName string
 	WatchFunc     func(string, map[string]string) error
+	ConfigMapName string
 }
 
 type ConfigMapWatchers struct {

--- a/pkg/util/worker/worker.go
+++ b/pkg/util/worker/worker.go
@@ -53,8 +53,8 @@ type queuedWorkerPool[T any, U any] struct {
 // inputs were pushed onto the group.
 type ordered[T any, U any] struct {
 	workPool WorkerPool[T, U]
-	results  []U
 	wg       *sync.WaitGroup
+	results  []U
 	count    int
 }
 


### PR DESCRIPTION
Not tested or intended to merge; currently an example.

Results are from: https://github.com/dkorunic/betteralign

This could be a significant opportunity to a fixed % reduction in memory consumption. Most notable would be reducing the memory footprint of allocations (328 bytes per allocation to 120 bytes). I have not investigated the side effects of running this. My primary concern would be  marshalling to storage and unmarshalling from storage - and there may be other concerns as well.

```
> betteralign -apply ./...
/home/steven/src/kubecost/opencost/pkg/log/counter.go:5:14: struct with 32 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/storage/azurestorage.go:69:18: struct with 272 pointer bytes could be 224
/home/steven/src/kubecost/opencost/pkg/storage/azurestorage.go:93:22: struct of size 144 could be 136
/home/steven/src/kubecost/opencost/pkg/storage/azurestorage.go:109:19: struct with 184 pointer bytes could be 176
/home/steven/src/kubecost/opencost/pkg/storage/gcsstorage.go:28:17: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/storage/s3storage.go:65:15: struct of size 360 could be 344
/home/steven/src/kubecost/opencost/pkg/storage/s3storage.go:99:19: struct with 136 pointer bytes could be 72
/home/steven/src/kubecost/opencost/pkg/storage/s3storage.go:160:16: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/storage/s3storage.go:590:14: struct with 112 pointer bytes could be 104
/home/steven/src/kubecost/opencost/pkg/storage/storage.go:18:18: struct with 48 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/util/atomic/atomicrunstate.go:9:21: struct with 32 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/config/configfile.go:55:17: struct with 152 pointer bytes could be 136
/home/steven/src/kubecost/opencost/pkg/config/configfile.go:360:15: struct with 24 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/cloud/models/models.go:41:11: struct with 328 pointer bytes could be 320
/home/steven/src/kubecost/opencost/pkg/cloud/models/models.go:75:23: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/cloud/models/models.go:88:9: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/cloud/models/models.go:113:29: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/cloud/models/models.go:246:20: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/cloud/models/models.go:265:27: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/cloud/models/serviceaccounts.go:10:27: struct with 32 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/cloud/models/serviceaccounts.go:41:26: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/util/timeutil/profile.go:56:19: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/clustercache/clusterexporter.go:37:22: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/clustercache/clusterimporter.go:18:22: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/clustercache/watchcontroller.go:43:29: struct with 96 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/filter21/ast/lexer.go:97:12: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/filter21/ast/lexer.go:106:14: struct with 80 pointer bytes could be 64
/home/steven/src/kubecost/opencost/pkg/filter21/ast/parser.go:44:13: struct with 48 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/filter21/matcher/stringmapmatcher.go:35:30: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/filter21/matcher/stringmatcher.go:35:27: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/filter21/matcher/stringslicematcher.go:36:32: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/collections/blockingqueue.go:39:32: struct with 40 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/util/stringutil/stringutil.go:26:17: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/util/httputil/roundtrip.go:5:25: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/prom/error.go:29:17: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/prom/error.go:86:26: struct with 56 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/prom/prom.go:116:34: struct with 88 pointer bytes could be 72
/home/steven/src/kubecost/opencost/pkg/prom/prom.go:212:18: struct with 88 pointer bytes could be 80
/home/steven/src/kubecost/opencost/pkg/prom/prom.go:225:19: struct with 48 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/prom/prom.go:347:29: struct with 64 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/prom/query.go:32:14: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/kubecost/allocation.go:54:17: struct with 328 pointer bytes could be 120
/home/steven/src/kubecost/opencost/pkg/kubecost/allocation.go:1105:35: struct of size 160 could be 144
/home/steven/src/kubecost/opencost/pkg/kubecost/allocation.go:2603:25: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/kubecost/allocation_json.go:13:21: struct with 400 pointer bytes could be 392
/home/steven/src/kubecost/opencost/pkg/kubecost/allocationmatcher.go:102:26: struct with 296 pointer bytes could be 288
/home/steven/src/kubecost/opencost/pkg/kubecost/allocationprops.go:94:27: struct with 184 pointer bytes could be 168
/home/steven/src/kubecost/opencost/pkg/kubecost/asset.go:1100:11: struct with 192 pointer bytes could be 160
/home/steven/src/kubecost/opencost/pkg/kubecost/asset.go:1764:11: struct with 200 pointer bytes could be 112
/home/steven/src/kubecost/opencost/pkg/kubecost/asset.go:3242:20: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/kubecost/asset.go:3793:23: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/kubecost/audit.go:267:15: struct with 88 pointer bytes could be 64
/home/steven/src/kubecost/opencost/pkg/kubecost/cloudcost.go:397:24: struct with 40 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/kubecost/cloudcostprops.go:90:26: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/kubecost/coverage.go:11:15: struct with 96 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/kubecost/etlrange.go:12:25: struct with 32 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/kubecost/query.go:38:29: struct of size 168 could be 152
/home/steven/src/kubecost/opencost/pkg/kubecost/query.go:72:24: struct of size 88 could be 72
/home/steven/src/kubecost/opencost/pkg/kubecost/query.go:86:29: struct of size 216 could be 208
/home/steven/src/kubecost/opencost/pkg/kubecost/query.go:95:23: struct with 152 pointer bytes could be 136
/home/steven/src/kubecost/opencost/pkg/kubecost/status.go:6:16: struct with 144 pointer bytes could be 128
/home/steven/src/kubecost/opencost/pkg/kubecost/status.go:19:22: struct with 72 pointer bytes could be 64
/home/steven/src/kubecost/opencost/pkg/kubecost/status.go:28:17: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/kubecost/status.go:39:18: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/kubecost/status.go:47:23: struct with 128 pointer bytes could be 112
/home/steven/src/kubecost/opencost/pkg/kubecost/status.go:58:27: struct with 128 pointer bytes could be 112
/home/steven/src/kubecost/opencost/pkg/kubecost/summaryallocation.go:24:24: struct with 72 pointer bytes could be 64
/home/steven/src/kubecost/opencost/pkg/kubecost/summaryallocation.go:362:27: struct with 64 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/kubecost/summaryallocation.go:1362:32: struct with 80 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/kubecost/summaryallocation_json.go:11:32: struct with 160 pointer bytes could be 152
/home/steven/src/kubecost/opencost/pkg/kubecost/summaryallocation_json.go:82:40: struct with 48 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/boaconfiguration.go:11:23: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:174:18: struct with 120 pointer bytes could be 112
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:203:28: struct with 96 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:278:28: struct of size 48 could be 40
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:299:26: struct with 24 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:321:14: struct with 120 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:1053:12: struct of size 40 could be 32
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:1165:11: struct with 96 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/cloud/alibaba/provider.go:1179:27: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/cloud/aws/athenaconfiguration.go:11:26: struct with 112 pointer bytes could be 104
/home/steven/src/kubecost/opencost/pkg/cloud/aws/athenaintegration.go:50:25: struct with 200 pointer bytes could be 192
/home/steven/src/kubecost/opencost/pkg/cloud/aws/provider.go:152:10: struct of size 488 could be 472
/home/steven/src/kubecost/opencost/pkg/cloud/aws/provider.go:260:19: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/cloud/aws/provider.go:291:22: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/cloud/aws/provider.go:1881:22: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/cloud/aws/provider.go:1975:13: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/cloud/aws/s3configuration.go:11:22: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/cloud/azure/billingexportparser.go:21:23: struct with 120 pointer bytes could be 112
/home/steven/src/kubecost/opencost/pkg/cloud/azure/billingexportparser.go:51:26: struct with 88 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/cloud/azure/pricesheetdownloader.go:23:27: struct with 88 pointer bytes could be 80
/home/steven/src/kubecost/opencost/pkg/cloud/azure/pricesheetdownloader.go:274:30: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/cloud/azure/provider.go:355:25: struct with 80 pointer bytes could be 72
/home/steven/src/kubecost/opencost/pkg/cloud/azure/provider.go:365:35: struct of size 280 could be 272
/home/steven/src/kubecost/opencost/pkg/cloud/azure/provider.go:395:12: struct of size 184 could be 176
/home/steven/src/kubecost/opencost/pkg/cloud/azure/provider.go:523:22: struct with 24 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/cloud/azure/storageconfiguration.go:10:27: struct with 96 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/bigqueryconfiguration.go:13:28: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:94:10: struct with 240 pointer bytes could be 192
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:114:20: struct with 56 pointer bytes could be 48
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:121:28: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:180:21: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:570:17: struct with 136 pointer bytes could be 120
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:583:18: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:591:24: struct with 72 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:601:18: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:1183:26: struct with 80 pointer bytes could be 64
/home/steven/src/kubecost/opencost/pkg/cloud/gcp/provider.go:1196:25: struct with 24 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/util/watcher/configwatchers.go:9:23: struct with 24 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/cloud/provider/customprovider.go:29:21: struct with 160 pointer bytes could be 128
/home/steven/src/kubecost/opencost/pkg/cloud/provider/customprovider.go:74:24: struct with 72 pointer bytes could be 64
/home/steven/src/kubecost/opencost/pkg/costmodel/clusters/clustermap.go:104:27: struct with 72 pointer bytes could be 48
/home/steven/src/kubecost/opencost/pkg/filemanager/filemanager.go:137:21: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/metrics/deploymentmetrics.go:59:34: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/metrics/events.go:6:29: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/metrics/nodemetrics.go:208:46: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/metrics/nodemetrics.go:254:43: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/metrics/nodemetrics.go:300:27: struct with 88 pointer bytes could be 80
/home/steven/src/kubecost/opencost/pkg/metrics/podmetrics.go:119:17: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/metrics/podmetrics.go:1007:25: struct with 96 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/metrics/pvmetrics.go:45:17: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/metrics/servicemetrics.go:59:34: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/metrics/statefulsetmetrics.go:58:35: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/services/clusters/boltdbstorage.go:8:27: struct with 32 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/services/clusters/clustermanager.go:38:25: struct with 48 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/services/clusters/clustermanager.go:46:24: struct with 56 pointer bytes could be 48
/home/steven/src/kubecost/opencost/pkg/services/clusters/clustersendpoints.go:15:19: struct with 40 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/services/services.go:27:26: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/costmodel/aggregation.go:47:18: struct with 592 pointer bytes could be 448
/home/steven/src/kubecost/opencost/pkg/costmodel/aggregation.go:132:25: struct with 24 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/costmodel/aggregation.go:138:21: struct with 32 pointer bytes could be 24
/home/steven/src/kubecost/opencost/pkg/costmodel/aggregation.go:254:25: struct with 96 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/costmodel/aggregation.go:1607:19: struct with 112 pointer bytes could be 104
/home/steven/src/kubecost/opencost/pkg/costmodel/aggregation.go:2288:12: struct with 16 pointer bytes could be 8
/home/steven/src/kubecost/opencost/pkg/costmodel/allocation_types.go:12:10: struct with 136 pointer bytes could be 128
/home/steven/src/kubecost/opencost/pkg/costmodel/allocation_types.go:81:10: struct with 120 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/costmodel/allocation_types.go:127:9: struct with 104 pointer bytes could be 88
/home/steven/src/kubecost/opencost/pkg/costmodel/allocation_types.go:210:13: struct with 56 pointer bytes could be 48
/home/steven/src/kubecost/opencost/pkg/costmodel/allocationnode.go:36:18: struct with 96 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/costmodel/cluster.go:49:19: struct with 104 pointer bytes could be 40
/home/steven/src/kubecost/opencost/pkg/costmodel/cluster.go:110:11: struct with 216 pointer bytes could be 176
/home/steven/src/kubecost/opencost/pkg/costmodel/cluster.go:478:11: struct with 240 pointer bytes could be 136
/home/steven/src/kubecost/opencost/pkg/costmodel/cluster.go:709:19: struct with 120 pointer bytes could be 104
/home/steven/src/kubecost/opencost/pkg/costmodel/costmodel.go:53:16: struct with 96 pointer bytes could be 80
/home/steven/src/kubecost/opencost/pkg/costmodel/costmodel.go:79:15: struct with 456 pointer bytes could be 448
/home/steven/src/kubecost/opencost/pkg/costmodel/costmodel.go:2339:32: struct with 104 pointer bytes could be 96
/home/steven/src/kubecost/opencost/pkg/costmodel/csv_export.go:167:17: struct with 24 pointer bytes could be 16
/home/steven/src/kubecost/opencost/pkg/costmodel/metrics.go:69:24: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/costmodel/router.go:84:15: struct with 240 pointer bytes could be 232
/home/steven/src/kubecost/opencost/pkg/costmodel/router.go:168:15: struct with 64 pointer bytes could be 56
/home/steven/src/kubecost/opencost/pkg/costmodel/router.go:1189:18: struct with 40 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/util/cache/cachegroup.go:20:31: struct with 48 pointer bytes could be 32
/home/steven/src/kubecost/opencost/pkg/util/worker/worker.go:54:28: struct with 48 pointer bytes could be 32
```
