### PR TITLE
[ENG-947] Window rounding, remove prom duration with offset logic

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: install protobuf-go
         run: |
           go install github.com/golang/protobuf/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@1.3.0
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
           which protoc-gen-go-grpc
       -
         name: Validate

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: install protobuf-go
         run: |
           go install github.com/golang/protobuf/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@1.3.0
           which protoc-gen-go-grpc
       -
         name: Validate

--- a/core/pkg/opencost/window.go
+++ b/core/pkg/opencost/window.go
@@ -303,8 +303,14 @@ func parseWindow(window string, now time.Time) (Window, error) {
 		// "entirety" is defined as midnight to midnight, UTC. given this definition, we round forward the calculated
 		// start and end times to the nearest day to align with midnight boundaries
 		// an analogous definition applies to "the past X weeks" and "the past X hours"
-		end = now.Truncate(dur).Add(dur)
-		start = end.Add(-time.Duration(num) * dur)
+		if match[2] == "w" {
+			// special case - with a week, we say the week ends today
+			end = end.Truncate(timeutil.Day).Add(timeutil.Day)
+			start = start.Truncate(timeutil.Day).Add(timeutil.Day)
+		} else {
+			end = now.Truncate(dur).Add(dur)
+			start = end.Add(-time.Duration(num) * dur)
+		}
 
 		return NewWindow(&start, &end), nil
 	}

--- a/core/pkg/opencost/window.go
+++ b/core/pkg/opencost/window.go
@@ -298,14 +298,13 @@ func parseWindow(window string, now time.Time) (Window, error) {
 		end := now
 		start := end.Add(-time.Duration(num) * dur)
 
-		// when using windows such as "7d" and "1w", we have to have a definition for what "the past X days" means.
+		// when using windows such as "7d", "1w", and "2h" we have to have a definition for what "the past X days/hours" means.
 		// let "the past X days" be defined as the entirety of today plus the entirety of the past X-1 days, where
 		// "entirety" is defined as midnight to midnight, UTC. given this definition, we round forward the calculated
 		// start and end times to the nearest day to align with midnight boundaries
-		if match[2] == "d" || match[2] == "w" {
-			end = end.Truncate(timeutil.Day).Add(timeutil.Day)
-			start = start.Truncate(timeutil.Day).Add(timeutil.Day)
-		}
+		// an analogous definition applies to "the past X weeks" and "the past X hours"
+		end = now.Truncate(dur).Add(dur)
+		start = end.Add(-time.Duration(num) * dur)
 
 		return NewWindow(&start, &end), nil
 	}
@@ -741,53 +740,6 @@ func (w Window) DurationOffset() (time.Duration, time.Duration, error) {
 	offset := time.Since(*w.End())
 
 	return duration, offset, nil
-}
-
-// DurationOffsetForPrometheus returns strings representing durations for the
-// duration and offset of the given window, factoring in the Thanos offset if
-// necessary. Whereas duration is a simple duration string (e.g. "1d"), the
-// offset includes the word "offset" (e.g. " offset 2d") so that the values
-// returned can be used directly in the formatting string "some_metric[%s]%s"
-// to generate the query "some_metric[1d] offset 2d".
-func (w Window) DurationOffsetForPrometheus() (string, string, error) {
-	duration, offset, err := w.DurationOffset()
-	if err != nil {
-		return "", "", err
-	}
-
-	// If using Thanos, increase offset to 3 hours, reducing the duration by
-	// equal measure to maintain the same starting point.
-	// TODO: This logic should technically be decoupled from this type, but
-	// TODO: current use cases are unclear. To ensure we do not break existing
-	// TODO: (or legacy) use-cases, temporarily support this one-off logic.
-	thanosDur := thanosOffset()
-	if offset < thanosDur && isThanosEnabled() {
-		diff := thanosDur - offset
-		offset += diff
-		duration -= diff
-	}
-
-	// If duration < 0, return an error
-	if duration < 0 {
-		return "", "", fmt.Errorf("negative duration: %s", duration)
-	}
-
-	// Negative offset means that the end time is in the future. Prometheus
-	// fails for non-positive offset values, so shrink the duration and
-	// remove the offset altogether.
-	if offset < 0 {
-		duration = duration + offset
-		offset = 0
-	}
-
-	durStr, offStr := timeutil.DurationOffsetStrings(duration, offset)
-	if offset < time.Minute {
-		offStr = ""
-	} else {
-		offStr = " offset " + offStr
-	}
-
-	return durStr, offStr, nil
 }
 
 // DurationOffsetStrings returns formatted, Prometheus-compatible strings representing

