### PR TITLE
Add carbon estimation functionality to assets

### DIFF
--- a/pkg/carbon/carbonassets.go
+++ b/pkg/carbon/carbonassets.go
@@ -1,0 +1,177 @@
+package carbon
+
+import (
+	"embed"
+	"encoding/csv"
+	"strconv"
+	"strings"
+
+	"github.com/opencost/opencost/core/pkg/log"
+	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/core/pkg/util"
+)
+
+//go:embed carbonlookupdata.csv
+var f embed.FS
+
+var carbonLookupNode map[interface{}]float64
+var carbonLookupDisk map[interface{}]float64
+
+var carbonValidInstanceTypes map[string]string
+var carbonValidRegions map[string]string
+
+func init() {
+
+	carbonData, err := f.ReadFile("carbonlookupdata.csv")
+	if err != nil {
+		log.Errorf("Error getting content of carbon lookup file: %s", err)
+		return
+	}
+
+	reader := csv.NewReader(strings.NewReader(string(carbonData)))
+
+	// skip header
+	reader.Read()
+	if err != nil {
+		log.Errorf("Error reading carbon lookup data: %s", err)
+		return
+	}
+
+	dat, err := reader.ReadAll()
+	if err != nil {
+		log.Errorf("Error reading carbon lookup data: %s", err)
+		return
+	}
+
+	carbonLookupNode = make(map[interface{}]float64)
+	carbonLookupDisk = make(map[interface{}]float64)
+
+	carbonValidInstanceTypes = make(map[string]string)
+	carbonValidRegions = make(map[string]string)
+
+	for _, carbonItem := range dat {
+
+		if coeff, err := strconv.ParseFloat(carbonItem[5], 64); err != nil {
+
+			log.DedupedWarningf(5, "Error setting carbon lookup item: malformed carbon cost '%s'", carbonItem[5])
+
+		} else {
+
+			provider := carbonItem[0]
+			region := carbonItem[1]
+			instanceType := carbonItem[2]
+			assetType := carbonItem[3]
+
+			switch assetType {
+			case "Node":
+				carbonLookupNode[struct {
+					provider     string
+					region       string
+					instanceType string
+				}{
+					provider:     provider,
+					region:       region,
+					instanceType: instanceType,
+				}] = coeff
+			case "Disk":
+				carbonLookupDisk[struct {
+					provider string
+					region   string
+				}{
+					provider: provider,
+					region:   region,
+				}] = coeff
+			}
+
+			carbonValidInstanceTypes[instanceType] = provider
+			carbonValidRegions[region] = provider
+
+		}
+
+	}
+
+}
+
+type CarbonRow struct {
+	Co2e float64 `json:"co2e"`
+}
+
+func RelateCarbonAssets(as *opencost.AssetSet) (map[string]CarbonRow, error) {
+
+	res := make(map[string]CarbonRow)
+
+	for key, asset := range as.Assets {
+
+		// If no valid region, default to per-provider calculated average
+		region, _ := util.GetRegion(asset.GetLabels())
+		if _, ok := carbonValidRegions[region]; !ok {
+			region = "average-region"
+		}
+
+		// If no valid instance type, also default to per-provider calculated average
+		instanceType, _ := util.GetInstanceType(asset.GetLabels())
+		if _, ok := carbonValidInstanceTypes[instanceType]; !ok {
+			region = "average-region"
+		}
+
+		provider := getProviderFromProviderID(asset.GetProperties().ProviderID)
+
+		// If we're not able to parse the provider id, try to fetch the provider from the carbon data
+		if provider == "" && region != "average-region" {
+			provider = carbonValidRegions[region]
+		} else {
+			log.DedupedErrorf(10, "Cannot infer region information for asset '%s'", asset.GetProperties().ProviderID)
+		}
+
+		var foundCarbonCoeff bool
+		var carbonCoeff float64
+		switch asset.Type() {
+		case opencost.NodeAssetType:
+			carbonCoeff, foundCarbonCoeff = carbonLookupNode[struct {
+				provider     string
+				region       string
+				instanceType string
+			}{
+				provider:     provider,
+				region:       region,
+				instanceType: instanceType,
+			}]
+		case opencost.DiskAssetType:
+			carbonCoeff, foundCarbonCoeff = carbonLookupDisk[struct {
+				provider string
+				region   string
+			}{
+				provider: provider,
+				region:   region,
+			}]
+		}
+
+		if !foundCarbonCoeff {
+
+			carbonCoeff = 0
+
+		}
+
+		res[key] = CarbonRow{
+			Co2e: carbonCoeff * asset.GetWindow().Duration().Hours(),
+		}
+
+	}
+
+	return res, nil
+
+}
+
+func getProviderFromProviderID(providerid string) string {
+
+	if strings.HasPrefix(providerid, "gke") {
+		return opencost.GCPProvider
+	} else if strings.HasPrefix(providerid, "i-") {
+		return opencost.AWSProvider
+	} else if strings.HasPrefix(providerid, "azure") {
+		return opencost.AzureProvider
+	}
+
+	return ""
+
+}

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -64,6 +64,9 @@ func Execute(opts *CostModelOpts) error {
 		a.Router.GET("/allocation", a.ComputeAllocationHandler)
 		a.Router.GET("/allocation/summary", a.ComputeAllocationHandlerSummary)
 		a.Router.GET("/assets", a.ComputeAssetsHandler)
+		if env.IsCarbonEstimatesEnabled() {
+			a.Router.GET("/assets/carbon", a.ComputeAssetsCarbonHandler)
+		}
 	}
 
 	a.Router.GET("/cloudCost", a.CloudCostQueryService.GetCloudCostHandler())

