### PR TITLE
Wrap unknown tag columns in double qotes

### DIFF
--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -94,8 +94,9 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.Cloud
 	// of columns to query.
 	for column := range allColumns {
 		if strings.HasPrefix(column, LabelColumnPrefix) {
-			groupByColumns = append(groupByColumns, column)
-			aqi.TagColumns = append(aqi.TagColumns, column)
+			quotedTag := fmt.Sprintf(`"%s"`, column)
+			groupByColumns = append(groupByColumns, quotedTag)
+			aqi.TagColumns = append(aqi.TagColumns, quotedTag)
 		}
 	}
 	var selectColumns []string
@@ -334,7 +335,11 @@ func (ai *AthenaIntegration) RowToCloudCost(row types.Row, aqi AthenaQueryIndexe
 	labels := opencost.CloudCostLabels{}
 	labelValues := []string{}
 	for _, tagColumnName := range aqi.TagColumns {
-		labelName := strings.TrimPrefix(tagColumnName, LabelColumnPrefix)
+		// remove quotes
+		labelName := strings.TrimPrefix(tagColumnName, `"`)
+		labelName = strings.TrimSuffix(tagColumnName, `"`)
+		// remove prefix
+		labelName = strings.TrimPrefix(tagColumnName, LabelColumnPrefix)
 		value := GetAthenaRowValue(row, aqi.ColumnIndexes, tagColumnName)
 		if value != "" {
 			labels[labelName] = value


### PR DESCRIPTION
## What does this PR change?
This PR addresses an issue encountered by a user where a special character in a user defined tag column of their CUR could not be handled be the Athena SQL dialect without being wrapped in double quotes `ó`.   

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested by running cloud cost ingestion with updated query

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
