### PR TITLE
Allocation properties: Add support for aliased labels

### DIFF
--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -43,6 +43,10 @@ func (apt *AllocationProperty) GetAnnotation() string {
 
 // IsAliasedLabel returns true if the allocation property corresponds to an aliased label
 func (apt *AllocationProperty) IsAliasedLabel() bool {
+	if apt == nil {
+		return false
+	}
+
 	return *apt == AllocationDepartmentProp ||
 		*apt == AllocationEnvironmentProp ||
 		*apt == AllocationOwnerProp ||

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -41,6 +41,33 @@ func (apt *AllocationProperty) GetAnnotation() string {
 	return ""
 }
 
+// IsAliasedLabel returns true if the allocation property corresponds to an aliased label
+func (apt *AllocationProperty) IsAliasedLabel() bool {
+	return *apt == AllocationDepartmentProp ||
+		*apt == AllocationEnvironmentProp ||
+		*apt == AllocationOwnerProp ||
+		*apt == AllocationProductProp ||
+		*apt == AllocationTeamProp
+}
+
+// GetAliasedLabelDefault returns the corresponding default aliased label name
+func (apt *AllocationProperty) GetAliasedLabelDefault() string {
+	switch *apt {
+	case AllocationDepartmentProp:
+		return "department"
+	case AllocationEnvironmentProp:
+		return "env"
+	case AllocationOwnerProp:
+		return "owner"
+	case AllocationProductProp:
+		return "app"
+	case AllocationTeamProp:
+		return "team"
+	default:
+		return ""
+	}
+}
+
 const (
 	AllocationNilProp            AllocationProperty = ""
 	AllocationClusterProp                           = "cluster"


### PR DESCRIPTION
## What does this PR change?
This PR adds support for handling aliased labels in allocation properties. Specific to KC Cloud only.

## Does this PR relate to any other PRs?
https://github.com/kubecost/kubecost-cloud/pull/163

## How will this PR impact users?
Users will be able to filter and aggregate leveraging default aliased label names. 

## Does this PR address any GitHub or Zendesk issues?
N/A

## How was this PR tested?
Local

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
