### PR TITLE
use the existing variable in error message

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -208,7 +208,7 @@ func getRegions(service string, subscriptionsClient subscriptions.Client, provid
 						if loc, ok := allLocations[displName]; ok {
 							supLocations[loc] = displName
 						} else {
-							log.Warnf("unsupported cloud region %q", loc)
+							log.Warnf("unsupported cloud region %q", displName)
 						}
 					}
 					break
@@ -226,7 +226,7 @@ func getRegions(service string, subscriptionsClient subscriptions.Client, provid
 						if loc, ok := allLocations[displName]; ok {
 							supLocations[loc] = displName
 						} else {
-							log.Warnf("unsupported cloud region %q", loc)
+							log.Warnf("unsupported cloud region %q", displName)
 						}
 					}
 					break


### PR DESCRIPTION
the error message was trying to use the variable/value which was not there and which was the reason for the error message in the first place

## What does this PR change?
* using the existing variable in an error message instead of the non-existent one

## Does this PR relate to any other PRs?
no

## How will this PR impact users?
In case they had the error message before like that:
```
2023-07-18T11:47:05.702704554Z WRN unsupported cloud region ""
```
Now instead of the `""` empty string it should give a better information of the region in question.

## Does this PR address any GitHub or Zendesk issues?
no

## How was this PR tested?
manually running in a kubernetes cluster next to the official docker image binary.. sadly at that time neither (the original 1.105.0 version nor the self compiled one) showed the error message, so the real output is not clear,  but it looks like the variables are both strings, so it should work.

## Does this PR require changes to documentation?
no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
I will try to label it.