--- a/core/pkg/opencost/window_test.go
+++ b/core/pkg/opencost/window_test.go
@@ -709,15 +709,15 @@ func TestWindow_Duration(t *testing.T) {
 		t.Fatalf(`unexpected error parsing "2h": %s`, err)
 	}
 
-	if w.Duration().String() != "2h" {
+	if w.Duration().String() != "2h0m0s" {
 		t.Fatalf(`expect: window to be "2h"; actual: "%s"`, w.Duration().String())
 	}
-	w, err = ParseWindowUTC("10m")
+	w, err = ParseWindowUTC("10m0s")
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "10m": %s`, err)
 	}
 
-	if w.Duration().String() != "10m" {
+	if w.Duration().String() != "10m0s" {
 		t.Fatalf(`expect: window to be "10m"; actual: "%s"`, w.Duration().String())
 	}
 
@@ -725,7 +725,7 @@ func TestWindow_Duration(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1589448338,1589534798": %s`, err)
 	}
-	if w.Duration().String() != "1441m" {
+	if w.Duration().String() != "1441m0s" {
 		t.Fatalf(`expect: window to be "1441m"; actual: "%s"`, w.Duration().String())
 	}
 
@@ -733,7 +733,7 @@ func TestWindow_Duration(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "yesterday": %s`, err)
 	}
-	if w.Duration().String() != "1d" {
+	if w.Duration().String() != "1d0h0m0s" {
 		t.Fatalf(`expect: window to be "1d"; actual: "%s"`, w.Duration().String())
 	}
 

--- a/core/pkg/opencost/window_test.go
+++ b/core/pkg/opencost/window_test.go
@@ -725,8 +725,8 @@ func TestWindow_Duration(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1589448338,1589534798": %s`, err)
 	}
-	if w.Duration().String() != "1441m0s" {
-		t.Fatalf(`expect: window to be "1441m"; actual: "%s"`, w.Duration().String())
+	if w.Duration().String() != "24h1m0s" {
+		t.Fatalf(`expect: window to be "24h1m0s"; actual: "%s"`, w.Duration().String())
 	}
 
 	w, err = ParseWindowUTC("yesterday")

--- a/core/pkg/opencost/window_test.go
+++ b/core/pkg/opencost/window_test.go
@@ -712,7 +712,7 @@ func TestWindow_Duration(t *testing.T) {
 	if w.Duration().String() != "2h0m0s" {
 		t.Fatalf(`expect: window to be "2h"; actual: "%s"`, w.Duration().String())
 	}
-	w, err = ParseWindowUTC("10m0s")
+	w, err = ParseWindowUTC("10m")
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "10m": %s`, err)
 	}

--- a/core/pkg/opencost/window_test.go
+++ b/core/pkg/opencost/window_test.go
@@ -733,8 +733,8 @@ func TestWindow_Duration(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "yesterday": %s`, err)
 	}
-	if w.Duration().String() != "1d0h0m0s" {
-		t.Fatalf(`expect: window to be "1d"; actual: "%s"`, w.Duration().String())
+	if w.Duration().String() != "24h0m0s" {
+		t.Fatalf(`expect: window to be "24h0m0s"; actual: "%s"`, w.Duration().String())
 	}
 
 }

