### PR TITLE
improve auth error handling and response for AWS orphaned resources

### DIFF
--- a/pkg/cloud/aws/athenaquerier.go
+++ b/pkg/cloud/aws/athenaquerier.go
@@ -110,6 +110,9 @@ func (aq *AthenaQuerier) queryAthenaPaginated(ctx context.Context, query string,
 
 	// Create Athena Client
 	cli, err := aq.GetAthenaClient()
+	if err != nil {
+		return fmt.Errorf("QueryAthenaPaginated: GetAthenaClient error: %s", err.Error())
+	}
 
 	// Query Athena
 	startQueryExecutionOutput, err := cli.StartQueryExecution(ctx, startQueryExecutionInput)


### PR DESCRIPTION
## What does this PR change?
* Improve error logic for AWS orphaned resources (volumes and addresses)

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users are less likely to see errors related to authentication and regions they are not allowed to view - these errors have been moved to info level logs, since it may be an intentional implementation decision and not an error.
* Orphaned resources will now prioritize returning valid volumes or addresses over returning errors.
* Prevents a panic if the incorrect AWS role name is configured when using AWS Keys

## Does this PR address any GitHub or Zendesk issues?
* Closes [...](https://kubecost.atlassian.net/browse/CORE-204)

## How was this PR tested?
* Manually, locally

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* can't
