### PR TITLE
Remove label sanitation from cloud cost agg property parsing

### DIFF
--- a/core/pkg/opencost/cloudcostprops.go
+++ b/core/pkg/opencost/cloudcostprops.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/opencost/opencost/core/pkg/log"
-	"github.com/opencost/opencost/core/pkg/util/promutil"
 )
 
 type CloudCostProperty string
@@ -70,7 +69,7 @@ func ParseCloudCostProperty(text string) (CloudCostProperty, error) {
 	}
 
 	if strings.HasPrefix(text, "label:") {
-		label := promutil.SanitizeLabelName(strings.TrimSpace(strings.TrimPrefix(text, "label:")))
+		label := strings.TrimSpace(strings.TrimPrefix(text, "label:"))
 		return CloudCostProperty(fmt.Sprintf("label:%s", label)), nil
 	}
 


### PR DESCRIPTION
## What does this PR change?
* 

## Does this PR relate to any other PRs?
* This bug fixes an issue that prevent users on GCP and Azure from aggregating by labels that contained special characters such as '-', '/', or '.'

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
