### PR TITLE
Minor typo fixes in the new Cloud Cost UI

### DIFF
--- a/ui/src/cloudCost/tokens.js
+++ b/ui/src/cloudCost/tokens.js
@@ -19,7 +19,7 @@ const aggregationOptions = [
   { name: "Provider", value: "provider" },
   { name: "Service ", value: "service" },
   { name: "Category", value: "category" },
-  { name: "item", value: "item" },
+  { name: "Item", value: "item" },
 ];
 
 const costMetricOptions = [

--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -26,7 +26,7 @@ const Header = (props) => {
   const { title, breadcrumbs } = props;
   const { pathname } = useLocation();
 
-  const headerTitle = pathname === "/cloud" ? "Cloud Cost" : "Cost Allocation";
+  const headerTitle = pathname === "/cloud" ? "Cloud Costs" : "Cost Allocation";
 
   return (
     <div className={classes.root}>


### PR DESCRIPTION
"item"->"Item"
"Cloud Cost"->"Cloud Costs" to match sidebar

<img width="1208" alt="Screenshot 2023-11-01 at 10 57 49 PM" src="https://github.com/opencost/opencost/assets/330023/0f365793-6fea-4ac6-ab57-daaf394beeac">
