### PR TITLE
Azure cloud costs: Add IsAzureDownloadBillingDataToDisk

### DIFF
--- a/pkg/cloud/azure/storagebillingparser.go
+++ b/pkg/cloud/azure/storagebillingparser.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"fmt"
@@ -59,29 +60,42 @@ func (asbp *AzureStorageBillingParser) ParseBillingData(start, end time.Time, re
 	}
 
 	for _, blobName := range blobNames {
-		localPath := filepath.Join(env.GetConfigPathWithDefault(env.DefaultConfigMountPath), "db", "cloudcost")
-		localFilePath := filepath.Join(localPath, filepath.Base(blobName))
+		if env.IsAzureDownloadBillingDataToDisk() {
+			localPath := filepath.Join(env.GetConfigPathWithDefault(env.DefaultConfigMountPath), "db", "cloudcost")
+			localFilePath := filepath.Join(localPath, filepath.Base(blobName))
 
-		if _, err := asbp.deleteFilesOlderThan7d(localPath); err != nil {
-			log.Warnf("CloudCost: Azure: ParseBillingData: failed to remove the following stale files: %v", err)
-		}
+			if _, err := asbp.deleteFilesOlderThan7d(localPath); err != nil {
+				log.Warnf("CloudCost: Azure: ParseBillingData: failed to remove the following stale files: %v", err)
+			}
 
-		err := asbp.DownloadBlobToFile(localFilePath, blobName, client, ctx)
-		if err != nil {
-			asbp.ConnectionStatus = cloud.FailedConnection
-			return err
-		}
+			err := asbp.DownloadBlobToFile(localFilePath, blobName, client, ctx)
+			if err != nil {
+				asbp.ConnectionStatus = cloud.FailedConnection
+				return err
+			}
 
-		fp, err := os.Open(localFilePath)
-		if err != nil {
-			asbp.ConnectionStatus = cloud.FailedConnection
-			return err
-		}
-		defer fp.Close()
-		err = asbp.parseCSV(start, end, csv.NewReader(fp), resultFn)
-		if err != nil {
-			asbp.ConnectionStatus = cloud.ParseError
-			return err
+			fp, err := os.Open(localFilePath)
+			if err != nil {
+				asbp.ConnectionStatus = cloud.FailedConnection
+				return err
+			}
+			defer fp.Close()
+			err = asbp.parseCSV(start, end, csv.NewReader(fp), resultFn)
+			if err != nil {
+				asbp.ConnectionStatus = cloud.ParseError
+				return err
+			}
+		} else {
+			blobBytes, err2 := asbp.DownloadBlob(blobName, client, ctx)
+			if err2 != nil {
+				asbp.ConnectionStatus = cloud.FailedConnection
+				return err2
+			}
+			err2 = asbp.parseCSV(start, end, csv.NewReader(bytes.NewReader(blobBytes)), resultFn)
+			if err2 != nil {
+				asbp.ConnectionStatus = cloud.ParseError
+				return err2
+			}
 		}
 	}
 	asbp.ConnectionStatus = cloud.SuccessfulConnection

--- a/pkg/cloud/azure/storageconnection.go
+++ b/pkg/cloud/azure/storageconnection.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -44,6 +45,29 @@ func (sc *StorageConnection) getBlobURLTemplate() string {
 	}
 	// default to Public Cloud template
 	return "https://%s.blob.core.windows.net/%s"
+}
+
+// DownloadBlob downloads the Azure Billing CSV into a byte slice
+func (sc *StorageConnection) DownloadBlob(blobName string, client *azblob.Client, ctx context.Context) ([]byte, error) {
+	log.Infof("Azure Storage: retrieving blob: %v", blobName)
+
+	downloadResponse, err := client.DownloadStream(ctx, sc.Container, blobName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Azure: DownloadBlob: failed to download %w", err)
+	}
+	// NOTE: automatically retries are performed if the connection fails
+	retryReader := downloadResponse.NewRetryReader(ctx, &azblob.RetryReaderOptions{})
+	defer retryReader.Close()
+
+	// read the body into a buffer
+	downloadedData := bytes.Buffer{}
+
+	_, err = downloadedData.ReadFrom(retryReader)
+	if err != nil {
+		return nil, fmt.Errorf("Azure: DownloadBlob: failed to read downloaded data %w", err)
+	}
+
+	return downloadedData.Bytes(), nil
 }
 
 // DownloadBlobToFile downloads the Azure Billing CSV to a local file

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -20,8 +20,9 @@ const (
 	AlibabaAccessKeyIDEnvVar     = "ALIBABA_ACCESS_KEY_ID"
 	AlibabaAccessKeySecretEnvVar = "ALIBABA_SECRET_ACCESS_KEY"
 
-	AzureOfferIDEnvVar        = "AZURE_OFFER_ID"
-	AzureBillingAccountEnvVar = "AZURE_BILLING_ACCOUNT"
+	AzureOfferIDEnvVar                   = "AZURE_OFFER_ID"
+	AzureBillingAccountEnvVar            = "AZURE_BILLING_ACCOUNT"
+	AzureDownloadBillingDataToDiskEnvVar = "AZURE_DOWNLOAD_BILLING_DATA_TO_DISK"
 
 	KubecostNamespaceEnvVar        = "KUBECOST_NAMESPACE"
 	PodNameEnvVar                  = "POD_NAME"
@@ -311,6 +312,13 @@ func GetAzureOfferID() string {
 // price sheet API.
 func GetAzureBillingAccount() string {
 	return env.Get(AzureBillingAccountEnvVar, "")
+}
+
+// IsAzureDownloadBillingDataToDisk returns the environment variable value for
+// AzureDownloadBillingDataToDiskEnvVar which indicates whether the Azure
+// Billing Data should be held in memory or written to disk.
+func IsAzureDownloadBillingDataToDisk() bool {
+	return env.GetBool(AzureDownloadBillingDataToDiskEnvVar, true)
 }
 
 // GetKubecostNamespace returns the environment variable value for KubecostNamespaceEnvVar which


### PR DESCRIPTION
## What does this PR change?
This PR re-introduces the `AZURE_DOWNLOAD_BILLING_DATA_TO_DISK` environment variable to bring back the option of downloading Azure cloud cost blobs into a byte slice. 

**Important: the current behaviour, where the blobs are saved to file on disk, is still maintained as the default**; the environment variable has default value "true". 

## Does this PR relate to any other PRs?
This PR brings back the DownloadBlob method deleted in https://github.com/opencost/opencost/pull/2456

## How will this PR impact users?
Users will be able to specify whether Azure cloud cost blobs should be temporarily persisted on disk or downloaded into a byte slice.

## Does this PR address any GitHub or Zendesk issues?
N/A

## How was this PR tested?
N/A

## Does this PR require changes to documentation?
N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
TBD
