### PR TITLE
Make field map access concurrency-safe

### DIFF
--- a/core/pkg/filter/allocation/parser.go
+++ b/core/pkg/filter/allocation/parser.go
@@ -1,10 +1,6 @@
 package allocation
 
-import (
-	"sync"
-
-	"github.com/opencost/opencost/core/pkg/filter/ast"
-)
+import "github.com/opencost/opencost/core/pkg/filter/ast"
 
 // a slice of all the allocation field instances the lexer should recognize as
 // valid left-hand comparators
@@ -28,22 +24,18 @@ var allocationFilterFields []*ast.Field = []*ast.Field{
 }
 
 // fieldMap is a lazily loaded mapping from AllocationField to ast.Field
-var fieldMapLock sync.Mutex
 var fieldMap map[AllocationField]*ast.Field
+
+func init() {
+	fieldMap = make(map[AllocationField]*ast.Field, len(allocationFilterFields))
+	for _, f := range allocationFilterFields {
+		ff := *f
+		fieldMap[AllocationField(ff.Name)] = &ff
+	}
+}
 
 // DefaultFieldByName returns only default allocation filter fields by name.
 func DefaultFieldByName(field AllocationField) *ast.Field {
-	fieldMapLock.Lock()
-	defer fieldMapLock.Unlock()
-
-	if fieldMap == nil {
-		fieldMap = make(map[AllocationField]*ast.Field, len(allocationFilterFields))
-		for _, f := range allocationFilterFields {
-			ff := *f
-			fieldMap[AllocationField(ff.Name)] = &ff
-		}
-	}
-
 	if af, ok := fieldMap[field]; ok {
 		afcopy := *af
 		return &afcopy

--- a/core/pkg/filter/allocation/parser.go
+++ b/core/pkg/filter/allocation/parser.go
@@ -1,6 +1,10 @@
 package allocation
 
-import "github.com/opencost/opencost/core/pkg/filter/ast"
+import (
+	"sync"
+
+	"github.com/opencost/opencost/core/pkg/filter/ast"
+)
 
 // a slice of all the allocation field instances the lexer should recognize as
 // valid left-hand comparators
@@ -24,10 +28,14 @@ var allocationFilterFields []*ast.Field = []*ast.Field{
 }
 
 // fieldMap is a lazily loaded mapping from AllocationField to ast.Field
+var fieldMapLock sync.Mutex
 var fieldMap map[AllocationField]*ast.Field
 
 // DefaultFieldByName returns only default allocation filter fields by name.
 func DefaultFieldByName(field AllocationField) *ast.Field {
+	fieldMapLock.Lock()
+	defer fieldMapLock.Unlock()
+
 	if fieldMap == nil {
 		fieldMap = make(map[AllocationField]*ast.Field, len(allocationFilterFields))
 		for _, f := range allocationFilterFields {

--- a/core/pkg/filter/asset/parser.go
+++ b/core/pkg/filter/asset/parser.go
@@ -25,16 +25,16 @@ var assetFilterFields []*ast.Field = []*ast.Field{
 // fieldMap is a lazily loaded mapping from AllocationField to ast.Field
 var fieldMap map[AssetField]*ast.Field
 
+func init() {
+	fieldMap = make(map[AssetField]*ast.Field, len(assetFilterFields))
+	for _, f := range assetFilterFields {
+		ff := *f
+		fieldMap[AssetField(ff.Name)] = &ff
+	}
+}
+
 // DefaultFieldByName returns only default allocation filter fields by name.
 func DefaultFieldByName(field AssetField) *ast.Field {
-	if fieldMap == nil {
-		fieldMap = make(map[AssetField]*ast.Field, len(assetFilterFields))
-		for _, f := range assetFilterFields {
-			ff := *f
-			fieldMap[AssetField(ff.Name)] = &ff
-		}
-	}
-
 	if af, ok := fieldMap[field]; ok {
 		afcopy := *af
 		return &afcopy

--- a/core/pkg/filter/cloudcost/parser.go
+++ b/core/pkg/filter/cloudcost/parser.go
@@ -17,16 +17,16 @@ var cloudCostFilterFields []*ast.Field = []*ast.Field{
 // fieldMap is a lazily loaded mapping from CloudAggregationField to ast.Field
 var fieldMap map[CloudCostField]*ast.Field
 
+func init() {
+	fieldMap = make(map[CloudCostField]*ast.Field, len(cloudCostFilterFields))
+	for _, f := range cloudCostFilterFields {
+		ff := *f
+		fieldMap[CloudCostField(ff.Name)] = &ff
+	}
+}
+
 // DefaultFieldByName returns only default cloud cost filter fields by name.
 func DefaultFieldByName(field CloudCostField) *ast.Field {
-	if fieldMap == nil {
-		fieldMap = make(map[CloudCostField]*ast.Field, len(cloudCostFilterFields))
-		for _, f := range cloudCostFilterFields {
-			ff := *f
-			fieldMap[CloudCostField(ff.Name)] = &ff
-		}
-	}
-
 	if af, ok := fieldMap[field]; ok {
 		afcopy := *af
 		return &afcopy


### PR DESCRIPTION
## What does this PR change?
* Fixes a rare panic caused by concurrent access to this map
```
fatal error: concurrent map writes

goroutine 4037 [running]:
github.com/opencost/opencost/core/pkg/filter/allocation.DefaultFieldByName({0x1041ec0f5, 0x7})
        /Users/delta/devel/kubecost/model/opencost/core/pkg/filter/allocation/parser.go:35 +0x198
github.com/opencost/opencost/core/pkg/filter/ops.asField[...]({0x1041ec0f5, 0x7})
        /Users/delta/devel/kubecost/model/opencost/core/pkg/filter/ops/ops.go:53 +0x7c
github.com/opencost/opencost/core/pkg/filter/ops.toFieldAndKey[...]({0x1041ec0f5, 0x7})
        /Users/delta/devel/kubecost/model/opencost/core/pkg/filter/ops/ops.go:156 +0xd0
github.com/opencost/opencost/core/pkg/filter/ops.identifier[...](...)
        /Users/delta/devel/kubecost/model/opencost/core/pkg/filter/ops/ops.go:160
```

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* Fixes a rare nil panic when filter fields are accessed concurrently

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* Error which was reliably occurring locally no longer occurs