### PR TITLE
Fix sharing coefficients when unmounted PVs are folded into namespaces

### DIFF
--- a/pkg/kubecost/summaryallocation_json.go
+++ b/pkg/kubecost/summaryallocation_json.go
@@ -24,6 +24,8 @@ type SummaryAllocationResponse struct {
 	RAMCost                *float64  `json:"ramCost"`
 	SharedCost             *float64  `json:"sharedCost"`
 	ExternalCost           *float64  `json:"externalCost"`
+	TotalEfficiency        *float64  `json:"totalEfficiency"`
+	TotalCost              *float64  `json:"totalCost"`
 }
 
 // ToResponse converts a SummaryAllocation to a SummaryAllocationResponse,
@@ -49,6 +51,8 @@ func (sa *SummaryAllocation) ToResponse() *SummaryAllocationResponse {
 		RAMCost:                formatutil.Float64ToResponse(sa.RAMCost),
 		SharedCost:             formatutil.Float64ToResponse(sa.SharedCost),
 		ExternalCost:           formatutil.Float64ToResponse(sa.ExternalCost),
+		TotalEfficiency:        formatutil.Float64ToResponse(sa.TotalEfficiency()),
+		TotalCost:              formatutil.Float64ToResponse(sa.TotalCost()),
 	}
 }
 

--- a/pkg/kubecost/totals.go
+++ b/pkg/kubecost/totals.go
@@ -10,6 +10,16 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
+type AllocationTotalsResult struct {
+	Cluster map[string]*AllocationTotals `json:"cluster"`
+	Node    map[string]*AllocationTotals `json:"node"`
+}
+
+type AssetTotalsResult struct {
+	Cluster map[string]*AssetTotals `json:"cluster"`
+	Node    map[string]*AssetTotals `json:"node"`
+}
+
 // AllocationTotals represents aggregate costs of all Allocations for
 // a given cluster or tuple of (cluster, node) between a given start and end
 // time, where the costs are aggregated per-resource. AllocationTotals
@@ -35,6 +45,10 @@ type AllocationTotals struct {
 	PersistentVolumeCostAdjustment float64   `json:"persistentVolumeCostAdjustment"`
 	RAMCost                        float64   `json:"ramCost"`
 	RAMCostAdjustment              float64   `json:"ramCostAdjustment"`
+	// UnmountedPVCost is used to track how much of the cost in
+	// PersistentVolumeCost is for an unmounted PV. It is not additive of that
+	// field, and need not be sent in API responses.
+	UnmountedPVCost float64 `json:"-"`
 }
 
 // ClearAdjustments sets all adjustment fields to 0.0

--- a/pkg/kubecost/totals_json.go
+++ b/pkg/kubecost/totals_json.go
@@ -1,0 +1,77 @@
+package kubecost
+
+import (
+	"time"
+
+	"github.com/opencost/opencost/pkg/util/formatutil"
+)
+
+type AllocationTotalsResponse struct {
+	Start                          time.Time `json:"start"`
+	End                            time.Time `json:"end"`
+	Cluster                        string    `json:"cluster"`
+	Node                           string    `json:"node"`
+	Count                          int       `json:"count"`
+	CPUCost                        *float64  `json:"cpuCost"`
+	CPUCostAdjustment              *float64  `json:"cpuCostAdjustment"`
+	GPUCost                        *float64  `json:"gpuCost"`
+	GPUCostAdjustment              *float64  `json:"gpuCostAdjustment"`
+	LoadBalancerCost               *float64  `json:"loadBalancerCost"`
+	LoadBalancerCostAdjustment     *float64  `json:"loadBalancerCostAdjustment"`
+	NetworkCost                    *float64  `json:"networkCost"`
+	NetworkCostAdjustment          *float64  `json:"networkCostAdjustment"`
+	PersistentVolumeCost           *float64  `json:"persistentVolumeCost"`
+	PersistentVolumeCostAdjustment *float64  `json:"persistentVolumeCostAdjustment"`
+	RAMCost                        *float64  `json:"ramCost"`
+	RAMCostAdjustment              *float64  `json:"ramCostAdjustment"`
+	TotalCost                      *float64  `json:"totalCost"`
+}
+
+func (arts *AllocationTotals) ToResponse() *AllocationTotalsResponse {
+	if arts == nil {
+		return nil
+	}
+
+	return &AllocationTotalsResponse{
+		Start:                          arts.Start,
+		End:                            arts.End,
+		Cluster:                        arts.Cluster,
+		Node:                           arts.Node,
+		Count:                          arts.Count,
+		CPUCost:                        formatutil.Float64ToResponse(arts.CPUCost),
+		CPUCostAdjustment:              formatutil.Float64ToResponse(arts.CPUCostAdjustment),
+		GPUCost:                        formatutil.Float64ToResponse(arts.GPUCost),
+		GPUCostAdjustment:              formatutil.Float64ToResponse(arts.GPUCostAdjustment),
+		LoadBalancerCost:               formatutil.Float64ToResponse(arts.LoadBalancerCost),
+		LoadBalancerCostAdjustment:     formatutil.Float64ToResponse(arts.LoadBalancerCostAdjustment),
+		NetworkCost:                    formatutil.Float64ToResponse(arts.NetworkCost),
+		NetworkCostAdjustment:          formatutil.Float64ToResponse(arts.NetworkCostAdjustment),
+		PersistentVolumeCost:           formatutil.Float64ToResponse(arts.PersistentVolumeCost),
+		PersistentVolumeCostAdjustment: formatutil.Float64ToResponse(arts.PersistentVolumeCostAdjustment),
+		RAMCost:                        formatutil.Float64ToResponse(arts.RAMCost),
+		RAMCostAdjustment:              formatutil.Float64ToResponse(arts.RAMCostAdjustment),
+		TotalCost:                      formatutil.Float64ToResponse(arts.TotalCost()),
+	}
+}
+
+type AllocationTotalsResultResponse struct {
+	Cluster map[string]*AllocationTotalsResponse `json:"cluster"`
+	Node    map[string]*AllocationTotalsResponse `json:"node"`
+}
+
+func (atr *AllocationTotalsResult) ToResponse() *AllocationTotalsResultResponse {
+	response := &AllocationTotalsResultResponse{
+		Cluster: map[string]*AllocationTotalsResponse{},
+		Node:    map[string]*AllocationTotalsResponse{},
+	}
+
+	for k, v := range atr.Cluster {
+		response.Cluster[k] = v.ToResponse()
+	}
+
+	for k, v := range atr.Node {
+		response.Node[k] = v.ToResponse()
+	}
+
+	return response
+}


