### PR TITLE
return err from query

### DIFF
--- a/pkg/cloud/gcp/bigqueryquerier.go
+++ b/pkg/cloud/gcp/bigqueryquerier.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/opencost/opencost/pkg/cloud"
@@ -49,9 +50,12 @@ func (bqq *BigQueryQuerier) Query(ctx context.Context, queryStr string) (*bigque
 	// If result is empty and connection status is not already successful update status to missing data
 	if iter == nil && bqq.ConnectionStatus != cloud.SuccessfulConnection {
 		bqq.ConnectionStatus = cloud.MissingData
-		return iter, nil
+	} else {
+		bqq.ConnectionStatus = cloud.SuccessfulConnection
 	}
 
-	bqq.ConnectionStatus = cloud.SuccessfulConnection
+	if err != nil {
+		return iter, fmt.Errorf("BigQueryQuerier: Query: error reading query results: %w", err)
+	}
 	return iter, nil
 }


### PR DESCRIPTION
## What does this PR change?
* This PR address a bug introduced in https://github.com/opencost/opencost/pull/2222 which allows the big query queier to return a nil iterator without error

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
