### PR TITLE
FIX: Direct link provided to Prometheus Installation docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To see the full functionality of OpenCost you can view [OpenCost features](https
 - Dynamic onDemand asset pricing enabled by integrations with AWS, Azure, and GCP billing APIs
 - Supports on-prem k8s clusters with custom CSV pricing
 - Allocation for in-cluster resources like CPU, GPU, memory, and persistent volumes.
-- Easily export pricing data to Prometheus with /metrics endpoint ([learn more](PROMETHEUS.md))
+- Easily export pricing data to Prometheus with /metrics endpoint ([learn more](https://www.opencost.io/docs/installation/prometheus))
 - Free and open source distribution (Apache2 license)
 
 ## Getting Started


### PR DESCRIPTION
## What does this PR change?
*  FIX issue #2202 , provides direct link to  Prometheus Installation docs  when clicked on learn more
in README.MD



## How will this PR impact users?
* Direct redirection than having to be redirect multiple times


