### PR TITLE
remove empty vscode launch json 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cmd/costmodel/costmodel
 cmd/costmodel/costmodel-amd64
 cmd/costmodel/costmodel-arm64
 pkg/cloud/azureorphan_test.go
+
+# VS Code
+.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,0 @@
-{
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": []
-}


### PR DESCRIPTION
## What does this PR change?
* Add .vscode to .gitignore file and remove empty vscode launch config crept into the repo with PR https://github.com/opencost/opencost/pull/2183 

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* None

## Does this PR address any GitHub or Zendesk issues?
* Closes ... None

## How was this PR tested?
* No need

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Ignore
