### PR TITLE
cloud cost status returns empty slice instead of nil

### DIFF
--- a/pkg/cloudcost/pipelineservice.go
+++ b/pkg/cloudcost/pipelineservice.go
@@ -35,9 +35,11 @@ func NewPipelineService(repo Repository, ic *config.Controller, ingConf Ingestor
 // Status merges status values from the config.Controller and the IngestionManager to give a combined view of that state
 // of configs and their ingestion status
 func (dp *PipelineService) Status() []Status {
-	var statuses []Status
 	// Pull config status from the config controller
 	confStatuses := dp.configController.GetStatus()
+
+	statuses := make([]Status, 0, len(confStatuses))
+
 	refreshRate := time.Hour * time.Duration(env.GetCloudCostRefreshRateHours())
 	for _, confStat := range confStatuses {
 		var conf cloudconfig.Config


### PR DESCRIPTION
## What does this PR change?
* This PR updates the response from the `Status()` function to return an empty slice rather than nil when there are no statuses.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
