### PR TITLE
[Opencost-Core] Parse CloudCostProperty

### DIFF
--- a/core/pkg/opencost/cloudcostprops.go
+++ b/core/pkg/opencost/cloudcostprops.go
@@ -55,13 +55,13 @@ func ParseCloudProperties(props []string) ([]CloudCostProperty, error) {
 
 func ParseCloudCostProperty(text string) (CloudCostProperty, error) {
 	switch strings.TrimSpace(strings.ToLower(text)) {
-	case "invoiceEntityID":
+	case "invoiceentityid":
 		return CloudCostProperty(CloudCostInvoiceEntityIDProp), nil
-	case "accountID":
+	case "accountid":
 		return CloudCostProperty(CloudCostAccountIDProp), nil
 	case "provider":
 		return CloudCostProperty(CloudCostProviderProp), nil
-	case "providerID":
+	case "providerid":
 		return CloudCostProperty(CloudCostProviderIDProp), nil
 	case "category":
 		return CloudCostProperty(CloudCostCategoryProp), nil

--- a/pkg/cloudcost/queryservice_helper.go
+++ b/pkg/cloudcost/queryservice_helper.go
@@ -64,14 +64,6 @@ func ParseCloudCostRequest(qp httputil.QueryParams) (*QueryRequest, error) {
 	return opts, nil
 }
 
-func convertProps[T ~string](values []T) []string {
-	var result []string
-	for _, value := range values {
-		result = append(result, string(value))
-	}
-	return result
-}
-
 func parseCloudCostViewRequest(qp httputil.QueryParams) (*ViewQueryRequest, error) {
 	qr, err := ParseCloudCostRequest(qp)
 	if err != nil {


### PR DESCRIPTION
Update to move CloudCostProperty parsing to the opencost-core package to match allocations and assets. 