### PR TITLE
add x-frame-options header

### DIFF
--- a/ui/default.nginx.conf
+++ b/ui/default.nginx.conf
@@ -44,6 +44,7 @@ server {
     index index.html;
     large_client_header_buffers 4 32k;
     add_header Cache-Control "must-revalidate";
+    add_header X-Frame-Options "SAMEORIGIN";
 
     error_page 504 /custom_504.html;
     location = /custom_504.html {


### PR DESCRIPTION
## What does this PR change?
* Adds X-FRAME-OPTIONS header to nginx config to prevent serving via iframe.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users cannot display Opencost in an iFrame by default. Prevents clickjacking.

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
