### PR TITLE
check for licensing fee in in meter category when assigning category

### DIFF
--- a/pkg/cloud/azure/billingexportparser.go
+++ b/pkg/cloud/azure/billingexportparser.go
@@ -285,7 +285,7 @@ func AzureSetProviderID(abv *BillingRowValues) (providerID string, isVMSSShared 
 }
 
 func SelectAzureCategory(meterCategory string) string {
-	if meterCategory == "Virtual Machines" {
+	if meterCategory == "Virtual Machines" || meterCategory == "Virtual Machines Licenses" {
 		return opencost.ComputeCategory
 	} else if meterCategory == "Storage" {
 		return opencost.StorageCategory


### PR DESCRIPTION
## What does this PR change?
* 

## Does this PR relate to any other PRs?
This PR addresses an issue with Azure Cloud Cost ingestion where line items with "Virtual Machines Licenses" received an incorrect categorization as "other" while representing the cost of compute resources

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
