### PR TITLE
Restore the standard quay.io repositories

### DIFF
--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -142,7 +142,7 @@ spec:
       restartPolicy: Always
       serviceAccountName: opencost
       containers:
-        - image: gcr.io/kubecost1/opencost
+        - image: quay.io/kubecost1/kubecost-cost-model:latest
           name: opencost
           resources:
             requests:
@@ -167,7 +167,7 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1001
-        - image: gcr.io/kubecost1/opencost-ui
+        - image: quay.io/kubecost1/opencost-ui:latest
           name: opencost-ui
           resources:
             requests:


### PR DESCRIPTION
During testing for the Cloud Costs feature the default repository was set to gcr.io, but that's not where builds are published by default. Restores back to the previous defaults