### PR TITLE
feat(metrics): emit carbon costs as metrics

### DIFF
--- a/pkg/carbon/carbonassets.go
+++ b/pkg/carbon/carbonassets.go
@@ -169,3 +169,26 @@ func getProviderFromProviderID(providerid string) string {
 	return ""
 
 }
+
+func GetCarbonLookupKeyNode(provider string, region string, instanceType string) carbonLookupKeyNode {
+	return carbonLookupKeyNode{
+		provider:     provider,
+		region:       region,
+		instanceType: instanceType,
+	}
+}
+
+func GetCarbonLookupKeyDisk(provider string, region string) carbonLookupKeyNode {
+	return carbonLookupKeyNode{
+		provider: provider,
+		region:   region,
+	}
+}
+
+func (carbonLookupKeyNode carbonLookupKeyNode) GetCarbonCoeff() float64 {
+	return carbonLookupNode[carbonLookupKeyNode]
+}
+
+func (carbonLookupKeyDisk carbonLookupKeyDisk) GetCarbonCoeff() float64 {
+	return carbonLookupDisk[carbonLookupKeyDisk]
+}

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -76,6 +76,9 @@ func Execute(opts *CostModelOpts) error {
 		customCostPipelineService = costmodel.InitializeCustomCost(router)
 	}
 
+	log.Infof("Carbon estimates enabled: %t", env.IsCarbonEstimatesEnabled())
+	log.Infof("Carbon metrics enabled: %t", env.IsCarbonMetricsEnabled())
+
 	// this endpoint is intentionally left out of the "if env.IsCustomCostEnabled()" conditional; in the handler, it is
 	// valid for CustomCostPipelineService to be nil
 	router.GET("/customCost/status", customCostPipelineService.GetCustomCostStatusHandler())

--- a/pkg/costmodel/handlers.go
+++ b/pkg/costmodel/handlers.go
@@ -39,7 +39,7 @@ func (a *Accesses) ComputeAssetsHandler(w http.ResponseWriter, r *http.Request, 
 	w.Write(WrapData(assetSet, nil))
 }
 
-// ComputeAllocationHandler returns the assets from the CostModel.
+// ComputeAssetsCarbonHandler returns the assets from the CostModel.
 func (a *Accesses) ComputeAssetsCarbonHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -62,6 +62,10 @@ func (a *Accesses) ComputeAssetsCarbonHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	carbonEstimates, err := carbon.RelateCarbonAssets(assetSet)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error getting carbon estimates: %s", err), http.StatusInternalServerError)
+		return
+	}
 
 	w.Write(WrapData(carbonEstimates, nil))
 }

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -139,6 +139,7 @@ const (
 	OCIPricingURL = "OCI_PRICING_URL"
 
 	CarbonEstimatesEnabledEnvVar = "CARBON_ESTIMATES_ENABLED"
+	CarbonMetricsEnabledEnvVar   = "CARBON_METRICS_ENABLED"
 )
 
 const DefaultConfigMountPath = "/var/configs"
@@ -722,4 +723,11 @@ func GetCustomCostRefreshRateHours() string {
 
 func IsCarbonEstimatesEnabled() bool {
 	return env.GetBool(CarbonEstimatesEnabledEnvVar, false)
+}
+
+func IsCarbonMetricsEnabled() bool {
+	if !IsCarbonEstimatesEnabled() {
+		return false
+	}
+	return env.GetBool(CarbonMetricsEnabledEnvVar, false)
 }


### PR DESCRIPTION
feat(metrics): emit carbon costs as metrics

## What does this PR change?
* Adds ability to emit carbon costs as metrics.
* This brings the base to build a Grafana dashboard for the carbon costs.

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* It is disabled by default

## Does this PR address any GitHub or Zendesk issues?
* Closes #2799

## How was this PR tested?
* Manually deployed on a K3s cluster via the Helm Chart.
* Tested if it is disabled by default.
* Tested if the metrics are getting emitted.

## Does this PR require changes to documentation?
* It seems to me, that there are currently no metrics documented. 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Currently, it is only a draft PR. I need some feedback before I can proceed with it. 
