### PR TITLE
Update `/installInfo` endpoint. Adds startTime back in.

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1204,6 +1204,7 @@ type InstallInfo struct {
 type ContainerInfo struct {
 	ContainerName string `json:"containerName"`
 	Image         string `json:"image"`
+	StartTime     string `json:"startTime"`
 }
 
 func (a *Accesses) GetInstallInfo(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -1233,6 +1234,7 @@ func (a *Accesses) GetInstallInfo(w http.ResponseWriter, r *http.Request, _ http
 				c := ContainerInfo{
 					ContainerName: container.Name,
 					Image:         container.Image,
+					StartTime:     pod.Status.StartTime.String(),
 				}
 				info.Containers = append(info.Containers, c)
 			}


### PR DESCRIPTION
## What does this PR change?
* Re-introduce the `startTime` field in the API response. Previously removed by PR https://github.com/opencost/opencost/pull/2663.
* The `imageID` and `restarts` are slightly more difficult to reintroduce because they require data from iterating over `pod.Status.ContainerStatuses`. It's possible to merge data between `pod.Spec` and `pod.Status`, however I'm wary to do so since we moved away from `pod.Status` for reliability issues to begin with.

## Does this PR relate to any other PRs?
* Patches https://github.com/opencost/opencost/pull/2663

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?

```sh
export CONFIG_PATH="/tmp/localrun/default"
export PROMETHEUS_SERVER_ENDPOINT="http://127.0.0.1:9080"
export KUBERNETES_PORT="localrun"
export KUBECOST_NAMESPACE=kubecost-amp-multi

go run cmd/costmodel/main.go
```

Hitting `http://localhost:9003/installInfo` returned the following:

<details>
<summary> API response here </summary>

```json
{
  "containers": [
    {
      "containerName": "sigv4proxy",
      "image": "public.ecr.aws/aws-observability/aws-sigv4-proxy:latest",
      "startTime": "2024-03-25 19:15:28 -0700 PDT"
    },
    {
      "containerName": "cost-model",
      "image": "gcr.io/kubecost1/cost-model:prod-2.2.0-rc.4",
      "startTime": "2024-03-25 19:15:28 -0700 PDT"
    },
    {
      "containerName": "cost-analyzer-frontend",
      "image": "gcr.io/kubecost1/frontend:prod-2.2.0-rc.4",
      "startTime": "2024-03-25 19:15:28 -0700 PDT"
    },
    {
      "containerName": "aggregator",
      "image": "gcr.io/kubecost1/cost-model:prod-2.2.0-rc.4",
      "startTime": "2024-03-25 19:15:28 -0700 PDT"
    },
    {
      "containerName": "cloud-cost",
      "image": "gcr.io/kubecost1/cost-model:prod-2.2.0-rc.4",
      "startTime": "2024-03-25 19:15:28 -0700 PDT"
    }
  ],
  "clusterInfo": {
    "nodeCount": "7",
    "podCount": "247"
  },
  "version": "dev (HEAD)"
}
```

</details>

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
