### PR TITLE
Fix pathing issue for multi-cloud water

### DIFF
--- a/pkg/cloud/config/watcher.go
+++ b/pkg/cloud/config/watcher.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"path"
 
 	"github.com/opencost/opencost/pkg/cloud"
 	"github.com/opencost/opencost/pkg/cloud/alibaba"
@@ -20,7 +19,6 @@ import (
 
 const authSecretPath = "/var/secrets/service-key.json"
 const storageConfigSecretPath = "/var/azure-storage-config/azure-storage-config.json"
-const cloudIntegrationSecretPath = "/cloud-integration/cloud-integration.json"
 
 type HelmWatcher struct {
 	providerConfig models.ProviderConfig
@@ -239,13 +237,9 @@ type MultiCloudWatcher struct {
 }
 
 func (mcw *MultiCloudWatcher) GetConfigs() []cloud.KeyedConfig {
-	var multiConfigPath string
 
-	if env.IsKubernetesEnabled() {
-		multiConfigPath = path.Join(env.GetConfigPathWithDefault("/var/configs"), cloudIntegrationSecretPath)
-	} else {
-		multiConfigPath = env.GetCloudCostConfigPath()
-	}
+	multiConfigPath := env.GetCloudCostConfigPath()
+
 	exists, err := fileutil.FileExists(multiConfigPath)
 	if err != nil {
 		log.Errorf("MultiCloudWatcher:  error checking file at '%s': %s", multiConfigPath, err.Error())
@@ -253,17 +247,7 @@ func (mcw *MultiCloudWatcher) GetConfigs() []cloud.KeyedConfig {
 
 	// If config does not exist implies that this configuration method was not used
 	if !exists {
-		// check the original location of secret mount
-		multiConfigPath = path.Join("/var", cloudIntegrationSecretPath)
-		exists, err = fileutil.FileExists(multiConfigPath)
-		if err != nil {
-			log.Errorf("MultiCloudWatcher:  error checking file at '%s': %s", multiConfigPath, err.Error())
-		}
-
-		// If config does not exist implies that this configuration method was not used
-		if !exists {
-			return nil
-		}
+		return nil
 	}
 
 	log.Debugf("MultiCloudWatcher GetConfigs: multiConfigPath: %s", multiConfigPath)

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/env"
@@ -126,6 +127,8 @@ const (
 )
 
 const DefaultConfigMountPath = "/var/configs"
+
+const cloudIntegrationSecretPath = "/cloud-integration/cloud-integration.json"
 
 func IsETLReadOnlyMode() bool {
 	return env.GetBool(ETLReadOnlyMode, false)
@@ -628,7 +631,7 @@ func IsCloudCostEnabled() bool {
 }
 
 func GetCloudCostConfigPath() string {
-	return env.Get(CloudCostConfigPath, "cloud-integration.json")
+	return env.Get(CloudCostConfigPath, path.Join(GetConfigPathWithDefault(DefaultConfigMountPath), cloudIntegrationSecretPath))
 }
 
 func GetCloudCostMonthToDateInterval() int {

--- a/pkg/env/costmodelenv_test.go
+++ b/pkg/env/costmodelenv_test.go
@@ -163,11 +163,11 @@ func TestGetCloudCostConfigPath(t *testing.T) {
 	}{
 		{
 			name: "Ensure the default value is 'cloud-integration.json'",
-			want: "cloud-integration.json",
+			want: "/var/configs/cloud-integration/cloud-integration.json",
 		},
 		{
 			name: "Ensure the value is 'cloud-integration.json' when CLOUD_COST_CONFIG_PATH is set to ''",
-			want: "cloud-integration.json",
+			want: "/var/configs/cloud-integration/cloud-integration.json",
 			pre: func() {
 				os.Setenv("CLOUD_COST_CONFIG_PATH", "")
 			},


### PR DESCRIPTION
## What does this PR change?
* 

## Does this PR relate to any other PRs?
This PR addresses a bug where the Cloud Cost container is unable to find the location of the multi-cloud config file, which causes it to not run on those configurations. This has manifested in the nightly environment. 

The bug appears to have been introduced by https://github.com/opencost/opencost/pull/2317 which relies on the env variable "KUBERNETES_PORT" being set automatically. This does not appear to always happen which leads me to believe that we should not rely on it. 

This PR is hopefully a compromise between the old way path was determined and the ability to configure it. It leaves in place a check for the "CLOUD_COST_CONFIG_PATH" env variable, which if not set defaults to the standard secret path.

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
