### PR TITLE
average over time makes more sense to read kubecost_cluster_info then point in time read of the same metrics but with potential risk

### DIFF
--- a/pkg/costmodel/clusters/clustermap_test.go
+++ b/pkg/costmodel/clusters/clustermap_test.go
@@ -1,0 +1,37 @@
+package clusters
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func Test_clusterInfoQuery(t *testing.T) {
+	testCases := map[string]struct {
+		testOffset             string
+		testRefreshTime        time.Duration
+		testClusterFilter      string
+		expectClusterInfoQuery string
+	}{
+		"is refresh time 5m yield right prometheus query": {
+			testOffset:             "offset 3h",
+			testRefreshTime:        5 * time.Minute,
+			testClusterFilter:      "",
+			expectClusterInfoQuery: fmt.Sprintf("avg_over_time(kubecost_cluster_info{%s}[%s]%s)", "", "5m", "offset 3h"),
+		},
+		"is cluster filter with id=test working in yield right prometheus query": {
+			testOffset:             "",
+			testRefreshTime:        5 * time.Minute,
+			testClusterFilter:      "id=\"test\"",
+			expectClusterInfoQuery: fmt.Sprintf("avg_over_time(kubecost_cluster_info{%s}[%s]%s)", "id=\"test\"", "5m", ""),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			returnquery := clusterInfoQuery(tc.testOffset, tc.testClusterFilter, tc.testRefreshTime)
+			if tc.expectClusterInfoQuery != returnquery {
+				t.Fatalf("Case: %s failed to return expected query `%s` but returned `%s`", name, tc.expectClusterInfoQuery, returnquery)
+			}
+		})
+	}
+}


### PR DESCRIPTION
PR in draft state uptil we get visual confirmation from User that this PR will resolve customer issue 

## What does this PR change?
* Just to illustrate a scenario where user for BURNDOWN-143 might not have delayed kubecost_cluster_info from secondary cluster[it is just hunch keep it as draft PR untill User comes up with numbers]. To have the cluster info capture better to average over time.

**POTENTIAL RISK**

ClusterInfoMap will have stale entry when id or name is changed and kubecost is redeployed but the clusterInfoMap refreshes during next iteration of load cluster.

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* ClusterInfoMap will have stale entry when id or name is changed and kubecost is redeployed but the clusterInfoMap refreshes during next iteration of load cluster. This is a risk we need to take if hunch that kubecost_cluster_info has delayed metrics populated from secondary cluster to solve BURNDOWN-143

## Does this PR address any GitHub or Zendesk issues?
* Closes ... Might close [BURNDOWN-143](https://kubecost.atlassian.net/browse/BURNDOWN-143)

## How was this PR tested?
* Unit test cases to get right metrics and then we can check this is regular single cluster if clusterInfoMap and metrics is valid kubecost_cluster_info and avg_over_time(kubecost_cluster_info[5m]) is the same until either id or name is changed.

## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* I prefer this go in v1.107
