### PR TITLE
fix: use spot label nodes from custom provider config

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -666,6 +666,9 @@ func (k *awsKey) Features() string {
 // If the instance is a spot instance, it will return PreemptibleType
 // Otherwise returns an empty string
 func (k *awsKey) getUsageType(labels map[string]string) string {
+	if kLabel, ok := labels[k.SpotLabelName]; ok && kLabel == k.SpotLabelValue {
+		return PreemptibleType
+	}
 	if eksLabel, ok := labels[EKSCapacityTypeLabel]; ok && eksLabel == EKSCapacitySpotTypeValue {
 		// We currently write out spot instances as "preemptible" in the pricing data, so these need to match
 		return PreemptibleType

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/opencost/opencost/pkg/cloud/models"
+	v1 "k8s.io/api/core/v1"
 )
 
 func Test_awsKey_getUsageType(t *testing.T) {
@@ -492,5 +493,35 @@ func Test_populate_pricing(t *testing.T) {
 	if !reflect.DeepEqual(expectedPricing, awsTest.Pricing) {
 		t.Fatalf("expected parsed pricing did not match actual parsed result (cn)")
 	}
+}
 
+func TestFeatures(t *testing.T) {
+	testCases := map[string]struct {
+		aws      awsKey
+		expected string
+	}{
+		"Spot from custom labels": {
+			aws: awsKey{
+				SpotLabelName:  "node-type",
+				SpotLabelValue: "node-spot",
+				Labels: map[string]string{
+					"node-type":                "node-spot",
+					v1.LabelOSStable:           "linux",
+					v1.LabelHostname:           "my-hostname",
+					v1.LabelTopologyRegion:     "us-west-2",
+					v1.LabelTopologyZone:       "us-west-2b",
+					v1.LabelInstanceTypeStable: "m5.large",
+				},
+			},
+			expected: "us-west-2,m5.large,linux,preemptible",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features := tc.aws.Features()
+			if features != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, features)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What does this PR change?
* Use `spotLabel` and `spotLabelValue` from custom provider config. We don't use Karpenter nor EKS but have our own self-managed Kubernetes clusters on AWS

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* For users that specify the `spotLabel` and `SpotLabelValue` in a custom provider, it will use those labels.

```json
  aws.json: |-
    {
        "athenaBucketName": "s3://...",
        "athenaCatalog": "..",
        "athenaDatabase": "..",
        "athenaProjectID": "...",
        "athenaRegion": "us-west-2",
        "athenaTable": "...",
        "athenaWorkgroup": "...",
        "description": "pricing model form Athena. AWS pricing API data still used for total node cost.",
        "provider": "aws",
        "spotLabel": "node-type",
        "spotLabelValue": "node-spot"
    }
```

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Unit tests and local cluster

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
