### PR TITLE
cost-model was missing the build-args for version and commit

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,6 +43,8 @@ build IMAGETAG VERSION=version: test (build-binary VERSION)
         --platform "linux/amd64" \
         -f 'Dockerfile.cross' \
         --build-arg binarypath=./cmd/costmodel/costmodel-amd64 \
+        --build-arg version={{version}} \
+        --build-arg commit={{commit}} \
         --provenance=false \
         -t {{IMAGETAG}}-amd64 \
         --push \
@@ -53,6 +55,8 @@ build IMAGETAG VERSION=version: test (build-binary VERSION)
         --platform "linux/arm64" \
         -f 'Dockerfile.cross' \
         --build-arg binarypath=./cmd/costmodel/costmodel-arm64 \
+        --build-arg version={{version}} \
+        --build-arg commit={{commit}} \
         --provenance=false \
         -t {{IMAGETAG}}-arm64 \
         --push \


### PR DESCRIPTION
same as #2587, but for `develop`

## What does this PR change?
* 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
