### PR TITLE
pkg/prom: fix dropped errors

### DIFF
--- a/pkg/prom/ratelimitedclient_test.go
+++ b/pkg/prom/ratelimitedclient_test.go
@@ -156,6 +156,9 @@ func TestRateLimitedOnceAndSuccess(t *testing.T) {
 
 	// we just need to execute this  once to see retries in effect
 	res, body, err := client.Do(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if res.StatusCode != 200 {
 		t.Fatalf("200 StatusCode expected. Got: %d", res.StatusCode)
@@ -198,6 +201,9 @@ func TestRateLimitedOnceAndFail(t *testing.T) {
 
 	// we just need to execute this  once to see retries in effect
 	res, body, err := client.Do(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if res.StatusCode != 400 {
 		t.Fatalf("400 StatusCode expected. Got: %d", res.StatusCode)


### PR DESCRIPTION
This fixes two dropped test `err` variables in `pkg/prom`.