### PR TITLE
set max results param for athena pagination

### DIFF
--- a/pkg/cloud/aws/athenaquerier.go
+++ b/pkg/cloud/aws/athenaquerier.go
@@ -126,8 +126,10 @@ func (aq *AthenaQuerier) queryAthenaPaginated(ctx context.Context, query string,
 	if err != nil {
 		return fmt.Errorf("QueryAthenaPaginated: query execution error: %s", err.Error())
 	}
+	var maxResults int32 = 10000
 	queryResultsInput := &athena.GetQueryResultsInput{
 		QueryExecutionId: startQueryExecutionOutput.QueryExecutionId,
+		MaxResults:       &maxResults,
 	}
 	getQueryResultsPaginator := athena.NewGetQueryResultsPaginator(cli, queryResultsInput)
 	for getQueryResultsPaginator.HasMorePages() {


### PR DESCRIPTION
## What does this PR change?
* Enable athena result pagination

## Does this PR relate to any other PRs?
* Set the parameter that sets the page limit when querying Athena result. Currently hard coded to 10000

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