### PR DESCRIPTION
## What does this PR change?
* Fixes sharing coefficients for both Summary Allocation API and Allocation API when used with aggregated store data (i.e. from the AggregatedStoreDriver) by accurately tracking and accounting for unmounted PV costs.

## Does this PR relate to any other PRs?
* Required for https://github.com/kubecost/kubecost-cost-model/pull/1792

## How will this PR impact users?
* Shared costs should be accurate in Allocation and Summary Allocation APIs.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/BURNDOWN-142

## How was this PR tested?
* Manually, by logging sum of sharing coeffs (should == 1.0) and by spot checking matching values in the FE

Logs for the following requests, which previously did not sum to 1.0 for summary:
* eks.dev1.niko.kubecost.xyz:9090/model/allocation/summary?window=7d&aggregate=cluster&shareNamespaces=kube-system
* eks.dev1.niko.kubecost.xyz:9090/model/allocation/summary?window=7d&aggregate=namespace&shareNamespaces=kube-system,kubecost,default
* eks.dev1.niko.kubecost.xyz:9090/model/allocation/summary?window=7d&aggregate=label:app&shareNamespaces=niko,kube-system&shareLabels=app:cost-analyzer
```
2023-09-28T23:47:32.647959655Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:32.649401687Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:32.650647535Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:32.651960019Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:32.653284568Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:32.654480016Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:32.6556301Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:47:33.945121381Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:47:33.945263569Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:47:33.945385557Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:47:33.945503272Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:47:33.945628507Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:47:33.945749448Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:47:33.94585698Z INF BD-142: summary: sum(coeff) = 1.000000

2023-09-28T23:48:17.363786442Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:17.366495958Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:17.368951401Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:17.371407975Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:17.374155766Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:17.376937456Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:17.379669194Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:20.346418394Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:20.347544183Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:20.34831502Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:20.349183666Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:20.350216933Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:20.351205965Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:20.351986146Z INF BD-142: summary: sum(coeff) = 1.000000

2023-09-28T23:48:42.406228729Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:42.408287158Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:42.410086812Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:42.412745402Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:42.416964813Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:42.420691856Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:42.42445394Z INF BD-142: allocation: sum(coeff) = 1.000000
2023-09-28T23:48:44.270608924Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:44.271602445Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:44.272538583Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:44.27356558Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:44.27458594Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:44.275591867Z INF BD-142: summary: sum(coeff) = 1.000000
2023-09-28T23:48:44.276564664Z INF BD-142: summary: sum(coeff) = 1.000000
```

In the UI, this can be tested by ensuring that the "Inspect shared costs" values match perfectly the table shared cost column:
![Screenshot from 2023-09-28 17-53-25](https://github.com/opencost/opencost/assets/8070055/5522e6c5-9d99-4e0b-a85f-6d04dbdffdfc)
![Screenshot from 2023-09-28 17-53-35](https://github.com/opencost/opencost/assets/8070055/04148829-3563-4446-8799-c5c797d65c01)
![Screenshot from 2023-09-28 17-53-54](https://github.com/opencost/opencost/assets/8070055/630a8b5b-1ab0-4388-978f-3fd0de6de6d8)


## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes
