### PR TITLE
Remove non-root user to restore UI

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -9,16 +9,8 @@ FROM nginx:alpine
 COPY --from=builder /opt/ui/dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
-RUN rm -rf /etc/nginx/conf.d/default.conf
-
-RUN adduser 1001 -g 1000 -D
-RUN chown 1001:1000 -R /var/www
-RUN chown 1001:1000 -R /etc/nginx
 
 ENV BASE_URL=/model
-
-
-USER 1001
 
 COPY ./docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -1,17 +1,10 @@
 FROM nginx:alpine
-
 COPY ./dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
-COPY ./docker-entrypoint.sh /usr/local/bin/
-
-RUN adduser 1001 -g 1000 -D
-RUN chown 1001:1000 -R /var/www
-RUN chown 1001:1000 -R /etc/nginx
 
 ENV BASE_URL=/model
 
-USER 1001
-
+COPY ./docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## What does this PR change?
* Reverts OpenCost UI container to running as root, fixing https://github.com/opencost/opencost/issues/2144. I synchronized the `Dockerfile` and `Dockerfile.cross` so they've got the same content where appropriate. 

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/2130 brought in the original change.

## How will this PR impact users?
* The OpenCost UI will run as root again, which was flagged as a security concern. We need to fix this properly, but 1.106 was already released.

## How was this PR tested?
* EKS amd64, Kind arm64, K3s arm64, K3s amd64

## Does this PR require changes to documentation?
* 1.106.0 wasn't released for OpenCost, we'll do the 1.106.1 release instead.
