### PR TITLE
Deprecate the "container_name" label in favor of "container" in ComputeAllocation queries

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -17,11 +17,11 @@ const (
 	queryFmtPodsUID                     = `avg(kube_pod_container_status_running{%s}) by (pod, namespace, uid, %s)[%s:%s]`
 	queryFmtRAMBytesAllocated           = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s, provider_id)`
 	queryFmtRAMRequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
-	queryFmtRAMUsageAvg                 = `avg(avg_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
-	queryFmtRAMUsageMax                 = `max(max_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
+	queryFmtRAMUsageAvg                 = `avg(avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", %s}[%s])) by (container, pod_name, pod, namespace, instance, %s)`
+	queryFmtRAMUsageMax                 = `max(max_over_time(container_memory_working_set_bytes{container!="",  container!="POD", %s}[%s])) by (container, pod_name, pod, namespace, instance, %s)`
 	queryFmtCPUCoresAllocated           = `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtCPURequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
-	queryFmtCPUUsageAvg                 = `avg(rate(container_cpu_usage_seconds_total{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
+	queryFmtCPUUsageAvg                 = `avg(rate(container_cpu_usage_seconds_total{container!="", container!="POD", %s}[%s])) by (container, pod_name, pod, namespace, instance, %s)`
 	queryFmtGPUsRequested               = `avg(avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtGPUsAllocated               = `avg(avg_over_time(container_gpu_allocation{container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtNodeCostPerCPUHr            = `avg(avg_over_time(node_cpu_hourly_cost{%s}[%s])) by (node, %s, instance_type, provider_id)`
@@ -73,7 +73,7 @@ const (
 	//
 	// If changing the name of the recording rule, make sure to update the
 	// corresponding diagnostic query to avoid confusion.
-	queryFmtCPUUsageMaxRecordingRule = `max(max_over_time(kubecost_container_cpu_usage_irate{%s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
+	queryFmtCPUUsageMaxRecordingRule = `max(max_over_time(kubecost_container_cpu_usage_irate{%s}[%s])) by (container, pod_name, pod, namespace, instance, %s)`
 	// This is the subquery equivalent of the above recording rule query. It is
 	// more expensive, but does not require the recording rule. It should be
 	// used as a fallback query if the recording rule data does not exist.

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -84,7 +84,7 @@ const (
 	// the resolution, to make sure the irate always has two points to query
 	// in case the Prom scrape duration has been reduced to be equal to the
 	// ETL resolution.
-	queryFmtCPUUsageMaxSubquery = `max(max_over_time(irate(container_cpu_usage_seconds_total{container_name!="POD", container_name!="", %s}[%s])[%s:%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
+	queryFmtCPUUsageMaxSubquery = `max(max_over_time(irate(container_cpu_usage_seconds_total{container!="POD", container!="", %s}[%s])[%s:%s])) by (container, pod_name, pod, namespace, instance, %s)`
 )
 
 // Constants for Network Cost Subtype


### PR DESCRIPTION
## What does this PR change?
* In BYO prometheus, its hard dependency that user has prometheus relabelling block if in helm chart added to their [prometheus config ](https://github.com/kubecost/cost-analyzer-helm-chart/blob/06100016aaf0c46feb45fc853a4293c18e46d8a9/cost-analyzer/charts/prometheus/values.yaml#L1217C1-L1228C28). 
There shouldnt be any such dependency since kubernetes v1.14 onwards cadvisor only support container instead of container_name given via [1.14 release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md?plain=1#L985). This change ensure that if user config is missing the relabel our subquery fallback actually works.

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* Kubernetes clusters before v1.14 will be impacted, because the kubelet cAdvisor would still be emitting container_name. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md?plain=1#L985

## Does this PR address any GitHub or Zendesk issues?
* Closes ... [Zendesk-4333](https://kubecost.zendesk.com/agent/tickets/4333) and Jira [CORE-330](https://kubecost.atlassian.net/browse/CORE-330)

## How was this PR tested?
Ensure both query returned same output
![Screen Shot 2023-08-09 at 10 51 37 AM](https://github.com/opencost/opencost/assets/11470561/0708ec58-3a80-4a48-b4e9-ff80883b16b8)
![Screen Shot 2023-08-09 at 10 51 18 AM](https://github.com/opencost/opencost/assets/11470561/9a736abb-7c27-4dea-b956-b6a048aba910)

model/allocation before the fix and after the fix for unaccumulate and unaggregate allocation had same result, this is actually implied by the above test but just to be sure.

Before: 
![Screen Shot 2023-08-09 at 10 53 16 AM](https://github.com/opencost/opencost/assets/11470561/640f76e0-ecd2-4e19-addb-ba8573ca803f)

After:
![Screen Shot 2023-08-09 at 11 20 10 AM](https://github.com/opencost/opencost/assets/11470561/0822351e-5ffe-4943-8679-e4f11d95d316)

Non 10m request sizing option were seen too after the fix and disabling the recording rule

![Screen Shot 2023-08-09 at 11 19 00 AM](https://github.com/opencost/opencost/assets/11470561/eba289b7-ca03-48f5-8b8a-a415c59e5bed)

## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v1.106
