### PR TITLE
Fix missing items in Azure CloudCosts

### DIFF
--- a/pkg/cloud/azure/azurestorageintegration.go
+++ b/pkg/cloud/azure/azurestorageintegration.go
@@ -67,11 +67,8 @@ func (asi *AzureStorageIntegration) GetCloudCost(start, end time.Time) (*kubecos
 			},
 		}
 
-		// Check if Item
-		if abv.IsCompute(cc.Properties.Category) {
-			// TODO: Will need to split VMSS for other features
-			ccsr.LoadCloudCost(cc)
-		}
+		ccsr.LoadCloudCost(cc)
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## What does this PR change?
Fixes an issue where Azure cloud costs from CSV were not parsing `Other` cloudcosts, causing missing line items.

## Does this PR relate to any other PRs?
No.

## How will this PR impact users?
Fixes an issue with missing items in cloudcosts.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested parsing customer CSV data before and after change in separate local go test. 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
