### PR TITLE
Preserve node label if present in usage data.

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -156,7 +156,11 @@ const (
 			label_replace(
 				label_replace(
 					label_replace(
-						count_over_time(container_memory_working_set_bytes{container!="", container!="POD", instance!="", %s}[%s] %s), "node", "$1", "instance", "(.+)"
+						label_replace(
+							label_replace(
+								count_over_time(container_memory_working_set_bytes{container!="", container!="POD", instance!="", %s}[%s] %s), "node_name", "$1", "node", "(.+)"
+							), "node", "$1", "instance", "(.+)"
+						), "node", "$1", "node_name", "(.+)"
 					), "container_name", "$1", "container", "(.+)"
 				), "pod_name", "$1", "pod", "(.+)"
 			)
@@ -164,7 +168,11 @@ const (
 			label_replace(
 				label_replace(
 					label_replace(
-						avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", instance!="", %s}[%s] %s), "node", "$1", "instance", "(.+)"
+						label_replace(
+							label_replace(
+								avg_over_time(container_memory_working_set_bytes{container!="", container!="POD", instance!="", %s}[%s] %s), "node_name", "$1", "node", "(.+)"
+							), "node", "$1", "instance", "(.+)"
+						), "node", "$1", "node_name", "(.+)"
 					), "container_name", "$1", "container", "(.+)"
 				), "pod_name", "$1", "pod", "(.+)"
 			)
@@ -185,9 +193,13 @@ const (
 		label_replace(
 			label_replace(
 				label_replace(
-					rate(
-						container_cpu_usage_seconds_total{container!="", container!="POD", instance!="", %s}[%s] %s
-					), "node", "$1", "instance", "(.+)"
+					label_replace(
+						label_replace(
+							rate(
+								container_cpu_usage_seconds_total{container!="", container!="POD", instance!="", %s}[%s] %s
+							), "node_name", "$1", "node", "(.+)"
+						), "node", "$1", "instance", "(.+)"
+					), "node", "$1", "node_name", "(.+)"
 				), "container_name", "$1", "container", "(.+)"
 			), "pod_name", "$1", "pod", "(.+)"
 		)


### PR DESCRIPTION
## What does this PR change?
The prometheus usage queries have an aggressive relabel strategy and the expectation that `instance` matches the kubernetes reported `node` name for a pod. Seemingly this is generally true but not guaranteed to be the case. In some cases (ie. prometheus operator) the usage data is available with both an `instance` label and `node` label. The `instance` label matches the `ip:port` of the scrape job but `node` matches the kubernetes node name. By relabeling from instance -> node, it breaks the usage queries as the new `node` label does not match the kubernetes node name.

This change preserves the node label and preferentially uses that over the `instance` label. I'm not much of a promql expert so I'm not sure if there is a better way to do this. This does change the default behavior but in the case a metric is already labeled with `node` it seems it would be preferable to use that.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Clusters deployed on EKS 1.23 + Latest prometheus operator results in duplicated cost data because of the `instance` -> `node` relabel. This generates results which do not match the expected node name, leading to no usage data for api reported pods and seemingly backfilled invalid data with unexpected node names from the usage data.

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Change was validated on multiple versions of AWS EKS from 1.23 to 1.26.

## Does this PR require changes to documentation?
* Might be worth documenting the label expectation for usage data to function as expected.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Not sure.
