### PR TITLE
use `policy/v1` for `PodDisruptionBudget`

### DIFF
--- a/pkg/clustercache/clustercache.go
+++ b/pkg/clustercache/clustercache.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	stv1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
@@ -61,7 +61,7 @@ type ClusterCache interface {
 	GetAllJobs() []*batchv1.Job
 
 	// GetAllPodDisruptionBudgets returns all cached pod disruption budgets
-	GetAllPodDisruptionBudgets() []*v1beta1.PodDisruptionBudget
+	GetAllPodDisruptionBudgets() []*policyv1.PodDisruptionBudget
 
 	// GetAllReplicationControllers returns all cached replication controllers
 	GetAllReplicationControllers() []*v1.ReplicationController
@@ -102,7 +102,7 @@ func NewKubernetesClusterCache(client kubernetes.Interface) ClusterCache {
 	appsRestClient := client.AppsV1().RESTClient()
 	storageRestClient := client.StorageV1().RESTClient()
 	batchClient := client.BatchV1().RESTClient()
-	pdbClient := client.PolicyV1beta1().RESTClient()
+	pdbClient := client.PolicyV1().RESTClient()
 
 	kubecostNamespace := env.GetKubecostNamespace()
 	log.Infof("NAMESPACE: %s", kubecostNamespace)
@@ -122,7 +122,7 @@ func NewKubernetesClusterCache(client kubernetes.Interface) ClusterCache {
 		pvcWatch:                   NewCachingWatcher(coreRestClient, "persistentvolumeclaims", &v1.PersistentVolumeClaim{}, "", fields.Everything()),
 		storageClassWatch:          NewCachingWatcher(storageRestClient, "storageclasses", &stv1.StorageClass{}, "", fields.Everything()),
 		jobsWatch:                  NewCachingWatcher(batchClient, "jobs", &batchv1.Job{}, "", fields.Everything()),
-		pdbWatch:                   NewCachingWatcher(pdbClient, "poddisruptionbudgets", &v1beta1.PodDisruptionBudget{}, "", fields.Everything()),
+		pdbWatch:                   NewCachingWatcher(pdbClient, "poddisruptionbudgets", &policyv1.PodDisruptionBudget{}, "", fields.Everything()),
 		replicationControllerWatch: NewCachingWatcher(coreRestClient, "replicationcontrollers", &v1.ReplicationController{}, "", fields.Everything()),
 	}
 
@@ -300,11 +300,11 @@ func (kcc *KubernetesClusterCache) GetAllJobs() []*batchv1.Job {
 	return jobs
 }
 
-func (kcc *KubernetesClusterCache) GetAllPodDisruptionBudgets() []*v1beta1.PodDisruptionBudget {
-	var pdbs []*v1beta1.PodDisruptionBudget
+func (kcc *KubernetesClusterCache) GetAllPodDisruptionBudgets() []*policyv1.PodDisruptionBudget {
+	var pdbs []*policyv1.PodDisruptionBudget
 	items := kcc.pdbWatch.GetAll()
 	for _, pdb := range items {
-		pdbs = append(pdbs, pdb.(*v1beta1.PodDisruptionBudget))
+		pdbs = append(pdbs, pdb.(*policyv1.PodDisruptionBudget))
 	}
 	return pdbs
 }

--- a/pkg/clustercache/clusterexporter.go
+++ b/pkg/clustercache/clusterexporter.go
@@ -11,26 +11,26 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	stv1 "k8s.io/api/storage/v1"
 )
 
 // clusterEncoding is used to represent the cluster objects in the encoded states.
 type clusterEncoding struct {
-	Namespaces             []*v1.Namespace                `json:"namespaces,omitempty"`
-	Nodes                  []*v1.Node                     `json:"nodes,omitempty"`
-	Pods                   []*v1.Pod                      `json:"pods,omitempty"`
-	Services               []*v1.Service                  `json:"services,omitempty"`
-	DaemonSets             []*appsv1.DaemonSet            `json:"daemonSets,omitempty"`
-	Deployments            []*appsv1.Deployment           `json:"deployments,omitempty"`
-	StatefulSets           []*appsv1.StatefulSet          `json:"statefulSets,omitempty"`
-	ReplicaSets            []*appsv1.ReplicaSet           `json:"replicaSets,omitempty"`
-	PersistentVolumes      []*v1.PersistentVolume         `json:"persistentVolumes,omitempty"`
-	PersistentVolumeClaims []*v1.PersistentVolumeClaim    `json:"persistentVolumeClaims,omitempty"`
-	StorageClasses         []*stv1.StorageClass           `json:"storageClasses,omitempty"`
-	Jobs                   []*batchv1.Job                 `json:"jobs,omitempty"`
-	PodDisruptionBudgets   []*v1beta1.PodDisruptionBudget `json:"podDisruptionBudgets,omitempty"`
-	ReplicationControllers []*v1.ReplicationController    `json:"replicationController,omitempty"`
+	Namespaces             []*v1.Namespace                 `json:"namespaces,omitempty"`
+	Nodes                  []*v1.Node                      `json:"nodes,omitempty"`
+	Pods                   []*v1.Pod                       `json:"pods,omitempty"`
+	Services               []*v1.Service                   `json:"services,omitempty"`
+	DaemonSets             []*appsv1.DaemonSet             `json:"daemonSets,omitempty"`
+	Deployments            []*appsv1.Deployment            `json:"deployments,omitempty"`
+	StatefulSets           []*appsv1.StatefulSet           `json:"statefulSets,omitempty"`
+	ReplicaSets            []*appsv1.ReplicaSet            `json:"replicaSets,omitempty"`
+	PersistentVolumes      []*v1.PersistentVolume          `json:"persistentVolumes,omitempty"`
+	PersistentVolumeClaims []*v1.PersistentVolumeClaim     `json:"persistentVolumeClaims,omitempty"`
+	StorageClasses         []*stv1.StorageClass            `json:"storageClasses,omitempty"`
+	Jobs                   []*batchv1.Job                  `json:"jobs,omitempty"`
+	PodDisruptionBudgets   []*policyv1.PodDisruptionBudget `json:"podDisruptionBudgets,omitempty"`
+	ReplicationControllers []*v1.ReplicationController     `json:"replicationController,omitempty"`
 }
 
 // ClusterExporter manages and runs an file export process which dumps the local kubernetes cluster to a target location.

--- a/pkg/clustercache/clusterimporter.go
+++ b/pkg/clustercache/clusterimporter.go
@@ -9,7 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	stv1 "k8s.io/api/storage/v1"
 )
 
@@ -271,14 +271,14 @@ func (ci *ClusterImporter) GetAllJobs() []*batchv1.Job {
 }
 
 // GetAllPodDisruptionBudgets returns all cached pod disruption budgets
-func (ci *ClusterImporter) GetAllPodDisruptionBudgets() []*v1beta1.PodDisruptionBudget {
+func (ci *ClusterImporter) GetAllPodDisruptionBudgets() []*policyv1.PodDisruptionBudget {
 	ci.dataLock.Lock()
 	defer ci.dataLock.Unlock()
 
 	// Deep copy here to avoid callers from corrupting the cache
 	// This also mimics the behavior of the default cluster cache impl.
 	pdbs := ci.data.PodDisruptionBudgets
-	cloneList := make([]*v1beta1.PodDisruptionBudget, 0, len(pdbs))
+	cloneList := make([]*policyv1.PodDisruptionBudget, 0, len(pdbs))
 	for _, v := range pdbs {
 		cloneList = append(cloneList, v.DeepCopy())
 	}


### PR DESCRIPTION
## What does this PR change?
* uses policy/v1 for listing PDBs

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* policy/v1beta1 is no longer served as of 1.25

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
