### PR TITLE
Custom Cost Inconsistencies - ENG-2212

### DIFF
--- a/pkg/customcost/queryservice_helper.go
+++ b/pkg/customcost/queryservice_helper.go
@@ -28,6 +28,8 @@ func ParseCustomCostTotalRequest(qp httputil.QueryParams) (*CostTotalRequest, er
 		return nil, err
 	}
 
+	accumulate := opencost.ParseAccumulate(qp.Get("accumulate", "day"))
+
 	var filter filter.Filter
 	filterString := qp.Get("filter", "")
 	if filterString != "" {
@@ -42,6 +44,7 @@ func ParseCustomCostTotalRequest(qp httputil.QueryParams) (*CostTotalRequest, er
 		Start:       *window.Start(),
 		End:         *window.End(),
 		AggregateBy: aggregateBy,
+		Accumulate:  accumulate,
 		Filter:      filter,
 	}
 
@@ -68,7 +71,7 @@ func ParseCustomCostTimeseriesRequest(qp httputil.QueryParams) (*CostTimeseriesR
 		return nil, err
 	}
 
-	accumulate := opencost.ParseAccumulate(qp.Get("accumulate", ""))
+	accumulate := opencost.ParseAccumulate(qp.Get("accumulate", "day"))
 
 	var filter filter.Filter
 	filterString := qp.Get("filter", "")

--- a/pkg/customcost/queryservice_helper.go
+++ b/pkg/customcost/queryservice_helper.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/filter"
 	"github.com/opencost/opencost/core/pkg/opencost"
-	"github.com/opencost/opencost/core/pkg/util/httputil"
+	"github.com/opencost/opencost/core/pkg/util/mapper"
 )
 
-func ParseCustomCostTotalRequest(qp httputil.QueryParams) (*CostTotalRequest, error) {
+func ParseCustomCostTotalRequest(qp mapper.PrimitiveMap) (*CostTotalRequest, error) {
 	windowStr := qp.Get("window", "")
 	if windowStr == "" {
 		return nil, fmt.Errorf("missing require window param")
@@ -51,7 +51,7 @@ func ParseCustomCostTotalRequest(qp httputil.QueryParams) (*CostTotalRequest, er
 	return opts, nil
 }
 
-func ParseCustomCostTimeseriesRequest(qp httputil.QueryParams) (*CostTimeseriesRequest, error) {
+func ParseCustomCostTimeseriesRequest(qp mapper.PrimitiveMap) (*CostTimeseriesRequest, error) {
 	windowStr := qp.Get("window", "")
 	if windowStr == "" {
 		return nil, fmt.Errorf("missing require window param")

--- a/pkg/customcost/queryservice_helper_test.go
+++ b/pkg/customcost/queryservice_helper_test.go
@@ -1,0 +1,53 @@
+package customcost
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/core/pkg/util/httputil"
+)
+
+// Test_ParseCustomCostRequest_Accumulate focuses on testing that both Custom Cost request parsing functions properly
+// set the `accumulate` field, inspired by a desire to prevent a regression of https://kubecost.atlassian.net/browse/ENG-2212
+func Test_ParseCustomCostRequest_Accumulate(t *testing.T) {
+	testCases := map[string]struct {
+		accumulateString   string
+		expectedAccumulate opencost.AccumulateOption
+	}{
+		"no accumulate": {
+			accumulateString:   "",
+			expectedAccumulate: opencost.AccumulateOptionDay,
+		},
+		"hour accumulate": {
+			accumulateString:   "hour",
+			expectedAccumulate: opencost.AccumulateOptionHour,
+		},
+		"day accumulate": {
+			accumulateString:   "day",
+			expectedAccumulate: opencost.AccumulateOptionDay,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			qp := httputil.NewQueryParams(map[string][]string{})
+			qp.Set("window", "7d")
+			if len(tc.accumulateString) > 0 {
+				qp.Set("accumulate", tc.accumulateString)
+			}
+
+			totalRequest, err := ParseCustomCostTotalRequest(qp)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			} else if totalRequest.Accumulate != tc.expectedAccumulate {
+				t.Fatalf("expected %v, got %v", tc.expectedAccumulate, totalRequest.Accumulate)
+			}
+
+			timeseriesRequest, err := ParseCustomCostTimeseriesRequest(qp)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			} else if timeseriesRequest.Accumulate != tc.expectedAccumulate {
+				t.Fatalf("expected %v, got %v", tc.expectedAccumulate, timeseriesRequest.Accumulate)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* Adds missing `accumulate` parameter parsing to the function that handles Custom Cost totals requests.
  * There were circumstances where Custom Cost `totals` and `timeseries` requests would be processed differently, even with the same request parameters. This was caused by downstream logic that would attempt to pick a value for `accumulate` when not explicitly set, which could set `accumulate` to a different value than what the user passed in.
* Defaults `accumulate` to `day`, for both `totals` and `timeseries`.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* Custom Cost totals and timeseries requests will be handled as expected.

## Does this PR address any GitHub or Zendesk issues?
* Closes [ENG-2212](https://kubecost.atlassian.net/browse/ENG-2212).

## How was this PR tested?
* Reproduced issue with nightly data, and validated that these changes resolved the issue.

## Does this PR require changes to documentation?
* Nope.
