### PR TITLE
Correct GCP's default discount percentage

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -164,7 +164,7 @@ func (gcp *GCP) GetConfig() (*models.CustomPricing, error) {
 		return nil, err
 	}
 	if c.Discount == "" {
-		c.Discount = "30%"
+		c.Discount = "0%"
 	}
 	if c.NegotiatedDiscount == "" {
 		c.NegotiatedDiscount = "0%"


### PR DESCRIPTION
## What does this PR change?
* Correct the GCP's default discount value to 0%, this should be the correct value when this field is not set, also all other clouds' configs are 0%.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
