### PR TITLE
Make telemetry metrics respect disable state

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -346,7 +346,7 @@ func NewCostModelMetricsEmitter(promClient promclient.Client, clusterCache clust
 		EmitKubeStateMetricsV1Only:    env.IsEmitKsmV1MetricsOnly(),
 	})
 
-	metrics.InitKubecostTelemetry(metricsConfig)
+	metrics.InitOpencostTelemetry(metricsConfig)
 
 	return &CostModelMetricsEmitter{
 		PrometheusClient:              promClient,

--- a/pkg/metrics/telemetry.go
+++ b/pkg/metrics/telemetry.go
@@ -22,37 +22,47 @@ var (
 	buildInfo     *prometheus.GaugeVec
 )
 
-// InitKubecostTelemetry registers kubecost application telemetry.
-func InitKubecostTelemetry(config *MetricsConfig) {
-	// TODO(bolt): Check MetricsConfig for disabled metrics
-
+// InitOpencostTelemetry registers Opencost application telemetry.
+func InitOpencostTelemetry(config *MetricsConfig) {
 	once.Do(func() {
+		disabledMetrics := config.GetDisabledMetricsMap()
+
 		// register prometheus metrics
-		buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "opencost_build_info",
-			Help: "opencost_build_info Build information",
-		}, []string{"version", "revision"})
 
-		buildInfo.WithLabelValues(version.Version, version.GitCommit)
+		if _, disabled := disabledMetrics["opencost_build_info"]; !disabled {
+			buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "opencost_build_info",
+				Help: "opencost_build_info Build information",
+			}, []string{"version", "revision"})
+			buildInfo.WithLabelValues(version.Version, version.GitCommit)
+			prometheus.MustRegister(buildInfo)
+		}
 
-		requestsCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "kubecost_http_requests_total",
-			Help: "kubecost_http_requests_total Total number of HTTP requests",
-		}, []string{"handler", "method", "code"})
+		if _, disabled := disabledMetrics["kubecost_http_requests_total"]; !disabled {
+			requestsCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "kubecost_http_requests_total",
+				Help: "kubecost_http_requests_total Total number of HTTP requests",
+			}, []string{"handler", "method", "code"})
+			prometheus.MustRegister(requestsCount)
+		}
 
-		var buckets = []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720}
-		responseTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "kubecost_http_response_time_seconds",
-			Help:    "kubecost_http_response_time_seconds Response time in seconds",
-			Buckets: buckets,
-		}, []string{"handler", "method", "code"})
+		if _, disabled := disabledMetrics["kubecost_http_response_time_seconds"]; !disabled {
+			var buckets = []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120, 240, 360, 720}
+			responseTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name:    "kubecost_http_response_time_seconds",
+				Help:    "kubecost_http_response_time_seconds Response time in seconds",
+				Buckets: buckets,
+			}, []string{"handler", "method", "code"})
+			prometheus.MustRegister(responseTime)
+		}
 
-		responseSize = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-			Name: "kubecost_http_response_size_bytes",
-			Help: "kubecost_http_response_size_bytes Response size in bytes",
-		}, []string{"handler", "method", "code"})
-
-		prometheus.MustRegister(requestsCount, responseTime, responseSize, buildInfo)
+		if _, disabled := disabledMetrics["kubecost_http_response_size_bytes"]; !disabled {
+			responseSize = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+				Name: "kubecost_http_response_size_bytes",
+				Help: "kubecost_http_response_size_bytes Response size in bytes",
+			}, []string{"handler", "method", "code"})
+			prometheus.MustRegister(responseSize)
+		}
 
 		// register event listeners
 		dispatcher = events.GlobalDispatcherFor[HttpHandlerMetricEvent]()
@@ -65,7 +75,13 @@ func InitKubecostTelemetry(config *MetricsConfig) {
 func onHttpHandlerMetricEvent(event HttpHandlerMetricEvent) {
 	code := fmt.Sprintf("%d", event.Code)
 
-	requestsCount.WithLabelValues(event.Handler, event.Method, code).Inc()
-	responseSize.WithLabelValues(event.Handler, event.Method, code).Observe(float64(event.ResponseSize))
-	responseTime.WithLabelValues(event.Handler, event.Method, code).Observe(event.ResponseTime.Seconds())
+	if requestsCount != nil {
+		requestsCount.WithLabelValues(event.Handler, event.Method, code).Inc()
+	}
+	if responseSize != nil {
+		responseSize.WithLabelValues(event.Handler, event.Method, code).Observe(float64(event.ResponseSize))
+	}
+	if responseTime != nil {
+		responseTime.WithLabelValues(event.Handler, event.Method, code).Observe(event.ResponseTime.Seconds())
+	}
 }


### PR DESCRIPTION
## What does this PR change?
* The `opencost_build_info`, `kubecost_http_requests_total`, `kubecost_http_response_time_seconds`, and `kubecost_http_response_size_bytes` will now respect the disabled metric configuration.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* By Jesse in a live env, disabling all of these metrics successfully using the config.