### PR TITLE
Parameterize "node" label in Prom queries

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -782,7 +782,7 @@ func resToNodeLabels(resNodeLabels []*prom.QueryResult) map[nodeKey]map[string]s
 	nodeLabels := map[nodeKey]map[string]string{}
 
 	for _, res := range resNodeLabels {
-		nodeKey, err := resultNodeKey(res, env.GetPromClusterLabel(), "node")
+		nodeKey, err := resultNodeKey(res, env.GetPromClusterLabel(), env.GetPromNodeLabel())
 		if err != nil {
 			continue
 		}

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -246,7 +246,7 @@ func applyCPUCoresAllocated(podMap map[podKey]*pod, resCPUCoresAllocated []*prom
 			hours := thisPod.Allocations[container].Minutes() / 60.0
 			thisPod.Allocations[container].CPUCoreHours = cpuCores * hours
 
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: CPU allocation query result missing 'node': %s", key)
 				continue
@@ -304,7 +304,7 @@ func applyCPUCoresRequested(podMap map[podKey]*pod, resCPUCoresRequested []*prom
 				log.Infof("[WARNING] Very large cpu allocation, clamping! to %f", res.Values[0].Value*(thisPod.Allocations[container].Minutes()/60.0))
 				thisPod.Allocations[container].CPUCoreHours = res.Values[0].Value * (thisPod.Allocations[container].Minutes() / 60.0)
 			}
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: CPU request query result missing 'node': %s", key)
 				continue
@@ -453,7 +453,7 @@ func applyRAMBytesAllocated(podMap map[podKey]*pod, resRAMBytesAllocated []*prom
 			hours := thisPod.Allocations[container].Minutes() / 60.0
 			thisPod.Allocations[container].RAMByteHours = ramBytes * hours
 
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: RAM allocation query result missing 'node': %s", key)
 				continue
@@ -508,7 +508,7 @@ func applyRAMBytesRequested(podMap map[podKey]*pod, resRAMBytesRequested []*prom
 				pod.Allocations[container].RAMByteHours = res.Values[0].Value * (pod.Allocations[container].Minutes() / 60.0)
 			}
 
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: RAM request query result missing 'node': %s", key)
 				continue
@@ -1473,7 +1473,7 @@ func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*nodePricing, resNodeCostPerCPUHr
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node CPU cost query result missing field: \"%s\" for node \"%s\"", err, node)
 			continue
@@ -1511,7 +1511,7 @@ func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*nodePricing, resNodeCostPerRA
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node RAM cost query result missing field: \"%s\" for node \"%s\"", err, node)
 			continue
@@ -1549,7 +1549,7 @@ func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*nodePricing, resNodeCostPerGPUHr
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node GPU cost query result missing field: \"%s\" for node \"%s\"", err, node)
 			continue
