### PR TITLE
Switch from JSON to protobuf for kube-api requests

### DIFF
--- a/pkg/kubeconfig/loader.go
+++ b/pkg/kubeconfig/loader.go
@@ -17,7 +17,14 @@ func LoadKubeconfig(path string) (*rest.Config, error) {
 		loadingRules.ExplicitPath = path
 	}
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	return loader.ClientConfig()
+	config, err := loader.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	config.UserAgent = "opencost"
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+	return config, nil
 }
 
 // LoadKubeClient accepts a path to a kubeconfig to load and returns the clientset

--- a/pkg/kubeconfig/loader.go
+++ b/pkg/kubeconfig/loader.go
@@ -24,6 +24,8 @@ func LoadKubeconfig(path string) (*rest.Config, error) {
 		return nil, fmt.Errorf("loading kubeconfig: %w", err)
 	}
 	config.UserAgent = "opencost"
+	// use protobuf for faster serialization instead of default json
+	// https://kubernetes.io/docs/reference/using-api/api-concepts/#alternate-representations-of-resources
 	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	config.ContentType = "application/vnd.kubernetes.protobuf"
 	return config, nil

--- a/pkg/kubeconfig/loader.go
+++ b/pkg/kubeconfig/loader.go
@@ -1,6 +1,8 @@
 package kubeconfig
 
 import (
+	"fmt"
+
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -19,7 +21,7 @@ func LoadKubeconfig(path string) (*rest.Config, error) {
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 	config, err := loader.ClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading kubeconfig: %w", err)
 	}
 	config.UserAgent = "opencost"
 	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"


### PR DESCRIPTION
## What does this PR change?

Switch from JSON to protobuf for kube-api requests. Improve performance. I assume it should also reduce load on kube-api.

On my test it:
- reduced memory allocation from 350MB to 300MB (for data fetching)
- reduced object allocation from 1.700.000 to 1.100.000 objects (for data fetching)
- max memory usage (in a test) reduced from 300MB to 240MB. (total for all app)
- added a new frame for each object type to a profiler, previously all of them were bundled together. (Now it visible pods are number one, followed by a ReplicaSet on my cluster)
- reduced CPU consumption for resource parsing from 520ms to 180

Memory allocation space diff:
![Screenshot 2024-02-27 at 12 58 55](https://github.com/opencost/opencost/assets/2599261/be5f6491-cb25-4fe5-9d54-770a31a4db6b)

Related issue #2473


For the future references, my test setup:

AKS cluster with ~2500 pods.

```
package main

import (
	"fmt"
	"io"
	"net/http"
	"os"
	"runtime"
	"testing"
	"time"

	"github.com/opencost/opencost/pkg/cmd"
	"github.com/stretchr/testify/require"
)

func TestMemory(t *testing.T) {
	os.Setenv("KUBECONFIG", "/Users/r2k1/p/playground/performance-test/tc1.yaml")
	os.Setenv("PROMETHEUS_SERVER_ENDPOINT", "http://localhost:9092")
	os.Setenv("KUBERNETES_PORT", "443")
	os.Setenv("PPROF_ENABLED", "true")
	os.Setenv("CACHE_WARMING_ENABLED", "false")
	os.Setenv("DISABLE_AGGREGATE_COST_MODEL_CACHE", "true")
	os.Setenv("MAX_QUERY_CONCURRENCY", "5")

	go func() {
		err := cmd.Execute(nil)
		require.NoError(t, err)
	}()

	maxUsage := uint64(0)
	go trackMaxMemoryUsage(100*time.Microsecond, &maxUsage)
	time.Sleep(30 * time.Second)

	end := time.Now()
	start := end.Add(-time.Hour * 24)
	testFetch(t, fmt.Sprintf("http://localhost:9003/metrics"))
	testFetch(t, fmt.Sprintf("http://localhost:9003/allocation/compute?aggregate=namespace,controllerKind,controller,label:app,label:team,label:pod_template_hash&idleByNode=true&includeIdle=true&includeProportionalAssetResourceCosts=true&step=window&window=%s,%s", start.Format("2006-01-02T15:04:05Z"), end.Format("2006-01-02T15:04:05Z")))
	testFetch(t, fmt.Sprintf("http://localhost:9003/assets?window=%s,%s", start.Format("2006-01-02T15:04:05Z"), end.Format("2006-01-02T15:04:05Z")))
	t.Log("Max memory usage, KiB:", maxUsage/1024)
}


func testFetch(t *testing.T, url string) {
	startTime := time.Now()
	resp, err := http.Get(url)
	require.NoError(t, err)
	require.Less(t, resp.StatusCode, 300)
	require.GreaterOrEqual(t, resp.StatusCode, 200)
	data, err := io.ReadAll(resp.Body)
	require.NoError(t, err)
	t.Logf("%s, %v MiB, %s", time.Since(startTime), len(data)/1024/1024, url)
}

func trackMaxMemoryUsage(interval time.Duration, maxUsage *uint64) {
	var memStats runtime.MemStats

	for {
		runtime.ReadMemStats(&memStats)

		// Update maxUsage if the current HeapAlloc is greater
		if memStats.HeapAlloc > *maxUsage {
			*maxUsage = memStats.HeapAlloc
		}

		time.Sleep(interval)
	}
}
```