### PR TITLE
Updated URL and other warning messages to reflect OpenCost not Kubecost

### DIFF
--- a/ui/src/cloudCostReports.js
+++ b/ui/src/cloudCostReports.js
@@ -135,12 +135,12 @@ const CloudCostReports = () => {
           {
             primary: "Failed to load report data",
             secondary:
-              "Please update Kubecost to the latest version, then contact support if problems persist.",
+            "Please update OpenCost to the latest version, and open an Issue if problems persist.",
           },
         ]);
       } else {
         let secondary =
-          "Please contact Kubecost support with a bug report if problems persist.";
+          "Please open an Issue with OpenCost if problems persist.";
         if (err.message.length > 0) {
           secondary = err.message;
         }
@@ -217,7 +217,7 @@ const CloudCostReports = () => {
           Learn more about setting up Cloud Costs{" "}
           <Link
             href={
-              "https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/cloud-costs-explorer#installation-and-configuration"
+              "https://www.opencost.io/docs/configuration/#cloud-costs"
             }
             target="_blank"
           >


### PR DESCRIPTION
## What does this PR change?
* Corrects the URL to point to OpenCost docs
* Removes references to Kubecost support

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* More appropriate error messaging

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/2346

## How was this PR tested?
* Local testing

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Fixes a URL in an unreleased update
