### PR TITLE
Fix failing build with go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/aws/smithy-go v1.20.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getsentry/sentry-go v0.25.0
+	github.com/google/martian v2.1.0+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/go-plugin v1.6.0


### PR DESCRIPTION
## What does this PR change?
This PR contains the result of running `go mod tidy` in response to errors running tests locally and ci/cd testing failures on Github

 
![Screenshot 2024-06-10 at 10 43 22 AM](https://github.com/opencost/opencost/assets/12225425/ed35b77a-da88-42fe-8eba-0ca8658e9db3)


## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