@@ -1587,7 +1587,7 @@ func applyNodeSpot(nodeMap map[nodeKey]*nodePricing, resNodeIsSpot []*prom.Query
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node spot query result missing field: %s", err)
 			continue

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -394,7 +394,7 @@ func ClusterDisks(client prometheus.Client, provider models.Provider, start, end
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.DedupedWarningf(5, "ClusterDisks: local active mins data missing instance")
 			continue

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -54,7 +54,7 @@ func buildCPUCostMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: CPU cost data missing node")
 			continue
@@ -128,7 +128,7 @@ func buildRAMCostMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: RAM cost data missing node")
 			continue
@@ -203,7 +203,7 @@ func buildGPUCostMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: GPU cost data missing node")
 			continue
@@ -271,7 +271,7 @@ func buildGPUCountMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: GPU count data missing node")
 			continue
@@ -303,7 +303,7 @@ func buildCPUCoresMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: CPU cores data missing node")
 			continue
@@ -331,7 +331,7 @@ func buildRAMBytesMap(resNodeRAMBytes []*prom.QueryResult) map[nodeIdentifierNoP
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: RAM bytes data missing node")
 			continue
@@ -538,7 +538,7 @@ func buildActiveDataMap(resActiveMins []*prom.QueryResult, resolution time.Durat
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: active mins missing node")
 			continue
@@ -579,7 +579,7 @@ func buildPreemptibleMap(
 	m := make(map[NodeIdentifier]bool)
 
 	for _, result := range resIsSpot {
-		nodeName, err := result.GetString("node")
+		nodeName, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			continue
 		}
@@ -626,7 +626,7 @@ func buildLabelsMap(
 		if err != nil {
 			cluster = env.GetClusterID()
 		}
-		node, err := result.GetString("node")
+		node, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.DedupedWarningf(5, "ClusterNodes: label data missing node")
 			continue

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -183,7 +183,7 @@ func NewContainerMetricFromPrometheus(metrics map[string]interface{}, defaultClu
 	if !ok {
 		return nil, NoNamespaceNameErr
 	}
-	node, ok := metrics["node"]
+	node, ok := metrics[env.GetPromNodeLabel()]
 	if !ok {
 		log.Debugf("Prometheus vector does not have node name")
 		node = ""

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -471,7 +471,7 @@ func getCost(qrs []*prom.QueryResult) (map[string][]*util.Vector, error) {
 	toReturn := make(map[string][]*util.Vector)
 
 	for _, val := range qrs {
-		instance, err := val.GetString("node")
+		instance, err := val.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			return toReturn, err
 		}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -82,6 +82,7 @@ const (
 	LegacyExternalAPIDisabledVar         = "LEGACY_EXTERNAL_API_DISABLED"
 
 	PromClusterIDLabelEnvVar = "PROM_CLUSTER_ID_LABEL"
+	PromNodeLabelEnvVar      = "PROM_NODE_LABEL"
 
 	PricingConfigmapName  = "PRICING_CONFIGMAP_NAME"
 	MetricsConfigmapName  = "METRICS_CONFIGMAP_NAME"
@@ -584,6 +585,10 @@ func LegacyExternalCostsAPIDisabled() bool {
 // GetPromClusterLabel returns the environment variable value for PromClusterIDLabel
 func GetPromClusterLabel() string {
 	return Get(PromClusterIDLabelEnvVar, "cluster_id")
+}
+
+func GetPromNodeLabel() string {
+	return Get(PromNodeLabelEnvVar, "node")
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the


### PR DESCRIPTION
## What does this PR change?
* OpenCost currently defaults to keying on the "node" label when querying Prom metrics. This PR adds additional configurability for this label name when querying Prom. You can configure this via the `PROM_NODE_LABEL` environment variable.
* Note: These changes were built on top of the `v1.108` branch for immediate testing. Eventually I will need to re-create this PR but built on top of `develop` branch.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* By default, there should be no impact

## Does this PR address any GitHub or Zendesk issues?
* None

## How was this PR tested?

Default configuration. No relabeling of Prom metrics. Ran with no errors.

```sh
$ kubectl port-forward svc/thomasn-pr2435-prometheus-server 9080:80
$ curl 'http://localhost:9080/api/v1/query?query=node_total_hourly_cost'
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","instance":"ip-192-168-123-57.us-east-2.compute.internal","instance_type":"t3.medium","job":"kubecost","node":"ip-192-168-123-57.us-east-2.compute.internal","provider_id":"aws:///us-east-2c/i-0d51e5f572aa72456","region":"us-east-2"},"value":[1704410784.648,"0.04159934823226929"]},{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","instance":"ip-192-168-190-131.us-east-2.compute.internal","instance_type":"t3.medium","job":"kubecost","node":"ip-192-168-190-131.us-east-2.compute.internal","provider_id":"aws:///us-east-2a/i-03b62262abd3b2f70","region":"us-east-2"},"value":[1704410784.648,"0.041599365253448484"]},{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","instance":"ip-192-168-2-230.us-east-2.compute.internal","instance_type":"m5a.2xlarge","job":"kubecost","node":"ip-192-168-2-230.us-east-2.compute.internal","provider_id":"aws:///us-east-2c/i-057517f5cd0eade6c","region":"us-east-2"},"value":[1704410784.648,"0.006665583831787109"]},{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","instance":"ip-192-168-5-235.us-east-2.compute.internal","instance_type":"m5a.2xlarge","job":"kubecost","node":"ip-192-168-5-235.us-east-2.compute.internal","provider_id":"aws:///us-east-2c/i-09251ca6787132cdd","region":"us-east-2"},"value":[1704410784.648,"0.006665583831787109"]}]}}
```

```sh
$ export PROMETHEUS_SERVER_ENDPOINT="http://127.0.0.1:9080"
$ export KUBECOST_NAMESPACE="thomasn-pr2435"
$ go run cmd/costmodel/main.go
```

Relabeled Prometheus metrics. All labels named `node` are replaced with the label `exported_node`. No errors.

```sh
$ kubectl port-forward svc/thomasn-pr2435-relabel-node-prometheus-server 9080:80
$ curl 'http://localhost:9080/api/v1/query?query=node_total_hourly_cost'
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","exported_node":"ip-192-168-101-163.us-east-2.compute.internal","instance":"ip-192-168-101-163.us-east-2.compute.internal","instance_type":"t3.medium","job":"kubecost","provider_id":"aws:///us-east-2c/i-09484ca6d8171547c","region":"us-east-2"},"value":[1704414187.810,"0.04159934823226929"]},{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","exported_node":"ip-192-168-127-246.us-east-2.compute.internal","instance":"ip-192-168-127-246.us-east-2.compute.internal","instance_type":"t3.medium","job":"kubecost","provider_id":"aws:///us-east-2c/i-0469fcd5347ec88b4","region":"us-east-2"},"value":[1704414187.810,"0.04159934823226929"]},{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","exported_node":"ip-192-168-2-230.us-east-2.compute.internal","instance":"ip-192-168-2-230.us-east-2.compute.internal","instance_type":"m5a.2xlarge","job":"kubecost","provider_id":"aws:///us-east-2c/i-057517f5cd0eade6c","region":"us-east-2"},"value":[1704414187.810,"0.006665583831787109"]},{"metric":{"__name__":"node_total_hourly_cost","arch":"amd64","exported_node":"ip-192-168-5-235.us-east-2.compute.internal","instance":"ip-192-168-5-235.us-east-2.compute.internal","instance_type":"m5a.2xlarge","job":"kubecost","provider_id":"aws:///us-east-2c/i-09251ca6787132cdd","region":"us-east-2"},"value":[1704414187.810,"0.006665583831787109"]}]}}
```

```sh
$ export PROMETHEUS_SERVER_ENDPOINT="http://127.0.0.1:9080"
$ export KUBECOST_NAMESPACE="thomasn-pr2435-relabel-node"
$ export PROM_NODE_LABEL="exported_node"
$ go run cmd/costmodel/main.go
```

Relabeled Prometheus metrics, but leave the default configs. We correctly see errors here.

```sh
$ export PROMETHEUS_SERVER_ENDPOINT="http://127.0.0.1:9080"
$ export KUBECOST_NAMESPACE="thomasn-pr2435-relabel-node"
$ export PROM_NODE_LABEL="node"
$ go run cmd/costmodel/main.go
WRN ClusterNodes: active mins missing node
WRN ClusterNodes: active mins missing node
WRN ClusterNodes: active mins missing node
WRN ClusterNodes: active mins missing node
WRN ClusterNodes: GPU count data missing node
WRN ClusterNodes: GPU count data missing node
WRN ClusterNodes: GPU count data missing node
WRN ClusterNodes: GPU count data missing node
WRN ClusterNodes: CPU cost data missing node
WRN ClusterNodes: CPU cost data missing node
WRN ClusterNodes: CPU cost data missing node
WRN ClusterNodes: CPU cost data missing node
WRN ClusterNodes: RAM cost data missing node
WRN ClusterNodes: RAM cost data missing node
WRN ClusterNodes: RAM cost data missing node
WRN ClusterNodes: RAM cost data missing node
WRN ClusterNodes: GPU cost data missing node
WRN ClusterNodes: GPU cost data missing node
WRN ClusterNodes: GPU cost data missing node
WRN ClusterNodes: GPU cost data missing node
WRN ClusterNodes: CPU cores data missing node
WRN ClusterNodes: RAM bytes data missing node
WRN ClusterNodes: CPU cores data missing node
WRN ClusterNodes: RAM bytes data missing node
WRN ClusterNodes: label data missing node
WRN ClusterNodes: label data missing node
WRN ClusterNodes: label data missing node
WRN ClusterNodes: label data missing node
WRN ClusterDisks: local active mins data missing instance
WRN unable to derive node pool name from node labels
WRN unable to derive node pool name from node labels
WRN unable to derive node pool name from node labels
WRN unable to derive node pool name from node labels
```

## Does this PR require changes to documentation?
* Yes. It will require similar docs update as the changes made for `PROM_CLUSTER_ID_LABEL`.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
