### PR TITLE
Sean/lb private bingen

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -92,7 +92,7 @@ type Allocation struct {
 	// and appended to an Allocation, and so by default is is nil.
 	ProportionalAssetResourceCosts ProportionalAssetResourceCosts `json:"proportionalAssetResourceCosts"` //@bingen:field[ignore]
 	SharedCostBreakdown            SharedCostBreakdowns           `json:"sharedCostBreakdown"`            //@bingen:field[ignore]
-	LoadBalancers                  LbAllocations                  `json:"LoadBalancers"`                  // @bingen:field[version=17]
+	LoadBalancers                  LbAllocations                  `json:"LoadBalancers"`                  // @bingen:field[version=18]
 
 }
 

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2184,7 +2184,7 @@ type LoadBalancer struct {
 	Window     Window
 	Adjustment float64
 	Cost       float64
-	Private    bool
+	Private    bool // @bingen:field[version=20]
 }
 
 // NewLoadBalancer instantiates and returns a new LoadBalancer

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -46,7 +46,7 @@ package kubecost
 // @bingen:end
 
 // Allocation Version Set: Includes Allocation pipeline specific resources
-// @bingen:set[name=Allocation,version=17]
+// @bingen:set[name=Allocation,version=18]
 // @bingen:generate:Allocation
 // @bingen:generate[stringtable]:AllocationSet
 // @bingen:generate:AllocationSetRange

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -26,7 +26,7 @@ package kubecost
 // @bingen:generate:CoverageSet
 
 // Asset Version Set: Includes Asset pipeline specific resources
-// @bingen:set[name=Assets,version=19]
+// @bingen:set[name=Assets,version=20]
 // @bingen:generate:Any
 // @bingen:generate:Asset
 // @bingen:generate:AssetLabels

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -13,12 +13,11 @@ package kubecost
 
 import (
 	"fmt"
+	util "github.com/opencost/opencost/pkg/util"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
-
-	util "github.com/opencost/opencost/pkg/util"
 )
 
 const (
@@ -34,6 +33,12 @@ const (
 )
 
 const (
+	// AuditCodecVersion is used for any resources listed in the Audit version set
+	AuditCodecVersion uint8 = 1
+
+	// CloudCostCodecVersion is used for any resources listed in the CloudCost version set
+	CloudCostCodecVersion uint8 = 2
+
 	// DefaultCodecVersion is used for any resources listed in the Default version set
 	DefaultCodecVersion uint8 = 17
 
@@ -42,12 +47,6 @@ const (
 
 	// AllocationCodecVersion is used for any resources listed in the Allocation version set
 	AllocationCodecVersion uint8 = 17
-
-	// AuditCodecVersion is used for any resources listed in the Audit version set
-	AuditCodecVersion uint8 = 1
-
-	// CloudCostCodecVersion is used for any resources listed in the CloudCost version set
-	CloudCostCodecVersion uint8 = 2
 )
 
 //--------------------------------------------------------------------------
@@ -7335,6 +7334,7 @@ func (target *LbAllocation) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 		buff.WriteString(target.Service) // write string
 	}
 	buff.WriteFloat64(target.Cost) // write float64
+	buff.WriteBool(target.Private) // write bool
 	return nil
 }
 
@@ -7404,6 +7404,9 @@ func (target *LbAllocation) UnmarshalBinaryWithContext(ctx *DecodingContext) (er
 
 	d := buff.ReadFloat64() // read float64
 	target.Cost = d
+
+	e := buff.ReadBool() // read bool
+	target.Private = e
 
 	return nil
 }
@@ -7517,6 +7520,7 @@ func (target *LoadBalancer) MarshalBinaryWithContext(ctx *EncodingContext) (err 
 
 	buff.WriteFloat64(target.Adjustment) // write float64
 	buff.WriteFloat64(target.Cost)       // write float64
+	buff.WriteBool(target.Private)       // write bool
 	return nil
 }
 
@@ -7665,6 +7669,9 @@ func (target *LoadBalancer) UnmarshalBinaryWithContext(ctx *DecodingContext) (er
 
 	u := buff.ReadFloat64() // read float64
 	target.Cost = u
+
+	w := buff.ReadBool() // read bool
+	target.Private = w
 
 	return nil
 }

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -33,20 +33,20 @@ const (
 )
 
 const (
+	// DefaultCodecVersion is used for any resources listed in the Default version set
+	DefaultCodecVersion uint8 = 17
+
+	// AssetsCodecVersion is used for any resources listed in the Assets version set
+	AssetsCodecVersion uint8 = 20
+
+	// AllocationCodecVersion is used for any resources listed in the Allocation version set
+	AllocationCodecVersion uint8 = 18
+
 	// AuditCodecVersion is used for any resources listed in the Audit version set
 	AuditCodecVersion uint8 = 1
 
 	// CloudCostCodecVersion is used for any resources listed in the CloudCost version set
 	CloudCostCodecVersion uint8 = 2
-
-	// DefaultCodecVersion is used for any resources listed in the Default version set
-	DefaultCodecVersion uint8 = 17
-
-	// AssetsCodecVersion is used for any resources listed in the Assets version set
-	AssetsCodecVersion uint8 = 19
-
-	// AllocationCodecVersion is used for any resources listed in the Allocation version set
-	AllocationCodecVersion uint8 = 17
 )
 
 //--------------------------------------------------------------------------
@@ -1060,7 +1060,7 @@ func (target *Allocation) UnmarshalBinaryWithContext(ctx *DecodingContext) (err 
 
 	}
 	// field version check
-	if uint8(17) <= version {
+	if uint8(18) <= version {
 		// --- [begin][read][alias](LbAllocations) ---
 		var xx map[string]*LbAllocation
 		if buff.ReadUInt8() == uint8(0) {
@@ -7670,8 +7670,14 @@ func (target *LoadBalancer) UnmarshalBinaryWithContext(ctx *DecodingContext) (er
 	u := buff.ReadFloat64() // read float64
 	target.Cost = u
 
-	w := buff.ReadBool() // read bool
-	target.Private = w
+	// field version check
+	if uint8(20) <= version {
+		w := buff.ReadBool() // read bool
+		target.Private = w
+
+	} else {
+		target.Private = false // default
+	}
 
 	return nil
 }


### PR DESCRIPTION
## What does this PR change?
This PR updates bingen version tags for two fields.
Asset LoadBalancer field `Private` was added but did not get a bingen tag and bingen was not run. This would cause an issue the next time bingen was run for assets if the version tag was not added to `Private` then it would cause build failures on assets. This issue was caught at a point where there should be no repercussions 

Allocation new LoadBalancer field in 1.105 was given a tag for an allocation bingen version that went out in 1.104. Users that have that 1.104 bingen codec will have their Allocation data deleted by any future codec if this is not addressed. Users who have downloaded 1.105 RCs will have already lost their allocation data, and will lose it again with their next update, users that are still on the 1.104 bingen codec will not be impacted 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
