### PR TITLE
fix asset query duration

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -561,7 +561,7 @@ func ClusterNodes(cp models.Provider, client prometheus.Client, start, end time.
 		log.DedupedWarningf(3, "ClusterNodes(): Configured ETL resolution (%d seconds) is below the 60 seconds threshold. Overriding with 1 minute.", int(resolution.Seconds()))
 	}
 
-	durStr := timeutil.DurationString(resolution)
+	durStr := timeutil.DurationString(end.Sub(start))
 	if durStr == "" {
 		return nil, fmt.Errorf("illegal duration value for %s", kubecost.NewClosedWindow(start, end))
 	}


### PR DESCRIPTION
## What does this PR change?
* fixes a bug I introduced where the duration of the query is set to the resolution

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
