### PR TITLE
Add carbon env to CustomPricing

### DIFF
--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -197,6 +197,7 @@ type CustomPricing struct {
 	GoogleAnalyticsTag           string `json:"googleAnalyticsTag"`
 	ExcludeProviderID            string `json:"excludeProviderID"`
 	DefaultLBPrice               string `json:"defaultLBPrice"`
+	CarbonEstimates              string `json:"carbonEstimates"`
 }
 
 // GetSharedOverheadCostPerMonth parses and returns a float64 representation

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -197,7 +197,9 @@ type CustomPricing struct {
 	GoogleAnalyticsTag           string `json:"googleAnalyticsTag"`
 	ExcludeProviderID            string `json:"excludeProviderID"`
 	DefaultLBPrice               string `json:"defaultLBPrice"`
-	CarbonEstimates              string `json:"carbonEstimates"`
+	// CarbonEstimates a string-encoded bool describing whether carbon
+	// cost estimation is enabled for Kubecost.
+	CarbonEstimates string `json:"carbonEstimates"`
 }
 
 // GetSharedOverheadCostPerMonth parses and returns a float64 representation


### PR DESCRIPTION
## What does this PR change?
* Adds the `CarbonEstimates` field to CustomPricing to support Kubecost carbon estimation integration.

## Does this PR relate to any other PRs?
* Yes, see linked.

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* See linked PR.

## Does this PR require changes to documentation?
* See linked PR.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
