### PR TITLE
Revert UI container to 1.105.2 until 1.106.1 is released.

### DIFF
--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -167,7 +167,7 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1001
-        - image: quay.io/kubecost1/opencost-ui:latest
+        - image: quay.io/kubecost1/opencost-ui:1.105.2
           name: opencost-ui
           resources:
             requests:


### PR DESCRIPTION
Fixes https://github.com/opencost/opencost/issues/2144

This rolls the UI container back to `1.105.2` instead of `latest` until we can get a `1.106.1` release that addresses the permissions issue. https://github.com/opencost/opencost/pull/2148 is the code rollback, but it's not in a release yet. 