### PR TITLE
Add the Close Stale Issues GitHub Action

### DIFF
--- a/.github/configs/stale.yaml
+++ b/.github/configs/stale.yaml
@@ -1,0 +1,5 @@
+## https://github.com/marketplace/actions/close-stale-issues#recommended-permissions
+# Give stalebot permission to update issues and pull requests
+permissions:
+  issues: write
+  pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue has been marked as stale because it has been open for 180 days with no activity. Please remove the stale label or comment or this issue will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been inactive for 185 days with no activity.'
+          stale-pr-message: 'This pull request has been marked as stale because it has been open for 60 days with no activity. Please remove the stale label or comment or this pull request will be closed in 5 days.'
+          close-pr-message: 'This pull request was closed because it has been inactive for 65 days with no activity.'
+          days-before-issue-stale: 180
+          days-before-issue-close: 5
+          days-before-pr-stale: 60
+          days-before-pr-close: 5


### PR DESCRIPTION
https://github.com/marketplace/actions/close-stale-issues Defaulting to 180 days for issues and 90 days for PRs with 5 day notices

## What does this PR change?
* This will automatically mark issues as stale after 180 days and PRs after 90 days, with a 5 day grace period before closing them.

## Does this PR relate to any other PRs?
* It will start marking them as stale and closing them.

## How will this PR impact users?
* Older issues that have not been addressed will be closed automatically.

## Does this PR address any GitHub or Zendesk issues?
* Possibly, if they're related to older issues and PRs.

## How was this PR tested?
* Deployed into the opencost-helm-chart repository first.

## Does this PR require changes to documentation?
* not applicable

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* not applicable
