### PR TITLE
Proposed fix for CVE-2023-5363

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -4,6 +4,10 @@ FROM alpine:latest
 # outside of Docker.
 ARG binarypath
 
+# fixes https://security.alpinelinux.org/vuln/CVE-2023-5363
+# can remove after alpine releases fixed container image
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
+#
 RUN apk add --update --no-cache ca-certificates
 
 ADD --chmod=644 ./configs/default.json /models/default.json


### PR DESCRIPTION
Latest alpine image can be fixed with this small PR see: https://github.com/alpinelinux/docker-alpine/issues/352

## What does this PR change?
* This fixes: https://security.alpinelinux.org/vuln/CVE-2023-5363, see https://github.com/alpinelinux/docker-alpine/issues/352. This should be a temporary fix until a newer version of Alpine with the fix lands as `latest`

## Does this PR relate to any other PRs?
*  no

## How will this PR impact users?
* it will require a new build of opencost

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
