### PR TITLE
Create a hash key when agg properties are not set for Cloud Cost

### DIFF
--- a/core/pkg/opencost/cloudcost.go
+++ b/core/pkg/opencost/cloudcost.go
@@ -345,6 +345,7 @@ func (ccs *CloudCostSet) Insert(cc *CloudCost) error {
 		ccs.CloudCosts = map[string]*CloudCost{}
 	}
 
+	// If the Aggregation properties is not set the returned key will be a hash of the properties values
 	ccKey := cc.Properties.GenerateKey(ccs.AggregationProperties)
 
 	// Add the given CloudCost to the existing entry, if there is one;

--- a/core/pkg/opencost/cloudcostprops.go
+++ b/core/pkg/opencost/cloudcostprops.go
@@ -290,7 +290,9 @@ func (ccp *CloudCostProperties) GenerateKey(props []string) string {
 }
 
 // HashKey creates a key on the entire property set including labels of a uniform length.
-// This key is meant to be used when constructing unaggregated CloudCostSet for storage
+// This key is meant to be used when constructing unaggregated CloudCostSet for storage.
+// Including labels prevents CloudCosts that are missing providerIDs from having their labels
+// erased as they are saved to cloud cost set.
 func (ccp *CloudCostProperties) hashKey() string {
 	builder := strings.Builder{}
 	builder.WriteString(ccp.ProviderID)
@@ -300,7 +302,8 @@ func (ccp *CloudCostProperties) hashKey() string {
 	builder.WriteString(ccp.Service)
 	builder.WriteString(ccp.Category)
 
-	// Sort label keys before adding key/value pairs to the hash string
+	// Sort label keys before adding key/value pairs to the hash string to ensure label set is
+	// always returns the same key
 	labelKeys := maps.Keys(ccp.Labels)
 	sort.Strings(labelKeys)
 	for _, k := range labelKeys {

--- a/core/pkg/opencost/cloudcostprops_test.go
+++ b/core/pkg/opencost/cloudcostprops_test.go
@@ -163,3 +163,65 @@ func TestCloudCostPropertiesIntersection(t *testing.T) {
 		})
 	}
 }
+
+func TestCloudCostProperties_hashKey(t *testing.T) {
+
+	tests := map[string]struct {
+		props *CloudCostProperties
+		want  string
+	}{
+		"enpty props": {
+			props: &CloudCostProperties{},
+			want:  "cbf29ce484222325",
+		},
+		"All props no labels": {
+			props: &CloudCostProperties{
+				ProviderID:      "providerid1",
+				Provider:        "provider1",
+				AccountID:       "workgroup1",
+				InvoiceEntityID: "billing1",
+				Service:         "service1",
+				Category:        "category1",
+				Labels:          map[string]string{},
+			},
+			want: "a19b7dddf0032572",
+		},
+		"All props": {
+			props: &CloudCostProperties{
+				ProviderID:      "providerid1",
+				Provider:        "provider1",
+				AccountID:       "workgroup1",
+				InvoiceEntityID: "billing1",
+				Service:         "service1",
+				Category:        "category1",
+				Labels: map[string]string{
+					"label1": "value1",
+					"label2": "value2",
+				},
+			},
+			want: "9d54403e40ad4db6",
+		},
+		"All props swap labels": {
+			props: &CloudCostProperties{
+				ProviderID:      "providerid1",
+				Provider:        "provider1",
+				AccountID:       "workgroup1",
+				InvoiceEntityID: "billing1",
+				Service:         "service1",
+				Category:        "category1",
+				Labels: map[string]string{
+					"label2": "value2",
+					"label1": "value1",
+				},
+			},
+			want: "9d54403e40ad4db6",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.props.hashKey(); got != tt.want {
+				t.Errorf("hashKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
This PR updates the way keys are generated for CloudCostSet when no aggregation properties are included. This is primarily meant to change the way that CloudCostSet are keyed when unaggregated to bingen file. Users have observed that certain line items that are missing the ProviderID field are aggregated when the CloudCost set is saved which erases their label set. To preserve this label set it is being included the new key creation process.

The new key creation process simply creates a 64 bit hash from property set  including the labels sorted by key. The result is a fixed length key with a vanishingly low chance of collision. 

This change has resulted in generally smaller cloud cost bingen file size due to the fixed length key being shorter the concatenated key. So much so that it off set the increased number of Cloud Costs.

In testing on the billing data I observed small increases in the number of Cloud Costs. These are the percentage increases by provider:
AWS: 0.008%
GCP: 7.590%
Azure: 0.0%
These numbers were retrieved over a 30 day window

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested with local runs and a unit test for the new hash key function

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
