### PR TITLE
Set configs in `aws.json` to empty strings

### DIFF
--- a/configs/aws.json
+++ b/configs/aws.json
@@ -14,12 +14,12 @@
     "spotLabelValue": "spotinstance-nodes",
     "awsServiceKeyName": "",
     "awsServiceKeySecret": "",
-    "awsSpotDataRegion":"us-east-2",
-    "awsSpotDataBucket": "x",
+    "awsSpotDataRegion":"",
+    "awsSpotDataBucket": "",
     "awsSpotDataPrefix": "",
-    "athenaBucketName": "s3://x",
-    "athenaRegion": "us-east-1",
+    "athenaBucketName": "",
+    "athenaRegion": "",
     "athenaDatabase": "",
     "athenaTable": "",
-    "projectID": "12345"
+    "projectID": ""
 }


### PR DESCRIPTION
## What does this PR change?
* Sets configs in `aws.json` to empty strings
* Previously, having placeholder variables there would lead Kubecost to attempt to create a cloud integration with those variables. The cloud integration would inevitably fail.

```
WRN Skipping AWS spot data download: operation error S3: ListObjects, https response error StatusCode: 400, RequestID: 3N7Q18SCD7ME07N7, HostID: 28MSYCNm0emMYW+Nb5UHOw5POHlxyc/9S78TwOn9wfdVrBs9jQsLxQDkBPOeSZ0rbcoQ0wsWLek=, api error InvalidBucketName: The specified bucket is not valid.
INF CloudCost: IngestionManager: creating integration with key: 12345/s3://x
```

## Does this PR relate to any other PRs?
* Similar effect to https://github.com/opencost/opencost/pull/2122

## How will this PR impact users?
* Cleaner install

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Build/run OpenCost locally.
* On a running Kubecost instance (v1.106.4), update the `aws.json` on the filesystem and restart the pod.

Images before:
![Screenshot 2023-11-09 at 4 22 58 PM](https://github.com/opencost/opencost/assets/11251627/9d54e863-29f0-4908-b707-5078d91f5b0c)
![Screenshot 2023-11-09 at 4 23 06 PM](https://github.com/opencost/opencost/assets/11251627/1860b10e-c234-4889-a3ae-1bf02311dac9)

Images after:
![Screenshot 2023-11-09 at 4 47 18 PM](https://github.com/opencost/opencost/assets/11251627/0d10fad6-bee2-41da-a442-ea9319f4eaf4)
![Screenshot 2023-11-09 at 4 50 32 PM](https://github.com/opencost/opencost/assets/11251627/12d29823-9ea6-461b-a786-ad20fdc3348b)

## Does this PR require changes to documentation?
* Current Kubecost docs provide examples on what format these strings should be: https://docs.kubecost.com/install-and-configure/install/cloud-integration/multi-cloud

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v1.108 ?
