### PR TITLE
fix formatting for deduplicated log messages

### DIFF
--- a/core/pkg/log/log.go
+++ b/core/pkg/log/log.go
@@ -76,7 +76,7 @@ func DedupedErrorf(logTypeLimit int, format string, a ...interface{}) {
 		Errorf(format, a...)
 	} else if timesLogged == logTypeLimit {
 		Errorf(format, a...)
-		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+		Infof("%s logged %d times: suppressing future logs", fmt.Sprintf(format, a...), logTypeLimit)
 	}
 }
 
@@ -91,7 +91,7 @@ func DedupedWarningf(logTypeLimit int, format string, a ...interface{}) {
 		Warnf(format, a...)
 	} else if timesLogged == logTypeLimit {
 		Warnf(format, a...)
-		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+		Infof("%s logged %d times: suppressing future logs", fmt.Sprintf(format, a...), logTypeLimit)
 	}
 }
 
@@ -110,7 +110,7 @@ func DedupedInfof(logTypeLimit int, format string, a ...interface{}) {
 		Infof(format, a...)
 	} else if timesLogged == logTypeLimit {
 		Infof(format, a...)
-		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+		Infof("%s logged %d times: suppressing future logs", fmt.Sprintf(format, a...), logTypeLimit)
 	}
 }
 


### PR DESCRIPTION
## What does this PR change?
* When a `Deduped*` function from the log package is called, the formatting of the message is fixed. 

Before:
```
2024-05-28T11:53:39.175101308Z WRN Node i-xyz marked preemptible but we have no data in spot feed
2024-05-28T11:53:39.175154309Z INF Node %s marked preemptible but we have no data in spot feed logged 5 times: suppressing future logs
```

After:
```
2024-05-28T11:53:39.175101308Z WRN Node i-xyz marked preemptible but we have no data in spot feed
2024-05-28T11:53:39.175154309Z INF Node i-xyz marked preemptible but we have no data in spot feed logged 5 times: suppressing future logs
```

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Log message readability will be improved

## How was this PR tested?
* I ran opencost locally

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* I will once I figure out how to
