### PR TITLE
Add trace log level (Trace and Tracef) to the log package

### DIFF
--- a/core/pkg/log/log.go
+++ b/core/pkg/log/log.go
@@ -126,6 +126,14 @@ func Debugf(format string, a ...interface{}) {
 	log.Debug().Msgf(format, a...)
 }
 
+func Trace(msg string) {
+	log.Trace().Msg(msg)
+}
+
+func Tracef(format string, a ...interface{}) {
+	log.Trace().Msgf(format, a...)
+}
+
 func Fatalf(format string, a ...interface{}) {
 	log.Fatal().Msgf(format, a...)
 }


### PR DESCRIPTION
## What does this PR change?
Adds trace log level (`Trace` and `Tracef`) to the log package. This allows us to produce high-granularity logs at a level below debug, thus allowing us to reduce logspam for users.

## Does this PR relate to any other PRs?
* Moved from https://github.com/opencost/opencost/pull/2454 after the big core/ refactor.

## How will this PR impact users?
* Setting LOG_LEVEL to `trace` will now be meaningful.