### PR TITLE
Fix aws spot price with default config

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1336,7 +1336,7 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 			}, meta, nil
 		} else {
 			// return defaults if public pricing not found
-			log.DedupedWarningf(5, "Could not find Node %s's public pricing info", k.ID())
+			log.DedupedWarningf(5, "Could not find Node %s's public pricing info, using default configured spot prices instead", k.ID())
 			return &models.Node{
 				VCPU:         terms.VCpu,
 				VCPUCost:     aws.BaseSpotCPUPrice,

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1284,6 +1284,20 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 	key := k.Features()
 
 	meta := models.PricingMetadata{}
+	var cost string
+	publicPricingFound := true
+	c, ok := terms.OnDemand.PriceDimensions[strings.Join([]string{terms.Sku, terms.OnDemand.OfferTermCode, HourlyRateCode}, ".")]
+	if ok {
+		cost = c.PricePerUnit.USD
+	} else {
+		// Check for Chinese pricing
+		c, ok = terms.OnDemand.PriceDimensions[strings.Join([]string{terms.Sku, terms.OnDemand.OfferTermCode, HourlyRateCodeCn}, ".")]
+		if ok {
+			cost = c.PricePerUnit.CNY
+		} else {
+			publicPricingFound = false
+		}
+	}
 
 	if spotInfo, ok := aws.spotPricing(k.ID()); ok {
 		var spotcost string
@@ -1307,9 +1321,14 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 		}, meta, nil
 	} else if aws.isPreemptible(key) { // Preemptible but we don't have any data in the pricing report.
 		log.DedupedWarningf(5, "Node %s marked preemptible but we have no data in spot feed", k.ID())
+		// Throw error if public price is not found
+		if !publicPricingFound {
+			log.Errorf("Could not fetch public pricing data for spot instance \"%s\"", k.ID())
+			return nil, meta, fmt.Errorf("Could not fetch data for \"%s\"", k.ID())
+		}
 		return &models.Node{
+			Cost:         cost,
 			VCPU:         terms.VCpu,
-			VCPUCost:     aws.BaseSpotCPUPrice,
 			RAM:          terms.Memory,
 			GPU:          terms.GPU,
 			Storage:      terms.Storage,
@@ -1347,18 +1366,10 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 		}, meta, nil
 
 	}
-	var cost string
-	c, ok := terms.OnDemand.PriceDimensions[strings.Join([]string{terms.Sku, terms.OnDemand.OfferTermCode, HourlyRateCode}, ".")]
-	if ok {
-		cost = c.PricePerUnit.USD
-	} else {
-		// Check for Chinese pricing before throwing error
-		c, ok = terms.OnDemand.PriceDimensions[strings.Join([]string{terms.Sku, terms.OnDemand.OfferTermCode, HourlyRateCodeCn}, ".")]
-		if ok {
-			cost = c.PricePerUnit.CNY
-		} else {
-			return nil, meta, fmt.Errorf("Could not fetch data for \"%s\"", k.ID())
-		}
+	// Throw error if public price is not found
+	if !publicPricingFound {
+		log.Errorf("Could not fetch data for \"%s\"", k.ID())
+		return nil, meta, fmt.Errorf("Could not fetch data for \"%s\"", k.ID())
 	}
 
 	return &models.Node{

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1336,6 +1336,7 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 			}, meta, nil
 		} else {
 			// return defaults if public pricing not found
+			log.DedupedWarningf(5, "Could not find Node %s's public pricing info", k.ID())
 			return &models.Node{
 				VCPU:         terms.VCpu,
 				VCPUCost:     aws.BaseSpotCPUPrice,


### PR DESCRIPTION
## What does this PR change?
* Currently, when user does not provide spot data feed but uses spot instances, the code picks hardcoded spot cpu cost. The solution here is to pick the public pricing for spot instances with default config (no spot data feed configured).

## Does this PR relate to any other PRs?
* I hope not.

## How will this PR impact users?
* When user does not provide spot data feed but uses opencost on spot instances, public pricing will be picked.

## Does this PR address any GitHub or Zendesk issues?
* Closes ... https://github.com/opencost/opencost/issues/2243

## How was this PR tested?
* The changes were tested on AWS spot instances

## Does this PR require changes to documentation?
* I hope not. When the user does not configure spot data feed, opencost should be expected to provide public pricing.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Release eligibility has not yet been determined.
