### PR TITLE
update Tiltfile to support nginx template change

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -90,7 +90,7 @@ docker_build(
     only=[
         'dist',
         'nginx.conf',
-        'default.nginx.conf',
+        'default.nginx.conf.template',
         'docker-entrypoint.sh',
     ],
     live_update=[


### PR DESCRIPTION
## What does this PR change?
* Tiltfile was referencing a nginx config file that was renamed. PR #2366 did not update all the references in the repo before merging.

## Does this PR relate to any other PRs?
* Root cause: https://github.com/opencost/opencost/pull/2366
* Identical issue: https://github.com/opencost/opencost/pull/2373

## How will this PR impact users?
* Installs - no effect
* Tilt / local installation users - Tilt will work again

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Tilt works again

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A, and also - I can't tag. I don't know why this is still in the template.
