### PR TITLE
avoid nil panic when seaching for GPU costs in non-existent nodes

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -619,8 +619,17 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				if len(costs.GPUReq) > 0 {
 					// allocation here is set to the request because shared GPU usage not yet supported.
 					// if VPGUs, request x (actual/virtual)
-					vgpu, verr := strconv.ParseFloat(nodes[nodeName].VGPU, 64)
-					gpu, err := strconv.ParseFloat(nodes[nodeName].GPU, 64)
+					vgpu := 0.0
+					gpu := 0.0
+					var err, verr error
+					if matchedNode, found := nodes[nodeName]; found {
+						vgpu, verr = strconv.ParseFloat(matchedNode.VGPU, 64)
+						gpu, err = strconv.ParseFloat(matchedNode.GPU, 64)
+					} else {
+						log.Tracef("cost data for node %s had GPUReq, but there was no cost data available for the node", nodeName)
+						log.Trace("defaulting GPU to 0 cost")
+					}
+
 					gpualloc := costs.GPUReq[0].Value
 					if verr != nil && err != nil && vgpu != 0 {
 						gpualloc = gpualloc * (gpu / vgpu)


### PR DESCRIPTION
## What does this PR change?
* When a node isn't returned from a prom query, just default its GPU costs to 0 

## Does this PR relate to any other PRs?
* none

## How will this PR impact users?
* stops a crashloop

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* tested in kubecost dev cluster in ADOT namespace 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
