### PR TITLE
Functions in Opencost to achieve distributing shared VMSS disk and network cost across VMs in VMSS in closed source

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/pkg/cloud/azure/azurestorageintegration.go
+++ b/pkg/cloud/azure/azurestorageintegration.go
@@ -30,12 +30,13 @@ func (asi *AzureStorageIntegration) GetCloudCost(start, end time.Time) (*kubecos
 			k8sPtc = 1.0
 		}
 
+		providerID, _ := AzureSetProviderID(abv)
 		// Create CloudCost
 		// Using the NetCost as a 'placeholder' for Invoiced and Amortized Net costs now,
 		// until we can revisit and spend the time to do the calculations correctly
 		cc := &kubecost.CloudCost{
 			Properties: &kubecost.CloudCostProperties{
-				ProviderID:      AzureSetProviderID(abv),
+				ProviderID:      providerID,
 				Provider:        kubecost.AzureProvider,
 				AccountID:       abv.SubscriptionID,
 				InvoiceEntityID: abv.InvoiceEntityID,

--- a/pkg/cloud/azure/billingexportparser.go
+++ b/pkg/cloud/azure/billingexportparser.go
@@ -258,7 +258,7 @@ func encloseInBrackets(jsonString string) string {
 	return fmt.Sprintf("{%s}", jsonString)
 }
 
-func AzureSetProviderID(abv *BillingRowValues) (providerID string, isAggregated bool) {
+func AzureSetProviderID(abv *BillingRowValues) (providerID string, isShared bool) {
 	category := SelectAzureCategory(abv.MeterCategory)
 	if value, ok := abv.AdditionalInfo["VMName"]; ok {
 		return "azure://" + resourceGroupToLowerCase(abv.InstanceID) + getVMNumberForVMSS(fmt.Sprintf("%v", value)), false
@@ -279,7 +279,7 @@ func AzureSetProviderID(abv *BillingRowValues) (providerID string, isAggregated 
 			return getSubStringAfterFinalSlash(abv.InstanceID), true
 		}
 	}
-	return "azure://" + resourceGroupToLowerCase(abv.InstanceID), false
+	return "azure://" + resourceGroupToLowerCase(abv.InstanceID), true
 }
 
 func SelectAzureCategory(meterCategory string) string {

--- a/pkg/cloud/azure/billingexportparser.go
+++ b/pkg/cloud/azure/billingexportparser.go
@@ -258,7 +258,9 @@ func encloseInBrackets(jsonString string) string {
 	return fmt.Sprintf("{%s}", jsonString)
 }
 
-func AzureSetProviderID(abv *BillingRowValues) (providerID string, isShared bool) {
+// isVMSSShared represents a bool that lets you know while setting providerID we were
+// able to get the actual VMName associated with a VM of a group of VMs in VMSS.
+func AzureSetProviderID(abv *BillingRowValues) (providerID string, isVMSSShared bool) {
 	category := SelectAzureCategory(abv.MeterCategory)
 	if value, ok := abv.AdditionalInfo["VMName"]; ok {
 		return "azure://" + resourceGroupToLowerCase(abv.InstanceID) + getVMNumberForVMSS(fmt.Sprintf("%v", value)), false

--- a/pkg/cloud/azure/billingexportparser.go
+++ b/pkg/cloud/azure/billingexportparser.go
@@ -258,28 +258,28 @@ func encloseInBrackets(jsonString string) string {
 	return fmt.Sprintf("{%s}", jsonString)
 }
 
-func AzureSetProviderID(abv *BillingRowValues) string {
+func AzureSetProviderID(abv *BillingRowValues) (providerID string, isAggregated bool) {
 	category := SelectAzureCategory(abv.MeterCategory)
 	if value, ok := abv.AdditionalInfo["VMName"]; ok {
-		return "azure://" + resourceGroupToLowerCase(abv.InstanceID) + getVMNumberForVMSS(fmt.Sprintf("%v", value))
+		return "azure://" + resourceGroupToLowerCase(abv.InstanceID) + getVMNumberForVMSS(fmt.Sprintf("%v", value)), false
 	} else if value, ok := abv.AdditionalInfo["VmName"]; ok {
-		return "azure://" + resourceGroupToLowerCase(abv.InstanceID) + getVMNumberForVMSS(fmt.Sprintf("%v", value))
+		return "azure://" + resourceGroupToLowerCase(abv.InstanceID) + getVMNumberForVMSS(fmt.Sprintf("%v", value)), false
 	} else if value2, ook := abv.AdditionalInfo["IpAddress"]; ook && abv.MeterCategory == "Virtual Network" {
-		return fmt.Sprintf("%v", value2)
+		return fmt.Sprintf("%v", value2), false
 	}
 
 	if category == kubecost.StorageCategory || (category == kubecost.NetworkCategory && abv.MeterCategory == "Bandwidth") {
 		if value2, ok2 := abv.Tags["creationSource"]; ok2 {
 			creationSource := fmt.Sprintf("%v", value2)
-			return strings.TrimPrefix(creationSource, "aks-")
+			return strings.TrimPrefix(creationSource, "aks-"), true
 		} else if value2, ok2 := abv.Tags["aks-managed-creationSource"]; ok2 {
 			creationSource := fmt.Sprintf("%v", value2)
-			return strings.TrimPrefix(creationSource, "vmssclient-")
+			return strings.TrimPrefix(creationSource, "vmssclient-"), true
 		} else {
-			return getSubStringAfterFinalSlash(abv.InstanceID)
+			return getSubStringAfterFinalSlash(abv.InstanceID), true
 		}
 	}
-	return "azure://" + resourceGroupToLowerCase(abv.InstanceID)
+	return "azure://" + resourceGroupToLowerCase(abv.InstanceID), false
 }
 
 func SelectAzureCategory(meterCategory string) string {

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -3211,24 +3211,27 @@ func (as *AssetSet) ReconciliationMatchMap() map[string]map[string]Asset {
 			continue
 		}
 
-		if _, ok := matchMap[props.ProviderID]; !ok {
-			matchMap[props.ProviderID] = make(map[string]Asset)
+		// we can't guarantee case in providerID for Azure provider to have map working for all providers,
+		// lower casing providerID  while creating reconciliation map
+		providerID := strings.ToLower(props.ProviderID)
+		if _, ok := matchMap[providerID]; !ok {
+			matchMap[providerID] = make(map[string]Asset)
 		}
 
 		// Check if a match is already in the map
-		if duplicateAsset, ok := matchMap[props.ProviderID][props.Category]; ok {
+		if duplicateAsset, ok := matchMap[providerID][props.Category]; ok {
 			log.DedupedWarningf(5, "duplicate asset found when reconciling for %s", props.ProviderID)
 			// if one asset already has adjustment use that one
 			if duplicateAsset.GetAdjustment() == 0 && asset.GetAdjustment() != 0 {
-				matchMap[props.ProviderID][props.Category] = asset
+				matchMap[providerID][props.Category] = asset
 			} else if duplicateAsset.GetAdjustment() != 0 && asset.GetAdjustment() == 0 {
-				matchMap[props.ProviderID][props.Category] = duplicateAsset
+				matchMap[providerID][props.Category] = duplicateAsset
 				// otherwise use the one with the higher cost
 			} else if duplicateAsset.TotalCost() < asset.TotalCost() {
-				matchMap[props.ProviderID][props.Category] = asset
+				matchMap[providerID][props.Category] = asset
 			}
 		} else {
-			matchMap[props.ProviderID][props.Category] = asset
+			matchMap[providerID][props.Category] = asset
 		}
 
 	}

--- a/pkg/kubecost/cloudcost.go
+++ b/pkg/kubecost/cloudcost.go
@@ -147,6 +147,15 @@ func (cc *CloudCost) GetCostMetric(costMetricName string) (CostMetric, error) {
 	return CostMetric{}, fmt.Errorf("invalid Cost Metric: %s", costMetricName)
 }
 
+// WeightCostMetrics weights all the cost metrics with the given weightedAverage
+func (cc *CloudCost) WeightCostMetrics(weightedAverge float64) {
+	cc.AmortizedCost.Cost *= weightedAverge
+	cc.NetCost.Cost *= weightedAverge
+	cc.AmortizedNetCost.Cost *= weightedAverge
+	cc.InvoicedCost.Cost *= weightedAverge
+	cc.AmortizedCost.Cost *= weightedAverge
+}
+
 // CloudCostSet follows the established set pattern of windowed data types. It has addition metadata types that can be
 // used to preserve data consistency and be used for validation.
 // - Integration is the ID for the integration that a CloudCostSet was sourced from, this value is cleared if when a

--- a/pkg/kubecost/cloudcost.go
+++ b/pkg/kubecost/cloudcost.go
@@ -149,7 +149,7 @@ func (cc *CloudCost) GetCostMetric(costMetricName string) (CostMetric, error) {
 
 // WeightCostMetrics weights all the cost metrics with the given weightedAverage
 func (cc *CloudCost) WeightCostMetrics(weightedAverge float64) {
-	cc.AmortizedCost.Cost *= weightedAverge
+	cc.ListCost.Cost *= weightedAverge
 	cc.NetCost.Cost *= weightedAverge
 	cc.AmortizedNetCost.Cost *= weightedAverge
 	cc.InvoicedCost.Cost *= weightedAverge


### PR DESCRIPTION
## What does this PR change?
* Adds a flag to distinguish when the cost is shared and unshared while returning the providerID, i.e when using tags to set providerID we have a shared resource between all VMS in a VMSS

## Does this PR relate to any other PRs?
*[ KCM PR](https://github.com/kubecost/kubecost-cost-model/pull/1794) 

## How will this PR impact users?
* None on OC but in KCM impact please refer KCM PR link

## Does this PR address any GitHub or Zendesk issues?
* Closes ... BURNDOWN-157
* https://github.com/kubecost/cost-analyzer-helm-chart/issues/2386

## How was this PR tested?
* Please refer KCM PR

## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* upto management discretion
