### PR TITLE
Reduce memory consumption

### DIFF
--- a/pkg/clustercache/watchcontroller.go
+++ b/pkg/clustercache/watchcontroller.go
@@ -88,19 +88,7 @@ func NewCachingWatcher(restClient rest.Interface, resource string, resourceType 
 }
 
 func (c *CachingWatchController) GetAll() []interface{} {
-	list := c.indexer.List()
-
-	// since the indexer returns the as-is pointer to the resource,
-	// we deep copy the resources such that callers don't corrupt the
-	// index
-	cloneList := make([]interface{}, 0, len(list))
-	for _, v := range list {
-		if deepCopyable, ok := v.(rt.Object); ok {
-			cloneList = append(cloneList, deepCopyable.DeepCopyObject())
-		}
-	}
-
-	return cloneList
+	return c.indexer.List()
 }
 
 func (c *CachingWatchController) SetUpdateHandler(handler WatchHandler) WatchController {


### PR DESCRIPTION
Opencost stores Kubernetes objects (Pod, ReplicaSet, Deployment, DaemonSet, etc.) with all their fields in memory.

For every request to the /metrics endpoint, a copy of these objects is created, which can lead to significant memory usage, particularly for large clusters.

I suspect this is to prevent accidental modifications, but how likely is that? I think there should be no reason to modify the k8s objects.

I ran some tests on a single-node cluster, creating 300 deployments. Max memory usage dropped from 125MB to 105MB after avoiding the extra copies. Taking generic overhead into account it may produce greater benefits for the large clusters.

Related issue #2637
