### PR TITLE
Expose shareIdle parameter in public API

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2284,7 +2284,9 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// include aggregated labels/annotations if true
 	includeAggregatedMetadata := qp.GetBool("includeAggregatedMetadata", false)
 
-	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, accumulateBy)
+	shareIdle := qp.GetBool("shareIdle", false)
+
+	asr, err := a.Model.QueryAllocation(window, resolution, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, accumulateBy, shareIdle)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "bad request") {
 			WriteError(w, BadRequest(err.Error()))


### PR DESCRIPTION
## What does this PR change?
This PR adds the new query parameter `shareIdle` to the Allocations API.

The `shareIdle` parameter can be described as follows:
_"Whether to allocate idle costs across non-idle allocations. The idle costs are allocated proportionally to the non-idle costs of each allocation. That is, if an allocation has twice as much non-idle costs than another allocation, it will also be allocated twice as much of the idle costs. Idle costs can be shared per cluster or per node, see parameter `idleByNode`. Default is `false`."_

This functionality already exists in the cost model. This PR only exposes it to the API.

## Does this PR relate to any other PRs?
No.

## How will this PR impact users?
The change is backwards-compatible, because the new parameter is optional and its default value is `false`, which results in the current behavior.

## Does this PR address any GitHub or Zendesk issues?
No.

## How was this PR tested?
Unit tests and integration were run locally. No additional test was added, because costallocation_test.go already contains test cases for the `shareIdle` parameter. Additionally I compared the results for the combinations in a manual test in a local cluster to verify that the parameter is propagated correctly:
* `shareIdle=false`
* `shareIdle=true`, `idleByNode=true`
* `shareIdle=true`, `idleByNode=false`

## Does this PR require changes to documentation?
Yes. We need to document the new parameter `shareIdle` in the API documentation (https://github.com/opencost/opencost-website/blob/main/docs/integrations/api.md#allocation).

Additionally, we also need to document the already existing, but not yet documented parameter `idleByNode`.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
No. Should be decided by the maintainers.

## Additional context
This PR is a follow-up to the following slack discussion: https://cloud-native.slack.com/archives/C03D56FPD4G/p1718971058262759
