### PR TITLE
Fix the mismatch in sharing namespaces due to unmounted pv cost in each allocation

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -858,12 +858,21 @@ func (a *Allocation) IsUnallocated() bool {
 }
 
 // IsUnmounted is true if the given Allocation represents unmounted volume costs.
+// Note: Due to change in https://github.com/opencost/opencost/pull/1477 made to include Unmounted
+// PVC cost inside namespace we need to check unmounted suffix across all the three major properties
+// to actually classify it as unmounted.
 func (a *Allocation) IsUnmounted() bool {
 	if a == nil {
 		return false
 	}
 
-	return strings.Contains(a.Name, UnmountedSuffix)
+	props := a.Properties
+	if props != nil {
+		if props.Container == UnmountedSuffix && props.Namespace == UnmountedSuffix && props.Pod == UnmountedSuffix {
+			return true
+		}
+	}
+	return false
 }
 
 // Minutes returns the number of minutes the Allocation represents, as defined

--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -982,34 +982,57 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 	// 11. Distribute shared resources according to sharing coefficients.
 	// NOTE: ShareEven is not supported
 	if len(shareSet.SummaryAllocations) > 0 {
+		totalTotalCost := 0.0
+		sharedTotalCost := 0.0
+
 		sharingCoeffDenominator := 0.0
 		for _, rt := range allocTotals {
 			sharingCoeffDenominator += rt.TotalCost()
+			totalTotalCost += rt.TotalCost()
 		}
 
 		// Do not include the shared costs, themselves, when determining
 		// sharing coefficients.
 		for _, rt := range sharedResourceTotals {
 			sharingCoeffDenominator -= rt.TotalCost()
+			sharedTotalCost += rt.TotalCost()
 		}
 
 		// Do not include the unmounted costs when determining sharing
 		// coefficients because they do not receive shared costs.
 		sharingCoeffDenominator -= totalUnmountedCost
 
+		log.Infof("BD-152: sharingCoeffDenom=%f (total cost: %f; shared cost: %f; unmounted cost: %f)", sharingCoeffDenominator, totalTotalCost, sharedTotalCost, totalUnmountedCost)
+
 		if sharingCoeffDenominator <= 0.0 {
 			log.Warnf("SummaryAllocation: sharing coefficient denominator is %f", sharingCoeffDenominator)
 		} else {
+			// Needs to be 1.00000
+			sumSharingCoeffs := 0.0
+
 			// Compute sharing coeffs by dividing the thus-far accumulated
 			// numerators by the now-finalized denominator.
 			for key := range sharingCoeffs {
 				if sharingCoeffs[key] > 0.0 {
+					before := sharingCoeffs[key]
 					sharingCoeffs[key] /= sharingCoeffDenominator
+
+					log.Infof("BD152: sharingCoeff[%s]=%f ; numerator before=%f", key, sharingCoeffs[key], before)
+
+					sumSharingCoeffs += sharingCoeffs[key]
 				} else {
 					log.Warnf("SummaryAllocation: detected illegal sharing coefficient for %s: %v (setting to zero)", key, sharingCoeffs[key])
 					sharingCoeffs[key] = 0.0
 				}
 			}
+
+			// HERE if you add all the sharingCoeffs, you should get 1.00000 exactly
+			//  "integration": 0.27
+			//  "ally": 0.13
+			//  ...
+			//  TOTAL : 1.000000
+
+			log.Infof("BD152: sum of sharingCoeffs = %f", sumSharingCoeffs)
 
 			for key, sa := range resultSet.SummaryAllocations {
 				// Idle and unmounted allocations, by definition, do not

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -114,8 +114,17 @@ func ComputeAllocationTotals(as *AllocationSet, prop string) map[string]*Allocat
 
 	for _, alloc := range as.Allocations {
 		// Do not count idle or unmounted allocations
-		if alloc.IsIdle() || alloc.IsUnmounted() {
+		if alloc.IsIdle() {
 			continue
+		}
+		if alloc.IsUnmounted() {
+			props := alloc.Properties
+			if props == nil {
+				continue
+			}
+			if props.Container == UnmountedSuffix && props.Namespace == UnmountedSuffix && props.Pod == UnmountedSuffix {
+				continue
+			}
 		}
 
 		// Default to computing totals by Cluster, but allow override to use Node.

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -114,16 +114,8 @@ func ComputeAllocationTotals(as *AllocationSet, prop string) map[string]*Allocat
 
 	for _, alloc := range as.Allocations {
 		// Do not count idle or unmounted allocations
-		if alloc.IsIdle() {
+		if alloc.IsIdle() || alloc.IsUnmounted() {
 			continue
-		}
-		if alloc.IsUnmounted() {
-			props := alloc.Properties
-			if props != nil {
-				if props.Container == UnmountedSuffix && props.Namespace == UnmountedSuffix && props.Pod == UnmountedSuffix {
-					continue
-				}
-			}
 		}
 
 		// Default to computing totals by Cluster, but allow override to use Node.

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -119,11 +119,10 @@ func ComputeAllocationTotals(as *AllocationSet, prop string) map[string]*Allocat
 		}
 		if alloc.IsUnmounted() {
 			props := alloc.Properties
-			if props == nil {
-				continue
-			}
-			if props.Container == UnmountedSuffix && props.Namespace == UnmountedSuffix && props.Pod == UnmountedSuffix {
-				continue
+			if props != nil {
+				if props.Container == UnmountedSuffix && props.Namespace == UnmountedSuffix && props.Pod == UnmountedSuffix {
+					continue
+				}
 			}
 		}
 


### PR DESCRIPTION
## What does this PR change?
* Fixes the issue seen in https://github.com/kubecost/cost-analyzer-helm-chart/issues/2359, this was due to unmounted pv cost in each allocation that while computation is ignored both in totals and in summary allocation. As a result the sharing isnt proportional. These definitely fixes the problem but there's a pending question as to if the unmounted pv cost should even be a part of each allocation?

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* Get accurate result when custom shared resources and sharing idle by cluster or node 

## Does this PR address any GitHub or Zendesk issues?
* Closes ... https://kubecost.atlassian.net/browse/BURNDOWN-152 and subsequently https://github.com/kubecost/cost-analyzer-helm-chart/issues/2359

## How was this PR tested?
* Port-forwarding Niko's dev cluster as instructed and hitting end point 
1. localhost:9003/allocation/view?window=2023-07-07T00:00:00Z,2023-07-08T00:00:00Z&aggregate=namespace
<img width="1066" alt="Screen Shot 2023-07-11 at 9 36 35 AM" src="https://github.com/opencost/opencost/assets/11470561/8108fb0c-4eaa-4a61-a8f7-3d33b7cc3462">

2. localhost:9003/allocation/view?window=2023-07-07T00:00:00Z,2023-07-08T00:00:00Z&aggregate=namespace&shareNamespaces=kube-system

<img width="1190" alt="Screen Shot 2023-07-11 at 9 37 23 AM" src="https://github.com/opencost/opencost/assets/11470561/d2ca371d-2f34-4ec8-ab91-1fef60041f93">


Also tried shareIdle by node via REST call
localhost:9003/allocation/view?window=2023-07-07T00:00:00Z,2023-07-08T00:00:00Z&aggregate=namespace&shareNamespaces=kube-system&shareIdle=true&idleByNode=true&cache=false

<img width="1165" alt="Screen Shot 2023-07-11 at 9 37 15 AM" src="https://github.com/opencost/opencost/assets/11470561/c81f7e77-1c29-443c-b130-992243c564b7">


The logs yield a sharing coefficient sum of 1.00XXX as expected 
![Screen Shot 2023-07-11 at 9 21 44 AM](https://github.com/opencost/opencost/assets/11470561/7fb61c37-2108-413f-a2c5-19b7201595b1)

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v1.105
