### PR TITLE
add fix for GCP instance types that contain 'Nvidia' but not 'Nvidia Tesla' in description

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -86,7 +86,8 @@ var gcpRegions = []string{
 }
 
 var (
-	nvidiaGPURegex = regexp.MustCompile("(Nvidia Tesla [^ ]+) ")
+	nvidiaTeslaGPURegex = regexp.MustCompile("(Nvidia Tesla [^ ]+) ")
+	nvidiaGPURegex      = regexp.MustCompile("(Nvidia [^ ]+) ")
 	// gce://guestbook-12345/...
 	//  => guestbook-12345
 	gceRegex = regexp.MustCompile("gce://([^/]*)/*")
@@ -772,10 +773,20 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 				}
 
 				var gpuType string
-				for matchnum, group := range nvidiaGPURegex.FindStringSubmatch(product.Description) {
+				for matchnum, group := range nvidiaTeslaGPURegex.FindStringSubmatch(product.Description) {
 					if matchnum == 1 {
 						gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
 						log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
+					}
+				}
+
+				// If a 'Nvidia Tesla' is not found, try 'Nvidia'
+				if gpuType == "" {
+					for matchnum, group := range nvidiaGPURegex.FindStringSubmatch(product.Description) {
+						if matchnum == 1 {
+							gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
+							log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
+						}
 					}
 				}
 


### PR DESCRIPTION
## What does this PR change?
* Update GCP Billing Parsing Logic to get pricing data for non-'Tesla' Nvidia GPUs

## Does this PR relate to any other PRs?
* Additional fixes on top of: https://github.com/opencost/opencost/pull/2231

## How will this PR impact users?
* More GCP GPU types will have billing data available (g2 instance type)

## Does this PR address any GitHub or Zendesk issues?
* https://github.com/opencost/opencost/issues/2215
* https://kubecost.atlassian.net/browse/BURNDOWN-256

## How was this PR tested?
* Debug code; all GCP instance billing items with a Description containing 'Nvidia' have GPU pricing logic applied

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Can't
