### PR TITLE
Emit empty string instead of <none> for storageclass label on kube_persistentvolumeclaim_info to match KSM changes

### DIFF
--- a/pkg/metrics/kubemetrics.go
+++ b/pkg/metrics/kubemetrics.go
@@ -156,7 +156,7 @@ func getPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
 	}
 
 	// Special non-empty string to indicate absence of storage class.
-	return "<none>"
+	return ""
 }
 
 // toResourceUnitValue accepts a resource name and quantity and returns the sanitized resource, the unit, and the value in the units.


### PR DESCRIPTION
## What does this PR change?
* Emit empty string instead of <none> for storageclass label on kube_persistentvolumeclaim_info to match KSM changes

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/2176

## How was this PR tested?
* Deployed to a cluster and observed the metric did not change
* (Need to find a cluster with this particular case if we want to test this code path -- asked Jesse, but we don't apparently have one at hand.)
