### PR TITLE
Use new filters for sharing

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2215,7 +2215,7 @@ func (a *Accesses) ComputeAllocationHandlerSummary(w http.ResponseWriter, r *htt
 
 	sasl := []*kubecost.SummaryAllocationSet{}
 	for _, as := range asr.Slice() {
-		sas := kubecost.NewSummaryAllocationSet(as, nil, []kubecost.AllocationMatchFunc{}, false, false)
+		sas := kubecost.NewSummaryAllocationSet(as, nil, nil, false, false)
 		sasl = append(sasl, sas)
 	}
 	sasr := kubecost.NewSummaryAllocationSetRange(sasl...)

--- a/pkg/filter21/ast/walker.go
+++ b/pkg/filter21/ast/walker.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/opencost/opencost/pkg/filter21/util"
@@ -366,4 +367,43 @@ func indent(depth int) string {
 		return ""
 	}
 	return strings.Repeat("  ", depth)
+}
+
+func Fields(filter FilterNode) []Field {
+	fields := map[Field]bool{}
+
+	PreOrderTraversal(filter, func(fn FilterNode, state TraversalState) {
+		if fn == nil {
+			return
+		}
+		switch n := fn.(type) {
+		case *EqualOp:
+			if n.Left.Field != nil {
+				fields[*n.Left.Field] = true
+			}
+		case *ContainsOp:
+			if n.Left.Field != nil {
+				fields[*n.Left.Field] = true
+			}
+		case *ContainsPrefixOp:
+			if n.Left.Field != nil {
+				fields[*n.Left.Field] = true
+			}
+		case *ContainsSuffixOp:
+			if n.Left.Field != nil {
+				fields[*n.Left.Field] = true
+			}
+		}
+	})
+
+	response := make([]Field, 0, len(fields))
+	for field := range fields {
+		response = append(response, field)
+	}
+
+	sort.Slice(response, func(i, j int) bool {
+		return response[i].Name < response[j].Name
+	})
+
+	return response
 }

--- a/pkg/filter21/ast/walker_test.go
+++ b/pkg/filter21/ast/walker_test.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
 )
 
 func ExampleTransformLeaves() {
@@ -49,4 +51,102 @@ func ExampleTransformLeaves() {
 	//     Equals { Left: field2, Right: bar }
 	//   }
 	// }
+}
+
+func TestFields(t *testing.T) {
+	type testCase struct {
+		name   string
+		filter FilterNode
+		exp    []Field
+	}
+
+	fieldNamespace := *NewField("namespace")
+	fieldCluster := *NewField("cluster")
+	fieldControllerKind := *NewField("controllerKind")
+
+	testCases := []testCase{
+		{
+			name:   ``,
+			filter: &VoidOp{},
+			exp:    []Field{},
+		},
+		{
+			name: `namespace:"kubecost"`,
+			filter: &EqualOp{
+				Left: Identifier{
+					Field: NewField("namespace"),
+					Key:   "",
+				},
+				Right: "kubecost",
+			},
+			exp: []Field{fieldNamespace},
+		},
+		{
+			name: `namespace: "kubecost" | cluster:"cluster-one" | controllerKind:"deployment"`,
+			filter: &OrOp{
+				Operands: []FilterNode{
+					&EqualOp{
+						Left: Identifier{
+							Field: NewField("namespace"),
+							Key:   "",
+						},
+						Right: "kubecost",
+					},
+					&EqualOp{
+						Left: Identifier{
+							Field: NewField("cluster"),
+							Key:   "",
+						},
+						Right: "cluster-one",
+					},
+					&EqualOp{
+						Left: Identifier{
+							Field: NewField("controllerKind"),
+							Key:   "",
+						},
+						Right: "deployment",
+					},
+				},
+			},
+			exp: []Field{fieldCluster, fieldControllerKind, fieldNamespace},
+		},
+		{
+			name: `namespace: "kubecost" | namespace:"kube-system" | namespace:"default"`,
+			filter: &OrOp{
+				Operands: []FilterNode{
+					&EqualOp{
+						Left: Identifier{
+							Field: NewField("namespace"),
+							Key:   "",
+						},
+						Right: "kubecost",
+					},
+					&EqualOp{
+						Left: Identifier{
+							Field: NewField("namespace"),
+							Key:   "",
+						},
+						Right: "kube-system",
+					},
+					&EqualOp{
+						Left: Identifier{
+							Field: NewField("namespace"),
+							Key:   "",
+						},
+						Right: "default",
+					},
+				},
+			},
+			exp: []Field{fieldNamespace},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			act := Fields(tc.filter)
+			if !reflect.DeepEqual(tc.exp, act) {
+				t.Errorf("fields do not match; expected %v; got %v", tc.exp, act)
+			}
+		})
+	}
 }

--- a/pkg/util/filterutil/filterutil.go
+++ b/pkg/util/filterutil/filterutil.go
@@ -355,6 +355,20 @@ func AllocationFilterFromParamsV1(
 	return andFilter
 }
 
+func AllocationSharerFromParamsV1(params AllocationFilterV1) filter.Filter {
+	var filterOps []ast.FilterNode
+
+	if len(params.Namespaces) > 0 {
+		filterOps = push(filterOps, filterV1SingleValueFromList(params.Namespaces, afilter.FieldNamespace))
+	}
+
+	if len(params.Labels) > 0 {
+		filterOps = push(filterOps, filterV1DoubleValueFromList(params.Labels, afilter.FieldLabel))
+	}
+
+	return opsToAnd(filterOps)
+}
+
 func AssetFilterFromParamsV1(
 	qp mapper.PrimitiveMapReader,
 	clusterMap clusters.ClusterMap,


### PR DESCRIPTION
## What does this PR change?
* Replaces old match funcs with new filters for allocation sharing

## Does this PR relate to any other PRs?
* Required for https://github.com/kubecost/kubecost-cost-model/pull/1772

## How will this PR impact users?
* Enables other features that require introspection of filters and sharing (e.g. https://github.com/kubecost/kubecost-cost-model/pull/1772)

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Unit tests

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes
