### PR TITLE
Remove redundant `len` and `nil` check before loop

### DIFF
--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -869,6 +869,8 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 				sa.GPUCost += idle.GPUCost * gpuCoeff
 				sa.RAMCost += idle.RAMCost * ramCoeff
 			}
+		} else {
+			log.Errorf("SummaryAllocations: idle allocation is empty")
 		}
 
 		// The key becomes the allocation's name, which is used as the key by
@@ -935,6 +937,8 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 				sa.RAMCost += idle.RAMCost * ramCoeff
 			}
 		}
+	} else {
+		log.Warnf("SummaryAllocations: shared allocation and idle allocation are empty")
 	}
 
 	// 10. Apply idle filtration, which "filters" the idle cost, i.e. scales

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1822,11 +1822,9 @@ func (aws *AWS) isDiskOrphaned(vol *ec2Types.Volume) bool {
 	}
 
 	// Do not consider volume orphaned if volume is attached to any attachments
-	if len(vol.Attachments) != 0 {
-		for _, attachment := range vol.Attachments {
-			if attachment.State == AttachedState {
-				return false
-			}
+	for _, attachment := range vol.Attachments {
+		if attachment.State == AttachedState {
+			return false
 		}
 	}
 

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2359,18 +2359,15 @@ func getAllocatableVGPUs(cache clustercache.ClusterCache) (float64, error) {
 	for _, ds := range daemonsets {
 		dsContainerList := &ds.Spec.Template.Spec.Containers
 		for _, ctnr := range *dsContainerList {
-			if ctnr.Args != nil {
-				for _, arg := range ctnr.Args {
-					if strings.Contains(arg, "--vgpu=") {
-						vgpus, err := strconv.ParseFloat(arg[strings.IndexByte(arg, '=')+1:], 64)
-						if err != nil {
-							log.Errorf("failed to parse vgpu allocation string %s: %v", arg, err)
-							continue
-						}
-						vgpuCount = vgpus
-						return vgpuCount, nil
+			for _, arg := range ctnr.Args {
+				if strings.Contains(arg, "--vgpu=") {
+					vgpus, err := strconv.ParseFloat(arg[strings.IndexByte(arg, '=')+1:], 64)
+					if err != nil {
+						log.Errorf("failed to parse vgpu allocation string %s: %v", arg, err)
+						continue
 					}
-
+					vgpuCount = vgpus
+					return vgpuCount, nil
 				}
 			}
 		}

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -597,17 +597,15 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				podName := costs.PodName
 				containerName := costs.Name
 
-				if costs.PVCData != nil {
-					for _, pvc := range costs.PVCData {
-						if pvc.Volume != nil {
-							timesClaimed := pvc.TimesClaimed
-							if timesClaimed == 0 {
-								timesClaimed = 1 // unallocated PVs are unclaimed but have a full allocation
-							}
-							cmme.PVAllocationRecorder.WithLabelValues(namespace, podName, pvc.Claim, pvc.VolumeName).Set(pvc.Values[0].Value / float64(timesClaimed))
-							labelKey := getKeyFromLabelStrings(namespace, podName, pvc.Claim, pvc.VolumeName)
-							pvcSeen[labelKey] = true
+				for _, pvc := range costs.PVCData {
+					if pvc.Volume != nil {
+						timesClaimed := pvc.TimesClaimed
+						if timesClaimed == 0 {
+							timesClaimed = 1 // unallocated PVs are unclaimed but have a full allocation
 						}
+						cmme.PVAllocationRecorder.WithLabelValues(namespace, podName, pvc.Claim, pvc.VolumeName).Set(pvc.Values[0].Value / float64(timesClaimed))
+						labelKey := getKeyFromLabelStrings(namespace, podName, pvc.Claim, pvc.VolumeName)
+						pvcSeen[labelKey] = true
 					}
 				}
 

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1262,6 +1262,8 @@ func GetKubecostContainers(kubeClientSet kubernetes.Interface) ([]ContainerInfo,
 				containers = append(containers, c)
 			}
 		}
+	} else {
+		log.Infof("Empty list of pods")
 	}
 
 	return containers, nil


### PR DESCRIPTION
## What does this PR change?

From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the slice or map is nil (https://pkg.go.dev/builtin#len). Therefore, having these checks before a loop is unnecessary:

- `len(v) != 0`
- `len(v) > 0`
- `v != nil`

## Does this PR relate to any other PRs?
No.

## How will this PR impact users?
No user-facing change.

## Does this PR address any GitHub or Zendesk issues?


## How was this PR tested?
`go build ./...` and `go test ./...`

## Does this PR require changes to documentation?
No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
No. External contributor cannot label PR.
