### PR TITLE
Add lock on file check and download so that partially downloaded file…

### DIFF
--- a/pkg/cloudcost/integration.go
+++ b/pkg/cloudcost/integration.go
@@ -63,10 +63,18 @@ func GetIntegrationFromConfig(kc cloud.KeyedConfig) CloudCostIntegration {
 		}
 	case *azure.AzureStorageBillingParser:
 		return &azure.AzureStorageIntegration{
-			AzureStorageBillingParser: *keyedConfig,
+			AzureStorageBillingParser: azure.AzureStorageBillingParser{
+				StorageConnection: azure.StorageConnection{
+					StorageConfiguration: keyedConfig.StorageConfiguration},
+			},
 		}
 	case *azure.AzureStorageIntegration:
-		return keyedConfig
+		return &azure.AzureStorageIntegration{
+			AzureStorageBillingParser: azure.AzureStorageBillingParser{
+				StorageConnection: azure.StorageConnection{
+					StorageConfiguration: keyedConfig.StorageConfiguration},
+			},
+		}
 	// S3SelectIntegration
 	case *aws.S3Configuration:
 		return &aws.S3SelectIntegration{

--- a/pkg/cloudcost/integration.go
+++ b/pkg/cloudcost/integration.go
@@ -57,7 +57,8 @@ func GetIntegrationFromConfig(kc cloud.KeyedConfig) CloudCostIntegration {
 	case *azure.StorageConnection:
 		return &azure.AzureStorageIntegration{
 			AzureStorageBillingParser: azure.AzureStorageBillingParser{
-				StorageConnection: *keyedConfig,
+				StorageConnection: azure.StorageConnection{
+					StorageConfiguration: keyedConfig.StorageConfiguration},
 			},
 		}
 	case *azure.AzureStorageBillingParser:


### PR DESCRIPTION
… do not get accessed

## What does this PR change?
This PR prevents a race condition in which multiple threads of an azure storage billing integration attempt to access a file that is still currently being downloaded. The result is the downloading file stops downloading in a corrupt state blocking the downloading process and producing errors for other processes trying to use the file.
```
ERR CloudCost[xxxxx]: ingestor: build failed for window [2024-07-19T00:00:00+0000, 2024-07-26T00:00:00+0000): record on line 170057: wrong number of fields
```

To address this I have added a per integration lock before the file is checked or downloaded. The time a file needs to be download the process trying to access will hold the lock until the download is complete, preventing this issue from occurring.

This solution is not the fastest in that it prevent concurrent file downloads, however it is the simplest and lowest risk solution to this problem. Any slow down here is also of low concern as this part of the system is not a serious bottle neck.

To prevent the lock from causing a deadlock I have also added a timeout to the download, and code to clean up a file on failed download.

Finally I have updated the name of local files to include more of their blob path to prevent collisions in file name for partitioned exports

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* This PR was tested against integration that repeatedly reproduced the issue.

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
