### PR TITLE
Provide mechanism for aggregating metadata across accumulations

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1221,6 +1221,12 @@ func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAg
 	shouldShare := len(options.SharedHourlyCosts) > 0 || len(options.ShareFuncs) > 0
 	if !shouldAggregate && !shouldFilter && !shouldShare && options.ShareIdle == ShareNone && !options.IncludeProportionalAssetResourceCosts {
 		// There is nothing for AggregateBy to do, so simply return nil
+		// before returning, set aggregated metadata inclusion in properties
+		if options.IncludeAggregatedMetadata {
+			for index := range as.Allocations {
+				as.Allocations[index].Properties.AggregatedMetadata = true
+			}
+		}
 		return nil
 	}
 

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -161,6 +161,7 @@ func (p *AllocationProperties) Clone() *AllocationProperties {
 	}
 	clone.NamespaceAnnotations = nsAnnotations
 
+	clone.AggregatedMetadata = p.AggregatedMetadata
 	return clone
 }
 


### PR DESCRIPTION
## What does this PR change?
* propagates aggregated metadata info via alloc properties to address customer request in BURNDOWN 107

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* allows users to aggregate labels across accumulations

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/kubecost/cost-analyzer-helm-chart/issues/2222

## How was this PR tested?
* ensured that after this change, with the includedAggregatedMetadata param set, lables are now bubbling up 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
