### PR TITLE
Set docker/login-action to a stable version instead of a SHA

### DIFF
--- a/.github/workflows/build-and-publish-release.yml
+++ b/.github/workflows/build-and-publish-release.yml
@@ -65,7 +65,7 @@ jobs:
           repository: 'opencost/opencost'
           ref: '${{ steps.branch.outputs.BRANCH_NAME }}'
           path: ./opencost
-      
+
       - name: Checkout UI Repo
         uses: actions/checkout@v4
         with:
@@ -83,7 +83,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION

## What does this PR change?
* Set docker/login-action to a stable version instead of a SHA

## Does this PR relate to any other PRs?
* closes https://github.com/opencost/opencost/pull/2651

## How will this PR impact users?
* part of testing

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/pull/2651

## How was this PR tested?
* GHA

## Does this PR require changes to documentation?
* no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* no
