### PR TITLE
Fixed panic in Coverage IsEmpty/Clone functions.

### DIFF
--- a/pkg/kubecost/coverage.go
+++ b/pkg/kubecost/coverage.go
@@ -26,6 +26,10 @@ func (c *Coverage) Key() string {
 }
 
 func (c *Coverage) IsEmpty() bool {
+	if c == nil {
+		log.Warnf("calling IsEmpty() on a nil Coverage")
+		return true
+	}
 	return c.Type == "" && c.Count == 0 && len(c.Errors) == 0 && len(c.Warnings) == 0 && c.Updated == time.Time{}
 }
 

--- a/pkg/kubecost/coverage.go
+++ b/pkg/kubecost/coverage.go
@@ -34,6 +34,10 @@ func (c *Coverage) IsEmpty() bool {
 }
 
 func (c *Coverage) Clone() *Coverage {
+	if c == nil {
+		log.Warnf("calling Clone() on a nil Coverage")
+		return nil
+	}
 	var errors []string
 	if len(c.Errors) > 0 {
 		errors = make([]string, len(c.Errors))


### PR DESCRIPTION
## What does this PR change?
* Fixes a panic when calling IsEmpty or Clone on a nil Coverage.

## Does this PR relate to any other PRs?
* In a way, it relates to [an old change](https://github.com/opencost/opencost/commit/8ebac44359b8f646305d46b4bfe4ad93375637d4) from Niko.

## How will this PR impact users?
* nil Coverages will now be considered empty, instead of panic-inducing.

## Does this PR address any GitHub or Zendesk issues?
* Addresses [this ticket](https://kubecost.zendesk.com/agent/tickets/4456).

## How was this PR tested?
* Deployed to personal namespace, verified nobody panicked.

## Does this PR require changes to documentation?
* Nope.