--- a/pkg/costmodel/handlers.go
+++ b/pkg/costmodel/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/filter/matcher"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/util/httputil"
+	"github.com/opencost/opencost/pkg/carbon"
 	"github.com/opencost/opencost/pkg/env"
 )
 
@@ -27,12 +28,50 @@ func (a *Accesses) ComputeAssetsHandler(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	assetSet, err := a.Model.ComputeAssets(*window.Start(), *window.End())
+	filterString := qp.Get("filter", "")
+
+	assetSet, err := a.computeAssetsFromCostmodel(window, filterString)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Error computing asset set: %s", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Error getting assets: %s", err), http.StatusInternalServerError)
 		return
 	}
+
+	w.Write(WrapData(assetSet, nil))
+}
+
+// ComputeAllocationHandler returns the assets from the CostModel.
+func (a *Accesses) ComputeAssetsCarbonHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+
+	qp := httputil.NewQueryParams(r.URL.Query())
+
+	// Window is a required field describing the window of time over which to
+	// compute allocation data.
+	window, err := opencost.ParseWindowWithOffset(qp.Get("window", ""), env.GetParsedUTCOffset())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid 'window' parameter: %s", err), http.StatusBadRequest)
+		return
+	}
+
 	filterString := qp.Get("filter", "")
+
+	assetSet, err := a.computeAssetsFromCostmodel(window, filterString)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error getting assets: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	carbonEstimates, err := carbon.RelateCarbonAssets(assetSet)
+
+	w.Write(WrapData(carbonEstimates, nil))
+}
+
+func (a *Accesses) computeAssetsFromCostmodel(window opencost.Window, filterString string) (*opencost.AssetSet, error) {
+
+	assetSet, err := a.Model.ComputeAssets(*window.Start(), *window.End())
+	if err != nil {
+		return nil, fmt.Errorf("error computing asset set: %s", err)
+	}
 
 	var filter opencost.AssetMatcher
 	if filterString == "" {
@@ -41,17 +80,17 @@ func (a *Accesses) ComputeAssetsHandler(w http.ResponseWriter, r *http.Request, 
 		parser := assetfilter.NewAssetFilterParser()
 		tree, errParse := parser.Parse(filterString)
 		if errParse != nil {
-			http.Error(w, fmt.Sprintf("err parsing filter '%s': %v", ast.ToPreOrderShortString(tree), errParse), http.StatusBadRequest)
+			return nil, fmt.Errorf("err parsing filter '%s': %v", ast.ToPreOrderShortString(tree), errParse)
 		}
 		compiler := opencost.NewAssetMatchCompiler()
 		var err error
 		filter, err = compiler.Compile(tree)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("err compiling filter '%s': %v", ast.ToPreOrderShortString(tree), err), http.StatusBadRequest)
+			return nil, fmt.Errorf("err compiling filter '%s': %v", ast.ToPreOrderShortString(tree), err)
 		}
 	}
 	if filter == nil {
-		http.Error(w, fmt.Sprintf("unexpected nil filter"), http.StatusInternalServerError)
+		return nil, fmt.Errorf("unexpected nil filter")
 	}
 
 	for key, asset := range assetSet.Assets {
@@ -60,5 +99,5 @@ func (a *Accesses) ComputeAssetsHandler(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
-	w.Write(WrapData(assetSet, nil))
+	return assetSet, nil
 }

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -134,6 +134,8 @@ const (
 	PluginExecutableDirEnvVar = "PLUGIN_EXECUTABLE_DIR"
 
 	OCIPricingURL = "OCI_PRICING_URL"
+
+	CarbonEstimatesEnabledEnvVar = "CARBON_ESTIMATES_ENABLED"
 )
 
 const DefaultConfigMountPath = "/var/configs"
@@ -703,4 +705,8 @@ func GetPluginExecutableDir() string {
 
 func GetCustomCostRefreshRateHours() string {
 	return env.Get(CustomCostRefreshRateHoursEnvVar, "12h")
+}
+
+func IsCarbonEstimatesEnabled() bool {
+	return env.GetBool(CarbonEstimatesEnabledEnvVar, false)
 }


### PR DESCRIPTION
## What does this PR change?
Adds carbon estimation functionality to Opencost `/assets`, assigning a carbon cost in CO2e to each node/disk based off a lookup table.

Enabled by setting the `CARBON_ESTIMATES_ENABLED` env var.

## Does this PR relate to any other PRs?
No.

## How will this PR impact users?
* Adds the `/assets/carbon` endpoint to Opencost, allowing users to see carbon costs for node and disk assets.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Locally against Prom by querying endpoint.
* On an existing install of Opencost by querying endpoint.

## Does this PR require changes to documentation?
* Yes.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
