### PR TITLE
Fix Read-only file system issue during CSV Export

### DIFF
--- a/kubernetes/exporter/opencost-exporter.yaml
+++ b/kubernetes/exporter/opencost-exporter.yaml
@@ -155,7 +155,21 @@ spec:
               value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key. This is supplied just for evaluation.
             - name: CLUSTER_ID
               value: "cluster-one" # Default cluster ID to use if cluster_id is not set in Prometheus metrics.
+            - name: EXPORT_CSV_FILE
+              value: "s3://path/to/csv"
+            - name: AWS_ACCESS_KEY_ID  
+              value: "XXXXXXXXXXXXXXX" ## AWS Access KeyID
+            - name: AWS_SECRET_ACCESS_KEY
+              value: "XXXXXXXXXXXXXXX" ## AWS Secret Access Key
+            - name: AWS_REGION
+              value: "us-west-2" ## AWS Region where bucket is hosted
           imagePullPolicy: Always
+          volumeMounts:
+          - name: tmp-volume
+            mountPath: /tmp
+      volumes:
+      - name: tmp-volume
+        emptyDir: {}
 ---
 
 # Expose the cost model with a service


### PR DESCRIPTION
## What does this PR change?
* 
Fix the Read Only file system (in the Pod container /tmp/ path) issue in CSV export feature 
## Does this PR relate to any other PRs?
* 
No
## How will this PR impact users?
* 
No Impact
## Does this PR address any GitHub or Zendesk issues?
* https://github.com/opencost/opencost/issues/2343

## How was this PR tested?
* Tested in AWS EKS, Kuberntes version 1.27

## Does this PR require changes to documentation?
* 
Yes. 
## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
Its a minor bug fix.