### PR TITLE
Add Artur Khantimirov to the OpenCost Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 | Maintainer | GitHub ID | Affiliation | Email |
 | --------------- | --------- | ----------- | ----------- |
 | Ajay Tripathy | @AjayTripathy | Kubecost | <Ajay@kubecost.com> |
+| Artur Khantimirov | @r2k1 | Microsoft | |
 | Matt Bolt | @​mbolt35 | Kubecost | <matt@kubecost.com> |
 | Matt Ray | @mattray | Kubecost | <mattray@kubecost.com> |
 | Michael Dresser | @michaelmdresser | Kubecost | <michael@kubecost.com> |


### PR DESCRIPTION
## What does this PR change?
* This will add @r2k1 as an OpenCost Maintainer

## Does this PR relate to any other PRs?
* n/a

## How will this PR impact users?
* Artur has been an active committer to OpenCost and contributed CSV exports, better AKS integration, and many performance and quality enhancements with regard to OpenCost's Prometheus usage. His engagement in #opencost Slack and in reviewing Issues and PRs has been greatly appreciated by the OpenCost community. Adding him as a Maintainer will help OpenCost become more community-focused and strengthen the project.

## Does this PR address any GitHub or Zendesk issues?
* n/a

## How was this PR tested?
* n/a

## Does this PR require changes to documentation?
* n/a

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* n/a
