### PR TITLE
Extend Issues to 360 days and PRs to 90 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
           close-issue-message: 'This issue was closed because it has been inactive for 185 days with no activity.'
           stale-pr-message: 'This pull request has been marked as stale because it has been open for 60 days with no activity. Please remove the stale label or comment or this pull request will be closed in 5 days.'
           close-pr-message: 'This pull request was closed because it has been inactive for 65 days with no activity.'
-          days-before-issue-stale: 180
+          days-before-issue-stale: 360
           days-before-issue-close: 5
-          days-before-pr-stale: 60
+          days-before-pr-stale: 90
           days-before-pr-close: 5


### PR DESCRIPTION
## What does this PR change?
* There was some concern that Issues were being closed too fast, so we've extended them to 360 days and PRs to 90 days (from 180 and 60 respectively).

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Issues and PRs will remain open longer before being marked `stale`

## Does this PR address any GitHub or Zendesk issues?
* n/a

## How was this PR tested?
* n/a

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* n/a
