### PR TITLE
[BURNDOWN-234] filter to correct KSM implementation

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	queryFmtPods                        = `avg(kube_pod_container_status_running{%s}) by (pod, namespace, %s)[%s:%s]`
-	queryFmtPodsUID                     = `avg(kube_pod_container_status_running{%s}) by (pod, namespace, uid, %s)[%s:%s]`
+	queryFmtPods                        = `avg(kube_pod_container_status_running{job="kubecost", %s}) by (pod, namespace, %s)[%s:%s]`
+	queryFmtPodsUID                     = `avg(kube_pod_container_status_running{job="kubecost", %s}) by (pod, namespace, uid, %s)[%s:%s]`
 	queryFmtRAMBytesAllocated           = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s, provider_id)`
 	queryFmtRAMRequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtRAMUsageAvg                 = `avg(avg_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -13,8 +13,13 @@ import (
 )
 
 const (
-	queryFmtPods                        = `avg(kube_pod_container_status_running{job="kubecost", %s}) by (pod, namespace, %s)[%s:%s]`
-	queryFmtPodsUID                     = `avg(kube_pod_container_status_running{job="kubecost", %s}) by (pod, namespace, uid, %s)[%s:%s]`
+	// https://kubecost.atlassian.net/browse/BURNDOWN-234
+	// upstream KSM has implementation change vs OC internal KSM - it sets metric to 0 when pod goes down
+	// VS OC implementation which stops emitting it
+	// by adding != 0 filter, we keep just the active times in the prom result
+	queryFmtPods                        = `avg(kube_pod_container_status_running{%s} != 0) by (pod, namespace, %s)[%s:%s]`
+	queryFmtPodsUID                     = `avg(kube_pod_container_status_running{%s} != 0) by (pod, namespace, uid, %s)[%s:%s]`
+
 	queryFmtRAMBytesAllocated           = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s, provider_id)`
 	queryFmtRAMRequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
 	queryFmtRAMUsageAvg                 = `avg(avg_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`


### PR DESCRIPTION
## What does this PR change?
* filters out zero values for kube_container_status_running readings. This is due to kubecosts' exported KSM behaving differently than upstream KSM. The following screenshot illustrates the problem: 
![image](https://github.com/opencost/opencost/assets/6842995/e293cf87-e249-42c8-87e2-71ae3a1b86ea)

A query for a certain pod that ran for 1 hour returns 2 results: 1 set of values is emitted from kubecosts' implementation of the KSM container status running metric, the other results is from another KSM that came bundled with prometheus. As you can see, the light blue line simply stops returning results when the pod exists, however, the third party KSM keeps emitting the metric but sets it to 0 when the pod exits. Our prom query was just querying for all values and taking the date of the last result, which from the other KSM installation, was the current time even if the value was 0. Our logic then thought the pod was still alive By adding the non zero filter, we stop emitting 0 metrics and pull the upstream KSM implementation query results more into line with what we typically emit. 

## Does this PR relate to any other PRs?
* None 

## How will this PR impact users?
* should make pod run times more reasonable 

## Does this PR address any GitHub or Zendesk issues?
* https://kubecost.atlassian.net/browse/BURNDOWN-234

## How was this PR tested?
* ensured that after this change was made, prom results returned start/end times matching the time the pod was known to be alive

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
