### PR TITLE
Allow opencost-ui to run with a read-only root filesystem

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -23,7 +23,8 @@ ENV API_PORT=9003
 ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
 
-COPY --from=builder /opt/ui/dist /var/www
+COPY --from=builder /opt/ui/dist /opt/ui/dist
+RUN mkdir -p /var/www
 COPY default.nginx.conf.template /etc/nginx/conf.d/default.nginx.conf.template
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/

--- a/ui/Dockerfile.cross
+++ b/ui/Dockerfile.cross
@@ -16,10 +16,11 @@ ENV API_PORT=9003
 ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
 
-COPY ./dist /var/www
+COPY ./dist /opt/ui/dist
 COPY default.nginx.conf.template /etc/nginx/conf.d/default.nginx.conf.template
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/
+RUN mkdir -p /var/www
 
 RUN rm -rf /etc/nginx/conf.d/default.conf
 

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+cp -rv /opt/ui/dist/* /var/www
+
 if [[ ! -z "$BASE_URL_OVERRIDE" ]]; then
     echo "running with BASE_URL=${BASE_URL_OVERRIDE}"
     sed -i "s^{PLACEHOLDER_BASE_URL}^$BASE_URL_OVERRIDE^g" /var/www/*.js


### PR DESCRIPTION
## What does this PR change?

Allow to run with a read-only root file system.

This is important for people who need to run this in Kubernetes with a policy set that only allows pods that have this set:

```yaml
          securityContext:
            readOnlyRootFilesystem: true
```

## Does this PR relate to any other PRs?
No 

## How will this PR impact users?

It does not directly affect users. The container continues to run with the same behavior as before. The only difference is, that now one can mount an emptyDir to /var/www and have the root filesystem read-only.

## Does this PR address any GitHub or Zendesk issues?

## How was this PR tested?
 

## Does this PR require changes to documentation?

Setting this in the Helm charts as a default would be possible. I guess that would make sense from a security point of view.

