### PR TITLE
update Dockerfile.cross with new default.nginx.conf.template

### DIFF
--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -5,7 +5,7 @@ ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
 
 COPY ./dist /var/www
-COPY default.nginx.conf /etc/nginx/conf.d/
+COPY default.nginx.conf.template /etc/nginx/conf.d/default.nginx.conf.template
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
## What does this PR change?
* adds the proper filename for nginx.conf.template to dockerfile.cross to fix issue with cross platform builds

## Does this PR relate to any other PRs?
* Fixes issue created from #2366 

## How will this PR impact users?
* Allow users to use Dockerfile.cross to build cross platform images

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Locally with docker buildx

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 1.108
