### PR TITLE
GCP Cloud Costs resource name fallback

### DIFF
--- a/pkg/cloud/gcp/bigqueryintegration.go
+++ b/pkg/cloud/gcp/bigqueryintegration.go
@@ -24,6 +24,7 @@ const (
 	SKUDescriptionColumnName     = "description"
 	LabelsColumnName             = "labels"
 	ResourceNameColumnName       = "resource"
+	ResourceGlobalNameColumnName = "global_resource"
 	CostColumnName               = "cost"
 	ListCostColumnName           = "list_cost"
 	CreditsColumnName            = "credits"
@@ -46,6 +47,7 @@ func (bqi *BigQueryIntegration) GetCloudCost(start time.Time, end time.Time) (*o
 		fmt.Sprintf("service.description as %s", ServiceDescriptionColumnName),
 		fmt.Sprintf("sku.description as %s", SKUDescriptionColumnName),
 		fmt.Sprintf("resource.name as %s", ResourceNameColumnName),
+		fmt.Sprintf("resource.global_name as %s", ResourceGlobalNameColumnName),
 		fmt.Sprintf("TO_JSON_STRING(labels) as %s", LabelsColumnName),
 		fmt.Sprintf("SUM(cost) as %s", CostColumnName),
 		fmt.Sprintf("SUM(cost_at_list) as %s", ListCostColumnName),
@@ -60,6 +62,7 @@ func (bqi *BigQueryIntegration) GetCloudCost(start time.Time, end time.Time) (*o
 		SKUDescriptionColumnName,
 		LabelsColumnName,
 		ResourceNameColumnName,
+		ResourceGlobalNameColumnName,
 	}
 
 	whereConjuncts := GetWhereConjuncts(start, end)

--- a/pkg/cloud/gcp/bigqueryintegration_types.go
+++ b/pkg/cloud/gcp/bigqueryintegration_types.go
@@ -122,6 +122,7 @@ func (ccl *CloudCostLoader) Load(values []bigquery.Value, schema bigquery.Schema
 
 			resourceGlobalNameValue := values[i]
 			if resourceGlobalNameValue == nil {
+				properties.ProviderID = ""
 				continue
 			}
 			resourceGlobalName, ok := resourceGlobalNameValue.(string)

--- a/pkg/cloud/gcp/bigqueryintegration_types_test.go
+++ b/pkg/cloud/gcp/bigqueryintegration_types_test.go
@@ -1,0 +1,75 @@
+package gcp
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+func Test_Load_ResourceFallback(t *testing.T) {
+	schema := bigquery.Schema{
+		&bigquery.FieldSchema{
+			Name: UsageDateColumnName,
+		},
+		&bigquery.FieldSchema{
+			Name: ResourceNameColumnName,
+		},
+		&bigquery.FieldSchema{
+			Name: ResourceGlobalNameColumnName,
+		},
+	}
+
+	testCases := map[string]struct {
+		values             []bigquery.Value
+		expectedProviderID string
+	}{
+		"no data": {
+			values: []bigquery.Value{
+				bigquery.Value(time.Now()),
+				bigquery.Value(nil),
+				bigquery.Value(nil),
+			},
+			expectedProviderID: "",
+		},
+		"resource name only": {
+			values: []bigquery.Value{
+				bigquery.Value(time.Now()),
+				bigquery.Value("resource_name"),
+				bigquery.Value(nil),
+			},
+			expectedProviderID: "resource_name",
+		},
+		"resource global name only": {
+			values: []bigquery.Value{
+				bigquery.Value(time.Now()),
+				bigquery.Value(nil),
+				bigquery.Value("resource_global_name"),
+			},
+			expectedProviderID: "resource_global_name",
+		},
+		"resource name and global name": {
+			values: []bigquery.Value{
+				bigquery.Value(time.Now()),
+				bigquery.Value("resource_name"),
+				bigquery.Value("resource_global_name"),
+			},
+			expectedProviderID: "resource_name",
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ccl := CloudCostLoader{
+				CloudCost: &opencost.CloudCost{},
+			}
+
+			err := ccl.Load(testCase.values, schema)
+			if err != nil {
+				t.Errorf("Other error during testing %s", err)
+			} else if ccl.CloudCost.Properties.ProviderID != testCase.expectedProviderID {
+				t.Errorf("Incorrect result, actual ProviderID: %s, expected: %s", ccl.CloudCost.Properties.ProviderID, testCase.expectedProviderID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* Updates Cloud Cost ingestion for GCP to fall back to `resource.global_name` when `resource.name` is `null` for determining `ProviderID`.
* This is particularly relevant for Cloud SQL, Cloud Storage, and Cloud Logging, which very often have null `resource.name` values, resulting in `__unallocated__` `ProviderID` values.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* Users will no longer see `__unallocated__` in place of the correct `ProviderID`, especially for Cloud SQL, Cloud Storage, and Cloud Logging.

## Does this PR address any GitHub or Zendesk issues?
* Closes [GTM-286](https://kubecost.atlassian.net/browse/GTM-286).

## How was this PR tested?
* Tested new query in BigQuery, validated query results and data present in `resource.global_name`.
* To be tested in-cluster.

## Does this PR require changes to documentation?
* Nope.