### PR TITLE
fix test, add defensive check to scaleway

### DIFF
--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -207,7 +207,13 @@ func (key *scalewayPVKey) Features() string {
 
 func (c *Scaleway) GetPVKey(pv *v1.PersistentVolume, parameters map[string]string, defaultRegion string) models.PVKey {
 	// the csi volume handle is the form <az>/<volume-id>
-	zone := strings.Split(pv.Spec.CSI.VolumeHandle, "/")[0]
+	zone := ""
+	if pv.Spec.CSI != nil {
+		zoneVolID := strings.Split(pv.Spec.CSI.VolumeHandle, "/")
+		if len(zoneVolID) > 0 {
+			zone = zoneVolID[0]
+		}
+	}
 	return &scalewayPVKey{
 		Labels:                 pv.Labels,
 		StorageClassName:       pv.Spec.StorageClassName,

--- a/pkg/cloudcost/memoryrepository_test.go
+++ b/pkg/cloudcost/memoryrepository_test.go
@@ -2,6 +2,7 @@ package cloudcost
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -172,6 +173,8 @@ func TestMemoryRepository_Keys(t *testing.T) {
 				t.Errorf("Keys() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			sort.Strings(got)
+			sort.Strings(tt.want)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Keys() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
## What does this PR change?
* Defensive check in case a scalway pv is missing a label
* Fix test that was flaking due to order of retrieved keys varying.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* If you deploy on a scaleway PV without the right PV labels, no panics

## How was this PR tested?
* Fake scaleway node with no labels

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v1.108
