### PR TITLE
Expose and make the API and UI ports configurable 

### DIFF
--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -78,7 +78,7 @@ func Execute(opts *CostModelOpts) error {
 	telemetryHandler := metrics.ResponseMetricMiddleware(rootMux)
 	handler := cors.AllowAll().Handler(telemetryHandler)
 
-	return http.ListenAndServe(":9003", errors.PanicHandlerMiddleware(handler))
+	return http.ListenAndServe(":"+env.GetAPIPort(), errors.PanicHandlerMiddleware(handler))
 }
 
 func StartExportWorker(ctx context.Context, model costmodel.AllocationModel) error {

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -78,7 +78,7 @@ func Execute(opts *CostModelOpts) error {
 	telemetryHandler := metrics.ResponseMetricMiddleware(rootMux)
 	handler := cors.AllowAll().Handler(telemetryHandler)
 
-	return http.ListenAndServe(":"+env.GetAPIPort(), errors.PanicHandlerMiddleware(handler))
+	return http.ListenAndServe(fmt.Sprint(":", env.GetAPIPort()), errors.PanicHandlerMiddleware(handler))
 }
 
 func StartExportWorker(ctx context.Context, model costmodel.AllocationModel) error {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	APIPortEnvVar = "API_PORT"
+
 	AWSAccessKeyIDEnvVar     = "AWS_ACCESS_KEY_ID"
 	AWSAccessKeySecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	AWSClusterIDEnvVar       = "AWS_CLUSTER_ID"
@@ -145,6 +147,12 @@ func IsPProfEnabled() bool {
 
 func GetExportCSVMaxDays() int {
 	return GetInt(ExportCSVMaxDays, 90)
+}
+
+// GetAPIPort returns the environment variable value for APIPortEnvVar which
+// is the port number the API is available on.
+func GetAPIPort() string {
+	return Get(APIPortEnvVar, "9003")
 }
 
 // GetKubecostConfigBucket returns a file location for a mounted bucket configuration which is used to store

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -151,8 +151,8 @@ func GetExportCSVMaxDays() int {
 
 // GetAPIPort returns the environment variable value for APIPortEnvVar which
 // is the port number the API is available on.
-func GetAPIPort() string {
-	return Get(APIPortEnvVar, "9003")
+func GetAPIPort() int {
+	return GetInt(APIPortEnvVar, 9003)
 }
 
 // GetKubecostConfigBucket returns a file location for a mounted bucket configuration which is used to store

--- a/pkg/env/costmodelenv_test.go
+++ b/pkg/env/costmodelenv_test.go
@@ -5,6 +5,44 @@ import (
 	"testing"
 )
 
+func TestGetAPIPort(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+		pre  func()
+	}{
+		{
+			name: "Ensure the default API port '9003'",
+			want: 9003,
+		},
+		{
+			name: "Ensure the default API port '9003' when API_PORT is set to ''",
+			want: 9003,
+			pre: func() {
+				os.Setenv("API_PORT", "")
+			},
+		},
+		{
+			name: "Ensure the API port '9004' when API_PORT is set to '9004'",
+			want: 9004,
+			pre: func() {
+				os.Setenv("API_PORT", "9004")
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.pre != nil {
+			tt.pre()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetAPIPort(); got != tt.want {
+				t.Errorf("GetAPIPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
 func TestIsCacheDisabled(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -7,8 +7,11 @@ RUN npx parcel build src/index.html
 
 FROM nginx:alpine
 
+ENV API_PORT=9003
+ENV UI_PORT=9090
+
 COPY --from=builder /opt/ui/dist /var/www
-COPY default.nginx.conf /etc/nginx/conf.d/
+COPY default.nginx.conf.template /etc/nginx/conf.d/default.nginx.conf.template
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,6 +8,7 @@ RUN npx parcel build src/index.html
 FROM nginx:alpine
 
 ENV API_PORT=9003
+ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
 
 COPY --from=builder /opt/ui/dist /var/www

--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -1,5 +1,9 @@
 FROM nginx:alpine
 
+ENV API_PORT=9003
+ENV API_SERVER=0.0.0.0
+ENV UI_PORT=9090
+
 COPY ./dist /var/www
 COPY default.nginx.conf /etc/nginx/conf.d/
 COPY nginx.conf /etc/nginx/

--- a/ui/default.nginx.conf.template
+++ b/ui/default.nginx.conf.template
@@ -35,7 +35,7 @@ gzip_types
 upstream model {
     # Update to the cost model endpoint
     # Example: host.docker.internal:9003;
-    server 0.0.0.0:9003;
+    server 0.0.0.0:${API_PORT};
 }
 
 server {
@@ -58,8 +58,8 @@ server {
     }
 
     add_header ETag "1.96.0";
-    listen 9090;
-    listen [::]:9090;
+    listen ${UI_PORT};
+    listen [::]:${UI_PORT};
     resolver 127.0.0.1 valid=5s;
     location /healthz {
         access_log /dev/null;

--- a/ui/default.nginx.conf.template
+++ b/ui/default.nginx.conf.template
@@ -35,7 +35,7 @@ gzip_types
 upstream model {
     # Update to the cost model endpoint
     # Example: host.docker.internal:9003;
-    server 0.0.0.0:${API_PORT};
+    server ${API_SERVER}:${API_PORT};
 }
 
 server {

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -9,5 +9,7 @@ else
     sed -i "s^{PLACEHOLDER_BASE_URL}^$BASE_URL^g" /var/www/*.js
 fi
 
+envsubst '$API_PORT $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
+
 # Run the parent (nginx) container's entrypoint script
 exec /docker-entrypoint.sh "$@"

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -4,12 +4,12 @@ set -e
 if [[ ! -z "$BASE_URL_OVERRIDE" ]]; then
     echo "running with BASE_URL=${BASE_URL_OVERRIDE}"
     sed -i "s^{PLACEHOLDER_BASE_URL}^$BASE_URL_OVERRIDE^g" /var/www/*.js
-else 
+else
     echo "running with BASE_URL=${BASE_URL}"
     sed -i "s^{PLACEHOLDER_BASE_URL}^$BASE_URL^g" /var/www/*.js
 fi
 
-envsubst '$API_PORT $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
+envsubst '$API_PORT $API_SERVER $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
 
 # Run the parent (nginx) container's entrypoint script
 exec /docker-entrypoint.sh "$@"


### PR DESCRIPTION
## What does this PR change?
* The API port and server and the UI port are all now configurable. The API port can be moved off of 9003 and the UI can be moved off of 9090 through environment variables. If you need to modify the API server in the `default.nginx.conf` you can set the `API_SERVER`.

## Does this PR relate to any other PRs?
* Continues the work started in https://github.com/opencost/opencost/pull/2283
* Enabled by https://github.com/opencost/opencost-helm-chart/pull/156

## How will this PR impact users?
* Ports are now configurable

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/2223
* https://github.com/opencost/opencost/pull/2317 needs this to work

## How was this PR tested?
* Tested as a standard build with an unaware Helm chart
* Tested with the updated Helm chart with no changes
* Tested with the updated Helm chart with changed API and UI ports
* Verified with port-forwarding 9091 and 9004
* Test added to the code for the API_PORT

## Does this PR require changes to documentation?
* It will be part of the "running with Docker" documentation to be added eventually

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes, if we want to be able to ship the Docker version of OpenCost
