### PR TITLE
Prevent prefix from being applied twice to files

### DIFF
--- a/pkg/storage/prefixedbucketstorage.go
+++ b/pkg/storage/prefixedbucketstorage.go
@@ -32,7 +32,7 @@ func validPrefix(prefix string) bool {
 }
 
 func conditionalPrefix(prefix, name string) string {
-	if len(name) > 0 {
+	if len(name) > 0 && !strings.HasPrefix(name, prefix) {
 		return withPrefix(prefix, name)
 	}
 


### PR DESCRIPTION
## What does this PR change?
This PR addresses and issue with the PrefixBucketStorage, where absolute paths returned by its list function which include the prefix that it prepends will have the prefix prepended to them again when passed back to the storage. To address this before adding on the prefix there is now a check that ensures that the prefix is not already present in the path provided.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
