### PR TITLE
Downgrade CSV Export error message

### DIFF
--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -55,7 +55,8 @@ func Execute(opts *CostModelOpts) error {
 func StartExportWorker(ctx context.Context, model costmodel.AllocationModel) error {
 	exportPath := env.GetExportCSVFile()
 	if exportPath == "" {
-		return fmt.Errorf("%s is not set, skipping CSV exporter", exportPath)
+		log.Infof("%s is not set, CSV export is disabled", env.ExportCSVFile)
+		return nil
 	}
 	fm, err := filemanager.NewFileManager(exportPath)
 	if err != nil {


### PR DESCRIPTION
## What does this PR change?
Currently, an error message -`ERR couldn't start CSV export worker:  is not set, skipping CSV exporter`- is being logged when the CSV exporter is not set up or not in use. This error message can cause undue concern for users, most of whom might not be using this feature.

## How will this PR impact users?
Don't expect any impact.

## How was this PR tested?
```
PROMETHEUS_SERVER_ENDPOINT=http://localhost:9094 go run ./cmd/costmodel/.
...
2023-07-24T11:22:51.808183+12:00 INF EXPORT_CSV_FILE is not set, CSV export is disabled
```

## Does this PR require changes to documentation?
No

