### PR TITLE
chore: opencost-helm-chart #176 issue consistent prometheus namespaceName and serviceName

### DIFF
--- a/kubernetes/exporter/opencost-exporter.yaml
+++ b/kubernetes/exporter/opencost-exporter.yaml
@@ -150,7 +150,7 @@ spec:
               memory: "1G"
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
-              value: "http://my-prometheus-server.prometheus.svc" # The endpoint should have the form http://<service-name>.<namespace-name>.svc
+              value: "http://prometheus-server.prometheus-system.svc" # The endpoint should have the form http://<service-name>.<namespace-name>.svc
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key. This is supplied just for evaluation.
             - name: CLUSTER_ID

--- a/kubernetes/opencost.yaml
+++ b/kubernetes/opencost.yaml
@@ -153,7 +153,7 @@ spec:
               memory: "1G"
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
-              value: "http://my-prometheus-server.prometheus.svc" # The endpoint should have the form http://<service-name>.<namespace-name>.svc
+              value: "http://prometheus-server.prometheus-system.svc" # The endpoint should have the form http://<service-name>.<namespace-name>.svc
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key. This is supplied just for evaluation.
             - name: CLUSTER_ID

--- a/ui/README.md
+++ b/ui/README.md
@@ -5,8 +5,8 @@
 See https://www.opencost.io/docs/install for the full instructions.
 
 ```
-helm install my-prometheus --repo https://prometheus-community.github.io/helm-charts prometheus \
-  --namespace prometheus --create-namespace \
+helm install prometheus --repo https://prometheus-community.github.io/helm-charts prometheus \
+  --namespace prometheus-system --create-namespace \
   --set pushgateway.enabled=false \
   --set alertmanager.enabled=false \
   -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml


### PR DESCRIPTION
## What does this PR change?
* Addresses issue [#176](https://github.com/opencost/opencost-helm-chart/issues/176), making prometheus installation example and configuration consistent across the manifests, helm and documentation. Using namespace `prometheus-system` and service name `prometheus-server` with release name `prometheus`.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Helm users will not be impacted since we are favoring helm default configuration. Users that used the manifests to install, most likely will not use them for upgrade.

## Does this PR address any GitHub or Zendesk issues?
* Closes 176

## How was this PR tested?
* On a local kind cluster.

## Does this PR require changes to documentation?
* Yes, there is a separate PR for such.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* This is a more house cleaning item than a bug.
