### PR TITLE
skip custom pricing if empty string

### DIFF
--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -249,13 +249,18 @@ func SetCustomPricingField(obj *CustomPricing, name string, value string) error 
 	// from getting set here.
 	switch strings.ToLower(name) {
 	case "cpu", "gpu", "ram", "spotcpu", "spotgpu", "spotram", "storage", "zonenetworkegress", "regionnetworkegress", "internetnetworkegress":
-		// Validate that "value" represents a real floating point number, and
-		// set precision, bits, etc. Do not allow NaN.
-		val, err := sanitizeFloatString(value, false)
-		if err != nil {
-			return fmt.Errorf("invalid numeric value for field '%s': %s", name, value)
+		//what should we default to here?
+		if value == "" {
+			value = "1.0"
+		} else {
+			// Validate that "value" represents a real floating point number, and
+			// set precision, bits, etc. Do not allow NaN.
+			val, err := sanitizeFloatString(value, false)
+			if err != nil {
+				return fmt.Errorf("invalid numeric value for field '%s': %s", name, value)
+			}
+			value = val
 		}
-		value = val
 	default:
 	}
 

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -249,9 +249,9 @@ func SetCustomPricingField(obj *CustomPricing, name string, value string) error 
 	// from getting set here.
 	switch strings.ToLower(name) {
 	case "cpu", "gpu", "ram", "spotcpu", "spotgpu", "spotram", "storage", "zonenetworkegress", "regionnetworkegress", "internetnetworkegress":
-		//what should we default to here?
+		// If we are sent an empty string, ignore the key and don't change the value
 		if value == "" {
-			value = "1.0"
+			return nil
 		} else {
 			// Validate that "value" represents a real floating point number, and
 			// set precision, bits, etc. Do not allow NaN.

--- a/pkg/cloud/models/models_test.go
+++ b/pkg/cloud/models/models_test.go
@@ -51,7 +51,7 @@ func TestSetSetCustomPricingField(t *testing.T) {
 			fieldName:  "%s",
 			fieldValue: "",
 			expValue:   defaultValue, // assert that the default value is not mutated
-			expError:   fmt.Errorf("invalid numeric value for field"),
+			expError:   nil,
 		},
 	}
 


### PR DESCRIPTION
## What does this PR change?
* Empty string values in custom pricing settings will be ignored in order to prevent the `/updateConfigByKey` endpoint from erroring 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Settings can be saved if a custom pricing value is set to empty string

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/SELFHOST-1157

## How was this PR tested?
* Built an image and put it on gke dev-1, observed settings page saving when custom pricing values are set to empty string

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v2.2?
