### PR TITLE
change URL for Kubecost issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/opencost-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/opencost-bug-report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the OpenCost bug is. Please ensure this is an issue related to the OpenCost cost model, API, UI or specification. Public Kubecost bugs may be opened at https://github.com/kubecost/cost-analyzer-helm-chart/ 
+A clear and concise description of what the OpenCost bug is. Please ensure this is an issue related to the OpenCost cost model, API, UI or specification. Public Kubecost bugs may be opened at https://github.com/kubecost/features-bugs
 
 **To Reproduce**
 Steps to reproduce the behavior:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## What does this PR change?
* Updates the URL in the issue template to point to the correct Kubecost repository.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Directs them to the appropriate GitHub repository for opening bugs specific to Kubecost.

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* N/A

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A
