### PR TITLE
pkg/costmodel: fix dropped errors

### DIFF
--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -50,10 +50,7 @@ func GetPVInfo(qrs []*prom.QueryResult, defaultClusterID string) (map[string]*Pe
 	toReturn := make(map[string]*PersistentVolumeClaimData)
 
 	for _, val := range qrs {
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -99,10 +96,7 @@ func GetPVAllocationMetrics(qrs []*prom.QueryResult, defaultClusterID string) (m
 	toReturn := make(map[string][]*PersistentVolumeClaimData)
 
 	for _, val := range qrs {
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -148,10 +142,7 @@ func GetPVCostMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[str
 	toReturn := make(map[string]*costAnalyzerCloud.PV)
 
 	for _, val := range qrs {
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -180,10 +171,7 @@ func GetNamespaceLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string)
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -215,10 +203,7 @@ func GetPodLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -247,10 +232,7 @@ func GetNamespaceAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID st
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -282,10 +264,8 @@ func GetPodAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID string) 
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
+
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -318,10 +298,7 @@ func GetStatefulsetMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID 
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -347,10 +324,7 @@ func GetPodDaemonsetsWithMetrics(qrs []*prom.QueryResult, defaultClusterID strin
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -381,10 +355,7 @@ func GetPodJobsWithMetrics(qrs []*prom.QueryResult, defaultClusterID string) (ma
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -416,10 +387,7 @@ func GetDeploymentMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -446,10 +414,7 @@ func GetServiceSelectorLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 			return toReturn, err
 		}
 
-		clusterID, err := val.GetString(env.GetPromClusterLabel())
-		if err != nil {
-			return toReturn, err
-		}
+		clusterID, _ := val.GetString(env.GetPromClusterLabel())
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -51,6 +51,9 @@ func GetPVInfo(qrs []*prom.QueryResult, defaultClusterID string) (map[string]*Pe
 
 	for _, val := range qrs {
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -97,6 +100,9 @@ func GetPVAllocationMetrics(qrs []*prom.QueryResult, defaultClusterID string) (m
 
 	for _, val := range qrs {
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -143,6 +149,9 @@ func GetPVCostMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[str
 
 	for _, val := range qrs {
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -172,6 +181,9 @@ func GetNamespaceLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string)
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -204,6 +216,9 @@ func GetPodLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -233,6 +248,9 @@ func GetNamespaceAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID st
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -265,6 +283,9 @@ func GetPodAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID string) 
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -298,6 +319,9 @@ func GetStatefulsetMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID 
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -324,6 +348,9 @@ func GetPodDaemonsetsWithMetrics(qrs []*prom.QueryResult, defaultClusterID strin
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -355,6 +382,9 @@ func GetPodJobsWithMetrics(qrs []*prom.QueryResult, defaultClusterID string) (ma
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -387,6 +417,9 @@ func GetDeploymentMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}
@@ -414,6 +447,9 @@ func GetServiceSelectorLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
+		if err != nil {
+			return toReturn, err
+		}
 		if clusterID == "" {
 			clusterID = defaultClusterID
 		}


### PR DESCRIPTION
This picks up 12 dropped `err` variables in the `promparser` code found in `pkg/costmodel`.