### PR TITLE
Resolve cross-platform opencost-ui container running as root

### DIFF
--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -1,10 +1,17 @@
 FROM nginx:alpine
+
 COPY ./dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
+COPY ./docker-entrypoint.sh /usr/local/bin/
+
+RUN adduser 1001 -g 1000 -D
+RUN chown 1001:1000 -R /var/www
+RUN chown 1001:1000 -R /etc/nginx
 
 ENV BASE_URL=/model
 
-COPY ./docker-entrypoint.sh /usr/local/bin/
+USER 1001
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## What does this PR change?
This fixes modifies the opencost-ui container so it'll run nginx as a non-root user by default. It is almost an exact copy of the contents from the original Dockerfile in the source directory.

CIS Kubernetes v1.23 advises in 5.2.7 to not run containers as root where not needed. Namespaces in K8S distros like RKE2 by default deny the ability to run as root. 

## Does this PR relate to any other PRs?
* Not that I've found.

## How will this PR impact users?
* It shouldn't impact anyone with a default k8s cluster configuration. Those running with CIS and other compliance modes can run the container without interventions.

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Following the OpenCost install instructions and integration tests noted in the contribuing guide. Work was done on RKE2 1.23 in CIS compliance mode.

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* No, as I can't see how to do this via the github editor.
