### PR TITLE
Remove default values for GCP cloud billing integration

### DIFF
--- a/configs/gcp.json
+++ b/configs/gcp.json
@@ -5,10 +5,10 @@
     "spotCPU": "0.006655",
     "RAM": "0.004237",
     "spotRAM": "0.000892",
-    "projectID": "todo",
+    "projectID": "",
     "storage": "0.00005479452",
     "zoneNetworkEgress": "0.01",
     "regionNetworkEgress": "0.01",
     "internetNetworkEgress": "0.12",
-    "billingDataDataset": "billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2"
+    "billingDataDataset": ""
 }


### PR DESCRIPTION
## What does this PR change?

* Remove default values for GCP cloud billing integration
* Otherwise, the existing values were interpreted to be real cloud configurations and would result in repeated CloudCost error logs.

```
"CloudCost[todo/billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2]: ingestor: build failed for window [2023-05-26T00:00:00+0000, 2023-06-02T00:00:00+0000): googleapi: Error 403: Request had insufficient authentication scopes.
Details:
[
  {
    "@type": "[type.googleapis.com/google.rpc.ErrorInfo](http://type.googleapis.com/google.rpc.ErrorInfo)",
    "domain": "[googleapis.com](http://googleapis.com/)",
    "metadata": {
      "method": "google.cloud.bigquery.v2.JobService.Query",
      "service": "[bigquery.googleapis.com](http://bigquery.googleapis.com/)"
    },
    "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
  }
]

More details:
Reason: insufficientPermissions, Message: Insufficient Permission"
```

## Does this PR relate to any other PRs?

* No

## How will this PR impact users?

* Reduced error logging if GCP cloud integration is not configured

## Does this PR address any GitHub or Zendesk issues?

* No

## How was this PR tested?

* Build/run OpenCost locally
* On a running Kubecost instance, update the `gcp.json` on the filesystem and restart the pod.

## Does this PR require changes to documentation?

* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

* Targeting v1.107
