### PR TITLE
add fix for looking up asset field type

### DIFF
--- a/pkg/filter21/ops/ops.go
+++ b/pkg/filter21/ops/ops.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/opencost/opencost/pkg/filter21/allocation"
+	"github.com/opencost/opencost/pkg/filter21/asset"
 	"github.com/opencost/opencost/pkg/filter21/ast"
 	"github.com/opencost/opencost/pkg/util/typeutil"
 )
@@ -26,7 +27,7 @@ type keyFieldType interface {
 var defaultFieldByType = map[string]any{
 	// typeutil.TypeOf[cloud.CloudAggregationField]():        cloud.DefaultFieldByName,
 	typeutil.TypeOf[allocation.AllocationField](): allocation.DefaultFieldByName,
-	// typeutil.TypeOf[asset.AssetField]():                   asset.DefaultFieldByName,
+	typeutil.TypeOf[asset.AssetField]():           asset.DefaultFieldByName,
 	// typeutil.TypeOf[containerstats.ContainerStatsField](): containerstats.DefaultFieldByName,
 }
 


### PR DESCRIPTION
## What does this PR change?
* While testing noticed bunch of error logs and also monitoring and active clusters werent show. This PR should fix the problem

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* Fixes regression issues created by asset filters v2.1 https://github.com/opencost/opencost/pull/1995

## Does this PR address any GitHub or Zendesk issues?
* Closes ...  [BURNDOWN-166](https://kubecost.atlassian.net/browse/BURNDOWN-166)

## How was this PR tested?
* Tested on my clusters

## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v1.105
