### PR TITLE
Implement Clone() for NodeOverhead so it shows up in accumulated results

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1589,6 +1589,10 @@ func (b *Breakdown) Clone() *Breakdown {
 
 // Equal returns true if the two Breakdowns are exact matches
 func (b *Breakdown) Equal(that *Breakdown) bool {
+	if b == nil && that == nil {
+		return true
+	}
+
 	if b == nil || that == nil {
 		return false
 	}
@@ -1887,6 +1891,21 @@ func (n *NodeOverhead) SanitizeNaN() {
 		log.DedupedWarningf(5, "NodeOverhead: Unexpected NaN found for OverheadCostFraction")
 		n.OverheadCostFraction = 0
 	}
+}
+
+func (n *NodeOverhead) Equal(other *NodeOverhead) bool {
+	if n == nil && other != nil {
+		return false
+	}
+	if n != nil && other == nil {
+		return false
+	}
+	if n == nil && other == nil {
+		return true
+	}
+
+	// This is okay because everything in NodeOverhead is a value type.
+	return *n == *other
 }
 
 func (n *NodeOverhead) Clone() *NodeOverhead {
@@ -2243,6 +2262,9 @@ func (n *Node) Equal(a Asset) bool {
 		return false
 	}
 	if n.Preemptible != that.Preemptible {
+		return false
+	}
+	if !n.Overhead.Equal(that.Overhead) {
 		return false
 	}
 

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1889,6 +1889,17 @@ func (n *NodeOverhead) SanitizeNaN() {
 	}
 }
 
+func (n *NodeOverhead) Clone() *NodeOverhead {
+	if n == nil {
+		return nil
+	}
+	return &NodeOverhead{
+		CpuOverheadFraction:  n.CpuOverheadFraction,
+		RamOverheadFraction:  n.RamOverheadFraction,
+		OverheadCostFraction: n.OverheadCostFraction,
+	}
+}
+
 // Node is an Asset representing a single node in a cluster
 type Node struct {
 	Properties   *AssetProperties
@@ -2171,6 +2182,7 @@ func (n *Node) Clone() Asset {
 		GPUCount:     n.GPUCount,
 		RAMCost:      n.RAMCost,
 		Preemptible:  n.Preemptible,
+		Overhead:     n.Overhead.Clone(),
 		Discount:     n.Discount,
 	}
 }

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -548,7 +548,37 @@ func TestNode_Add(t *testing.T) {
 }
 
 func TestNode_Clone(t *testing.T) {
-	// TODO
+	cases := []struct {
+		name string
+
+		input *Node
+	}{
+		{
+			name: "overhead nil",
+			input: &Node{
+				Overhead: nil,
+			},
+		},
+		{
+			name: "overhead non-nil",
+			input: &Node{
+				Overhead: &NodeOverhead{
+					CpuOverheadFraction:  3,
+					RamOverheadFraction:  7,
+					OverheadCostFraction: 6,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := c.input.Clone()
+			if !result.Equal(c.input) {
+				t.Errorf("clone result doesn't equal input")
+			}
+		})
+	}
 }
 
 func TestNode_MarshalJSON(t *testing.T) {

--- a/pkg/kubecost/assetprops.go
+++ b/pkg/kubecost/assetprops.go
@@ -199,8 +199,12 @@ func (ap *AssetProperties) Clone() *AssetProperties {
 	return clone
 }
 
-// Equal returns true only if both AssetProperties are non-nil exact matches
+// Equal returns true only if both AssetProperties are matches
 func (ap *AssetProperties) Equal(that *AssetProperties) bool {
+	if ap == nil && that == nil {
+		return true
+	}
+
 	if ap == nil || that == nil {
 		return false
 	}


### PR DESCRIPTION
## What does this PR change?
* Implements `Clone()` for Node Overhead. Accumulated Asset API results will now be able to show Node Overhead.
* Adds small unit test for `Clone()` using `Equal()` which necessitated a change to `Equal()` for Asset properties and Breakdown.

For reviewers, copied from a commit message:
> The full test is of (*Node).Equal() which necessitated a change to
> equality for Breakdown and Properties.
> 
> It is odd to say that two things which are nil pointers of the same type
> are unequal (the old behavior). I think this is an acceptable change.
> The risk revolves around any functionality which expects Equal() to fail
> on two nil pointers -- I sincerely hope that nothing behaves this way.

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* Overhead will appear in accumulated Asset API responses

## Does this PR address any GitHub or Zendesk issues?
* Relates to https://kubecost.atlassian.net/browse/SELFHOST-811

## How was this PR tested?
* New unit test
* Ran KC locally and observed Overhead show up in accumulated Asset API responses -- it was not showing up before

## Does this PR require changes to documentation?
* N/A