### PR TITLE
Enable (*FileStorage).ListDirectories to list symlinks which target directories

### DIFF
--- a/pkg/storage/filestorage_test.go
+++ b/pkg/storage/filestorage_test.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileStorageListDirectoriesSymlink(t *testing.T) {
+	storageBaseDir := t.TempDir()
+	subdirName := "sub"
+	slFileName := "sl"
+	symlinkTargetDir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(storageBaseDir, subdirName), 0700); err != nil {
+		t.Fatalf("failed to construct subdir: %s", err)
+	}
+
+	if err := os.Symlink(symlinkTargetDir, filepath.Join(storageBaseDir, subdirName, slFileName)); err != nil {
+		t.Fatalf("failed to create symlink at '%s' which points to '%s': %s", filepath.Join(storageBaseDir, subdirName, slFileName), symlinkTargetDir, err)
+	}
+
+	store := FileStorage{baseDir: storageBaseDir}
+	dirs, err := store.ListDirectories(subdirName)
+	if err != nil {
+		t.Fatalf("failed to list directories: %s", err)
+	}
+	if len(dirs) != 1 {
+		t.Fatalf("dirs should have 1 entry")
+	}
+	dir := dirs[0]
+	// This condition is important -- the returned path should be relative to
+	// the storage base dir, not the symlink's target dir.
+	if dir.Name != filepath.Join(subdirName, slFileName) {
+		t.Errorf("Expected dir.Name to be '%s' but it was '%s'", filepath.Join(subdirName, slFileName), dir.Name)
+	}
+}


### PR DESCRIPTION
## What does this PR change?
Enable `(*FileStorage).ListDirectories` to list symlinks which target directories

Done by making `DirFileToStargeInfo` follow symlinks to determine if the target is a directory, then returning the _unfollowed_ path as a valid directory so the path will be correctly constructed relative to the symlink, rather than relative to the target. The purpose is only to ensure that the target is in fact a directory.

## Does this PR relate to any other PRs?
- Required for https://github.com/kubecost/kubecost-cost-model/pull/2002

## How will this PR impact users?
* N/A, nobody should currently be using symlinks

## How was this PR tested?
* Used in https://github.com/kubecost/kubecost-cost-model/pull/2002 to successfully ingest data "stored" in a symlinked path