### PR TITLE
add a way to compare boundary errors

### DIFF
--- a/pkg/kubecost/window.go
+++ b/pkg/kubecost/window.go
@@ -875,3 +875,11 @@ func (be *BoundaryError) Error() string {
 
 	return fmt.Sprintf("boundary error: requested %s; supported %s: %s", be.Requested, be.Supported, be.Message)
 }
+
+func (be *BoundaryError) Is(target error) bool {
+	if _, ok := target.(*BoundaryError); ok {
+		return true
+	}
+
+	return false
+}

--- a/pkg/kubecost/window_test.go
+++ b/pkg/kubecost/window_test.go
@@ -2,6 +2,7 @@ package kubecost
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1217,5 +1218,26 @@ func TestMarshalUnmarshal(t *testing.T) {
 				t.Errorf(diff)
 			}
 		})
+	}
+}
+
+func TestBoundaryErrorIs(t *testing.T) {
+	baseError := &BoundaryError{Message: "cde"}
+	singleWrapError := fmt.Errorf("wrap: %w", &BoundaryError{Message: "abc"})
+
+	if errors.Is(singleWrapError, baseError) {
+		t.Logf("Single wrap success")
+	} else {
+		t.Errorf("Single wrap failure: %s != %s", baseError, singleWrapError)
+	}
+
+	multiWrapError := fmt.Errorf("wrap: %w", &BoundaryError{Message: "abc"})
+	multiWrapError = fmt.Errorf("wrap x2: %w", multiWrapError)
+	multiWrapError = fmt.Errorf("wrap x3: %w", multiWrapError)
+
+	if errors.Is(multiWrapError, baseError) {
+		t.Logf("Multi wrap success")
+	} else {
+		t.Errorf("Multi wrap failure: %s != %s", baseError, multiWrapError)
 	}
 }


### PR DESCRIPTION
## What does this PR change?
* Allows boundary errors to be compared to one another

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/1736

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/BURNDOWN-236

## How was this PR tested?
* Unit test

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
