### PR TITLE
Synced Date Range options

### DIFF
--- a/ui/src/Reports.js
+++ b/ui/src/Reports.js
@@ -36,14 +36,12 @@ import { currencyCodes } from "./constants/currencyCodes";
 const windowOptions = [
   { name: "Today", value: "today" },
   { name: "Yesterday", value: "yesterday" },
+  { name: "Last 24h", value: "24h" },
+  { name: "Last 48h", value: "48h" },
   { name: "Week-to-date", value: "week" },
-  { name: "Month-to-date", value: "month" },
   { name: "Last week", value: "lastweek" },
-  { name: "Last month", value: "lastmonth" },
-  { name: "Last 7 days", value: "6d" },
-  { name: "Last 30 days", value: "29d" },
-  { name: "Last 60 days", value: "59d" },
-  { name: "Last 90 days", value: "89d" },
+  { name: "Last 7 days", value: "7d" },
+  { name: "Last 14 days", value: "14d" },
 ];
 
 const aggregationOptions = [

--- a/ui/src/cloudCost/tokens.js
+++ b/ui/src/cloudCost/tokens.js
@@ -1,16 +1,12 @@
 const windowOptions = [
   { name: "Today", value: "today" },
   { name: "Yesterday", value: "yesterday" },
-  { name: "Week-to-date", value: "week" },
-  // { name: "Month-to-date", value: "month" },
-  { name: "Last week", value: "lastweek" },
-  // { name: "Last month", value: "lastmonth" },
   { name: "Last 24h", value: "24h" },
   { name: "Last 48h", value: "48h" },
+  { name: "Week-to-date", value: "week" },
+  { name: "Last week", value: "lastweek" },
   { name: "Last 7 days", value: "7d" },
-  // { name: "Last 30 days", value: "30d" },
-  // { name: "Last 60 days", value: "60d" },
-  // { name: "Last 90 days", value: "90d" },
+  { name: "Last 14 days", value: "14d" },
 ];
 
 const aggregationOptions = [


### PR DESCRIPTION
They were inconsistent between the Allocation and Cloud Costs, made them the same and chose defaults that are generally useful in th OpenCost UI

<img width="455" alt="Screenshot 2023-11-01 at 11 08 40 PM" src="https://github.com/opencost/opencost/assets/330023/86ef30bd-c3fa-4c3e-89e6-aad971b29af0">
