### PR TITLE
Add configuration option for AWS Athena pagination.

### DIFF
--- a/pkg/cloud/aws/athenaquerier.go
+++ b/pkg/cloud/aws/athenaquerier.go
@@ -126,9 +126,13 @@ func (aq *AthenaQuerier) queryAthenaPaginated(ctx context.Context, query string,
 	if err != nil {
 		return fmt.Errorf("QueryAthenaPaginated: query execution error: %s", err.Error())
 	}
+	maxQueryResults := aq.MaxQueryResults
+	if maxQueryResults <= 0 || maxQueryResults > 1000 {
+		maxQueryResults = 1000 // default value used by SDK
+	}
 	queryResultsInput := &athena.GetQueryResultsInput{
 		QueryExecutionId: startQueryExecutionOutput.QueryExecutionId,
-		MaxResults:       aws.Int32(1000), // this is the default value
+		MaxResults:       aws.Int32(maxQueryResults),
 	}
 	getQueryResultsPaginator := athena.NewGetQueryResultsPaginator(cli, queryResultsInput)
 	for getQueryResultsPaginator.HasMorePages() {


### PR DESCRIPTION
## What does this PR change?

* Adds a configuration option for max results returned by an Athena query.
* Should be configurable via the `cloud-integration.json`. Requires further testing.

## Does this PR relate to any other PRs?

* Adds configurability for https://github.com/opencost/opencost/pull/2171
* Similar to https://github.com/opencost/opencost/pull/2141

## How will this PR impact users?

* If the ingestion of CloudCosts results in Athena queries with result sets that are too large, this config can be tuned.

## Does this PR address any GitHub or Zendesk issues?

* None

## How was this PR tested?

* Not yet. Will need to tune the parameter and see how it affects queries in my deployment.

## Does this PR require changes to documentation?

* Yes, will do.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

* 
