### PR TITLE
Fix azure cluster management price

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.0
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,12 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.9.0 h1:H+U3Gk9zY56G3u872L82bk4thcsy2Gghb9ExT4Zvm1o=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.9.0/go.mod h1:mgrmMSgaLp9hmax62XQTd0N4aAqSE5E0DulSpVYK7vc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.6.0 h1:AAIdAyPkFff6XTct2lQCxOWN/+LnA41S7kIkzKaMbyE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.6.0/go.mod h1:noQIdW75SiQFB3mSFJBr4iRRH83S9skaFiBv4C0uEs0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0 h1:AifHbc4mg0x9zW52WOpKbsHaDKuRhlI7TVl47thgQ70=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0/go.mod h1:T5RfihdXtBDxt1Ch2wobif3TvzTdumDy29kahv6AV9A=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.0 h1:IfFdxTUDiV58iZqPKgyWiz4X4fCxZeQ1pTQPImLYXpY=

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -925,25 +925,28 @@ func (az *Azure) DownloadPricingData() error {
 
 	envManagedClustersName := env.GetAzureClusterName()
 
-	err = az.refreshClusterManagementPricing(config, envResourceGroupName, envManagedClustersName)
-	if err != nil {
-		log.Errorf("error getting managed cluster cost: %s", err.Error())
-	}
+	if envResourceGroupName != "" && envManagedClustersName != "" {
 
-	// AKS Tier can change. So we need to refresh the tier information to get the cluster management cost.
-	go func() {
-		defer errs.HandlePanic()
-
-		for {
-			log.Infof("Azure AKS Tier Refresh scheduled in %.2f minutes.", AzureAksTierRefreshDuration.Minutes())
-			time.Sleep(AzureAksTierRefreshDuration)
-
-			err := az.refreshClusterManagementPricing(config, envResourceGroupName, envManagedClustersName)
-			if err != nil {
-				log.Errorf("error getting managed cluster cost: %s", err.Error())
-			}
+		err = az.refreshClusterManagementPricing(config, envResourceGroupName, envManagedClustersName)
+		if err != nil {
+			log.Errorf("error getting managed cluster cost: %s", err.Error())
 		}
-	}()
+
+		// AKS Tier can change. So we need to refresh the tier information to get the cluster management cost.
+		go func() {
+			defer errs.HandlePanic()
+
+			for {
+				log.Infof("Azure AKS Tier Refresh scheduled in %.2f minutes.", AzureAksTierRefreshDuration.Minutes())
+				time.Sleep(AzureAksTierRefreshDuration)
+
+				err := az.refreshClusterManagementPricing(config, envResourceGroupName, envManagedClustersName)
+				if err != nil {
+					log.Errorf("error getting managed cluster cost: %s", err.Error())
+				}
+			}
+		}()
+	}
 
 	return nil
 }

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1728,12 +1728,17 @@ func (az *Azure) refreshClusterManagementPricing(config *models.CustomPricing) e
 
 	managedCluster, err := getManagedCluster(ctx, managedClustersClient, config.AzureResourceGroupName, config.AzureClusterName)
 	if err != nil {
-		log.Errorf("error getting managed cluster cost: %s", err.Error())
+		log.Errorf("error getting AKS cluster %s info, err: %s", config.AzureClusterName, err.Error())
 		return nil
 	}
 
-	if managedCluster == nil || managedCluster.SKU == nil || managedCluster.SKU.Tier == nil {
-		log.Errorf("managed cluster info not present: %s", *managedCluster.ID)
+	if managedCluster == nil {
+		log.Errorf("managed cluster info not present: %s", config.AzureClusterName)
+		return nil
+	}
+
+	if managedCluster.SKU == nil || managedCluster.SKU.Tier == nil {
+		log.Errorf("managed cluster sku info not present. cluster name: %s, managed cluster id: %s", config.AzureClusterName, *managedCluster.ID)
 		return nil
 	}
 

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -181,8 +181,6 @@ type CustomPricing struct {
 	AzureStorageContainer        string `json:"azureStorageContainer"`
 	AzureContainerPath           string `json:"azureContainerPath"`
 	AzureCloud                   string `json:"azureCloud"`
-	AzureResourceGroupName       string `json:"azureResourceGroupName"`
-	AzureClusterName             string `json:"azureClusterName"`
 	CurrencyCode                 string `json:"currencyCode"`
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -181,6 +181,8 @@ type CustomPricing struct {
 	AzureStorageContainer        string `json:"azureStorageContainer"`
 	AzureContainerPath           string `json:"azureContainerPath"`
 	AzureCloud                   string `json:"azureCloud"`
+	AzureResourceGroupName       string `json:"azureResourceGroupName"`
+	AzureClusterName             string `json:"azureClusterName"`
 	CurrencyCode                 string `json:"currencyCode"`
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -23,6 +23,8 @@ const (
 	AzureOfferIDEnvVar                   = "AZURE_OFFER_ID"
 	AzureBillingAccountEnvVar            = "AZURE_BILLING_ACCOUNT"
 	AzureDownloadBillingDataToDiskEnvVar = "AZURE_DOWNLOAD_BILLING_DATA_TO_DISK"
+	AzureResourceGroupEnvVar             = "AZURE_RESOURCE_GROUP_NAME"
+	AzureClusterNameEnvVar               = "AZURE_CLUSTER_NAME"
 
 	KubecostNamespaceEnvVar        = "KUBECOST_NAMESPACE"
 	KubecostScrapeIntervalEnvVar   = "KUBECOST_SCRAPE_INTERVAL"
@@ -321,6 +323,22 @@ func GetAlibabaAccessKeySecret() string {
 // the Azure offer ID for determining prices.
 func GetAzureOfferID() string {
 	return env.Get(AzureOfferIDEnvVar, "")
+}
+
+// GetAzureResourceGroupName returns the environment variable value for
+// AzureResourceGroupEnvVar which represents the Azure resource
+// group in which the cluster was created. This is being used to get
+// pricing tier of AKS
+func GetAzureResourceGroupName() string {
+	return env.Get(AzureResourceGroupEnvVar, "")
+}
+
+// GetAzureClusterName returns the environment variable value for
+// AzureClusterNameEnvVar which represents the Azure cluster
+// name. This is being used to get
+// pricing tier of AKS
+func GetAzureClusterName() string {
+	return env.Get(AzureClusterNameEnvVar, "")
 }
 
 // GetAzureBillingAccount returns the environment variable value for


### PR DESCRIPTION
## What does this PR change?
* Currently, cluster management cost for AKS is being reported as $0. The cluster management cost depends upon the tier of the AKS cluster. The tier of the AKS cluster can be changed. The change in this PR takes the cluster's name and resource group name as environment variables and calls Azure API to get the tier of the cluster every 15 minutes. The price according to the tier is then reported as cluster management cost.

## Does this PR relate to any other PRs?
* Not that I am aware of

## How will this PR impact users?
* If the users configure Azure cluster name and resource group name as environment variables, they will be able to get cluster management cost of their AKS cluster. 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* This PR was tested on an AKS cluster on Free, Standard and Premium tiers.

## Does this PR require changes to documentation?
* Yes, the environment variable change may require change in documentation

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Release eligibility has not yet been determined.
