### PR TITLE
Parameterize "node" and "namespace" label in Prom queries

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1754,7 +1754,7 @@ func (a *Accesses) warmAggregateCostModelCache() {
 			return nil, fmt.Errorf("invalid window from window string: %s", windowStr)
 		}
 
-		field := "namespace"
+		field := "namespace" // TODO: Parameterize?
 		subfields := []string{}
 
 		aggOpts := DefaultAggregateQueryOpts()

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -443,7 +443,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryNodeIsSpot := fmt.Sprintf(queryFmtNodeIsSpot, env.GetPromClusterFilter(), durStr)
 	resChNodeIsSpot := ctx.QueryAtTime(queryNodeIsSpot, end)
 
-	queryPVCInfo := fmt.Sprintf(queryFmtPVCInfo, env.GetPromClusterFilter(), env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
+	queryPVCInfo := fmt.Sprintf(queryFmtPVCInfo, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
 	resChPVCInfo := ctx.QueryAtTime(queryPVCInfo, end)
 
 	queryPodPVCAllocation := fmt.Sprintf(queryFmtPodPVCAllocation, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -389,10 +389,10 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryRAMRequests := fmt.Sprintf(queryFmtRAMRequests, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChRAMRequests := ctx.QueryAtTime(queryRAMRequests, end)
 
-	queryRAMUsageAvg := fmt.Sprintf(queryFmtRAMUsageAvg, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryRAMUsageAvg := fmt.Sprintf(queryFmtRAMUsageAvg, env.GetPromClusterFilter(), durStr, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChRAMUsageAvg := ctx.QueryAtTime(queryRAMUsageAvg, end)
 
-	queryRAMUsageMax := fmt.Sprintf(queryFmtRAMUsageMax, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryRAMUsageMax := fmt.Sprintf(queryFmtRAMUsageMax, env.GetPromClusterFilter(), durStr, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChRAMUsageMax := ctx.QueryAtTime(queryRAMUsageMax, end)
 
 	queryCPUCoresAllocated := fmt.Sprintf(queryFmtCPUCoresAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
@@ -401,10 +401,10 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryCPURequests := fmt.Sprintf(queryFmtCPURequests, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChCPURequests := ctx.QueryAtTime(queryCPURequests, end)
 
-	queryCPUUsageAvg := fmt.Sprintf(queryFmtCPUUsageAvg, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryCPUUsageAvg := fmt.Sprintf(queryFmtCPUUsageAvg, env.GetPromClusterFilter(), durStr, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChCPUUsageAvg := ctx.QueryAtTime(queryCPUUsageAvg, end)
 
-	queryCPUUsageMax := fmt.Sprintf(queryFmtCPUUsageMaxRecordingRule, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryCPUUsageMax := fmt.Sprintf(queryFmtCPUUsageMaxRecordingRule, env.GetPromClusterFilter(), durStr, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChCPUUsageMax := ctx.QueryAtTime(queryCPUUsageMax, end)
 	resCPUUsageMax, _ := resChCPUUsageMax.Await()
 	// If the recording rule has no data, try to fall back to the subquery.
@@ -414,7 +414,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 		// in case the Prom scrape duration has been reduced to be equal to the
 		// resolution.
 		doubleResStr := timeutil.DurationString(2 * resolution)
-		queryCPUUsageMax = fmt.Sprintf(queryFmtCPUUsageMaxSubquery, env.GetPromClusterFilter(), doubleResStr, durStr, resStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+		queryCPUUsageMax = fmt.Sprintf(queryFmtCPUUsageMaxSubquery, env.GetPromClusterFilter(), doubleResStr, durStr, resStr, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
 		resChCPUUsageMax = ctx.QueryAtTime(queryCPUUsageMax, end)
 		resCPUUsageMax, _ = resChCPUUsageMax.Await()
 
@@ -443,7 +443,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryNodeIsSpot := fmt.Sprintf(queryFmtNodeIsSpot, env.GetPromClusterFilter(), durStr)
 	resChNodeIsSpot := ctx.QueryAtTime(queryNodeIsSpot, end)
 
-	queryPVCInfo := fmt.Sprintf(queryFmtPVCInfo, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
+	queryPVCInfo := fmt.Sprintf(queryFmtPVCInfo, env.GetPromClusterFilter(), env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
 	resChPVCInfo := ctx.QueryAtTime(queryPVCInfo, end)
 
 	queryPodPVCAllocation := fmt.Sprintf(queryFmtPodPVCAllocation, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -17,37 +17,37 @@ const (
 	// upstream KSM has implementation change vs OC internal KSM - it sets metric to 0 when pod goes down
 	// VS OC implementation which stops emitting it
 	// by adding != 0 filter, we keep just the active times in the prom result
-	queryFmtPods    = `avg(kube_pod_container_status_running{%s} != 0) by (pod, namespace, %s)[%s:%s]`
-	queryFmtPodsUID = `avg(kube_pod_container_status_running{%s} != 0) by (pod, namespace, uid, %s)[%s:%s]`
+	queryFmtPods    = `avg(kube_pod_container_status_running{%s} != 0) by (pod, %s, %s)[%s:%s]`
+	queryFmtPodsUID = `avg(kube_pod_container_status_running{%s} != 0) by (pod, %s, uid, %s)[%s:%s]`
 
-	queryFmtRAMBytesAllocated           = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, namespace, %s, %s, provider_id)`
-	queryFmtRAMRequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, namespace, %s, %s)`
-	queryFmtRAMUsageAvg                 = `avg(avg_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
-	queryFmtRAMUsageMax                 = `max(max_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
-	queryFmtCPUCoresAllocated           = `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, namespace, %s, %s)`
-	queryFmtCPURequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, namespace, %s, %s)`
-	queryFmtCPUUsageAvg                 = `avg(rate(container_cpu_usage_seconds_total{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
-	queryFmtGPUsRequested               = `avg(avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", %s!="", %s}[%s])) by (container, pod, namespace, %s, %s)`
-	queryFmtGPUsAllocated               = `avg(avg_over_time(container_gpu_allocation{container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, namespace, %s, %s)`
+	queryFmtRAMBytesAllocated           = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, %s, %s, %s, provider_id)`
+	queryFmtRAMRequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, %s, %s, %s)`
+	queryFmtRAMUsageAvg                 = `avg(avg_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, %s, instance, %s)`
+	queryFmtRAMUsageMax                 = `max(max_over_time(container_memory_working_set_bytes{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, %s, instance, %s)`
+	queryFmtCPUCoresAllocated           = `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, %s, %s, %s)`
+	queryFmtCPURequests                 = `avg(avg_over_time(kube_pod_container_resource_requests{resource="cpu", unit="core", container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, %s, %s, %s)`
+	queryFmtCPUUsageAvg                 = `avg(rate(container_cpu_usage_seconds_total{container!="", container_name!="POD", container!="POD", %s}[%s])) by (container_name, container, pod_name, pod, %s, instance, %s)`
+	queryFmtGPUsRequested               = `avg(avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", %s!="", %s}[%s])) by (container, pod, %s, %s, %s)`
+	queryFmtGPUsAllocated               = `avg(avg_over_time(container_gpu_allocation{container!="", container!="POD", %s!="", %s}[%s])) by (container, pod, %s, %s, %s)`
 	queryFmtNodeCostPerCPUHr            = `avg(avg_over_time(node_cpu_hourly_cost{%s}[%s])) by (%s, %s, instance_type, provider_id)`
 	queryFmtNodeCostPerRAMGiBHr         = `avg(avg_over_time(node_ram_hourly_cost{%s}[%s])) by (%s, %s, instance_type, provider_id)`
 	queryFmtNodeCostPerGPUHr            = `avg(avg_over_time(node_gpu_hourly_cost{%s}[%s])) by (%s, %s, instance_type, provider_id)`
 	queryFmtNodeIsSpot                  = `avg_over_time(kubecost_node_is_spot{%s}[%s])`
-	queryFmtPVCInfo                     = `avg(kube_persistentvolumeclaim_info{volumename != "", %s}) by (persistentvolumeclaim, storageclass, volumename, namespace, %s)[%s:%s]`
-	queryFmtPodPVCAllocation            = `avg(avg_over_time(pod_pvc_allocation{%s}[%s])) by (persistentvolume, persistentvolumeclaim, pod, namespace, %s)`
-	queryFmtPVCBytesRequested           = `avg(avg_over_time(kube_persistentvolumeclaim_resource_requests_storage_bytes{%s}[%s])) by (persistentvolumeclaim, namespace, %s)`
+	queryFmtPVCInfo                     = `avg(kube_persistentvolumeclaim_info{volumename != "", %s}) by (persistentvolumeclaim, storageclass, volumename, %s, %s)[%s:%s]`
+	queryFmtPodPVCAllocation            = `avg(avg_over_time(pod_pvc_allocation{%s}[%s])) by (persistentvolume, persistentvolumeclaim, pod, %s, %s)`
+	queryFmtPVCBytesRequested           = `avg(avg_over_time(kube_persistentvolumeclaim_resource_requests_storage_bytes{%s}[%s])) by (persistentvolumeclaim, %s, %s)`
 	queryFmtPVActiveMins                = `count(kube_persistentvolume_capacity_bytes{%s}) by (persistentvolume, %s)[%s:%s]`
 	queryFmtPVBytes                     = `avg(avg_over_time(kube_persistentvolume_capacity_bytes{%s}[%s])) by (persistentvolume, %s)`
 	queryFmtPVCostPerGiBHour            = `avg(avg_over_time(pv_hourly_cost{%s}[%s])) by (volumename, %s)`
 	queryFmtPVMeta                      = `avg(avg_over_time(kubecost_pv_info{%s}[%s])) by (%s, persistentvolume, provider_id)`
-	queryFmtNetZoneGiB                  = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", sameZone="false", sameRegion="true", %s}[%s])) by (pod_name, namespace, %s) / 1024 / 1024 / 1024`
+	queryFmtNetZoneGiB                  = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", sameZone="false", sameRegion="true", %s}[%s])) by (pod_name, %s, %s) / 1024 / 1024 / 1024`
 	queryFmtNetZoneCostPerGiB           = `avg(avg_over_time(kubecost_network_zone_egress_cost{%s}[%s])) by (%s)`
-	queryFmtNetRegionGiB                = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", sameZone="false", sameRegion="false", %s}[%s])) by (pod_name, namespace, %s) / 1024 / 1024 / 1024`
+	queryFmtNetRegionGiB                = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", sameZone="false", sameRegion="false", %s}[%s])) by (pod_name, %s, %s) / 1024 / 1024 / 1024`
 	queryFmtNetRegionCostPerGiB         = `avg(avg_over_time(kubecost_network_region_egress_cost{%s}[%s])) by (%s)`
-	queryFmtNetInternetGiB              = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="true", %s}[%s])) by (pod_name, namespace, %s) / 1024 / 1024 / 1024`
+	queryFmtNetInternetGiB              = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="true", %s}[%s])) by (pod_name, %s, %s) / 1024 / 1024 / 1024`
 	queryFmtNetInternetCostPerGiB       = `avg(avg_over_time(kubecost_network_internet_egress_cost{%s}[%s])) by (%s)`
-	queryFmtNetReceiveBytes             = `sum(increase(container_network_receive_bytes_total{pod!="", %s}[%s])) by (pod_name, pod, namespace, %s)`
-	queryFmtNetTransferBytes            = `sum(increase(container_network_transmit_bytes_total{pod!="", %s}[%s])) by (pod_name, pod, namespace, %s)`
+	queryFmtNetReceiveBytes             = `sum(increase(container_network_receive_bytes_total{pod!="", %s}[%s])) by (pod_name, pod, %s, %s)`
+	queryFmtNetTransferBytes            = `sum(increase(container_network_transmit_bytes_total{pod!="", %s}[%s])) by (pod_name, pod, %s, %s)`
 	queryFmtNodeLabels                  = `avg_over_time(kube_node_labels{%s}[%s])`
 	queryFmtNamespaceLabels             = `avg_over_time(kube_namespace_labels{%s}[%s])`
 	queryFmtNamespaceAnnotations        = `avg_over_time(kube_namespace_annotations{%s}[%s])`
@@ -56,13 +56,13 @@ const (
 	queryFmtServiceLabels               = `avg_over_time(service_selector_labels{%s}[%s])`
 	queryFmtDeploymentLabels            = `avg_over_time(deployment_match_labels{%s}[%s])`
 	queryFmtStatefulSetLabels           = `avg_over_time(statefulSet_match_labels{%s}[%s])`
-	queryFmtDaemonSetLabels             = `sum(avg_over_time(kube_pod_owner{owner_kind="DaemonSet", %s}[%s])) by (pod, owner_name, namespace, %s)`
-	queryFmtJobLabels                   = `sum(avg_over_time(kube_pod_owner{owner_kind="Job", %s}[%s])) by (pod, owner_name, namespace ,%s)`
-	queryFmtPodsWithReplicaSetOwner     = `sum(avg_over_time(kube_pod_owner{owner_kind="ReplicaSet", %s}[%s])) by (pod, owner_name, namespace ,%s)`
-	queryFmtReplicaSetsWithoutOwners    = `avg(avg_over_time(kube_replicaset_owner{owner_kind="<none>", owner_name="<none>", %s}[%s])) by (replicaset, namespace, %s)`
-	queryFmtReplicaSetsWithRolloutOwner = `avg(avg_over_time(kube_replicaset_owner{owner_kind="Rollout", %s}[%s])) by (replicaset, namespace, owner_kind, owner_name, %s)`
-	queryFmtLBCostPerHr                 = `avg(avg_over_time(kubecost_load_balancer_cost{%s}[%s])) by (namespace, service_name, ingress_ip, %s)`
-	queryFmtLBActiveMins                = `count(kubecost_load_balancer_cost{%s}) by (namespace, service_name, %s)[%s:%s]`
+	queryFmtDaemonSetLabels             = `sum(avg_over_time(kube_pod_owner{owner_kind="DaemonSet", %s}[%s])) by (pod, owner_name, %s, %s)`
+	queryFmtJobLabels                   = `sum(avg_over_time(kube_pod_owner{owner_kind="Job", %s}[%s])) by (pod, owner_name, %s ,%s)`
+	queryFmtPodsWithReplicaSetOwner     = `sum(avg_over_time(kube_pod_owner{owner_kind="ReplicaSet", %s}[%s])) by (pod, owner_name, %s ,%s)`
+	queryFmtReplicaSetsWithoutOwners    = `avg(avg_over_time(kube_replicaset_owner{owner_kind="<none>", owner_name="<none>", %s}[%s])) by (replicaset, %s, %s)`
+	queryFmtReplicaSetsWithRolloutOwner = `avg(avg_over_time(kube_replicaset_owner{owner_kind="Rollout", %s}[%s])) by (replicaset, %s, owner_kind, owner_name, %s)`
+	queryFmtLBCostPerHr                 = `avg(avg_over_time(kubecost_load_balancer_cost{%s}[%s])) by (%s, service_name, ingress_ip, %s)`
+	queryFmtLBActiveMins                = `count(kubecost_load_balancer_cost{%s}) by (%s, service_name, %s)[%s:%s]`
 	queryFmtOldestSample                = `min_over_time(timestamp(group(node_cpu_hourly_cost{%s}))[%s:%s])`
 	queryFmtNewestSample                = `max_over_time(timestamp(group(node_cpu_hourly_cost{%s}))[%s:%s])`
 
@@ -79,7 +79,7 @@ const (
 	//
 	// If changing the name of the recording rule, make sure to update the
 	// corresponding diagnostic query to avoid confusion.
-	queryFmtCPUUsageMaxRecordingRule = `max(max_over_time(kubecost_container_cpu_usage_irate{%s}[%s])) by (container_name, container, pod_name, pod, namespace, instance, %s)`
+	queryFmtCPUUsageMaxRecordingRule = `max(max_over_time(kubecost_container_cpu_usage_irate{%s}[%s])) by (container_name, container, pod_name, pod, %s, instance, %s)`
 	// This is the subquery equivalent of the above recording rule query. It is
 	// more expensive, but does not require the recording rule. It should be
 	// used as a fallback query if the recording rule data does not exist.
@@ -90,7 +90,7 @@ const (
 	// the resolution, to make sure the irate always has two points to query
 	// in case the Prom scrape duration has been reduced to be equal to the
 	// ETL resolution.
-	queryFmtCPUUsageMaxSubquery = `max(max_over_time(irate(container_cpu_usage_seconds_total{container!="POD", container!="", %s}[%s])[%s:%s])) by (container, pod_name, pod, namespace, instance, %s)`
+	queryFmtCPUUsageMaxSubquery = `max(max_over_time(irate(container_cpu_usage_seconds_total{container!="POD", container!="", %s}[%s])[%s:%s])) by (container, pod_name, pod, %s, instance, %s)`
 )
 
 // Constants for Network Cost Subtype
@@ -383,28 +383,28 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 
 	ctx := prom.NewNamedContext(cm.PrometheusClient, prom.AllocationContextName)
 
-	queryRAMBytesAllocated := fmt.Sprintf(queryFmtRAMBytesAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryRAMBytesAllocated := fmt.Sprintf(queryFmtRAMBytesAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChRAMBytesAllocated := ctx.QueryAtTime(queryRAMBytesAllocated, end)
 
-	queryRAMRequests := fmt.Sprintf(queryFmtRAMRequests, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryRAMRequests := fmt.Sprintf(queryFmtRAMRequests, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChRAMRequests := ctx.QueryAtTime(queryRAMRequests, end)
 
-	queryRAMUsageAvg := fmt.Sprintf(queryFmtRAMUsageAvg, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryRAMUsageAvg := fmt.Sprintf(queryFmtRAMUsageAvg, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChRAMUsageAvg := ctx.QueryAtTime(queryRAMUsageAvg, end)
 
-	queryRAMUsageMax := fmt.Sprintf(queryFmtRAMUsageMax, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryRAMUsageMax := fmt.Sprintf(queryFmtRAMUsageMax, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChRAMUsageMax := ctx.QueryAtTime(queryRAMUsageMax, end)
 
-	queryCPUCoresAllocated := fmt.Sprintf(queryFmtCPUCoresAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryCPUCoresAllocated := fmt.Sprintf(queryFmtCPUCoresAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChCPUCoresAllocated := ctx.QueryAtTime(queryCPUCoresAllocated, end)
 
-	queryCPURequests := fmt.Sprintf(queryFmtCPURequests, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryCPURequests := fmt.Sprintf(queryFmtCPURequests, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChCPURequests := ctx.QueryAtTime(queryCPURequests, end)
 
-	queryCPUUsageAvg := fmt.Sprintf(queryFmtCPUUsageAvg, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryCPUUsageAvg := fmt.Sprintf(queryFmtCPUUsageAvg, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChCPUUsageAvg := ctx.QueryAtTime(queryCPUUsageAvg, end)
 
-	queryCPUUsageMax := fmt.Sprintf(queryFmtCPUUsageMaxRecordingRule, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryCPUUsageMax := fmt.Sprintf(queryFmtCPUUsageMaxRecordingRule, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChCPUUsageMax := ctx.QueryAtTime(queryCPUUsageMax, end)
 	resCPUUsageMax, _ := resChCPUUsageMax.Await()
 	// If the recording rule has no data, try to fall back to the subquery.
@@ -414,7 +414,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 		// in case the Prom scrape duration has been reduced to be equal to the
 		// resolution.
 		doubleResStr := timeutil.DurationString(2 * resolution)
-		queryCPUUsageMax = fmt.Sprintf(queryFmtCPUUsageMaxSubquery, env.GetPromClusterFilter(), doubleResStr, durStr, resStr, env.GetPromClusterLabel())
+		queryCPUUsageMax = fmt.Sprintf(queryFmtCPUUsageMaxSubquery, env.GetPromClusterFilter(), doubleResStr, durStr, resStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 		resChCPUUsageMax = ctx.QueryAtTime(queryCPUUsageMax, end)
 		resCPUUsageMax, _ = resChCPUUsageMax.Await()
 
@@ -425,10 +425,10 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 		}
 	}
 
-	queryGPUsRequested := fmt.Sprintf(queryFmtGPUsRequested, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryGPUsRequested := fmt.Sprintf(queryFmtGPUsRequested, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChGPUsRequested := ctx.QueryAtTime(queryGPUsRequested, end)
 
-	queryGPUsAllocated := fmt.Sprintf(queryFmtGPUsAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryGPUsAllocated := fmt.Sprintf(queryFmtGPUsAllocated, env.GetPromNodeLabel(), env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	resChGPUsAllocated := ctx.QueryAtTime(queryGPUsAllocated, end)
 
 	queryNodeCostPerCPUHr := fmt.Sprintf(queryFmtNodeCostPerCPUHr, env.GetPromClusterFilter(), durStr, env.GetPromNodeLabel(), env.GetPromClusterLabel())
@@ -443,13 +443,13 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryNodeIsSpot := fmt.Sprintf(queryFmtNodeIsSpot, env.GetPromClusterFilter(), durStr)
 	resChNodeIsSpot := ctx.QueryAtTime(queryNodeIsSpot, end)
 
-	queryPVCInfo := fmt.Sprintf(queryFmtPVCInfo, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, resStr)
+	queryPVCInfo := fmt.Sprintf(queryFmtPVCInfo, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
 	resChPVCInfo := ctx.QueryAtTime(queryPVCInfo, end)
 
-	queryPodPVCAllocation := fmt.Sprintf(queryFmtPodPVCAllocation, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryPodPVCAllocation := fmt.Sprintf(queryFmtPodPVCAllocation, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChPodPVCAllocation := ctx.QueryAtTime(queryPodPVCAllocation, end)
 
-	queryPVCBytesRequested := fmt.Sprintf(queryFmtPVCBytesRequested, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryPVCBytesRequested := fmt.Sprintf(queryFmtPVCBytesRequested, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChPVCBytesRequested := ctx.QueryAtTime(queryPVCBytesRequested, end)
 
 	queryPVActiveMins := fmt.Sprintf(queryFmtPVActiveMins, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, resStr)
@@ -464,25 +464,25 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryPVMeta := fmt.Sprintf(queryFmtPVMeta, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
 	resChPVMeta := ctx.QueryAtTime(queryPVMeta, end)
 
-	queryNetTransferBytes := fmt.Sprintf(queryFmtNetTransferBytes, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryNetTransferBytes := fmt.Sprintf(queryFmtNetTransferBytes, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChNetTransferBytes := ctx.QueryAtTime(queryNetTransferBytes, end)
 
-	queryNetReceiveBytes := fmt.Sprintf(queryFmtNetReceiveBytes, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryNetReceiveBytes := fmt.Sprintf(queryFmtNetReceiveBytes, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChNetReceiveBytes := ctx.QueryAtTime(queryNetReceiveBytes, end)
 
-	queryNetZoneGiB := fmt.Sprintf(queryFmtNetZoneGiB, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryNetZoneGiB := fmt.Sprintf(queryFmtNetZoneGiB, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChNetZoneGiB := ctx.QueryAtTime(queryNetZoneGiB, end)
 
 	queryNetZoneCostPerGiB := fmt.Sprintf(queryFmtNetZoneCostPerGiB, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
 	resChNetZoneCostPerGiB := ctx.QueryAtTime(queryNetZoneCostPerGiB, end)
 
-	queryNetRegionGiB := fmt.Sprintf(queryFmtNetRegionGiB, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryNetRegionGiB := fmt.Sprintf(queryFmtNetRegionGiB, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChNetRegionGiB := ctx.QueryAtTime(queryNetRegionGiB, end)
 
 	queryNetRegionCostPerGiB := fmt.Sprintf(queryFmtNetRegionCostPerGiB, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
 	resChNetRegionCostPerGiB := ctx.QueryAtTime(queryNetRegionCostPerGiB, end)
 
-	queryNetInternetGiB := fmt.Sprintf(queryFmtNetInternetGiB, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryNetInternetGiB := fmt.Sprintf(queryFmtNetInternetGiB, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChNetInternetGiB := ctx.QueryAtTime(queryNetInternetGiB, end)
 
 	queryNetInternetCostPerGiB := fmt.Sprintf(queryFmtNetInternetCostPerGiB, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
@@ -515,25 +515,25 @@ func (cm *CostModel) computeAllocation(start, end time.Time, resolution time.Dur
 	queryStatefulSetLabels := fmt.Sprintf(queryFmtStatefulSetLabels, env.GetPromClusterFilter(), durStr)
 	resChStatefulSetLabels := ctx.QueryAtTime(queryStatefulSetLabels, end)
 
-	queryDaemonSetLabels := fmt.Sprintf(queryFmtDaemonSetLabels, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryDaemonSetLabels := fmt.Sprintf(queryFmtDaemonSetLabels, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChDaemonSetLabels := ctx.QueryAtTime(queryDaemonSetLabels, end)
 
-	queryPodsWithReplicaSetOwner := fmt.Sprintf(queryFmtPodsWithReplicaSetOwner, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryPodsWithReplicaSetOwner := fmt.Sprintf(queryFmtPodsWithReplicaSetOwner, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChPodsWithReplicaSetOwner := ctx.QueryAtTime(queryPodsWithReplicaSetOwner, end)
 
-	queryReplicaSetsWithoutOwners := fmt.Sprintf(queryFmtReplicaSetsWithoutOwners, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryReplicaSetsWithoutOwners := fmt.Sprintf(queryFmtReplicaSetsWithoutOwners, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChReplicaSetsWithoutOwners := ctx.QueryAtTime(queryReplicaSetsWithoutOwners, end)
 
-	queryReplicaSetsWithRolloutOwner := fmt.Sprintf(queryFmtReplicaSetsWithRolloutOwner, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryReplicaSetsWithRolloutOwner := fmt.Sprintf(queryFmtReplicaSetsWithRolloutOwner, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChReplicaSetsWithRolloutOwner := ctx.QueryAtTime(queryReplicaSetsWithRolloutOwner, end)
 
-	queryJobLabels := fmt.Sprintf(queryFmtJobLabels, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryJobLabels := fmt.Sprintf(queryFmtJobLabels, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChJobLabels := ctx.QueryAtTime(queryJobLabels, end)
 
-	queryLBCostPerHr := fmt.Sprintf(queryFmtLBCostPerHr, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryLBCostPerHr := fmt.Sprintf(queryFmtLBCostPerHr, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	resChLBCostPerHr := ctx.QueryAtTime(queryLBCostPerHr, end)
 
-	queryLBActiveMins := fmt.Sprintf(queryFmtLBActiveMins, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, resStr)
+	queryLBActiveMins := fmt.Sprintf(queryFmtLBActiveMins, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
 	resChLBActiveMins := ctx.QueryAtTime(queryLBActiveMins, end)
 
 	resCPUCoresAllocated, _ := resChCPUCoresAllocated.Await()

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -1879,13 +1879,13 @@ func buildPVCMap(resolution time.Duration, pvcMap map[pvcKey]*pvc, pvMap map[pvK
 			cluster = env.GetClusterID()
 		}
 
-		values, err := res.GetStrings("persistentvolumeclaim", "storageclass", "volumename", env.GetDefaultPromNamespaceLabel())
+		values, err := res.GetStrings("persistentvolumeclaim", "storageclass", "volumename", env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: pvc info query result missing field: %s", err)
 			continue
 		}
 
-		namespace := values[env.GetDefaultPromNamespaceLabel()]
+		namespace := values[env.GetPromNamespaceLabel()]
 		name := values["persistentvolumeclaim"]
 		volume := values["volumename"]
 		storageClass := values["storageclass"]

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -77,9 +77,9 @@ func (cm *CostModel) buildPodMap(window kubecost.Window, resolution, maxBatchSiz
 			var queryPods string
 			// If ingesting UIDs, avg on them
 			if ingestPodUID {
-				queryPods = fmt.Sprintf(queryFmtPodsUID, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, resStr)
+				queryPods = fmt.Sprintf(queryFmtPodsUID, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
 			} else {
-				queryPods = fmt.Sprintf(queryFmtPods, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, resStr)
+				queryPods = fmt.Sprintf(queryFmtPods, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, resStr)
 			}
 
 			queryProfile := time.Now()
@@ -839,7 +839,7 @@ func resToPodLabels(resPodLabels []*prom.QueryResult, podUIDKeyMap map[podKey][]
 	podLabels := map[podKey]map[string]string{}
 
 	for _, res := range resPodLabels {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			continue
 		}

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -317,7 +317,7 @@ func applyCPUCoresRequested(podMap map[podKey]*pod, resCPUCoresRequested []*prom
 
 func applyCPUCoresUsedAvg(podMap map[podKey]*pod, resCPUCoresUsedAvg []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resCPUCoresUsedAvg {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage avg result missing field: %s", err)
 			continue
@@ -365,7 +365,7 @@ func applyCPUCoresUsedAvg(podMap map[podKey]*pod, resCPUCoresUsedAvg []*prom.Que
 
 func applyCPUCoresUsedMax(podMap map[podKey]*pod, resCPUCoresUsedMax []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resCPUCoresUsedMax {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage max result missing field: %s", err)
 			continue
@@ -521,7 +521,7 @@ func applyRAMBytesRequested(podMap map[podKey]*pod, resRAMBytesRequested []*prom
 
 func applyRAMBytesUsedAvg(podMap map[podKey]*pod, resRAMBytesUsedAvg []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resRAMBytesUsedAvg {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM avg usage result missing field: %s", err)
 			continue
@@ -565,7 +565,7 @@ func applyRAMBytesUsedAvg(podMap map[podKey]*pod, resRAMBytesUsedAvg []*prom.Que
 
 func applyRAMBytesUsedMax(podMap map[podKey]*pod, resRAMBytesUsedMax []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resRAMBytesUsedMax {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage max result missing field: %s", err)
 			continue
@@ -1879,13 +1879,13 @@ func buildPVCMap(resolution time.Duration, pvcMap map[pvcKey]*pvc, pvMap map[pvK
 			cluster = env.GetClusterID()
 		}
 
-		values, err := res.GetStrings("persistentvolumeclaim", "storageclass", "volumename", env.GetPromNamespaceLabel())
+		values, err := res.GetStrings("persistentvolumeclaim", "storageclass", "volumename", env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: pvc info query result missing field: %s", err)
 			continue
 		}
 
-		namespace := values[env.GetPromNamespaceLabel()]
+		namespace := values[env.GetDefaultPromNamespaceLabel()]
 		name := values["persistentvolumeclaim"]
 		volume := values["volumename"]
 		storageClass := values["storageclass"]

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -782,7 +782,7 @@ func resToNodeLabels(resNodeLabels []*prom.QueryResult) map[nodeKey]map[string]s
 	nodeLabels := map[nodeKey]map[string]string{}
 
 	for _, res := range resNodeLabels {
-		nodeKey, err := resultNodeKey(res, env.GetPromClusterLabel(), "node")
+		nodeKey, err := resultNodeKey(res, env.GetPromClusterLabel(), env.GetPromNodeLabel())
 		if err != nil {
 			continue
 		}

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -136,13 +136,13 @@ func applyPodResults(window kubecost.Window, resolution time.Duration, podMap ma
 			cluster = env.GetClusterID()
 		}
 
-		labels, err := res.GetStrings("namespace", "pod")
+		labels, err := res.GetStrings(env.GetPromNamespaceLabel(), "pod")
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: minutes query result missing field: %s", err)
 			continue
 		}
 
-		namespace := labels["namespace"]
+		namespace := labels[env.GetPromNamespaceLabel()]
 		podName := labels["pod"]
 		key := newPodKey(cluster, namespace, podName)
 
@@ -204,7 +204,7 @@ func applyPodResults(window kubecost.Window, resolution time.Duration, podMap ma
 
 func applyCPUCoresAllocated(podMap map[podKey]*pod, resCPUCoresAllocated []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resCPUCoresAllocated {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU allocation result missing field: %s", err)
 			continue
@@ -259,7 +259,7 @@ func applyCPUCoresAllocated(podMap map[podKey]*pod, resCPUCoresAllocated []*prom
 
 func applyCPUCoresRequested(podMap map[podKey]*pod, resCPUCoresRequested []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resCPUCoresRequested {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU request result missing field: %s", err)
 			continue
@@ -317,7 +317,7 @@ func applyCPUCoresRequested(podMap map[podKey]*pod, resCPUCoresRequested []*prom
 
 func applyCPUCoresUsedAvg(podMap map[podKey]*pod, resCPUCoresUsedAvg []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resCPUCoresUsedAvg {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage avg result missing field: %s", err)
 			continue
@@ -365,7 +365,7 @@ func applyCPUCoresUsedAvg(podMap map[podKey]*pod, resCPUCoresUsedAvg []*prom.Que
 
 func applyCPUCoresUsedMax(podMap map[podKey]*pod, resCPUCoresUsedMax []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resCPUCoresUsedMax {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage max result missing field: %s", err)
 			continue
@@ -415,7 +415,7 @@ func applyCPUCoresUsedMax(podMap map[podKey]*pod, resCPUCoresUsedMax []*prom.Que
 
 func applyRAMBytesAllocated(podMap map[podKey]*pod, resRAMBytesAllocated []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resRAMBytesAllocated {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM allocation result missing field: %s", err)
 			continue
@@ -466,7 +466,7 @@ func applyRAMBytesAllocated(podMap map[podKey]*pod, resRAMBytesAllocated []*prom
 
 func applyRAMBytesRequested(podMap map[podKey]*pod, resRAMBytesRequested []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resRAMBytesRequested {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM request result missing field: %s", err)
 			continue
@@ -521,7 +521,7 @@ func applyRAMBytesRequested(podMap map[podKey]*pod, resRAMBytesRequested []*prom
 
 func applyRAMBytesUsedAvg(podMap map[podKey]*pod, resRAMBytesUsedAvg []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resRAMBytesUsedAvg {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM avg usage result missing field: %s", err)
 			continue
@@ -565,7 +565,7 @@ func applyRAMBytesUsedAvg(podMap map[podKey]*pod, resRAMBytesUsedAvg []*prom.Que
 
 func applyRAMBytesUsedMax(podMap map[podKey]*pod, resRAMBytesUsedMax []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resRAMBytesUsedMax {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage max result missing field: %s", err)
 			continue
@@ -618,7 +618,7 @@ func applyGPUsAllocated(podMap map[podKey]*pod, resGPUsRequested []*prom.QueryRe
 		resGPUsRequested = resGPUsAllocated
 	}
 	for _, res := range resGPUsRequested {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: GPU request result missing field: %s", err)
 			continue
@@ -660,7 +660,7 @@ func applyGPUsAllocated(podMap map[podKey]*pod, resGPUsRequested []*prom.QueryRe
 
 func applyNetworkTotals(podMap map[podKey]*pod, resNetworkTransferBytes []*prom.QueryResult, resNetworkReceiveBytes []*prom.QueryResult, podUIDKeyMap map[podKey][]podKey) {
 	for _, res := range resNetworkTransferBytes {
-		podKey, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		podKey, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Network Transfer Bytes query result missing field: %s", err)
 			continue
@@ -690,7 +690,7 @@ func applyNetworkTotals(podMap map[podKey]*pod, resNetworkTransferBytes []*prom.
 		}
 	}
 	for _, res := range resNetworkReceiveBytes {
-		podKey, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		podKey, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Network Receive Bytes query result missing field: %s", err)
 			continue
@@ -734,7 +734,7 @@ func applyNetworkAllocation(podMap map[podKey]*pod, resNetworkGiB []*prom.QueryR
 	}
 
 	for _, res := range resNetworkGiB {
-		podKey, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		podKey, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: Network allocation query result missing field: %s", err)
 			continue
@@ -818,7 +818,7 @@ func resToNamespaceLabels(resNamespaceLabels []*prom.QueryResult) map[namespaceK
 	namespaceLabels := map[namespaceKey]map[string]string{}
 
 	for _, res := range resNamespaceLabels {
-		nsKey, err := resultNamespaceKey(res, env.GetPromClusterLabel(), "namespace")
+		nsKey, err := resultNamespaceKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			continue
 		}
@@ -874,7 +874,7 @@ func resToNamespaceAnnotations(resNamespaceAnnotations []*prom.QueryResult) map[
 	namespaceAnnotations := map[string]map[string]string{}
 
 	for _, res := range resNamespaceAnnotations {
-		namespace, err := res.GetString("namespace")
+		namespace, err := res.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			continue
 		}
@@ -895,7 +895,7 @@ func resToPodAnnotations(resPodAnnotations []*prom.QueryResult, podUIDKeyMap map
 	podAnnotations := map[podKey]map[string]string{}
 
 	for _, res := range resPodAnnotations {
-		key, err := resultPodKey(res, env.GetPromClusterLabel(), "namespace")
+		key, err := resultPodKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 		if err != nil {
 			continue
 		}
@@ -1010,7 +1010,7 @@ func resToDeploymentLabels(resDeploymentLabels []*prom.QueryResult) map[controll
 	deploymentLabels := map[controllerKey]map[string]string{}
 
 	for _, res := range resDeploymentLabels {
-		controllerKey, err := resultDeploymentKey(res, env.GetPromClusterLabel(), "namespace", "deployment")
+		controllerKey, err := resultDeploymentKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "deployment")
 		if err != nil {
 			continue
 		}
@@ -1043,7 +1043,7 @@ func resToStatefulSetLabels(resStatefulSetLabels []*prom.QueryResult) map[contro
 	statefulSetLabels := map[controllerKey]map[string]string{}
 
 	for _, res := range resStatefulSetLabels {
-		controllerKey, err := resultStatefulSetKey(res, env.GetPromClusterLabel(), "namespace", "statefulSet")
+		controllerKey, err := resultStatefulSetKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "statefulSet")
 		if err != nil {
 			continue
 		}
@@ -1105,7 +1105,7 @@ func resToPodDaemonSetMap(resDaemonSetLabels []*prom.QueryResult, podUIDKeyMap m
 	daemonSetLabels := map[podKey]controllerKey{}
 
 	for _, res := range resDaemonSetLabels {
-		controllerKey, err := resultDaemonSetKey(res, env.GetPromClusterLabel(), "namespace", "owner_name")
+		controllerKey, err := resultDaemonSetKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "owner_name")
 		if err != nil {
 			continue
 		}
@@ -1141,7 +1141,7 @@ func resToPodJobMap(resJobLabels []*prom.QueryResult, podUIDKeyMap map[podKey][]
 	jobLabels := map[podKey]controllerKey{}
 
 	for _, res := range resJobLabels {
-		controllerKey, err := resultJobKey(res, env.GetPromClusterLabel(), "namespace", "owner_name")
+		controllerKey, err := resultJobKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "owner_name")
 		if err != nil {
 			continue
 		}
@@ -1191,7 +1191,7 @@ func resToPodReplicaSetMap(resPodsWithReplicaSetOwner []*prom.QueryResult, resRe
 
 	// Create unowned ReplicaSet controller keys
 	for _, res := range resReplicaSetsWithoutOwners {
-		controllerKey, err := resultReplicaSetKey(res, env.GetPromClusterLabel(), "namespace", "replicaset")
+		controllerKey, err := resultReplicaSetKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "replicaset")
 		if err != nil {
 			continue
 		}
@@ -1201,7 +1201,7 @@ func resToPodReplicaSetMap(resPodsWithReplicaSetOwner []*prom.QueryResult, resRe
 
 	// Create Rollout-owned ReplicaSet controller keys
 	for _, res := range resReplicaSetsWithRolloutOwner {
-		controllerKey, err := resultReplicaSetRolloutKey(res, env.GetPromClusterLabel(), "namespace", "replicaset")
+		controllerKey, err := resultReplicaSetRolloutKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "replicaset")
 		if err != nil {
 			continue
 		}
@@ -1215,13 +1215,13 @@ func resToPodReplicaSetMap(resPodsWithReplicaSetOwner []*prom.QueryResult, resRe
 
 	for _, res := range resPodsWithReplicaSetOwner {
 		// First, check if this pod is owned by an unowned ReplicaSet
-		controllerKey, err := resultReplicaSetKey(res, env.GetPromClusterLabel(), "namespace", "owner_name")
+		controllerKey, err := resultReplicaSetKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "owner_name")
 		if err != nil {
 			continue
 		} else if _, ok := replicaSets[controllerKey]; !ok {
 			// If the pod is not owned by an unowned ReplicaSet, check if
 			// it's owned by a Rollout-owned ReplicaSet
-			controllerKey, err = resultReplicaSetRolloutKey(res, env.GetPromClusterLabel(), "namespace", "owner_name")
+			controllerKey, err = resultReplicaSetRolloutKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "owner_name")
 			if err != nil {
 				continue
 			} else if _, ok := replicaSets[controllerKey]; !ok {
@@ -1271,7 +1271,7 @@ func getServiceLabels(resServiceLabels []*prom.QueryResult) map[serviceKey]map[s
 	serviceLabels := map[serviceKey]map[string]string{}
 
 	for _, res := range resServiceLabels {
-		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), "namespace", "service")
+		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "service")
 		if err != nil {
 			continue
 		}
@@ -1345,7 +1345,7 @@ func applyServicesToPods(podMap map[podKey]*pod, podLabels map[podKey]map[string
 
 func getLoadBalancerCosts(lbMap map[serviceKey]*lbCost, resLBCost, resLBActiveMins []*prom.QueryResult, resolution time.Duration, window kubecost.Window) {
 	for _, res := range resLBActiveMins {
-		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), "namespace", "service_name")
+		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "service_name")
 		if err != nil || len(res.Values) == 0 {
 			continue
 		}
@@ -1363,7 +1363,7 @@ func getLoadBalancerCosts(lbMap map[serviceKey]*lbCost, resLBCost, resLBActiveMi
 	}
 
 	for _, res := range resLBCost {
-		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), "namespace", "service_name")
+		serviceKey, err := resultServiceKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "service_name")
 		if err != nil {
 			continue
 		}
@@ -1879,13 +1879,13 @@ func buildPVCMap(resolution time.Duration, pvcMap map[pvcKey]*pvc, pvMap map[pvK
 			cluster = env.GetClusterID()
 		}
 
-		values, err := res.GetStrings("persistentvolumeclaim", "storageclass", "volumename", "namespace")
+		values, err := res.GetStrings("persistentvolumeclaim", "storageclass", "volumename", env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(10, "CostModel.ComputeAllocation: pvc info query result missing field: %s", err)
 			continue
 		}
 
-		namespace := values["namespace"]
+		namespace := values[env.GetPromNamespaceLabel()]
 		name := values["persistentvolumeclaim"]
 		volume := values["volumename"]
 		storageClass := values["storageclass"]
@@ -1919,7 +1919,7 @@ func buildPVCMap(resolution time.Duration, pvcMap map[pvcKey]*pvc, pvMap map[pvK
 
 func applyPVCBytesRequested(pvcMap map[pvcKey]*pvc, resPVCBytesRequested []*prom.QueryResult) {
 	for _, res := range resPVCBytesRequested {
-		key, err := resultPVCKey(res, env.GetPromClusterLabel(), "namespace", "persistentvolumeclaim")
+		key, err := resultPVCKey(res, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), "persistentvolumeclaim")
 		if err != nil {
 			continue
 		}
@@ -1939,13 +1939,13 @@ func buildPodPVCMap(podPVCMap map[podKey][]*pvc, pvMap map[pvKey]*pv, pvcMap map
 			cluster = env.GetClusterID()
 		}
 
-		values, err := res.GetStrings("persistentvolume", "persistentvolumeclaim", "pod", "namespace")
+		values, err := res.GetStrings("persistentvolume", "persistentvolumeclaim", "pod", env.GetPromNamespaceLabel())
 		if err != nil {
 			log.DedupedWarningf(5, "CostModel.ComputeAllocation: pvc allocation query result missing field: %s", err)
 			continue
 		}
 
-		namespace := values["namespace"]
+		namespace := values[env.GetPromNamespaceLabel()]
 		pod := values["pod"]
 		name := values["persistentvolumeclaim"]
 		volume := values["persistentvolume"]

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -246,7 +246,7 @@ func applyCPUCoresAllocated(podMap map[podKey]*pod, resCPUCoresAllocated []*prom
 			hours := thisPod.Allocations[container].Minutes() / 60.0
 			thisPod.Allocations[container].CPUCoreHours = cpuCores * hours
 
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: CPU allocation query result missing 'node': %s", key)
 				continue
@@ -304,7 +304,7 @@ func applyCPUCoresRequested(podMap map[podKey]*pod, resCPUCoresRequested []*prom
 				log.Infof("[WARNING] Very large cpu allocation, clamping! to %f", res.Values[0].Value*(thisPod.Allocations[container].Minutes()/60.0))
 				thisPod.Allocations[container].CPUCoreHours = res.Values[0].Value * (thisPod.Allocations[container].Minutes() / 60.0)
 			}
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: CPU request query result missing 'node': %s", key)
 				continue
@@ -453,7 +453,7 @@ func applyRAMBytesAllocated(podMap map[podKey]*pod, resRAMBytesAllocated []*prom
 			hours := thisPod.Allocations[container].Minutes() / 60.0
 			thisPod.Allocations[container].RAMByteHours = ramBytes * hours
 
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: RAM allocation query result missing 'node': %s", key)
 				continue
@@ -508,7 +508,7 @@ func applyRAMBytesRequested(podMap map[podKey]*pod, resRAMBytesRequested []*prom
 				pod.Allocations[container].RAMByteHours = res.Values[0].Value * (pod.Allocations[container].Minutes() / 60.0)
 			}
 
-			node, err := res.GetString("node")
+			node, err := res.GetString(env.GetPromNodeLabel())
 			if err != nil {
 				log.Warnf("CostModel.ComputeAllocation: RAM request query result missing 'node': %s", key)
 				continue
@@ -1473,7 +1473,7 @@ func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*nodePricing, resNodeCostPerCPUHr
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node CPU cost query result missing field: \"%s\" for node \"%s\"", err, node)
 			continue
@@ -1511,7 +1511,7 @@ func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*nodePricing, resNodeCostPerRA
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node RAM cost query result missing field: \"%s\" for node \"%s\"", err, node)
 			continue
@@ -1549,7 +1549,7 @@ func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*nodePricing, resNodeCostPerGPUHr
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node GPU cost query result missing field: \"%s\" for node \"%s\"", err, node)
 			continue
@@ -1587,7 +1587,7 @@ func applyNodeSpot(nodeMap map[nodeKey]*nodePricing, resNodeIsSpot []*prom.Query
 			cluster = env.GetClusterID()
 		}
 
-		node, err := res.GetString("node")
+		node, err := res.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("CostModel.ComputeAllocation: Node spot query result missing field: %s", err)
 			continue

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -182,7 +182,7 @@ func ClusterDisks(client prometheus.Client, provider models.Provider, start, end
 	queryLocalStorageUsedAvg := fmt.Sprintf(`avg(sum(avg_over_time(container_fs_usage_bytes{device!="tmpfs", id="/", %s}[%s])) by (instance, %s, job)) by (instance, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromClusterLabel())
 	queryLocalStorageUsedMax := fmt.Sprintf(`max(sum(max_over_time(container_fs_usage_bytes{device!="tmpfs", id="/", %s}[%s])) by (instance, %s, job)) by (instance, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromClusterLabel())
 	queryLocalStorageBytes := fmt.Sprintf(`avg_over_time(sum(container_fs_limit_bytes{device!="tmpfs", id="/", %s}) by (instance, %s)[%s:%dm])`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution)
-	queryLocalActiveMins := fmt.Sprintf(`count(node_total_hourly_cost{%s}) by (%s, node)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution)
+	queryLocalActiveMins := fmt.Sprintf(`count(node_total_hourly_cost{%s}) by (%s, %s)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), durStr, minsPerResolution)
 
 	resChPVCost := ctx.QueryAtTime(queryPVCost, t)
 	resChPVSize := ctx.QueryAtTime(queryPVSize, t)

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -174,9 +174,9 @@ func ClusterDisks(client prometheus.Client, provider models.Provider, start, end
 	queryPVSize := fmt.Sprintf(`avg(avg_over_time(kube_persistentvolume_capacity_bytes{%s}[%s])) by (%s, persistentvolume)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
 	queryActiveMins := fmt.Sprintf(`avg(kube_persistentvolume_capacity_bytes{%s}) by (%s, persistentvolume)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution)
 	queryPVStorageClass := fmt.Sprintf(`avg(avg_over_time(kubecost_pv_info{%s}[%s])) by (%s, persistentvolume, storageclass)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
-	queryPVUsedAvg := fmt.Sprintf(`avg(avg_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, namespace)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
-	queryPVUsedMax := fmt.Sprintf(`max(max_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, namespace)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
-	queryPVCInfo := fmt.Sprintf(`avg(avg_over_time(kube_persistentvolumeclaim_info{%s}[%s])) by (%s, volumename, persistentvolumeclaim, namespace)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
+	queryPVUsedAvg := fmt.Sprintf(`avg(avg_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+	queryPVUsedMax := fmt.Sprintf(`max(max_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+	queryPVCInfo := fmt.Sprintf(`avg(avg_over_time(kube_persistentvolumeclaim_info{%s}[%s])) by (%s, volumename, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 	queryLocalStorageCost := fmt.Sprintf(`sum_over_time(sum(container_fs_limit_bytes{device!="tmpfs", id="/", %s}) by (instance, %s)[%s:%dm]) / 1024 / 1024 / 1024 * %f * %f`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution, hourlyToCumulative, costPerGBHr)
 	queryLocalStorageUsedCost := fmt.Sprintf(`sum_over_time(sum(container_fs_usage_bytes{device!="tmpfs", id="/", %s}) by (instance, %s)[%s:%dm]) / 1024 / 1024 / 1024 * %f * %f`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution, hourlyToCumulative, costPerGBHr)
 	queryLocalStorageUsedAvg := fmt.Sprintf(`avg(sum(avg_over_time(container_fs_usage_bytes{device!="tmpfs", id="/", %s}[%s])) by (instance, %s, job)) by (instance, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromClusterLabel())
@@ -234,7 +234,7 @@ func ClusterDisks(client prometheus.Client, provider models.Provider, start, end
 			log.Debugf("ClusterDisks: pv claim data missing persistentvolumeclaim")
 			continue
 		}
-		claimNamespace, err := result.GetString("namespace")
+		claimNamespace, err := result.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			log.Debugf("ClusterDisks: pv claim data missing namespace")
 			continue
@@ -578,8 +578,8 @@ func ClusterNodes(cp models.Provider, client prometheus.Client, start, end time.
 	queryNodeGPUCount := fmt.Sprintf(`avg(avg_over_time(node_gpu_count{%s}[%s])) by (%s, %s, provider_id)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNodeLabel())
 	queryNodeGPUHourlyCost := fmt.Sprintf(`avg(avg_over_time(node_gpu_hourly_cost{%s}[%s])) by (%s, %s, instance_type, provider_id)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNodeLabel())
 	queryNodeCPUModeTotal := fmt.Sprintf(`sum(rate(node_cpu_seconds_total{%s}[%s:%dm])) by (kubernetes_node, %s, mode)`, env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel())
-	queryNodeRAMSystemPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",namespace="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
-	queryNodeRAMUserPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",namespace!="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryNodeRAMSystemPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",%s="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetPromNamespaceLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryNodeRAMUserPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",%s!="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetPromNamespaceLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	queryActiveMins := fmt.Sprintf(`avg(node_total_hourly_cost{%s}) by (%s, %s, provider_id)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), durStr, minsPerResolution)
 	queryIsSpot := fmt.Sprintf(`avg_over_time(kubecost_node_is_spot{%s}[%s:%dm])`, env.GetPromClusterFilter(), durStr, minsPerResolution)
 	queryLabels := fmt.Sprintf(`count_over_time(kube_node_labels{%s}[%s:%dm])`, env.GetPromClusterFilter(), durStr, minsPerResolution)
@@ -743,8 +743,8 @@ func ClusterLoadBalancers(client prometheus.Client, start, end time.Time) (map[L
 
 	ctx := prom.NewNamedContext(client, prom.ClusterContextName)
 
-	queryLBCost := fmt.Sprintf(`avg(avg_over_time(kubecost_load_balancer_cost{%s}[%s])) by (namespace, service_name, %s, ingress_ip)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
-	queryActiveMins := fmt.Sprintf(`avg(kubecost_load_balancer_cost{%s}) by (namespace, service_name, %s, ingress_ip)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution)
+	queryLBCost := fmt.Sprintf(`avg(avg_over_time(kubecost_load_balancer_cost{%s}[%s])) by (%s, service_name, %s, ingress_ip)`, env.GetPromClusterFilter(), durStr, env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryActiveMins := fmt.Sprintf(`avg(kubecost_load_balancer_cost{%s}) by (%s, service_name, %s, ingress_ip)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), durStr, minsPerResolution)
 
 	resChLBCost := ctx.QueryAtTime(queryLBCost, t)
 	resChActiveMins := ctx.QueryAtTime(queryActiveMins, t)
@@ -763,7 +763,7 @@ func ClusterLoadBalancers(client prometheus.Client, start, end time.Time) (map[L
 		if err != nil {
 			cluster = env.GetClusterID()
 		}
-		namespace, err := result.GetString("namespace")
+		namespace, err := result.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			log.Warnf("ClusterLoadBalancers: LB cost data missing namespace")
 			continue
@@ -819,7 +819,7 @@ func ClusterLoadBalancers(client prometheus.Client, start, end time.Time) (map[L
 		if err != nil {
 			cluster = env.GetClusterID()
 		}
-		namespace, err := result.GetString("namespace")
+		namespace, err := result.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			log.Warnf("ClusterLoadBalancers: LB cost data missing namespace")
 			continue
@@ -943,7 +943,7 @@ func (a *Accesses) ComputeClusterCosts(client prometheus.Client, provider models
 	`
 
 	const fmtQueryRAMSystemPct = `
-		sum(sum_over_time(container_memory_usage_bytes{container_name!="",namespace="kube-system", %s}[%s:%dm]%s)) by (%s)
+		sum(sum_over_time(container_memory_usage_bytes{container_name!="",%s="kube-system", %s}[%s:%dm]%s)) by (%s)
 		/ sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm]%s)) by (%s)
 	`
 
@@ -992,7 +992,7 @@ func (a *Accesses) ComputeClusterCosts(client prometheus.Client, provider models
 
 	if withBreakdown {
 		queryCPUModePct := fmt.Sprintf(fmtQueryCPUModePct, env.GetPromClusterFilter(), windowStr, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, fmtOffset, env.GetPromClusterLabel())
-		queryRAMSystemPct := fmt.Sprintf(fmtQueryRAMSystemPct, env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel())
+		queryRAMSystemPct := fmt.Sprintf(fmtQueryRAMSystemPct, env.GetPromNamespaceLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel())
 		queryRAMUserPct := fmt.Sprintf(fmtQueryRAMUserPct, env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel())
 
 		bdResChs := ctx.QueryAll(
@@ -1464,7 +1464,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			log.Debugf("ClusterDisks: pv usage data missing persistentvolumeclaim")
 			continue
 		}
-		claimNamespace, err := result.GetString("namespace")
+		claimNamespace, err := result.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			log.Debugf("ClusterDisks: pv usage data missing namespace")
 			continue
@@ -1489,7 +1489,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 				log.Debugf("ClusterDisks: pv claim data missing persistentvolumeclaim")
 				continue
 			}
-			thatClaimNamespace, err := thatRes.GetString("namespace")
+			thatClaimNamespace, err := thatRes.GetString(env.GetPromNamespaceLabel())
 			if err != nil {
 				log.Debugf("ClusterDisks: pv claim data missing namespace")
 				continue
@@ -1525,7 +1525,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			log.Debugf("ClusterDisks: pv usage data missing persistentvolumeclaim")
 			continue
 		}
-		claimNamespace, err := result.GetString("namespace")
+		claimNamespace, err := result.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			log.Debugf("ClusterDisks: pv usage data missing namespace")
 			continue
@@ -1550,7 +1550,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 				log.Debugf("ClusterDisks: pv claim data missing persistentvolumeclaim")
 				continue
 			}
-			thatClaimNamespace, err := thatRes.GetString("namespace")
+			thatClaimNamespace, err := thatRes.GetString(env.GetPromNamespaceLabel())
 			if err != nil {
 				log.Debugf("ClusterDisks: pv claim data missing namespace")
 				continue

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -174,8 +174,8 @@ func ClusterDisks(client prometheus.Client, provider models.Provider, start, end
 	queryPVSize := fmt.Sprintf(`avg(avg_over_time(kube_persistentvolume_capacity_bytes{%s}[%s])) by (%s, persistentvolume)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
 	queryActiveMins := fmt.Sprintf(`avg(kube_persistentvolume_capacity_bytes{%s}) by (%s, persistentvolume)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution)
 	queryPVStorageClass := fmt.Sprintf(`avg(avg_over_time(kubecost_pv_info{%s}[%s])) by (%s, persistentvolume, storageclass)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel())
-	queryPVUsedAvg := fmt.Sprintf(`avg(avg_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
-	queryPVUsedMax := fmt.Sprintf(`max(max_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
+	queryPVUsedAvg := fmt.Sprintf(`avg(avg_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetDefaultPromNamespaceLabel())
+	queryPVUsedMax := fmt.Sprintf(`max(max_over_time(kubelet_volume_stats_used_bytes{%s}[%s])) by (%s, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetDefaultPromNamespaceLabel())
 	queryPVCInfo := fmt.Sprintf(`avg(avg_over_time(kube_persistentvolumeclaim_info{%s}[%s])) by (%s, volumename, persistentvolumeclaim, %s)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel())
 	queryLocalStorageCost := fmt.Sprintf(`sum_over_time(sum(container_fs_limit_bytes{device!="tmpfs", id="/", %s}) by (instance, %s)[%s:%dm]) / 1024 / 1024 / 1024 * %f * %f`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution, hourlyToCumulative, costPerGBHr)
 	queryLocalStorageUsedCost := fmt.Sprintf(`sum_over_time(sum(container_fs_usage_bytes{device!="tmpfs", id="/", %s}) by (instance, %s)[%s:%dm]) / 1024 / 1024 / 1024 * %f * %f`, env.GetPromClusterFilter(), env.GetPromClusterLabel(), durStr, minsPerResolution, hourlyToCumulative, costPerGBHr)
@@ -578,8 +578,8 @@ func ClusterNodes(cp models.Provider, client prometheus.Client, start, end time.
 	queryNodeGPUCount := fmt.Sprintf(`avg(avg_over_time(node_gpu_count{%s}[%s])) by (%s, %s, provider_id)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNodeLabel())
 	queryNodeGPUHourlyCost := fmt.Sprintf(`avg(avg_over_time(node_gpu_hourly_cost{%s}[%s])) by (%s, %s, instance_type, provider_id)`, env.GetPromClusterFilter(), durStr, env.GetPromClusterLabel(), env.GetPromNodeLabel())
 	queryNodeCPUModeTotal := fmt.Sprintf(`sum(rate(node_cpu_seconds_total{%s}[%s:%dm])) by (kubernetes_node, %s, mode)`, env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel())
-	queryNodeRAMSystemPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",%s="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetPromNamespaceLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
-	queryNodeRAMUserPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",%s!="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetPromNamespaceLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryNodeRAMSystemPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",%s="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
+	queryNodeRAMUserPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",%s!="kube-system", %s}[%s:%dm])) by (instance, %s) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes{%s}[%s:%dm])) by (%s, %s), "instance", "$1", "%s", "(.*)")) by (instance, %s)`, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromClusterLabel(), env.GetPromClusterFilter(), durStr, minsPerResolution, env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	queryActiveMins := fmt.Sprintf(`avg(node_total_hourly_cost{%s}) by (%s, %s, provider_id)[%s:%dm]`, env.GetPromClusterFilter(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), durStr, minsPerResolution)
 	queryIsSpot := fmt.Sprintf(`avg_over_time(kubecost_node_is_spot{%s}[%s:%dm])`, env.GetPromClusterFilter(), durStr, minsPerResolution)
 	queryLabels := fmt.Sprintf(`count_over_time(kube_node_labels{%s}[%s:%dm])`, env.GetPromClusterFilter(), durStr, minsPerResolution)
@@ -992,7 +992,7 @@ func (a *Accesses) ComputeClusterCosts(client prometheus.Client, provider models
 
 	if withBreakdown {
 		queryCPUModePct := fmt.Sprintf(fmtQueryCPUModePct, env.GetPromClusterFilter(), windowStr, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, fmtOffset, env.GetPromClusterLabel())
-		queryRAMSystemPct := fmt.Sprintf(fmtQueryRAMSystemPct, env.GetPromNamespaceLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel())
+		queryRAMSystemPct := fmt.Sprintf(fmtQueryRAMSystemPct, env.GetDefaultPromNamespaceLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel())
 		queryRAMUserPct := fmt.Sprintf(fmtQueryRAMUserPct, env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel(), env.GetPromClusterFilter(), windowStr, minsPerResolution, fmtOffset, env.GetPromClusterLabel())
 
 		bdResChs := ctx.QueryAll(
@@ -1464,7 +1464,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			log.Debugf("ClusterDisks: pv usage data missing persistentvolumeclaim")
 			continue
 		}
-		claimNamespace, err := result.GetString(env.GetPromNamespaceLabel())
+		claimNamespace, err := result.GetString(env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.Debugf("ClusterDisks: pv usage data missing namespace")
 			continue
@@ -1525,7 +1525,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			log.Debugf("ClusterDisks: pv usage data missing persistentvolumeclaim")
 			continue
 		}
-		claimNamespace, err := result.GetString(env.GetPromNamespaceLabel())
+		claimNamespace, err := result.GetString(env.GetDefaultPromNamespaceLabel())
 		if err != nil {
 			log.Debugf("ClusterDisks: pv usage data missing namespace")
 			continue

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -394,7 +394,7 @@ func ClusterDisks(client prometheus.Client, provider models.Provider, start, end
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.DedupedWarningf(5, "ClusterDisks: local active mins data missing instance")
 			continue

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -54,7 +54,7 @@ func buildCPUCostMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: CPU cost data missing node")
 			continue
@@ -128,7 +128,7 @@ func buildRAMCostMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: RAM cost data missing node")
 			continue
@@ -203,7 +203,7 @@ func buildGPUCostMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: GPU cost data missing node")
 			continue
@@ -271,7 +271,7 @@ func buildGPUCountMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: GPU count data missing node")
 			continue
@@ -303,7 +303,7 @@ func buildCPUCoresMap(
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: CPU cores data missing node")
 			continue
@@ -331,7 +331,7 @@ func buildRAMBytesMap(resNodeRAMBytes []*prom.QueryResult) map[nodeIdentifierNoP
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: RAM bytes data missing node")
 			continue
@@ -538,7 +538,7 @@ func buildActiveDataMap(resActiveMins []*prom.QueryResult, resolution time.Durat
 			cluster = env.GetClusterID()
 		}
 
-		name, err := result.GetString("node")
+		name, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.Warnf("ClusterNodes: active mins missing node")
 			continue
@@ -579,7 +579,7 @@ func buildPreemptibleMap(
 	m := make(map[NodeIdentifier]bool)
 
 	for _, result := range resIsSpot {
-		nodeName, err := result.GetString("node")
+		nodeName, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			continue
 		}
@@ -626,7 +626,7 @@ func buildLabelsMap(
 		if err != nil {
 			cluster = env.GetClusterID()
 		}
-		node, err := result.GetString("node")
+		node, err := result.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			log.DedupedWarningf(5, "ClusterNodes: label data missing node")
 			continue

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -640,7 +640,18 @@ func buildLabelsMap(
 		// ingested label data. This removes the label_ prefix that prometheus
 		// adds to emitted labels. It also keeps from ingesting prometheus labels
 		// that aren't a part of the asset.
-		m[key] = result.GetLabels()
+		// m[key] = result.GetLabels()
+
+		if _, ok := m[key]; !ok {
+			m[key] = map[string]string{}
+		}
+
+		for k, l := range result.GetLabels() {
+			m[key][k] = l
+			// TODO: remove log
+			log.Infof("buildLabelsMap: cluster=%s, node=%s, label=%s, value=%s", cluster, node, k, l)
+		}
+
 	}
 	return m
 }

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -177,7 +177,12 @@ func NewContainerMetricFromPrometheus(metrics map[string]interface{}, defaultClu
 	}
 	ns, ok := metrics[env.GetPromNamespaceLabel()]
 	if !ok {
-		return nil, NoNamespaceErr
+		// Check the default label name if the custom/relabeled label is not found
+		altns, ok := metrics["namespace"]
+		if !ok {
+			return nil, NoNamespaceErr
+		}
+		ns = altns
 	}
 	namespace, ok := ns.(string)
 	if !ok {

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -183,7 +183,7 @@ func NewContainerMetricFromPrometheus(metrics map[string]interface{}, defaultClu
 	if !ok {
 		return nil, NoNamespaceNameErr
 	}
-	node, ok := metrics["node"]
+	node, ok := metrics[env.GetPromNodeLabel()]
 	if !ok {
 		log.Debugf("Prometheus vector does not have node name")
 		node = ""

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -175,7 +175,7 @@ func NewContainerMetricFromPrometheus(metrics map[string]interface{}, defaultClu
 	if !ok {
 		return nil, NoPodNameErr
 	}
-	ns, ok := metrics["namespace"]
+	ns, ok := metrics[env.GetPromNamespaceLabel()]
 	if !ok {
 		return nil, NoNamespaceErr
 	}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1681,8 +1681,8 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, cp costAnalyzerC
 
 	ctx := prom.NewNamedContext(cli, prom.ComputeCostDataRangeContextName)
 
-	queryRAMAlloc := fmt.Sprintf(queryRAMAllocationByteHours, env.GetPromNodeLabel(), env.GetPromClusterFilter(), resStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), scrapeIntervalSeconds)
-	queryCPUAlloc := fmt.Sprintf(queryCPUAllocationVCPUHours, env.GetPromNodeLabel(), env.GetPromClusterFilter(), resStr, env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), scrapeIntervalSeconds)
+	queryRAMAlloc := fmt.Sprintf(queryRAMAllocationByteHours, env.GetPromNodeLabel(), env.GetPromClusterFilter(), resStr, env.GetDefaultPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), scrapeIntervalSeconds)
+	queryCPUAlloc := fmt.Sprintf(queryCPUAllocationVCPUHours, env.GetPromNodeLabel(), env.GetPromClusterFilter(), resStr, env.GetDefaultPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), scrapeIntervalSeconds)
 	queryRAMRequests := fmt.Sprintf(queryRAMRequestsStr, env.GetPromNodeLabel(), env.GetPromClusterFilter(), resStr, "", env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	queryRAMUsage := fmt.Sprintf(queryRAMUsageStr, env.GetPromClusterFilter(), resStr, "", env.GetPromNodeLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
 	queryCPURequests := fmt.Sprintf(queryCPURequestsStr, env.GetPromNodeLabel(), env.GetPromClusterFilter(), resStr, "", env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), env.GetPromNodeLabel(), env.GetPromClusterLabel())
@@ -1691,9 +1691,9 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, cp costAnalyzerC
 	queryPVRequests := fmt.Sprintf(queryPVRequestsStr, env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), env.GetPromClusterFilter(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
 	queryPVCAllocation := fmt.Sprintf(queryPVCAllocationFmt, env.GetPromClusterFilter(), resStr, env.GetPromClusterLabel(), env.GetPromNamespaceLabel(), scrapeIntervalSeconds)
 	queryPVHourlyCost := fmt.Sprintf(queryPVHourlyCostFmt, env.GetPromClusterFilter(), resStr)
-	queryNetZoneRequests := fmt.Sprintf(queryZoneNetworkUsage, env.GetPromClusterFilter(), resStr, "", env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
-	queryNetRegionRequests := fmt.Sprintf(queryRegionNetworkUsage, env.GetPromClusterFilter(), resStr, "", env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
-	queryNetInternetRequests := fmt.Sprintf(queryInternetNetworkUsage, env.GetPromClusterFilter(), resStr, "", env.GetPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryNetZoneRequests := fmt.Sprintf(queryZoneNetworkUsage, env.GetPromClusterFilter(), resStr, "", env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryNetRegionRequests := fmt.Sprintf(queryRegionNetworkUsage, env.GetPromClusterFilter(), resStr, "", env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
+	queryNetInternetRequests := fmt.Sprintf(queryInternetNetworkUsage, env.GetPromClusterFilter(), resStr, "", env.GetDefaultPromNamespaceLabel(), env.GetPromClusterLabel())
 	queryNormalization := fmt.Sprintf(normalizationStr, env.GetPromClusterFilter(), resStr, "")
 
 	// Submit all queries for concurrent evaluation

--- a/pkg/costmodel/key.go
+++ b/pkg/costmodel/key.go
@@ -105,7 +105,11 @@ func resultPodKey(res *prom.QueryResult, clusterLabel, namespaceLabel string) (p
 
 	namespace, err := res.GetString(namespaceLabel)
 	if err != nil {
-		return key, err
+		// Check the default label name if the custom/relabeled label is not found
+		namespace, err = res.GetString("namespace")
+		if err != nil {
+			return key, err
+		}
 	}
 	key.Namespace = namespace
 
@@ -198,7 +202,11 @@ func resultControllerKey(controllerKind string, res *prom.QueryResult, clusterLa
 
 	namespace, err := res.GetString(namespaceLabel)
 	if err != nil {
-		return key, err
+		// Check the default label name if the custom/relabeled label is not found
+		namespace, err = res.GetString("namespace")
+		if err != nil {
+			return key, err
+		}
 	}
 	key.Namespace = namespace
 
@@ -284,7 +292,11 @@ func resultServiceKey(res *prom.QueryResult, clusterLabel, namespaceLabel, servi
 
 	namespace, err := res.GetString(namespaceLabel)
 	if err != nil {
-		return key, err
+		// Check the default label name if the custom/relabeled label is not found
+		namespace, err = res.GetString("namespace")
+		if err != nil {
+			return key, err
+		}
 	}
 	key.Namespace = namespace
 
@@ -372,7 +384,11 @@ func resultPVCKey(res *prom.QueryResult, clusterLabel, namespaceLabel, pvcLabel 
 
 	namespace, err := res.GetString(namespaceLabel)
 	if err != nil {
-		return key, err
+		// Check the default label name if the custom/relabeled label is not found
+		namespace, err = res.GetString("namespace")
+		if err != nil {
+			return key, err
+		}
 	}
 	key.Namespace = namespace
 

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -149,7 +149,10 @@ func getNetworkUsage(qrs []*prom.QueryResult, defaultClusterID string) (map[stri
 
 		namespace, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return nil, err
+			namespace, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -147,7 +147,7 @@ func getNetworkUsage(qrs []*prom.QueryResult, defaultClusterID string) (map[stri
 			return nil, err
 		}
 
-		namespace, err := val.GetString("namespace")
+		namespace, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -57,7 +57,10 @@ func GetPVInfo(qrs []*prom.QueryResult, defaultClusterID string) (map[string]*Pe
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		pvcName, err := val.GetString("persistentvolumeclaim")
@@ -103,7 +106,10 @@ func GetPVAllocationMetrics(qrs []*prom.QueryResult, defaultClusterID string) (m
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		pod, err := val.GetString("pod")
@@ -168,7 +174,10 @@ func GetNamespaceLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string)
 		// We want Namespace and ClusterID for key generation purposes
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -200,7 +209,10 @@ func GetPodLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err := val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -229,7 +241,10 @@ func GetNamespaceAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID st
 		// We want Namespace and ClusterID for key generation purposes
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -261,7 +276,10 @@ func GetPodAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID string) 
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -294,7 +312,10 @@ func GetStatefulsetMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID 
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -320,7 +341,10 @@ func GetPodDaemonsetsWithMetrics(qrs []*prom.QueryResult, defaultClusterID strin
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -351,7 +375,10 @@ func GetPodJobsWithMetrics(qrs []*prom.QueryResult, defaultClusterID string) (ma
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -383,7 +410,10 @@ func GetDeploymentMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())
@@ -410,7 +440,10 @@ func GetServiceSelectorLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			return toReturn, err
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
+			if err != nil {
+				return toReturn, err
+			}
 		}
 
 		clusterID, err := val.GetString(env.GetPromClusterLabel())

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -471,7 +471,7 @@ func getCost(qrs []*prom.QueryResult) (map[string][]*util.Vector, error) {
 	toReturn := make(map[string][]*util.Vector)
 
 	for _, val := range qrs {
-		instance, err := val.GetString("node")
+		instance, err := val.GetString(env.GetPromNodeLabel())
 		if err != nil {
 			return toReturn, err
 		}

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -209,7 +209,7 @@ func GetPodLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[
 
 		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
-			ns, err := val.GetString(env.GetDefaultPromNamespaceLabel())
+			ns, err = val.GetString(env.GetDefaultPromNamespaceLabel())
 			if err != nil {
 				return toReturn, err
 			}

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -55,7 +55,7 @@ func GetPVInfo(qrs []*prom.QueryResult, defaultClusterID string) (map[string]*Pe
 			clusterID = defaultClusterID
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -101,7 +101,7 @@ func GetPVAllocationMetrics(qrs []*prom.QueryResult, defaultClusterID string) (m
 			clusterID = defaultClusterID
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -166,7 +166,7 @@ func GetNamespaceLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string)
 
 	for _, val := range qrs {
 		// We want Namespace and ClusterID for key generation purposes
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -198,7 +198,7 @@ func GetPodLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID string) (map[
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -227,7 +227,7 @@ func GetNamespaceAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID st
 
 	for _, val := range qrs {
 		// We want Namespace and ClusterID for key generation purposes
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -259,7 +259,7 @@ func GetPodAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID string) 
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -292,7 +292,7 @@ func GetStatefulsetMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID 
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -318,7 +318,7 @@ func GetPodDaemonsetsWithMetrics(qrs []*prom.QueryResult, defaultClusterID strin
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -349,7 +349,7 @@ func GetPodJobsWithMetrics(qrs []*prom.QueryResult, defaultClusterID string) (ma
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -381,7 +381,7 @@ func GetDeploymentMatchLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}
@@ -408,7 +408,7 @@ func GetServiceSelectorLabelsMetrics(qrs []*prom.QueryResult, defaultClusterID s
 			return toReturn, err
 		}
 
-		ns, err := val.GetString("namespace")
+		ns, err := val.GetString(env.GetPromNamespaceLabel())
 		if err != nil {
 			return toReturn, err
 		}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -590,16 +590,14 @@ func GetPromClusterLabel() string {
 
 func GetPromNodeLabel() string {
 	return Get(PromNodeLabelEnvVar, "node")
-
-	// TODO: ThomasN: This is a custom config. Revert back to above before merging.
-	// return Get(PromNodeLabelEnvVar, "exported_node")
 }
 
 func GetPromNamespaceLabel() string {
 	return Get(PromNamespaceLabelEnvVar, "namespace")
+}
 
-	// TODO: ThomasN: This is a custom config. Revert back to above before merging.
-	// return Get(PromNamespaceLabelEnvVar, "exported_namespace")
+func GetDefaultPromNamespaceLabel() string {
+	return "namespace"
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -82,6 +82,7 @@ const (
 	LegacyExternalAPIDisabledVar         = "LEGACY_EXTERNAL_API_DISABLED"
 
 	PromClusterIDLabelEnvVar = "PROM_CLUSTER_ID_LABEL"
+	PromNodeLabelEnvVar      = "PROM_NODE_LABEL"
 
 	PricingConfigmapName  = "PRICING_CONFIGMAP_NAME"
 	MetricsConfigmapName  = "METRICS_CONFIGMAP_NAME"
@@ -584,6 +585,10 @@ func LegacyExternalCostsAPIDisabled() bool {
 // GetPromClusterLabel returns the environment variable value for PromClusterIDLabel
 func GetPromClusterLabel() string {
 	return Get(PromClusterIDLabelEnvVar, "cluster_id")
+}
+
+func GetPromNodeLabel() string {
+	return Get(PromNodeLabelEnvVar, "node")
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -589,17 +589,17 @@ func GetPromClusterLabel() string {
 }
 
 func GetPromNodeLabel() string {
-	// return Get(PromNodeLabelEnvVar, "node")
+	return Get(PromNodeLabelEnvVar, "node")
 
 	// TODO: ThomasN: This is a custom config. Revert back to above before merging.
-	return Get(PromNodeLabelEnvVar, "exported_node")
+	// return Get(PromNodeLabelEnvVar, "exported_node")
 }
 
 func GetPromNamespaceLabel() string {
-	// return Get(PromNamespaceLabelEnvVar, "namespace")
+	return Get(PromNamespaceLabelEnvVar, "namespace")
 
 	// TODO: ThomasN: This is a custom config. Revert back to above before merging.
-	return Get(PromNamespaceLabelEnvVar, "exported_namespace")
+	// return Get(PromNamespaceLabelEnvVar, "exported_namespace")
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -83,6 +83,7 @@ const (
 
 	PromClusterIDLabelEnvVar = "PROM_CLUSTER_ID_LABEL"
 	PromNodeLabelEnvVar      = "PROM_NODE_LABEL"
+	PromNamespaceLabelEnvVar = "PROM_NAMESPACE_LABEL"
 
 	PricingConfigmapName  = "PRICING_CONFIGMAP_NAME"
 	MetricsConfigmapName  = "METRICS_CONFIGMAP_NAME"
@@ -589,6 +590,10 @@ func GetPromClusterLabel() string {
 
 func GetPromNodeLabel() string {
 	return Get(PromNodeLabelEnvVar, "node")
+}
+
+func GetPromNamespaceLabel() string {
+	return Get(PromNamespaceLabelEnvVar, "namespace")
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -593,7 +593,10 @@ func GetPromNodeLabel() string {
 }
 
 func GetPromNamespaceLabel() string {
-	return Get(PromNamespaceLabelEnvVar, "namespace")
+	// return Get(PromNamespaceLabelEnvVar, "namespace")
+
+	// TODO: ThomasN: This is a custom config. Revert back to above before merging.
+	return Get(PromNamespaceLabelEnvVar, "exported_namespace")
 }
 
 // IsIngestingPodUID returns the env variable from ingestPodUID, which alters the

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -589,7 +589,10 @@ func GetPromClusterLabel() string {
 }
 
 func GetPromNodeLabel() string {
-	return Get(PromNodeLabelEnvVar, "node")
+	// return Get(PromNodeLabelEnvVar, "node")
+
+	// TODO: ThomasN: This is a custom config. Revert back to above before merging.
+	return Get(PromNodeLabelEnvVar, "exported_node")
 }
 
 func GetPromNamespaceLabel() string {


### PR DESCRIPTION
## What does this PR change?
* OpenCost currently defaults to keying on the "node" and "namespace" label when querying Prom metrics. This PR adds additional configurability for this label name when querying Prom.
* Configurable via the `PROM_NODE_LABEL` and `PROM_NAMESPACE_LABEL` environment variables
* Note: These changes were built on directly top of the `v1.108` branch for immediate testing. Eventually this PR should be closed, and a new PR should be written which is built on top of the `develop` branch.

## Does this PR relate to any other PRs?
* Extends https://github.com/opencost/opencost/pull/2435.

## How will this PR impact users?
* By default, there is no impact.
* If users perform metric relabeling on any OpenCost, KubeStateMetrics, CAdvisor, or NodeExporter metrics, then this provides configurability for those labels.

## Does this PR address any GitHub or Zendesk issues?
* None

## How was this PR tested?
* TODO

## Does this PR require changes to documentation?
* TODO

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* TODO
