### PR TITLE
Sync Dockerfile and Dockerfile.cross and run as non-root user

### DIFF
--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -167,7 +167,7 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1001
-        - image: quay.io/kubecost1/opencost-ui:1.105.2
+        - image: quay.io/kubecost1/opencost-ui:latest
           name: opencost-ui
           resources:
             requests:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,20 +6,22 @@ ADD src /opt/ui/src
 RUN npx parcel build src/index.html
 
 FROM nginx:alpine
+
 COPY --from=builder /opt/ui/dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
+COPY ./docker-entrypoint.sh /usr/local/bin/
+
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
 RUN adduser 1001 -g 1000 -D
 RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
+RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 
-
 USER 1001
 
-COPY ./docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -5,9 +5,12 @@ COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/
 
+RUN rm -rf /etc/nginx/conf.d/default.conf
+
 RUN adduser 1001 -g 1000 -D
 RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
+RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 


### PR DESCRIPTION
## What does this PR change?
* Dockerfile and Dockerfile.cross now have the same commands and run nginx as user 1001

## Does this PR relate to any other PRs?
* Rolls back https://github.com/opencost/opencost/pull/2163 which was a temporary fix
* Rolls back https://github.com/opencost/opencost/pull/2148 which was a temporary fix

## How will this PR impact users?
* UI container doesn't run as the root user, which was flagged as a concern.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/2150

## How was this PR tested?
* Kind (Arm), EKS (x86), K3s (x86)

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes.
