### PR TITLE
Refactor Kubecost-specific environment variables to OPENCOST_ equivalents

### DIFF
--- a/pkg/clustercache/clustercache.go
+++ b/pkg/clustercache/clustercache.go
@@ -104,15 +104,15 @@ func NewKubernetesClusterCache(client kubernetes.Interface) ClusterCache {
 	batchClient := client.BatchV1().RESTClient()
 	pdbClient := client.PolicyV1beta1().RESTClient()
 
-	kubecostNamespace := env.GetKubecostNamespace()
-	log.Infof("NAMESPACE: %s", kubecostNamespace)
+	openCostNamespace := env.GetOpenCostNamespace()
+	log.Infof("NAMESPACE: %s", openCostNamespace)
 
 	kcc := &KubernetesClusterCache{
 		client:                     client,
 		namespaceWatch:             NewCachingWatcher(coreRestClient, "namespaces", &v1.Namespace{}, "", fields.Everything()),
 		nodeWatch:                  NewCachingWatcher(coreRestClient, "nodes", &v1.Node{}, "", fields.Everything()),
 		podWatch:                   NewCachingWatcher(coreRestClient, "pods", &v1.Pod{}, "", fields.Everything()),
-		kubecostConfigMapWatch:     NewCachingWatcher(coreRestClient, "configmaps", &v1.ConfigMap{}, kubecostNamespace, fields.Everything()),
+		kubecostConfigMapWatch:     NewCachingWatcher(coreRestClient, "configmaps", &v1.ConfigMap{}, openCostNamespace, fields.Everything()),
 		serviceWatch:               NewCachingWatcher(coreRestClient, "services", &v1.Service{}, "", fields.Everything()),
 		daemonsetsWatch:            NewCachingWatcher(appsRestClient, "daemonsets", &appsv1.DaemonSet{}, "", fields.Everything()),
 		deploymentsWatch:           NewCachingWatcher(appsRestClient, "deployments", &appsv1.Deployment{}, "", fields.Everything()),

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -139,7 +139,7 @@ func Execute(opts *AgentOpts) error {
 	}
 
 	// Lookup scrape interval for kubecost job, update if found
-	si, err := prom.ScrapeIntervalFor(promCli, env.GetKubecostJobName())
+	si, err := prom.ScrapeIntervalFor(promCli, env.GetOpenCostJobName())
 	if err == nil {
 		scrapeInterval = si
 	}
@@ -154,7 +154,7 @@ func Execute(opts *AgentOpts) error {
 
 	// Create ConfigFileManager for synchronization of shared configuration
 	confManager := config.NewConfigFileManager(&config.ConfigFileManagerOpts{
-		BucketStoreConfig: env.GetKubecostConfigBucket(),
+		BucketStoreConfig: env.GetOpenCostConfigBucket(),
 		LocalConfigPath:   "/",
 	})
 
@@ -169,11 +169,11 @@ func Execute(opts *AgentOpts) error {
 	watchConfigFunc := configWatchers.ToWatchFunc()
 	watchedConfigs := configWatchers.GetWatchedConfigs()
 
-	kubecostNamespace := env.GetKubecostNamespace()
+	openCostNamespace := env.GetOpenCostNamespace()
 
 	// We need an initial invocation because the init of the cache has happened before we had access to the provider.
 	for _, cw := range watchedConfigs {
-		configs, err := k8sClient.CoreV1().ConfigMaps(kubecostNamespace).Get(context.Background(), cw, metav1.GetOptions{})
+		configs, err := k8sClient.CoreV1().ConfigMaps(openCostNamespace).Get(context.Background(), cw, metav1.GetOptions{})
 		if err != nil {
 			log.Infof("No %s configmap found at install time, using existing configs: %s", cw, err.Error())
 		} else {

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1189,7 +1189,7 @@ func (a *Accesses) GetInstallNamespace(w http.ResponseWriter, r *http.Request, _
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	ns := env.GetKubecostNamespace()
+	ns := env.GetOpenCostNamespace()
 	w.Write([]byte(ns))
 }
 
@@ -1211,7 +1211,7 @@ func (a *Accesses) GetInstallInfo(w http.ResponseWriter, r *http.Request, _ http
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	pods, err := a.KubeClientSet.CoreV1().Pods(env.GetKubecostNamespace()).List(context.Background(), metav1.ListOptions{
+	pods, err := a.KubeClientSet.CoreV1().Pods(env.GetOpenCostNamespace()).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "app=cost-analyzer",
 		FieldSelector: "status.phase=Running",
 		Limit:         1,
@@ -1295,7 +1295,7 @@ func (a *Accesses) GetPodLogs(w http.ResponseWriter, r *http.Request, ps httprou
 
 	qp := httputil.NewQueryParams(r.URL.Query())
 
-	ns := qp.Get("namespace", env.GetKubecostNamespace())
+	ns := qp.Get("namespace", env.GetOpenCostNamespace())
 	pod := qp.Get("pod", "")
 	selector := qp.Get("selector", "")
 	container := qp.Get("container", "")
@@ -1568,7 +1568,7 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 	}
 
 	// Lookup scrape interval for kubecost job, update if found
-	si, err := prom.ScrapeIntervalFor(promCli, env.GetKubecostJobName())
+	si, err := prom.ScrapeIntervalFor(promCli, env.GetOpenCostJobName())
 	if err == nil {
 		scrapeInterval = si
 	}
@@ -1583,7 +1583,7 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 
 	// Create ConfigFileManager for synchronization of shared configuration
 	confManager := config.NewConfigFileManager(&config.ConfigFileManagerOpts{
-		BucketStoreConfig: env.GetKubecostConfigBucket(),
+		BucketStoreConfig: env.GetOpenCostConfigBucket(),
 		LocalConfigPath:   "/",
 	})
 
@@ -1612,10 +1612,10 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 	watchConfigFunc := configWatchers.ToWatchFunc()
 	watchedConfigs := configWatchers.GetWatchedConfigs()
 
-	kubecostNamespace := env.GetKubecostNamespace()
+	openCostNamespace := env.GetOpenCostNamespace()
 	// We need an initial invocation because the init of the cache has happened before we had access to the provider.
 	for _, cw := range watchedConfigs {
-		configs, err := kubeClientset.CoreV1().ConfigMaps(kubecostNamespace).Get(context.Background(), cw, metav1.GetOptions{})
+		configs, err := kubeClientset.CoreV1().ConfigMaps(openCostNamespace).Get(context.Background(), cw, metav1.GetOptions{})
 		if err != nil {
 			log.Infof("No %s configmap found at install time, using existing configs: %s", cw, err.Error())
 		} else {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -24,6 +24,7 @@ const (
 	AzureBillingAccountEnvVar = "AZURE_BILLING_ACCOUNT"
 
 	KubecostNamespaceEnvVar        = "KUBECOST_NAMESPACE"
+	OpenCostNamespaceEnvVar        = "OPENCOST_NAMESPACE"
 	PodNameEnvVar                  = "POD_NAME"
 	ClusterIDEnvVar                = "CLUSTER_ID"
 	ClusterProfileEnvVar           = "CLUSTER_PROFILE"
@@ -85,8 +86,10 @@ const (
 	PricingConfigmapName  = "PRICING_CONFIGMAP_NAME"
 	MetricsConfigmapName  = "METRICS_CONFIGMAP_NAME"
 	KubecostJobNameEnvVar = "KUBECOST_JOB_NAME"
+	OpenCostJobNameEnvVar = "OPENCOST_JOB_NAME"
 
 	KubecostConfigBucketEnvVar    = "KUBECOST_CONFIG_BUCKET"
+	OpenCostConfigBucketEnvVar    = "OPENCOST_CONFIG_BUCKET"
 	ClusterInfoFileEnabledEnvVar  = "CLUSTER_INFO_FILE_ENABLED"
 	ClusterCacheFileEnabledEnvVar = "CLUSTER_CACHE_FILE_ENABLED"
 
@@ -157,10 +160,14 @@ func GetAPIPort() int {
 	return env.GetInt(APIPortEnvVar, 9003)
 }
 
-// GetKubecostConfigBucket returns a file location for a mounted bucket configuration which is used to store
-// a subset of kubecost configurations that require sharing via remote storage.
-func GetKubecostConfigBucket() string {
-	return env.Get(KubecostConfigBucketEnvVar, "")
+// GetOpenCostConfigBucket returns a file location for a mounted bucket configuration which is used to store
+// a subset of opencost/kubecost configurations that require sharing via remote storage.
+func GetOpenCostConfigBucket() string {
+	bucket := env.Get(KubecostConfigBucketEnvVar, "")
+	if bucket == "" {
+		bucket = env.Get(OpenCostConfigBucketEnvVar, "")
+	}
+	return bucket
 }
 
 // IsClusterInfoFileEnabled returns true if the cluster info is read from a file or pulled from the local
@@ -308,10 +315,14 @@ func GetAzureBillingAccount() string {
 	return env.Get(AzureBillingAccountEnvVar, "")
 }
 
-// GetKubecostNamespace returns the environment variable value for KubecostNamespaceEnvVar which
-// represents the namespace the cost model exists in.
-func GetKubecostNamespace() string {
-	return env.Get(KubecostNamespaceEnvVar, "kubecost")
+// GetOpenCostNamespace returns the environment variable value for the namespace the cost model exists
+// in. If KUBECOST_NAMESPACE is set, that is used, if not OPENCOST_NAMESPACE or "opencost" is used
+func GetOpenCostNamespace() string {
+	namespace := env.Get(KubecostNamespaceEnvVar, "")
+	if namespace == "" {
+		namespace = env.Get(OpenCostNamespaceEnvVar, "opencost")
+	}
+	return namespace
 }
 
 // GetPodName returns the name of the current running pod. If this environment variable is not set,
@@ -532,9 +543,13 @@ func GetParsedUTCOffset() time.Duration {
 	return offset
 }
 
-// GetKubecostJobName returns the environment variable value for KubecostJobNameEnvVar
-func GetKubecostJobName() string {
-	return env.Get(KubecostJobNameEnvVar, "kubecost")
+// GetOpenCostJobName returns the environment variable value for KubecostJobNameEnvVar
+func GetOpenCostJobName() string {
+	jobname := env.Get(KubecostJobNameEnvVar, "")
+	if jobname == "" {
+		jobname = env.Get(OpenCostJobNameEnvVar, "opencost")
+	}
+	return jobname
 }
 
 func IsCacheWarmingEnabled() bool {

--- a/pkg/env/costmodelenv_test.go
+++ b/pkg/env/costmodelenv_test.go
@@ -190,5 +190,142 @@ func TestGetCloudCostConfigPath(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestGetOpenCostConfigBucket(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		pre  func()
+	}{
+		{
+			name: "Ensure the default value is ''",
+			want: "",
+		},
+		{
+			name: "Ensure the value is 'FOO' when KUBECOST_CONFIG_BUCKET is set to 'FOO'",
+			want: "FOO",
+			pre: func() {
+				os.Setenv("KUBECOST_CONFIG_BUCKET", "FOO")
+			},
+		},
+		{
+			name: "Ensure the value is 'FOO' when KUBECOST_CONFIG_BUCKET is set to 'FOO' and OPENCOST_CONFIG_BUCKET is set",
+			want: "FOO",
+			pre: func() {
+				os.Setenv("KUBECOST_CONFIG_BUCKET", "FOO")
+				os.Setenv("OPENCOST_CONFIG_BUCKET", "BAR")
+			},
+		},
+		{
+			name: "Ensure the value is 'BAR' when OPENCOST_CONFIG_BUCKET is set to 'BAR'",
+			want: "BAR",
+			pre: func() {
+				os.Setenv("KUBECOST_CONFIG_BUCKET", "")
+				os.Setenv("OPENCOST_CONFIG_BUCKET", "BAR")
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.pre != nil {
+			tt.pre()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetOpenCostConfigBucket(); got != tt.want {
+				t.Errorf("GetOpenCostConfigBucket() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOpenCostJobName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		pre  func()
+	}{
+		{
+			name: "Ensure the default value is 'opencost'",
+			want: "opencost",
+		},
+		{
+			name: "Ensure the value is 'FOO' when KUBECOST_JOB_NAME is set to 'FOO'",
+			want: "FOO",
+			pre: func() {
+				os.Setenv("KUBECOST_JOB_NAME", "FOO")
+			},
+		},
+		{
+			name: "Ensure the value is 'FOO' when KUBECOST_JOB_NAME is set to 'FOO' and OPENCOST_JOB_NAME is set",
+			want: "FOO",
+			pre: func() {
+				os.Setenv("KUBECOST_JOB_NAME", "FOO")
+				os.Setenv("OPENCOST_JOB_NAME", "BAR")
+			},
+		},
+		{
+			name: "Ensure the value is 'BAR' when OPENCOST_JOB_NAME is set to 'BAR'",
+			want: "BAR",
+			pre: func() {
+				os.Setenv("KUBECOST_JOB_NAME", "")
+				os.Setenv("OPENCOST_JOB_NAME", "BAR")
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.pre != nil {
+			tt.pre()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetOpenCostJobName(); got != tt.want {
+				t.Errorf("GetOpenCostJobName() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOpenCostNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		pre  func()
+	}{
+		{
+			name: "Ensure the default value is 'opencost'",
+			want: "opencost",
+		},
+		{
+			name: "Ensure the value is 'FOO' when KUBECOST_NAMESPACE is set to 'FOO'",
+			want: "FOO",
+			pre: func() {
+				os.Setenv("KUBECOST_NAMESPACE", "FOO")
+			},
+		},
+		{
+			name: "Ensure the value is 'FOO' when KUBECOST_NAMESPACE is set to 'FOO' and OPENCOST_NAMESPACE is set",
+			want: "FOO",
+			pre: func() {
+				os.Setenv("KUBECOST_NAMESPACE", "FOO")
+				os.Setenv("OPENCOST_NAMESPACE", "BAR")
+			},
+		},
+		{
+			name: "Ensure the value is 'BAR' when OPENCOST_NAMESPACE is set to 'BAR'",
+			want: "BAR",
+			pre: func() {
+				os.Setenv("KUBECOST_NAMESPACE", "")
+				os.Setenv("OPENCOST_NAMESPACE", "BAR")
+			},
+		},
+	}
+	for _, tt := range tests {
+		if tt.pre != nil {
+			tt.pre()
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetOpenCostNamespace(); got != tt.want {
+				t.Errorf("GetOpenCostNamespace() = %s, want %s", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
GetKubecostJobName->GetOpenCostJobName
GetKubecostNamespace->GetOpenCostNamespace
GetKubeostConfigBucket->GetOpenCostConfigBucket

## What does this PR change?
* Adds support for OPENCOST_NAMESPACE, OPENCOST_JOB_NAME, and OPENCOST_CONFIG_BUCKET without removing functionality of KUBECOST_* support. The defaults have changed, but if the environment variables were being used that shouldn't matter

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Probably very few were actually using it, it wasn't used by the OpenCost Helm chart

## Does this PR address any GitHub or Zendesk issues?
* Fixes https://github.com/opencost/opencost-website/issues/179

## How was this PR tested?
* added unit tests and local build/test

## Does this PR require changes to documentation?
* OpenCost usage was undocumented but noticed, need to verify values were being provided by Kubecost users

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes
