### PR TITLE
fix panic when running KCM/OC locally when downloading pricing data

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -893,7 +893,9 @@ func (aws *AWS) DownloadPricingData() error {
 	storageClassMap := make(map[string]map[string]string)
 	for _, storageClass := range storageClasses {
 		params := storageClass.Parameters
-		params["provisioner"] = storageClass.Provisioner
+		if params != nil {
+			params["provisioner"] = storageClass.Provisioner
+		}
 		storageClassMap[storageClass.ObjectMeta.Name] = params
 		if storageClass.GetAnnotations()["storageclass.kubernetes.io/is-default-class"] == "true" || storageClass.GetAnnotations()["storageclass.beta.kubernetes.io/is-default-class"] == "true" {
 			storageClassMap["default"] = params


### PR DESCRIPTION
## What does this PR change?
* fixes panic occuring when running Kubecost or OpenCost locally

## Does this PR relate to any other PRs?
* introduced in: https://github.com/opencost/opencost/pull/1931

## How will this PR impact users?
* application won't crash

## Does this PR address any GitHub or Zendesk issues?
* none

## How was this PR tested?
* make sure Kubecost doesn't crash on startup

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* can't
