### PR TITLE
Add carbon estimates field in custompricing

### DIFF
--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -197,6 +197,7 @@ type CustomPricing struct {
 	GoogleAnalyticsTag           string `json:"googleAnalyticsTag"`
 	ExcludeProviderID            string `json:"excludeProviderID"`
 	DefaultLBPrice               string `json:"defaultLBPrice"`
+	CarbonEstimates              string `json:"carbonEstimates"`
 }
 
 // GetSharedOverheadCostPerMonth parses and returns a float64 representation

--- a/pkg/customcost/repositoryquerier.go
+++ b/pkg/customcost/repositoryquerier.go
@@ -135,6 +135,10 @@ func getCustomCostAccumulateOption(window opencost.Window, from []opencost.Accum
 		return opencost.AccumulateOptionDay, nil
 	}
 
+	if oldestDaily.After(*window.Start()) {
+		return opencost.AccumulateOptionNone, fmt.Errorf("data store does not have coverage for %v", window)
+	}
+
 	return opencost.AccumulateOptionNone, fmt.Errorf("no valid accumulate option in %v for %s", from, window)
 }
 

--- a/pkg/customcost/repositoryquerier.go
+++ b/pkg/customcost/repositoryquerier.go
@@ -125,7 +125,7 @@ func getCustomCostAccumulateOption(window opencost.Window, from []opencost.Accum
 		return opencost.AccumulateOptionHour, nil
 	}
 
-	dailyStoreDays := env.GetCustomCostQueryWindowDays()
+	dailyStoreDays := env.GetDataRetentionDailyResolutionDays()
 	dailySteps := time.Duration(dailyStoreDays) * timeutil.Day
 	oldestDaily := time.Now().Add(-1 * dailySteps)
 	// Use daily if...

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -642,7 +642,7 @@ func GetRegionOverrideList() []string {
 }
 
 func GetDataRetentionDailyResolutionDays() int64 {
-	return env.GetInt64(DataRetentionDailyResolutionDaysEnvVar, 15)
+	return env.GetInt64(DataRetentionDailyResolutionDaysEnvVar, 30)
 }
 
 func GetDataRetentionHourlyResolutionHours() int64 {


### PR DESCRIPTION
## What does this PR change?
* Adds a field to CustomPricing for whether carbon estimation is enabled, for the purposes of serving `/getConfigs`.

## Does this PR relate to any other PRs?
* As mentioned

## How will this PR impact users?
* There will be one more field in CustomPricing.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* As part of a larger image, by calling `/getConfigs`

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
