### PR TITLE
feat: 2323 adding version and commit on opencost-ui logs

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -7,6 +7,11 @@ RUN npx parcel build src/index.html
 
 FROM nginx:alpine
 
+ARG version=dev
+ARG	commit=HEAD
+ENV VERSION=${version}
+ENV HEAD=${commit}
+
 ENV API_PORT=9003
 ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090

--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -1,5 +1,10 @@
 FROM nginx:alpine
 
+ARG version=dev
+ARG	commit=HEAD
+ENV VERSION=${version}
+ENV HEAD=${commit}
+
 ENV API_PORT=9003
 ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -11,5 +11,7 @@ fi
 
 envsubst '$API_PORT $API_SERVER $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
 
+echo "Starting ui version $VERSION ($HEAD)"
+
 # Run the parent (nginx) container's entrypoint script
 exec /docker-entrypoint.sh "$@"

--- a/ui/justfile
+++ b/ui/justfile
@@ -1,3 +1,6 @@
+version := `../tools/image-tag`
+commit := `git rev-parse --short HEAD`
+
 default:
     just --list
 
@@ -13,6 +16,8 @@ build IMAGETAG: build-local
         -f 'Dockerfile.cross' \
         --provenance=false \
         -t {{IMAGETAG}}-amd64 \
+        --build-arg version={{version}} \
+        --build-arg commit={{commit}} \
         --push \
         .
 
@@ -22,6 +27,8 @@ build IMAGETAG: build-local
         -f 'Dockerfile.cross' \
         --provenance=false \
         -t {{IMAGETAG}}-arm64 \
+        --build-arg version={{version}} \
+        --build-arg commit={{commit}} \
         --push \
         .
 


### PR DESCRIPTION
## What does this PR change?
* It adds version and commit on opencost-ui logs

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* upon running `kubectl logs <pod> -c opencost-ui`, users will see the version and commit SHA of the container.

## Does this PR address any GitHub or Zendesk issues?
* Closes ... 2323

## How was this PR tested?
* See commnad below:
```
% docker run quay.io/brito_rafa0/opencost-ui:testa
Unable to find image 'quay.io/brito_rafa0/opencost-ui:testa' locally
testa: Pulling from brito_rafa0/opencost-ui
Digest: sha256:bd2d828ae209e4f314159821225783d61c3439e2f0b94339393ef0c19f86ae54
Status: Downloaded newer image for quay.io/brito_rafa0/opencost-ui:testa
running with BASE_URL=/model
Starting ui version 2323-ui-version-c2bc77c0-WIP (c2bc77c0) ## <-----------------------------
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
```
## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes
