### PR TITLE
Add `statefulset`, `daemonset`, and `job` to drop-down options

### DIFF
--- a/ui/src/Reports.js
+++ b/ui/src/Reports.js
@@ -49,11 +49,14 @@ const aggregationOptions = [
   { name: "Cluster", value: "cluster" },
   { name: "Node", value: "node" },
   { name: "Namespace", value: "namespace" },
-  { name: "Controller kind", value: "controllerKind" },
+  { name: "Controller Kind", value: "controllerKind" },
   { name: "Controller", value: "controller" },
-  { name: "Service", value: "service" },
-  { name: "Pod", value: "pod" },
+  { name: "DaemonSet", value: "daemonset" },
   { name: "Deployment", value: "deployment" },
+  { name: "Job", value: "job" },
+  { name: "Service", value: "service" },
+  { name: "StatefulSet", value: "statefulset" },
+  { name: "Pod", value: "pod" },
   { name: "Container", value: "container" },
 ];
 


### PR DESCRIPTION
Fixes https://github.com/opencost/opencost/issues/2538

## What does this PR change?
* Adds 3 new drop-down options

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* more UI options

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/2538

## How was this PR tested?
* built locally, tested against K3s and GKE
* Container available here: https://github.com/users/mattray/packages/container/opencost-ui/180087766?tag=2538

## Does this PR require changes to documentation?
* not really

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* will be included
