### PR TITLE
Update the `/installInfo` endpoint

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1204,9 +1204,6 @@ type InstallInfo struct {
 type ContainerInfo struct {
 	ContainerName string `json:"containerName"`
 	Image         string `json:"image"`
-	ImageID       string `json:"imageID"`
-	StartTime     string `json:"startTime"`
-	Restarts      int32  `json:"restarts"`
 }
 
 func (a *Accesses) GetInstallInfo(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -1232,13 +1229,10 @@ func (a *Accesses) GetInstallInfo(w http.ResponseWriter, r *http.Request, _ http
 	// chart or more likely we are running locally - in either case Images field will return as null
 	if len(pods.Items) > 0 {
 		for _, pod := range pods.Items {
-			for _, container := range pod.Status.ContainerStatuses {
+			for _, container := range pod.Spec.Containers {
 				c := ContainerInfo{
 					ContainerName: container.Name,
 					Image:         container.Image,
-					ImageID:       container.ImageID,
-					StartTime:     pod.Status.StartTime.String(),
-					Restarts:      container.RestartCount,
 				}
 				info.Containers = append(info.Containers, c)
 			}


### PR DESCRIPTION
## What does this PR change?
* Updates the `/installInfo` endpoint to query the k8s `pod.Spec` instead of `pod.Status`.
* We've found that `pod.Status` can sometimes show stale information. Specifically, it will state that a container is running an image which it is actually no longer running. More details here: https://github.com/kubernetes/kubernetes/issues/74081
* To reproduce, swap out one of your existing container images via `kubectl edit deployment/kubecost-cost-analyzer` then run the following two commands:
  * `kubectl describe pod -l app=cost-analyzer | grep "Image"`
  * `kubectl get pod kubecost-cost-analyzer-7d65b9479f-wtnnz -oyaml | grep "image"`

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* Some users will be impacted if they were using the `/installInfo` endpoint to grab container metadata such as its ImageID or its number of restarts. This PR removes that metadata since the `pod.Spec` endpoint does not return that info.
* This only impacts users of the `/installInfo` endpoint. Deleted fields are not referenced internally anywhere in OpenCost codebase.

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?

```sh
export CONFIG_PATH="/tmp/localrun/default"
export PROMETHEUS_SERVER_ENDPOINT="http://127.0.0.1:9080"
export KUBERNETES_PORT="localrun"
export KUBECOST_NAMESPACE=kubecost-amp-multi

go run cmd/costmodel/main.go
```

Then hitting `http://localhost:9003/installInfo` correctly returns the kubecost containers running in the namespace.

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
