### PR TITLE
Add `domains` to `/customCost/status` response

### DIFF
--- a/pkg/customcost/pipelineservice.go
+++ b/pkg/customcost/pipelineservice.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -40,6 +41,11 @@ func getRegisteredPlugins(configDir string, execDir string) (map[string]*plugin.
 
 	// list of plugins that we must run are the strings before _
 	for _, file := range configFiles {
+		// skip hidden files and directories
+		if strings.HasPrefix(file.Name(), ".") || file.IsDir() {
+			continue
+		}
+
 		log.Tracef("parsing config file name: %s", file.Name())
 		fileParts := strings.Split(file.Name(), "_")
 
@@ -47,7 +53,7 @@ func getRegisteredPlugins(configDir string, execDir string) (map[string]*plugin.
 			return nil, fmt.Errorf("plugin config file name %s invalid. Config files must have the form <plugin name>_config.json", file.Name())
 		}
 
-		pluginNames[fileParts[0]] = configDir + "/" + file.Name()
+		pluginNames[fileParts[0]] = path.Join(configDir, file.Name())
 	}
 
 	if len(pluginNames) == 0 {

--- a/pkg/customcost/status.go
+++ b/pkg/customcost/status.go
@@ -9,6 +9,7 @@ import (
 // Status gives the details and metadata of a CustomCost integration
 type Status struct {
 	Enabled           bool                       `json:"enabled"`
+	Domains           []string                   `json:"domains"`
 	Key               string                     `json:"key,omitempty"`
 	Source            string                     `json:"source,omitempty"`
 	Provider          string                     `json:"provider,omitempty"`


### PR DESCRIPTION
## What does this PR change?
* Updates the `/customCost/status` response to include the list of currently enabled Custom Cost plugins.

## Does this PR relate to any other PRs?
* [Helm](https://github.com/kubecost/cost-analyzer-helm-chart/pull/3290).
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2342).

## How will this PR impact users?
* Custom Cost pages in the FE will be able to reliably determine if Custom Costs are enabled.

## Does this PR address any GitHub or Zendesk issues?
* Nope.

## How was this PR tested?
* To be tested.

## Does this PR require changes to documentation?
* Nope.