### PR TITLE
Fix default of 7 days so it doesn't report 'Custom' date range

### DIFF
--- a/ui/src/Reports.js
+++ b/ui/src/Reports.js
@@ -158,7 +158,7 @@ const ReportsPage = () => {
   const searchParams = new URLSearchParams(routerLocation.search);
   const routerHistory = useHistory();
   useEffect(() => {
-    setWindow(searchParams.get("window") || "6d");
+    setWindow(searchParams.get("window") || "7d");
     setAggregateBy(searchParams.get("agg") || "namespace");
     setAccumulate(searchParams.get("acc") === "true" || false);
     setCurrency(searchParams.get("currency") || "USD");


### PR DESCRIPTION
## What does this PR change?
* UI was defaulting to showing "Custom" in the date range on initial load

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Shows '7d' now

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Deployed on GKE

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* No
