### PR TITLE
Set timeout for Azure rate-card api call

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -846,7 +846,12 @@ func (az *Azure) DownloadPricingData() error {
 	rateCardFilter := fmt.Sprintf("OfferDurableId eq '%s' and Currency eq '%s' and Locale eq 'en-US' and RegionInfo eq '%s'", config.AzureOfferDurableID, config.CurrencyCode, config.AzureBillingRegion)
 
 	log.Infof("Using ratecard query %s", rateCardFilter)
-	result, err := rcClient.Get(context.TODO(), rateCardFilter)
+	// rate-card client is old, it can hang indefinitely in some cases
+	// this happens on the main thread, so it may block the whole app
+	// there is can be a better way to set timeout for the client
+	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
+	defer cancel()
+	result, err := rcClient.Get(ctx, rateCardFilter)
 	if err != nil {
 		log.Warnf("Error in pricing download query from API")
 		az.rateCardPricingError = err


### PR DESCRIPTION
## What does this PR change?

Sets a timeout for the Azure API call.

I observed a behavior where OpenCost hangs indefinitely without starting an HTTP server.

The last log message is `Using ratecard query OfferDurableId eq 'MS-AZR-0003p' and Currency eq 'USD' and Locale eq 'en-US' and RegionInfo eq 'US'`.

I think this issue is caused by network connectivity problems and the fact that the Rate-Card API client, which dates back to 2015, probably doesn't use any timeout.

Close #2714