### PR TITLE
Update CloudCost service categorization for AWS

### DIFF
--- a/pkg/cloud/aws/athenaquerier.go
+++ b/pkg/cloud/aws/athenaquerier.go
@@ -208,6 +208,10 @@ func SelectAWSCategory(providerID, usageType, service string) string {
 	// The node and volume conditions are mutually exclusive.
 	// Provider ID has prefix "i-"
 	if strings.HasPrefix(providerID, "i-") {
+		// GuardDuty has a ProviderID prefix of "i-", but should not be categorized as compute
+		if strings.ToUpper(service) == "AMAZONGUARDDUTY" {
+			return opencost.OtherCategory
+		}
 		return opencost.ComputeCategory
 	}
 	// Provider ID has prefix "vol-"


### PR DESCRIPTION
## What does this PR change?
* Update CloudCost service categorization for AWS. GuardDuty should not be classified as "Compute", but instead as "Other".

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* Fixes categorization of an AWS resource for the CloudCost API.
* For downstream apps (e.g. Kubecost), this also fixes the cost reconciliation process.

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?

Enabled AmazonGuardDuty in one of my environments (it's on a free trial, but still shows up in the CUR with a $0 charge).

Before this change, notice that AmazonGuardDuty was being categorized as "Compute" when it had a ProviderId of `i-*`. There are also cases when other AmazonGuardDuty services are categorized as "Network" or "Other" likely due to other columns in the CUR. Details here. [guardduty-cloudcost.txt](https://github.com/opencost/opencost/files/15180102/guardduty-cloudcost.txt)

After this change, all AmazonGuardDuty which has a ProviderID of `i-*` are now categorized as "Other". Even though runtime monitoring is being performed for each individual EC2 instance, we do not want to merge these costs into the cost of a node (which should solely be CPU + RAM + GPU). Details here. [guardduty-cloudcost-customimage.txt](https://github.com/opencost/opencost/files/15180119/guardduty-cloudcost-customimage.txt)

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
