### PR TITLE
Standardize RELEASE_VERSION and IMAGE_TAG across build scripts

### DIFF
--- a/.github/workflows/build-and-publish-release.yml
+++ b/.github/workflows/build-and-publish-release.yml
@@ -102,7 +102,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-    
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -145,7 +145,7 @@ jobs:
       - name: Build and push (multiarch) OpenCost UI
         working-directory: ./opencost/ui
         run: |
-          just build '${{ steps.tags.outputs.IMAGE_TAG_UI }}'
+          just build '${{ steps.tags.outputs.IMAGE_TAG_UI }}' '${{ steps.version_number.outputs.RELEASE_VERSION }}'
           crane copy '${{ steps.tags.outputs.IMAGE_TAG_UI }}' '${{ steps.tags.outputs.IMAGE_TAG_UI_LATEST }}'
           crane copy '${{ steps.tags.outputs.IMAGE_TAG_UI }}' '${{ steps.tags.outputs.IMAGE_TAG_UI_VERSION }}'
         #  crane copy '${steps.tags.outputs.IMAGE_TAG_UI}' '${steps.tags.outputs.IMAGE_TAG_UI_QUAY}'

--- a/justfile
+++ b/justfile
@@ -37,16 +37,16 @@ build-binary VERSION=version:
         -o ./costmodel-arm64
 
 # Build and push a multi-arch Docker image
-build IMAGETAG VERSION=version: test (build-binary VERSION)
+build IMAGE_TAG RELEASE_VERSION: test (build-binary RELEASE_VERSION)
     docker buildx build \
         --rm \
         --platform "linux/amd64" \
         -f 'Dockerfile.cross' \
         --build-arg binarypath=./cmd/costmodel/costmodel-amd64 \
-        --build-arg version={{version}} \
+        --build-arg version={{RELEASE_VERSION}} \
         --build-arg commit={{commit}} \
         --provenance=false \
-        -t {{IMAGETAG}}-amd64 \
+        -t {{IMAGE_TAG}}-amd64 \
         --push \
         .
 
@@ -55,14 +55,13 @@ build IMAGETAG VERSION=version: test (build-binary VERSION)
         --platform "linux/arm64" \
         -f 'Dockerfile.cross' \
         --build-arg binarypath=./cmd/costmodel/costmodel-arm64 \
-        --build-arg version={{version}} \
+        --build-arg version={{RELEASE_VERSION}} \
         --build-arg commit={{commit}} \
         --provenance=false \
-        -t {{IMAGETAG}}-arm64 \
+        -t {{IMAGE_TAG}}-arm64 \
         --push \
         .
 
     manifest-tool push from-args \
         --platforms "linux/amd64,linux/arm64" \
-        --template {{IMAGETAG}}-ARCH \
-        --target {{IMAGETAG}}
+        --template {{IMAGE_TAG}}-ARCH \

--- a/ui/justfile
+++ b/ui/justfile
@@ -1,4 +1,3 @@
-version := `../tools/image-tag`
 commit := `git rev-parse --short HEAD`
 thirdPartyLicenseFile := "THIRD_PARTY_LICENSES.txt"
 
@@ -10,15 +9,15 @@ build-local:
 
     npx parcel build src/index.html
 
-build IMAGETAG: build-local
+build IMAGE_TAG RELEASE_VERSION: build-local
     cp ../{{thirdPartyLicenseFile}} .
     docker buildx build \
         --rm \
         --platform "linux/amd64" \
         -f 'Dockerfile.cross' \
         --provenance=false \
-        -t {{IMAGETAG}}-amd64 \
-        --build-arg version={{version}} \
+        -t {{IMAGE_TAG}}-amd64 \
+        --build-arg version={{RELEASE_VERSION}} \
         --build-arg commit={{commit}} \
         --push \
         .
@@ -28,16 +27,15 @@ build IMAGETAG: build-local
         --platform "linux/arm64" \
         -f 'Dockerfile.cross' \
         --provenance=false \
-        -t {{IMAGETAG}}-arm64 \
-        --build-arg version={{version}} \
+        -t {{IMAGE_TAG}}-arm64 \
+        --build-arg version={{RELEASE_VERSION}} \
         --build-arg commit={{commit}} \
         --push \
         .
 
     manifest-tool push from-args \
         --platforms "linux/amd64,linux/arm64" \
-        --template {{IMAGETAG}}-ARCH \
-        --target {{IMAGETAG}}
+        --template {{IMAGE_TAG}}-ARCH \
+        --target {{IMAGE_TAG}}
 
     rm -f {{thirdPartyLicenseFile}}
-


### PR DESCRIPTION
Justfiles synced with the GHA. Tested locally and verified logging.