### PR TITLE
add profiling endpoints

### DIFF
--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -61,6 +62,16 @@ func Execute(opts *CostModelOpts) error {
 	a.Router.GET("/cloudCost/status", a.CloudCostPipelineService.GetCloudCostStatusHandler())
 	a.Router.GET("/cloudCost/rebuild", a.CloudCostPipelineService.GetCloudCostRebuildHandler())
 	a.Router.GET("/cloudCost/repair", a.CloudCostPipelineService.GetCloudCostRepairHandler())
+
+	if env.IsPProfEnabled() {
+		a.Router.HandlerFunc(http.MethodGet, "/debug/pprof/", pprof.Index)
+		a.Router.HandlerFunc(http.MethodGet, "/debug/pprof/cmdline", pprof.Cmdline)
+		a.Router.HandlerFunc(http.MethodGet, "/debug/pprof/profile", pprof.Profile)
+		a.Router.HandlerFunc(http.MethodGet, "/debug/pprof/symbol", pprof.Symbol)
+		a.Router.HandlerFunc(http.MethodGet, "/debug/pprof/trace", pprof.Trace)
+		a.Router.Handler(http.MethodGet, "/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		a.Router.Handler(http.MethodGet, "/debug/pprof/heap", pprof.Handler("heap"))
+	}
 
 	rootMux.Handle("/", a.Router)
 	rootMux.Handle("/metrics", promhttp.Handler())

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -51,6 +51,8 @@ const (
 	ThanosOffsetEnvVar       = "THANOS_QUERY_OFFSET"
 	ThanosMaxSourceResEnvVar = "THANOS_MAX_SOURCE_RESOLUTION"
 
+	PProfEnabledEnvVar = "PPROF_ENABLED"
+
 	LogCollectionEnabledEnvVar    = "LOG_COLLECTION_ENABLED"
 	ProductAnalyticsEnabledEnvVar = "PRODUCT_ANALYTICS_ENABLED"
 	ErrorReportingEnabledEnvVar   = "ERROR_REPORTING_ENABLED"
@@ -135,6 +137,10 @@ func GetExportCSVLabelsAll() bool {
 
 func GetExportCSVLabelsList() []string {
 	return GetList(ExportCSVLabelsList, ",")
+}
+
+func IsPProfEnabled() bool {
+	return GetBool(PProfEnabledEnvVar, false)
 }
 
 func GetExportCSVMaxDays() int {


### PR DESCRIPTION
## What does this PR change?
* adds /debug/ family of endpoints to allow opencost users to profile/tune memory usage

## Does this PR relate to any other PRs?
* none

## How will this PR impact users?
* adds new endpoints. endpoints disabled by default

## How was this PR tested?
* ensured 404 when disabled, valid heap file returned when enabled on local run

## Does this PR require changes to documentation? 
* additional endpoints are added. we can use kubecost docs for debugging here (e.g., https://docs.kubecost.com/troubleshooting/app-memory) 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 

cc @r2k1 @babbageclunk as per our discussion, should allow you to get heap dumps out of OC to see where the memory being used at scale 
