### PR TITLE
Sync Dockerfile and Dockerfile.cross and run as non-root user for 1.106

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,20 +6,21 @@ ADD src /opt/ui/src
 RUN npx parcel build src/index.html
 
 FROM nginx:alpine
+
 COPY --from=builder /opt/ui/dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
+COPY ./docker-entrypoint.sh /usr/local/bin/
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
 RUN adduser 1001 -g 1000 -D
 RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
+RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 
-
 USER 1001
 
-COPY ./docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -4,10 +4,12 @@ COPY ./dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/
+RUN rm -rf /etc/nginx/conf.d/default.conf
 
 RUN adduser 1001 -g 1000 -D
 RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
+RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 


### PR DESCRIPTION
Backported https://github.com/opencost/opencost/pull/2166 for 1.106.1

## What does this PR change?
* Successfully runs as non-root https://github.com/opencost/opencost/pull/2166

## Does this PR relate to any other PRs?
* 1.106 shipped with a broken UI container (https://github.com/opencost/opencost/issues/2144)
* Undoes the rollback (https://github.com/opencost/opencost/pull/2148)

## How will this PR impact users?
* UI container won't run as root, works.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/2150 for the 1.106 branch

## How was this PR tested?
* EKS (x86), Kind (Arm), K3s (Arm, x86), will retest with RCs before 1.106.1 release

## Does this PR require changes to documentation?
* can finally publish release notes for 1.106 for OpenCost

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* We'll finally publish 1.106 because we have a working UI container.
