### PR TITLE
Add labels to cloud cost view table rows

### DIFF
--- a/pkg/cloudcost/querier.go
+++ b/pkg/cloudcost/querier.go
@@ -29,7 +29,7 @@ const DefaultChartItemsLength int = 10
 // ViewQuerier defines a contract for return View types to the QueryService to service the View Api
 type ViewQuerier interface {
 	QueryViewGraph(ViewQueryRequest, context.Context) (ViewGraphData, error)
-	QueryViewTotals(ViewQueryRequest, context.Context) (*ViewTableRow, int, error)
+	QueryViewTotals(ViewQueryRequest, context.Context) (*ViewTotals, error)
 	QueryViewTable(ViewQueryRequest, context.Context) (ViewTableRows, error)
 }
 

--- a/pkg/cloudcost/queryservice.go
+++ b/pkg/cloudcost/queryservice.go
@@ -106,11 +106,6 @@ func (s *QueryService) GetCloudCostViewGraphHandler() func(w http.ResponseWriter
 	}
 }
 
-type CloudCostViewTotalsResponse struct {
-	NumResults int           `json:"numResults"`
-	Combined   *ViewTableRow `json:"combined"`
-}
-
 func (s *QueryService) GetCloudCostViewTotalsHandler() func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	// Return valid handler func
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -136,15 +131,10 @@ func (s *QueryService) GetCloudCostViewTotalsHandler() func(w http.ResponseWrite
 			return
 		}
 
-		totals, count, err := s.ViewQuerier.QueryViewTotals(*request, ctx)
+		resp, err := s.ViewQuerier.QueryViewTotals(*request, ctx)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Internal server error: %s", err), http.StatusInternalServerError)
 			return
-		}
-
-		resp := CloudCostViewTotalsResponse{
-			NumResults: count,
-			Combined:   totals,
 		}
 
 		_, spanResp := tracer.Start(ctx, "write response")

--- a/pkg/cloudcost/view.go
+++ b/pkg/cloudcost/view.go
@@ -31,14 +31,29 @@ func (vtrs ViewTableRows) Equal(that ViewTableRows) bool {
 }
 
 type ViewTableRow struct {
-	Name              string  `json:"name"`
-	KubernetesPercent float64 `json:"kubernetesPercent"`
-	Cost              float64 `json:"cost"`
+	Name              string            `json:"name"`
+	Labels            map[string]string `json:"labels"`
+	KubernetesPercent float64           `json:"kubernetesPercent"`
+	Cost              float64           `json:"cost"`
 }
 
 func (vtr *ViewTableRow) Equal(that *ViewTableRow) bool {
 	if vtr.Name != that.Name {
 		return false
+	}
+
+	if len(vtr.Labels) != len(that.Labels) {
+		return false
+	}
+
+	for key, value := range vtr.Labels {
+		thatValue, ok := that.Labels[key]
+		if !ok {
+			return false
+		}
+		if value != thatValue {
+			return false
+		}
 	}
 
 	if !mathutil.Approximately(vtr.KubernetesPercent, that.KubernetesPercent) {
@@ -104,4 +119,9 @@ func (vgdsi ViewGraphDataSetItem) Equal(that ViewGraphDataSetItem) bool {
 	}
 
 	return true
+}
+
+type ViewTotals struct {
+	NumResults int           `json:"numResults"`
+	Combined   *ViewTableRow `json:"combined"`
 }


### PR DESCRIPTION
## What does this PR change?
* Adds labels to the cloudcost.ViewTableRow struct so that they can be displayed in pills on the CloudCost page.

* Update the response from `QueryViewTotals` on the cloudcost.ViewQuerier interface to a match the type it is converted to for response

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* Users will be able to see labels in CloudCost in the Cloud Cost view table

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested in local deploys

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
