### PR TITLE
convert highAvailability to snake case

### DIFF
--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -283,7 +283,11 @@ func GetPodName() string {
 // GetClusterProfile returns the environment variable value for ClusterProfileEnvVar which
 // represents the cluster profile configured for
 func GetClusterProfile() string {
-	return Get(ClusterProfileEnvVar, "development")
+	prof := Get(ClusterProfileEnvVar, "development")
+	if prof == "highAvailability" {
+		return "high-availability"
+	}
+	return prof
 }
 
 // GetClusterID returns the environment variable value for ClusterIDEnvVar which represents the


### PR DESCRIPTION
## What does this PR change?
* Converts `highAvailability` to `high-availability` in the helm chart

## Does this PR relate to any other PRs?
* Yes, requires a front end change

## How will this PR impact users?
* Users can pass `highAvailability` or `high-availability` as a helm value (or env var) and it won't break the UI

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/BURNDOWN-169

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
