### PR TITLE
add gcp region europe-west9

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -72,6 +72,7 @@ var gcpRegions = []string{
 	"europe-west3",
 	"europe-west4",
 	"europe-west6",
+	"europe-west9",
 	"northamerica-northeast1",
 	"northamerica-northeast2",
 	"southamerica-east1",


### PR DESCRIPTION
## What does this PR change?
* add missing gcp region europe-west9

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* fix Error getting node pricing. Error: no pricing data found for europe-west9,e2standard,ondemand

## How was this PR tested?
* not tested i dont know how i can test this

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* i dont know how to label PR
