### PR TITLE
fix: Quote table name in Athena query to handle cases where table name does not begin with an alphabet

### DIFF
--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -147,7 +147,7 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*kubecost.Cloud
 	groupByStr := strings.Join(groupByColumns, ", ")
 	queryStr := `
 		SELECT %s
-		FROM %s
+		FROM "%s"
 		WHERE %s
 		GROUP BY %s
 	`


### PR DESCRIPTION
fix: Quote table name in Athena query to handle cases where table name does not begin with an alphabet

## What does this PR change?
Double quotes the table name in the generated query string for the AthenaIntegration

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
Should actually be a better user experience for users as they can name their table however they like and the CloudCost generated query within Athena should still work.

## Does this PR address any GitHub or Zendesk issues?
None officially reported, but we had created a glue db table for use with AWS CUR and kept getting this error:
`Queries of this type are not supported`. After digging into the `debug` logs to grab the query that was run, we tested it on Athena's query console instead and got this explanation for why the query was invalid: `line 1:361: identifiers must not start with a digit; surround the identifier with double quotes`. After enclosing the table name in double quotes, the query worked.

Updating the table name to begin with a string and not a number also works, but figured this change would make it more foolproof.

Image of error when using a table name that starts with a number:
![Screenshot 2023-11-10 at 5 37 22 PM](https://github.com/opencost/opencost/assets/9098149/240c873a-4391-4c73-8832-bd6b652c31f6)


## How was this PR tested?
* `go test ..`

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
I don't believe I have the power to label this PR, but would love for it to be released as part of the next release.
