### PR TITLE
Remove extra group by args for query

### DIFF
--- a/pkg/cloud/gcp/bigqueryintegration.go
+++ b/pkg/cloud/gcp/bigqueryintegration.go
@@ -181,7 +181,7 @@ func (bqi *BigQueryIntegration) queryFlexibleCUDTotalCosts(start time.Time, end 
 		  IFNULL(SUM((Select SUM(amount) FROM bd.credits)),0),
 		FROM %s
 		WHERE %s
-		GROUP BY usage_date, sku.description
+		GROUP BY usage_date
 	`
 
 	table := fmt.Sprintf(" `%s` bd ", bqi.GetBillingDataDataset())
@@ -214,7 +214,7 @@ func (bqi *BigQueryIntegration) queryFlexibleCUDTotalCredits(start time.Time, en
 	FROM %s
 	CROSS JOIN UNNEST(bd.credits) AS credits
 	WHERE %s
-	GROUP BY usage_date, credits.id
+	GROUP BY usage_date
 	`
 
 	table := fmt.Sprintf(" `%s` bd ", bqi.GetBillingDataDataset())


### PR DESCRIPTION
## What does this PR change?
* This PR fixes queries for Flexible CUD total credits and costs to return one row per day rather than one per day per Flexible CUD. Previously if multiple Flexible CUDs were present, for each day a random total credit and total cost were being selected, resulting in erroneous ratios being created. While the resulting rate from this update is not completely accurate as it is an average of all the CUD rates present in the bill, it will produce numbers that are correct against bill totals

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Tested manually against BigQuery Integration

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
