### PR TITLE
Add support for showing "__idle__" in the UI

### DIFF
--- a/ui/src/services/allocation.js
+++ b/ui/src/services/allocation.js
@@ -12,6 +12,7 @@ class AllocationService {
     const params = {
       window: win,
       aggregate: aggregate,
+      includeIdle: true,
       step: "1d",
     };
     if (typeof accumulate === "boolean") {


### PR DESCRIPTION
## What does this PR change?
* Adds `__idle__` field to UI reports on usage, showing what's not currently in use by the cluster. These values were in the API, just not rendered.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users will now have more accurate results when comparing to their cloud bills.

## Does this PR address any GitHub or Zendesk issues?
* https://github.com/opencost/opencost/issues/2162
* https://github.com/opencost/opencost/issues/2172

## How was this PR tested?
* Locally and with GKE

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* This will be called out when released, since it's a change in behavior
