### PR TITLE
Provide ability to toggle load balancer PARC behavior

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2275,6 +2275,7 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// Otherwise it is computed at the cluster level. (Not relevant if idle
 	// is not included.)
 	idleByNode := qp.GetBool("idleByNode", false)
+	sharedLoadBalancer := qp.GetBool("sharelb", false)
 
 	// IncludeProportionalAssetResourceCosts, if true,
 	includeProportionalAssetResourceCosts := qp.GetBool("includeProportionalAssetResourceCosts", false)
@@ -2282,7 +2283,7 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// include aggregated labels/annotations if true
 	includeAggregatedMetadata := qp.GetBool("includeAggregatedMetadata", false)
 
-	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, accumulateBy)
+	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, accumulateBy)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "bad request") {
 			WriteError(w, BadRequest(err.Error()))

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2499,10 +2499,6 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 			for _, alloc := range as.Allocations {
 				for rawKey, parc := range alloc.ProportionalAssetResourceCosts {
 
-					if parc.Type == "LoadBalancer" {
-						log.Debug("brk")
-					}
-
 					key := strings.TrimSuffix(strings.ReplaceAll(rawKey, ",", "/"), "/")
 					// for each parc , check the totals store for each
 					// on a totals hit, set the corresponding total and calculate percentage
@@ -2544,9 +2540,6 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 						parc.LoadBalancerTotalCost = totals.LoadBalancerCost
 					}
 
-					if parc.LoadBalancerProportionalCost > 0 {
-						log.Debug("brk")
-					}
 					kubecost.ComputePercentages(&parc)
 					alloc.ProportionalAssetResourceCosts[rawKey] = parc
 				}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2361,7 +2361,7 @@ func measureTimeAsync(start time.Time, threshold time.Duration, name string, ch 
 	}
 }
 
-func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata bool, accumulateBy kubecost.AccumulateOption) (*kubecost.AllocationSetRange, error) {
+func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer bool, accumulateBy kubecost.AccumulateOption) (*kubecost.AllocationSetRange, error) {
 	// Validate window is legal
 	if window.IsOpen() || window.IsNegative() {
 		return nil, fmt.Errorf("illegal window: %s", window)
@@ -2484,7 +2484,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 			}
 
 			var totalPublicLbCost, totalPrivateLbCost float64
-			if isAKS && env.IsSingleLB() {
+			if isAKS && sharedLoadBalancer {
 				// loop through all assetTotals, adding all load balancer costs by public and private
 				for _, tot := range totalStoreByNode {
 					if tot.PrivateLoadBalancer {
@@ -2525,7 +2525,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 					parc.GPUTotalCost = totals.GPUCost
 					parc.RAMTotalCost = totals.RAMCost
 					parc.PVTotalCost = totals.PersistentVolumeCost
-					if isAKS && env.IsSingleLB() && len(alloc.LoadBalancers) > 0 {
+					if isAKS && sharedLoadBalancer && len(alloc.LoadBalancers) > 0 {
 						// Azure is a special case - use computed totals above
 						// use the lbAllocations in the object to determine if
 						// this PARC is a public or private load balancer

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -86,7 +86,6 @@ const (
 	KubecostConfigBucketEnvVar    = "KUBECOST_CONFIG_BUCKET"
 	ClusterInfoFileEnabledEnvVar  = "CLUSTER_INFO_FILE_ENABLED"
 	ClusterCacheFileEnabledEnvVar = "CLUSTER_CACHE_FILE_ENABLED"
-	SingleLoadBalancerEnabled     = "SINGLE_LOAD_BALANCER"
 
 	PrometheusQueryOffsetEnvVar                 = "PROMETHEUS_QUERY_OFFSET"
 	PrometheusRetryOnRateLimitResponseEnvVar    = "PROMETHEUS_RETRY_ON_RATE_LIMIT"
@@ -112,10 +111,6 @@ const (
 const DefaultConfigMountPath = "/var/configs"
 
 var offsetRegex = regexp.MustCompile(`^(\+|-)(\d\d):(\d\d)$`)
-
-func IsSingleLB() bool {
-	return GetBool(SingleLoadBalancerEnabled, false)
-}
 
 func IsETLReadOnlyMode() bool {
 	return GetBool(ETLReadOnlyMode, false)

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -86,6 +86,7 @@ const (
 	KubecostConfigBucketEnvVar    = "KUBECOST_CONFIG_BUCKET"
 	ClusterInfoFileEnabledEnvVar  = "CLUSTER_INFO_FILE_ENABLED"
 	ClusterCacheFileEnabledEnvVar = "CLUSTER_CACHE_FILE_ENABLED"
+	SingleLoadBalancerEnabled     = "SINGLE_LOAD_BALANCER"
 
 	PrometheusQueryOffsetEnvVar                 = "PROMETHEUS_QUERY_OFFSET"
 	PrometheusRetryOnRateLimitResponseEnvVar    = "PROMETHEUS_RETRY_ON_RATE_LIMIT"
@@ -111,6 +112,10 @@ const (
 const DefaultConfigMountPath = "/var/configs"
 
 var offsetRegex = regexp.MustCompile(`^(\+|-)(\d\d):(\d\d)$`)
+
+func IsSingleLB() bool {
+	return GetBool(SingleLoadBalancerEnabled, false)
+}
 
 func IsETLReadOnlyMode() bool {
 	return GetBool(ETLReadOnlyMode, false)


### PR DESCRIPTION
## What does this PR change?
* provides a way to call the API with different settings, allowing caller to build blended cost of both shared costs (single load balancer per AKS cluster) AND individual costs (1 external IP per service) 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
