### PR TITLE
Put the network entry from Azure CSV into the cloud cost

### DIFF
--- a/pkg/cloud/azure/billingexportparser.go
+++ b/pkg/cloud/azure/billingexportparser.go
@@ -44,6 +44,9 @@ func (brv *BillingRowValues) IsCompute(category string) bool {
 	if category == kubecost.NetworkCategory && brv.MeterCategory == "Virtual Network" {
 		return true
 	}
+	if category == kubecost.NetworkCategory && brv.MeterCategory == "Bandwidth" {
+		return true
+	}
 	return false
 }
 
@@ -265,7 +268,7 @@ func AzureSetProviderID(abv *BillingRowValues) string {
 		return fmt.Sprintf("%v", value2)
 	}
 
-	if category == kubecost.StorageCategory {
+	if category == kubecost.StorageCategory || (category == kubecost.NetworkCategory && abv.MeterCategory == "Bandwidth") {
 		if value2, ok2 := abv.Tags["creationSource"]; ok2 {
 			creationSource := fmt.Sprintf("%v", value2)
 			return strings.TrimPrefix(creationSource, "aks-")


### PR DESCRIPTION
## What does this PR change?
* Put the CSV line entry that satisfy the condition of category = network and meterCategory= Bandwidth  that represent the cost for egress out of the AKS cluster into cloudCost.
* THis is later used to reconcile the Network charges into Asset via cloud cost.

## Does this PR relate to any other PRs?
* Corresponding KCM PR

## How will this PR impact users?
* They will finally get to see a Network entry for a VMSS in cloud cost.
![Screen Shot 2023-07-05 at 10 05 50 AM](https://github.com/opencost/opencost/assets/11470561/0ebf61ce-6269-45ed-9220-3383aae2b7b3)

## Does this PR address any GitHub or Zendesk issues?
* Closes ... [JIRA](https://kubecost.atlassian.net/browse/BURNDOWN-157)
Corresponding [github issue](https://github.com/kubecost/cost-analyzer-helm-chart/issues/2386)

## How was this PR tested?
* On Azure Cluster More details on KCM PR

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v1.105
