### PR TITLE
fix table in markdown

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,7 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 
 ## Opencost Emeritus Committers
 We would like to acknowledge previous committers and their huge contributions to our collective success:
+
 | Maintainer | GitHub ID | Affiliation | Email |
 | --------------- | --------- | ----------- | ----------- |
 | Michael Dresser | @michaelmdresser | Kubecost | <michaelmdresser@gmail.com> |


### PR DESCRIPTION
Without the blank line, the "Opencost Emeritus Committers" table doesn't render in Macdown or the IntelliJ Markdown plugin, even though the GitHub web UI works without the change. Seems that Markdown does expect a blank line to separate a paragraph and a table.

This is a documentation change only. The table still renders fine in the GitHub UI.