### PR TITLE
Fix shared cost coefficients for Summary Allocation API

### DIFF
--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -314,7 +314,7 @@ func Test_populate_pricing(t *testing.T) {
 		},
 	}
 
-	awsTest.populatePricing(&testResponse, inputkeys)
+	awsTest.populatePricing(testResponse.Body, inputkeys)
 
 	expectedProdTermsDisk := &AWSProductTerms{
 		Sku:     "M6UGCCQ3CDJQAA37",
@@ -453,7 +453,7 @@ func Test_populate_pricing(t *testing.T) {
 		},
 	}
 
-	awsTest.populatePricing(&testResponse, inputkeys)
+	awsTest.populatePricing(testResponse.Body, inputkeys)
 
 	expectedProdTermsDisk = &AWSProductTerms{
 		Sku:     "R83VXG9NAPDASEGN",

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2560,10 +2560,10 @@ func computeIdleAllocations(allocSet *kubecost.AllocationSet, assetSet *kubecost
 	var assetTotals map[string]*kubecost.AssetTotals
 
 	if idleByNode {
-		allocTotals = kubecost.ComputeAllocationTotals(allocSet, kubecost.AllocationNodeProp)
+		allocTotals, _ = kubecost.ComputeAllocationTotals(allocSet, kubecost.AllocationNodeProp)
 		assetTotals = kubecost.ComputeAssetTotals(assetSet, true)
 	} else {
-		allocTotals = kubecost.ComputeAllocationTotals(allocSet, kubecost.AllocationClusterProp)
+		allocTotals, _ = kubecost.ComputeAllocationTotals(allocSet, kubecost.AllocationClusterProp)
 		assetTotals = kubecost.ComputeAssetTotals(assetSet, false)
 	}
 

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -106,6 +106,8 @@ const (
 	ExportCSVFile       = "EXPORT_CSV_FILE"
 	ExportCSVLabelsList = "EXPORT_CSV_LABELS_LIST"
 	ExportCSVLabelsAll  = "EXPORT_CSV_LABELS_ALL"
+
+	AWSPricingFilePath = "AWS_PRICING_FILE_PATH"
 )
 
 const DefaultConfigMountPath = "/var/configs"
@@ -602,4 +604,8 @@ func GetRegionOverrideList() []string {
 	}
 
 	return regionList
+}
+
+func GetAWSPricingFilePath() string {
+	return Get(AWSPricingFilePath, "")
 }

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1970,6 +1970,19 @@ func computeShareCoeffs(aggregateBy []string, options *AllocationAggregationOpti
 	// Compute totals for all allocations
 	total := 0.0
 
+	cpuCost := 0.0
+	cpuAdj := 0.0
+	gpuCost := 0.0
+	gpuAdj := 0.0
+	ramCost := 0.0
+	ramAdj := 0.0
+	pvsCost := 0.0
+	pvsAdj := 0.0
+	lbsCost := 0.0
+	lbsAdj := 0.0
+	netCost := 0.0
+	netAdj := 0.0
+
 	// ShareEven counts each aggregation with even weight, whereas ShareWeighted
 	// counts each aggregation proportionally to its respective costs
 	shareType := options.ShareSplit
@@ -2024,6 +2037,23 @@ func computeShareCoeffs(aggregateBy []string, options *AllocationAggregationOpti
 			// cumulative coefficient will be divided by the total.
 			coeffs[name] += alloc.TotalCost() - alloc.SharedCost
 			total += alloc.TotalCost() - alloc.SharedCost
+
+			if alloc.LoadBalancerCost > 0.0 || alloc.LoadBalancerCostAdjustment > 0.0 {
+				log.Infof(" *** Allocation: Totals: %s: %s: %.6f + %.6f = %.6f", as.Window, alloc.Name, alloc.LoadBalancerCost, alloc.LoadBalancerCostAdjustment, alloc.LoadBalancerCost+alloc.LoadBalancerCostAdjustment)
+			}
+
+			cpuCost += alloc.CPUCost
+			cpuAdj += alloc.CPUCostAdjustment
+			gpuCost += alloc.GPUCost
+			gpuAdj += alloc.GPUCostAdjustment
+			ramCost += alloc.RAMCost
+			ramAdj += alloc.RAMCostAdjustment
+			pvsCost += alloc.PVCost()
+			pvsAdj += alloc.PVCostAdjustment
+			lbsCost += alloc.LoadBalancerCost
+			lbsAdj += alloc.LoadBalancerCostAdjustment
+			netCost += alloc.NetworkCost
+			netAdj += alloc.NetworkCostAdjustment
 		}
 	}
 
@@ -2036,6 +2066,8 @@ func computeShareCoeffs(aggregateBy []string, options *AllocationAggregationOpti
 			coeffs[a] = 0.0
 		}
 	}
+
+	log.Infof("Allocation: %s: total: %.6f = %.6f + %.6f + %.6f + %.6f + %.6f + %.6f + %.6f + %.6f + %.6f + %.6f + %.6f + %.6f", as.Window, total, cpuCost, cpuAdj, gpuCost, gpuAdj, ramCost, ramAdj, pvsCost, pvsAdj, lbsCost, lbsAdj, netCost, netAdj)
 
 	return coeffs, nil
 }

--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -832,7 +832,11 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 		// NOTE: SummaryAllocation does not support ShareEven, so only record
 		// by cost for cost-weighted distribution.
 		if sharingCoeffs != nil {
-			sharingCoeffs[key] += sa.TotalCost() - sa.SharedCost
+			// Idle and unmounted allocations, by definition, do not
+			// receive shared cost
+			if !sa.IsIdle() && !sa.IsUnmounted() {
+				sharingCoeffs[key] += sa.TotalCost() - sa.SharedCost
+			}
 		}
 
 		// 6. Distribute idle allocations according to the idle coefficients.
@@ -1009,7 +1013,6 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 		if sharingCoeffDenominator <= 0.0 {
 			log.Warnf("SummaryAllocation: sharing coefficient denominator is %f", sharingCoeffDenominator)
 		} else {
-
 			// Compute sharing coeffs by dividing the thus-far accumulated
 			// numerators by the now-finalized denominator.
 			for key := range sharingCoeffs {

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -113,8 +113,8 @@ func ComputeAllocationTotals(as *AllocationSet, prop string) map[string]*Allocat
 	arts := map[string]*AllocationTotals{}
 
 	for _, alloc := range as.Allocations {
-		// Do not count idle or unmounted allocations
-		if alloc.IsIdle() || alloc.IsUnmounted() {
+		// Do not count idle allocations
+		if alloc.IsIdle() {
 			continue
 		}
 


### PR DESCRIPTION
## What does this PR change?
* Fix shared cost coefficients for Summary Allocation API by removing the filter keeping unmounted costs out of AllocationTotals. Also, create a new env var to allow use of a local AWS pricing object. 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Fixed shared costs

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/BURNDOWN-142

## How was this PR tested?
* TODO (how are unit tests not catching this??)

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes
