### PR TITLE
BYO prometheus , common prometheus docs broken links fixed

### DIFF
--- a/pkg/prom/diagnostics.go
+++ b/pkg/prom/diagnostics.go
@@ -54,7 +54,7 @@ const (
 	KSMAllocatableCPUCoresMetricID = "ksmAllocatableCpuCoresMetric"
 )
 
-const DocumentationBaseURL = "https://github.com/kubecost/docs/blob/master/diagnostics.md"
+const DocumentationBaseURL = "https://www.opencost.io/docs/"
 
 // diagnostic definitions mapping holds all of the diagnostic definitions that can be used for prometheus metrics diagnostics
 var diagnosticDefinitions map[string]*diagnosticDefinition = map[string]*diagnosticDefinition{
@@ -117,7 +117,7 @@ var diagnosticDefinitions map[string]*diagnosticDefinition = map[string]*diagnos
 		QueryFmt:    `absent_over_time(kubecost_container_cpu_usage_irate{%s}[5m] %s)`,
 		Label:       "Kubecost's CPU usage recording rule is set up",
 		Description: "If the 'kubecost_container_cpu_usage_irate' recording rule is not set up, Allocation pipeline build may put pressure on your Prometheus due to the use of a subquery.",
-		DocLink:     "https://docs.kubecost.com/install-and-configure/install/custom-prom",
+		DocLink:     "https://www.opencost.io/docs/installation/prometheus",
 	},
 	CAdvisorWorkingSetBytesMetricID: {
 		ID:          CAdvisorWorkingSetBytesMetricID,

--- a/pkg/prom/helpers.go
+++ b/pkg/prom/helpers.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const PrometheusTroubleshootingURL = "https://gitbook.kubecost.com/v/1.0x/install-and-configure/install/custom-prom"
+const PrometheusTroubleshootingURL = "https://www.opencost.io/docs/integrations/prometheus"
 
 // ScrapeConfig is the minimalized view of a prometheus scrape configuration
 type ScrapeConfig struct {

--- a/pkg/prom/helpers.go
+++ b/pkg/prom/helpers.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const PrometheusTroubleshootingURL = "http://docs.kubecost.com/custom-prom#troubleshoot"
+const PrometheusTroubleshootingURL = "https://gitbook.kubecost.com/v/1.0x/install-and-configure/install/custom-prom"
 
 // ScrapeConfig is the minimalized view of a prometheus scrape configuration
 type ScrapeConfig struct {


### PR DESCRIPTION
### Title:
Update Broken Links in Opencost Prometheus Docs

### Description:
This pull request aims to resolve issue [#2669](https://github.com/opencost/opencost/issues/2669) 

This pull request addresses broken links in the Prometheus documentation section of our project. The broken links were a result of Kubecost's recent documentation updates following the release of version 2.1. To ensure our documentation remains accessible and helpful, I've made the following changes:

1. **Updated Links to OpenCost Prometheus Configuration Docs:** Several links previously directed users to Kubecost documentation that has been moved or updated in their 2.1 release. I've updated these links to point to the relevant sections of OpenCost's Prometheus configuration documentation, ensuring users have access to the correct and most current information.

2. **Temporary Redirection for "Bring Your Own Prometheus" Section:** The "Bring Your Own Prometheus" documentation has not yet been updated in OpenCost's docs . In anticipation of future updates, and to maintain continuity for users, I have temporarily redirected these links to Kubecost's version 1.x documentation on the same topic. This ensures users can still find relevant information until OpenCost updates its documentation.