### PR TITLE
chore: adding version on justfile and tweaking CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Dependencies:
 1. Docker (with `buildx`)
 2. [just](https://github.com/casey/just) (if you don't want to install it , Just read the `justfile` and run the commands manually)
 3. Multi-arch `buildx` builders set up via https://github.com/tonistiigi/binfmt
+4. `manifest-tool` via https://github.com/estesp/manifest-tool
 4. `npm` (if you want to build the UI)
 
 ### Build the backend

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 commonenv := "CGO_ENABLED=0"
 
-version := "dev"
+version := `./tools/image-tag`
 commit := `git rev-parse --short HEAD`
 
 default:


### PR DESCRIPTION
## What does this PR change?
* Set the opencost container version on `justfile` along with the same fashion of `Makefile`

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* For whoever building the container using `just build <TAG>`, it will get the correct version from now on. Please see comment [here](https://github.com/opencost/opencost/issues/2323#issuecomment-1837495788)

## Does this PR address any GitHub or Zendesk issues?
* Addresses partially #2323

## How was this PR tested?
* See comment on #2323 

## Does this PR require changes to documentation?
* No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* I did not label it because the end-users are already getting the correct information. 
