### PR TITLE
installation documentation address corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To see the full functionality of OpenCost you can view [OpenCost features](https
 
 You can deploy OpenCost on any Kubernetes 1.8+ cluster in a matter of minutes, if not seconds!
 
-Visit the full documentation for [recommended install options](https://www.opencost.io/docs/install).
+Visit the full documentation for [recommended install options](https://www.opencost.io/docs/installation/install).
 
 ## Usage
 


### PR DESCRIPTION
## What does this PR change?
installation documentation address 

## Does this PR relate to any other PRs?
no

## How will this PR impact users?
they will land correct page for installation 

## Does this PR address any GitHub or Zendesk issues?
no

## How was this PR tested?
opening the recently added link 

## Does this PR require changes to documentation?
yes, docs need to be updated where former link is referred

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
there is no corresponding issue
