### PR TITLE
Extends: Fixes drilldown per item day and descending order on agg by item - PR #2289

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ui/.parcel-cache
 ui/.cache
 ui/dist
+ui/.env
 ui/node_modules/
 cmd/costmodel/costmodel
 cmd/costmodel/costmodel-amd64

--- a/ui/src/cloudCost/cloudCostDetails.js
+++ b/ui/src/cloudCost/cloudCostDetails.js
@@ -33,7 +33,7 @@ const CloudCostDetails = ({
 
   const nextFilters = [
     ...(filters ?? []),
-    { property: "providerIds", value: selectedProviderId },
+    { property: "providerID", value: selectedProviderId },
   ];
 
   async function fetchData() {
@@ -122,7 +122,7 @@ const CloudCostDetails = ({
         title={`Costs over the last ${window}`}
         style={{ margin: "10%" }}
       >
-        <Paper>
+        <Paper style={{ padding: 20 }}>
           <Typography style={{ marginTop: "1rem" }} variant="body1">
             {selectedItem}
           </Typography>

--- a/ui/src/cloudCostReports.js
+++ b/ui/src/cloudCostReports.js
@@ -175,7 +175,6 @@ const CloudCostReports = () => {
       return {
         property,
         value,
-        name: aggMap[property] || property,
       };
     });
     setFilters(newFilters);
@@ -267,6 +266,7 @@ const CloudCostReports = () => {
               aggregationOptions={aggregationOptions}
               aggregateBy={aggregateBy}
               setAggregateBy={(agg) => {
+                setFilters([])
                 searchParams.set("agg", agg);
                 routerHistory.push({
                   search: `?${searchParams.toString()}`,

--- a/ui/src/services/cloudCostDayTotals.js
+++ b/ui/src/services/cloudCostDayTotals.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getCloudFilters } from "../util";
+import { parseFilters } from "../util";
 import { costMetricToPropName } from "../cloudCost/tokens";
 
 function formatItemsForCost({ data, costType }) {
@@ -21,12 +21,11 @@ class CloudCostDayTotalsService {
     if (this.BASE_URL.includes("PLACEHOLDER_BASE_URL")) {
       this.BASE_URL = `http://localhost:9090/model`;
     }
-
     if (aggregate.includes("item")) {
       const resp = await axios.get(
         `${
           this.BASE_URL
-        }/cloudCost?window=${window}&costMetric=${costMetric}${getCloudFilters(
+        }/cloudCost?window=${window}&costMetric=${costMetric}&filter=${parseFilters(
           filters
         )}`
       );

--- a/ui/src/services/cloudCostTop.js
+++ b/ui/src/services/cloudCostTop.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getCloudFilters, formatSampleItemsForGraph } from "../util";
+import { formatSampleItemsForGraph, parseFilters } from "../util";
 
 class CloudCostTopService {
   BASE_URL = process.env.BASE_URL || "{PLACEHOLDER_BASE_URL}";
@@ -13,7 +13,7 @@ class CloudCostTopService {
       window,
       aggregate,
       costMetric,
-      filters,
+      filter: parseFilters(filters ?? []),
       limit: 1000,
     };
 
@@ -21,7 +21,7 @@ class CloudCostTopService {
       const resp = await axios.get(
         `${
           this.BASE_URL
-        }/cloudCost?window=${window}&costMetric=${costMetric}${getCloudFilters(
+        }/cloudCost?window=${window}&costMetric=${costMetric}&filter=${parseFilters(
           filters
         )}`
       );


### PR DESCRIPTION
…s on Breakdown change

## What does this PR change?
* From  - Fixes filtering so data is right on drilldown and agg by item is in descending order

## Does this PR relate to any other PRs?
* Includes and fixes issues with https://github.com/opencost/opencost/pull/2289

## How will this PR impact users?
* From  - they'll have more accurate drilldown and be able to easily view cost in the table at it's largest to smallest.

## Does this PR address any GitHub or Zendesk issues?
- Closes https://github.com/opencost/opencost/issues/2276
- Closes https://github.com/opencost/opencost/issues/2278

## How was this PR tested?
* self tested

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

<img width="1223" alt="Screenshot 2023-12-08 at 2 48 40 PM" src="https://github.com/opencost/opencost/assets/13816099/150646e9-0c6c-4f3f-a1b1-f4884cba6728">

![image](https://github.com/opencost/opencost/assets/13816099/7f0c074e-47bc-4e8f-b7e7-6eb8c83393e0)

