### PR TITLE
Suppress undesirable provider error log [SELFHOST-1203]

### DIFF
--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -49,7 +49,7 @@ type Controller struct {
 // NewController initializes an Config Controller
 func NewController(cp models.Provider) *Controller {
 	var watchers map[ConfigSource]cloud.KeyedConfigWatcher
-	if env.IsKubernetesEnabled() {
+	if env.IsKubernetesEnabled() && cp != nil {
 		providerConfig := provider.ExtractConfigFromProviders(cp)
 		watchers = GetCloudBillingWatchers(providerConfig)
 	} else {


### PR DESCRIPTION
## What does this PR change?
* A number of code paths in both OC and KC call `NewController` with an explicit nil value. This, in turn, calls `ExtractConfigFromProviders`, which logs an error when passed a nil value:
   * `ERR cannot extract config from nil provider`
 * This PR skips the call to `ExtractConfigFromProviders` if the `Provider` is nil.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* A generally not-so-useful error message will no longer be logged.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* Nope.
