### PR TITLE
Support LB and PV item-level reconciliation

### DIFF
--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -122,11 +122,12 @@ func (orig LbAllocations) Clone() LbAllocations {
 }
 
 type LbAllocation struct {
-	Service string  `json:"service"`
-	Cost    float64 `json:"cost"`
-	Private bool    `json:"private"`
-	Ip      string  `json:"ip"`    //@bingen:field[version=19]
-	Hours   float64 `json:"hours"` //@bingen:field[version=21]
+	Service    string  `json:"service"`
+	Cost       float64 `json:"cost"`
+	Private    bool    `json:"private"`
+	Ip         string  `json:"ip"`         //@bingen:field[version=19]
+	Hours      float64 `json:"hours"`      //@bingen:field[version=21]
+	Adjustment float64 `json:"adjustment"` //@bingen:field[ignore]
 }
 
 func (lba *LbAllocation) SanitizeNaN() {
@@ -312,6 +313,7 @@ type PVAllocation struct {
 	ByteHours  float64 `json:"byteHours"`
 	Cost       float64 `json:"cost"`
 	ProviderID string  `json:"providerID"` // @bingen:field[version=20]
+	Adjustment float64 `json:"adjustment"` //@bingen:field[ignore]
 }
 
 // Equal returns true if the two PVAllocation instances contain approximately the same


### PR DESCRIPTION
## What does this PR change?
* Adds Adjustment fields to LB and PV types in order to allow item-level reconciliation.

## Does this PR relate to any other PRs?
* Required for https://github.com/kubecost/kubecost-cost-model/pull/2179

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* Manually

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes