### PR TITLE
Fix PV usage sanity limit

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -21,7 +21,12 @@ import (
 const CPU_SANITY_LIMIT = 512
 
 // Sanity Limit for PV usage, set to 10 PB, in bytes for now
-const PV_USAGE_SANITY_LIMIT_BYTES = 10737418240
+const KiB = 1024.0
+const MiB = 1024.0 * KiB
+const GiB = 1024.0 * MiB
+const TiB = 1024.0 * GiB
+const PiB = 1024.0 * TiB
+const PV_USAGE_SANITY_LIMIT_BYTES = 10.0 * PiB
 
 /* Pod Helpers */
 
@@ -1826,7 +1831,7 @@ func applyPVBytes(pvMap map[pvKey]*pv, resPVBytes []*prom.QueryResult) {
 			pvMap[key].Bytes = pvBytesUsed
 		} else {
 			pvMap[key].Bytes = 0
-			log.Infof("[WARNING] PV usage exceeds sanity limit, clamping to zero")
+			log.Warnf("PV usage exceeds sanity limit, clamping to zero")
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR change?
* Increases PV sanity limit from 10 GiB to 10 PiB

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/2051

## How will this PR impact users?
* Fixes limiting feature

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Manually (was seeing unexpected logs; now not)

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes
