### PR TITLE
Add Alex Meijer as a new Maintainer.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 | Maintainer | GitHub ID | Affiliation | Email |
 | --------------- | --------- | ----------- | ----------- |
 | Ajay Tripathy | @AjayTripathy | Kubecost | <Ajay@kubecost.com> |
+| Alex Meijer | @ameijer | Kubecost | <ameijer@kubecost.com> |
 | Artur Khantimirov | @r2k1 | Microsoft | |
 | Matt Bolt | @​mbolt35 | Kubecost | <matt@kubecost.com> |
 | Matt Ray | @mattray | Kubecost | <mattray@kubecost.com> |


### PR DESCRIPTION
Per the OpenCost [GOVERNANCE](https://github.com/opencost/opencost/blob/develop/GOVERNANCE.md) I'm proposing Alex join the Maintainers to replace @michaelmdresser. He's been active in the project and already maintains the [opencost/opencost-plugins](https://github.com/opencost/opencost-plugins).