### PR TITLE
prevent spam log in unconfigured cloudcost

### DIFF
--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -68,6 +68,10 @@ func (c *Controller) pullWatchers() {
 	if err != nil {
 		log.Warnf("Controller: pullWatchers: %s. Proceeding to create the file", err.Error())
 		statuses = Statuses{}
+		err = c.save(statuses)
+		if err != nil {
+			log.Errorf("Controller: pullWatchers: failed to save statuses %s", err.Error())
+		}
 	}
 	for source, watcher := range c.watchers {
 		watcherConfsByKey := map[string]cloud.KeyedConfig{}


### PR DESCRIPTION
## What does this PR change?
* This PR prevents a looping warning message from spamming logs when cloud cost configurations are not present. This is done by actually creating the missing file as the message suggests
<img width="1183" alt="Screenshot 2024-04-04 at 5 15 39 PM" src="https://github.com/opencost/opencost/assets/12225425/3838b8e3-36c9-4e28-9f80-9f1f50cc68b5">

## Does this PR relate to any other PRs?



## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