--- a/core/pkg/util/timeutil/timeutil_test.go
+++ b/core/pkg/util/timeutil/timeutil_test.go
@@ -407,13 +407,13 @@ func TestRoundToStartOfWeek(t *testing.T) {
 func TestRoundToStartOfFollowingWeek(t *testing.T) {
 	sunday := time.Date(2023, 03, 26, 12, 12, 12, 12, time.UTC)
 	roundedFromSunday := RoundToStartOfFollowingWeek(sunday)
-	if roundedFromSunday.Month() != 4 || roundedFromSunday.Day() != 2 || roundedFromSunday.Weekday() == time.Sunday {
+	if roundedFromSunday.Month() != 4 || roundedFromSunday.Day() != 2 || roundedFromSunday.Weekday() != time.Sunday {
 		t.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromSunday.Day(), roundedFromSunday.Weekday().String())
 	}
 
 	tuesday := time.Date(2023, 03, 28, 12, 12, 12, 12, time.UTC)
 	roundedFromTuesday := RoundToStartOfFollowingWeek(tuesday)
-	if roundedFromTuesday.Month() != 4 || roundedFromTuesday.Day() != 2 || roundedFromTuesday.Weekday() == time.Sunday {
+	if roundedFromTuesday.Month() != 4 || roundedFromTuesday.Day() != 2 || roundedFromTuesday.Weekday() != time.Sunday {
 		t.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromTuesday.Day(), roundedFromTuesday.Weekday().String())
 	}
 }

--- a/core/pkg/util/timeutil/timeutil_test.go
+++ b/core/pkg/util/timeutil/timeutil_test.go
@@ -1,7 +1,6 @@
 package timeutil
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -393,14 +392,14 @@ func Test_FormatDurationStringDaysToHours(t *testing.T) {
 func TestRoundToStartOfWeek(t *testing.T) {
 	sunday := time.Date(2023, 03, 26, 12, 12, 12, 12, time.UTC)
 	roundedFromSunday := RoundToStartOfWeek(sunday)
-	if roundedFromSunday.Day() != 26 || roundedFromSunday.Weekday() == time.Sunday {
-		fmt.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromSunday.Day(), roundedFromSunday.Weekday().String())
+	if roundedFromSunday.Day() != 26 || roundedFromSunday.Weekday() != time.Sunday {
+		t.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromSunday.Day(), roundedFromSunday.Weekday().String())
 	}
 
 	tuesday := time.Date(2023, 03, 28, 12, 12, 12, 12, time.UTC)
 	roundedFromTuesday := RoundToStartOfWeek(tuesday)
-	if roundedFromTuesday.Day() != 26 || roundedFromTuesday.Weekday() == time.Sunday {
-		fmt.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromTuesday.Day(), roundedFromTuesday.Weekday().String())
+	if roundedFromTuesday.Day() != 26 || roundedFromTuesday.Weekday() != time.Sunday {
+		t.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromTuesday.Day(), roundedFromTuesday.Weekday().String())
 	}
 }
 

--- a/core/pkg/util/timeutil/timeutil_test.go
+++ b/core/pkg/util/timeutil/timeutil_test.go
@@ -408,12 +408,12 @@ func TestRoundToStartOfFollowingWeek(t *testing.T) {
 	sunday := time.Date(2023, 03, 26, 12, 12, 12, 12, time.UTC)
 	roundedFromSunday := RoundToStartOfFollowingWeek(sunday)
 	if roundedFromSunday.Month() != 4 || roundedFromSunday.Day() != 2 || roundedFromSunday.Weekday() == time.Sunday {
-		fmt.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromSunday.Day(), roundedFromSunday.Weekday().String())
+		t.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromSunday.Day(), roundedFromSunday.Weekday().String())
 	}
 
 	tuesday := time.Date(2023, 03, 28, 12, 12, 12, 12, time.UTC)
 	roundedFromTuesday := RoundToStartOfFollowingWeek(tuesday)
 	if roundedFromTuesday.Month() != 4 || roundedFromTuesday.Day() != 2 || roundedFromTuesday.Weekday() == time.Sunday {
-		fmt.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromTuesday.Day(), roundedFromTuesday.Weekday().String())
+		t.Errorf("expected date to be rounded to the same sunday, got: %d, %s", roundedFromTuesday.Day(), roundedFromTuesday.Weekday().String())
 	}
 }

--- a/justfile
+++ b/justfile
@@ -6,8 +6,14 @@ commit := `git rev-parse --short HEAD`
 default:
     just --list
 
+# run core unit tests
+test-core: 
+    {{commonenv}} cd ./core && go test ./... -coverprofile=coverage.out
+    {{commonenv}} cd ./core && go vet ./...
+
+
 # Run unit tests
-test:
+test: test-core
     {{commonenv}} go test ./... -coverprofile=coverage.out
     {{commonenv}} go vet ./...
 


### PR DESCRIPTION
## What does this PR change?
* window parsing logic rounds all windows now, not just daily/weekly

## Does this PR relate to any other PRs?
* none

## How will this PR impact users?
* When users submit a window, it will automatically get rounded to each window boundary

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/ENG-947

## How was this PR tested?
* tested locally and via unit testing. A new unit test was added that enforces the rounding behavior

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
