### PR TITLE
scaleway :: fix gpu value

### DIFF
--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -149,7 +149,7 @@ func (c *Scaleway) NodePricing(key models.Key) (*models.Node, models.PricingMeta
 				RAM:         fmt.Sprintf("%d", info.RAM),
 				// This is tricky, as instances can have local volumes or not
 				Storage:      fmt.Sprintf("%d", info.PerVolumeConstraint.LSSD.MinSize),
-				GPU:          fmt.Sprintf("%d", info.Gpu),
+				GPU:          fmt.Sprintf("%d", *info.Gpu),
 				InstanceType: split[1],
 				Region:       split[0],
 				GPUName:      key.GPUType(),


### PR DESCRIPTION
## What does this PR change?
* Fix the GPU value

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Fix the Scaleway provider 
* The GPU value was  equal to the address of the var. All others vars computed from this var were wrong. 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* I deployed fixed version on my cluster

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
