### PR TITLE
Log and continue on a single record processing failures.

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2555,8 +2555,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 
 					if totals == nil {
 						log.Errorf("unable to locate asset totals for allocation %s", key)
-						return nil, fmt.Errorf("unable to locate allocation totals for allocation")
-
+						continue
 					}
 
 					parc.CPUTotalCost = totals.CPUCost

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2554,7 +2554,7 @@ func (cm *CostModel) QueryAllocation(window kubecost.Window, resolution, step ti
 					}
 
 					if totals == nil {
-						log.Errorf("unable to locate asset totals for allocation %s", key)
+						log.Errorf("unable to locate asset totals for allocation %s, corresponding PARC is being skipped", key)
 						continue
 					}
 


### PR DESCRIPTION
## What does this PR change?

"I'm experiencing an issue with multiple AKS clusters where opencost is returning a 500 error. The error message is `Error: unable to locate allocation totals for allocation,`. This message might be truncated and could contain more details, but I don't have access to that information (or any logs)

The current processing logic seems to halt opencost entirely when a single record fails. The proposed change is to ignore such failing records and allow processing to continue.