### PR TITLE
return default resource rates for suse rancher nodes

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1159,9 +1159,9 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 			nodeCost := cpuCost + gpuCost + ramCost
 
 			newCnode.Cost = fmt.Sprintf("%f", nodeCost)
-			newCnode.VCPUCost = fmt.Sprintf("%f", cpuCost)
-			newCnode.GPUCost = fmt.Sprintf("%f", gpuCost)
-			newCnode.RAMCost = fmt.Sprintf("%f", ramCost)
+			newCnode.VCPUCost = fmt.Sprintf("%f", defaultCPUCorePrice)
+			newCnode.GPUCost = fmt.Sprintf("%f", defaultGPUPrice)
+			newCnode.RAMCost = fmt.Sprintf("%f", defaultRAMPrice)
 			newCnode.RAMBytes = fmt.Sprintf("%f", ram)
 
 		} else if newCnode.GPU != "" && newCnode.GPUCost == "" {


### PR DESCRIPTION
## What does this PR change?
This PR changes the way resource rates are determined for Suse rancher RKE2 instances. Previously the values being emitted for each resource were by multiplied by the resource count which resulted in an hourly rate by resource type rather than an hourly rate by resource unit, the latter being expected at higher levels in the code. example
nodeCPUHourlyRate vs nodeCPUCoreHourlyRate

To illustrate the proper format of the values being determined in this code this snippet, which has remained stable since 2020, determines the total hourly rate of a node https://github.com/opencost/opencost/blob/2f5e8fe00e4c3db4ab71d68d7e5d6e59d19a8c36/pkg/costmodel/metrics.go#L516

As always it is worth stating that this portion of the code base is in desperate need of refactor and is incredibly fragile, changes here can have cascading effects across the application. 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
