### PR TITLE
ENG-136: Exclude local storage provisioner by sig-storage-local-provisioner on node to show up in assets when param ASSET_INCLUDE_LOCAL_DISK_COST is set to false

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -45,6 +45,9 @@ const (
 
 const MAX_LOCAL_STORAGE_SIZE = 1024 * 1024 * 1024 * 1024
 
+// When ASSET_INCLUDE_LOCAL_DISK_COST is set to false, local storage
+// provisioned by sig-storage-local-static-provisioner is excluded
+// by checking if the volume is prefixed by "local-pv-"
 const SIG_STORAGE_LOCAL_PROVISIONER_PREFIX = "local-pv-"
 
 // Costs represents cumulative and monthly cluster costs over a given duration. Costs

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/opencost/opencost/pkg/cloud/provider"
@@ -43,6 +44,8 @@ const (
 )
 
 const MAX_LOCAL_STORAGE_SIZE = 1024 * 1024 * 1024 * 1024
+
+const SIG_STORAGE_LOCAL_PROVISIONER_PREFIX = "local-pv-"
 
 // Costs represents cumulative and monthly cluster costs over a given duration. Costs
 // are broken down by cores, memory, and storage.
@@ -260,6 +263,10 @@ func ClusterDisks(client prometheus.Client, cp models.Provider, start, end time.
 		claimNamespace, err := result.GetString("namespace")
 		if err != nil {
 			log.Debugf("ClusterDisks: pv claim data missing namespace")
+			continue
+		}
+
+		if !env.GetAssetIncludeLocalDiskCost() && strings.HasPrefix(volumeName, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
 			continue
 		}
 
@@ -1420,6 +1427,10 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			continue
 		}
 
+		if !env.GetAssetIncludeLocalDiskCost() && strings.HasPrefix(name, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
+			continue
+		}
+
 		if len(result.Values) == 0 {
 			continue
 		}
@@ -1453,6 +1464,10 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			continue
 		}
 
+		if !env.GetAssetIncludeLocalDiskCost() && strings.HasPrefix(name, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
+			continue
+		}
+
 		// TODO niko/assets storage class
 
 		bytes := result.Values[0].Value
@@ -1482,6 +1497,10 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 		name, err := result.GetString("persistentvolume")
 		if err != nil {
 			log.Warnf("ClusterDisks: PV cost data missing persistentvolume")
+			continue
+		}
+
+		if !env.GetAssetIncludeLocalDiskCost() && strings.HasPrefix(name, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
 			continue
 		}
 
@@ -1548,11 +1567,17 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 				log.Debugf("ClusterDisks: pv claim data missing volumename")
 				continue
 			}
+
+			if !env.GetAssetIncludeLocalDiskCost() && strings.HasPrefix(thatVolumeName, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
+				continue
+			}
+
 			thatClaimName, err := thatRes.GetString("persistentvolumeclaim")
 			if err != nil {
 				log.Debugf("ClusterDisks: pv claim data missing persistentvolumeclaim")
 				continue
 			}
+
 			thatClaimNamespace, err := thatRes.GetString("namespace")
 			if err != nil {
 				log.Debugf("ClusterDisks: pv claim data missing namespace")
@@ -1589,6 +1614,7 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 			log.Debugf("ClusterDisks: pv usage data missing persistentvolumeclaim")
 			continue
 		}
+
 		claimNamespace, err := result.GetString("namespace")
 		if err != nil {
 			log.Debugf("ClusterDisks: pv usage data missing namespace")
@@ -1609,11 +1635,17 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 				log.Debugf("ClusterDisks: pv claim data missing volumename")
 				continue
 			}
+
+			if !env.GetAssetIncludeLocalDiskCost() && strings.HasPrefix(thatVolumeName, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
+				continue
+			}
+
 			thatClaimName, err := thatRes.GetString("persistentvolumeclaim")
 			if err != nil {
 				log.Debugf("ClusterDisks: pv claim data missing persistentvolumeclaim")
 				continue
 			}
+
 			thatClaimNamespace, err := thatRes.GetString("namespace")
 			if err != nil {
 				log.Debugf("ClusterDisks: pv claim data missing namespace")

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -47,7 +47,11 @@ const MAX_LOCAL_STORAGE_SIZE = 1024 * 1024 * 1024 * 1024
 
 // When ASSET_INCLUDE_LOCAL_DISK_COST is set to false, local storage
 // provisioned by sig-storage-local-static-provisioner is excluded
-// by checking if the volume is prefixed by "local-pv-"
+// by checking if the volume is prefixed by "local-pv-".
+//
+// This is based on the sig-storage-local-static-provisioner implementation,
+// which creates all PVs with the "local-pv-" prefix. For reference, see:
+// https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/b6f465027bd059e92c0032c81dd1e1d90e35c909/pkg/discovery/discovery.go#L410-L417
 const SIG_STORAGE_LOCAL_PROVISIONER_PREFIX = "local-pv-"
 
 // Costs represents cumulative and monthly cluster costs over a given duration. Costs

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -543,7 +543,7 @@ func ClusterDisks(client prometheus.Client, cp models.Provider, start, end time.
 	}
 
 	if !env.GetAssetIncludeLocalDiskCost() {
-		return filterSigStorageLocalProvisonerPVs(diskMap), nil
+		return filterOutLocalPVs(diskMap), nil
 	}
 
 	return diskMap, nil
@@ -1659,12 +1659,21 @@ func pvCosts(diskMap map[DiskIdentifier]*Disk, resolution time.Duration, resActi
 	}
 }
 
-func filterSigStorageLocalProvisonerPVs(diskMap map[DiskIdentifier]*Disk) map[DiskIdentifier]*Disk {
-	diskMapFilteredLocalPVs := map[DiskIdentifier]*Disk{}
+// filterOutLocalPVs removes local Persistent Volumes (PVs) from the given disk map.
+// Local PVs are identified by the prefix "local-pv-" in their names, which is the
+// convention used by sig-storage-local-static-provisioner.
+//
+// Parameters:
+//   - diskMap: A map of DiskIdentifier to Disk pointers, representing all PVs.
+//
+// Returns:
+//   - A new map of DiskIdentifier to Disk pointers, containing only non-local PVs.
+func filterOutLocalPVs(diskMap map[DiskIdentifier]*Disk) map[DiskIdentifier]*Disk {
+	nonLocalPVDiskMap := map[DiskIdentifier]*Disk{}
 	for key, val := range diskMap {
 		if !strings.HasPrefix(key.Name, SIG_STORAGE_LOCAL_PROVISIONER_PREFIX) {
-			diskMapFilteredLocalPVs[key] = val
+			nonLocalPVDiskMap[key] = val
 		}
 	}
-	return diskMapFilteredLocalPVs
+	return nonLocalPVDiskMap
 }

--- a/pkg/costmodel/cluster_test.go
+++ b/pkg/costmodel/cluster_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_filterSigStorageLocalProvisonerPVs(t *testing.T) {
+func Test_filterOutLocalPVs(t *testing.T) {
 	testCases := []struct {
 		name     string
 		input    map[DiskIdentifier]*Disk
@@ -47,7 +47,7 @@ func Test_filterSigStorageLocalProvisonerPVs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := filterSigStorageLocalProvisonerPVs(tc.input)
+			result := filterOutLocalPVs(tc.input)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/costmodel/cluster_test.go
+++ b/pkg/costmodel/cluster_test.go
@@ -1,0 +1,54 @@
+package costmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterSigStorageLocalProvisonerPVs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    map[DiskIdentifier]*Disk
+		expected map[DiskIdentifier]*Disk
+	}{
+		{
+			name: "Filter out local PVs",
+			input: map[DiskIdentifier]*Disk{
+				{Cluster: "cluster1", Name: "pv1"}:              &Disk{Name: "pv1"},
+				{Cluster: "cluster1", Name: "local-pv-123"}:     &Disk{Name: "local-pv-123"},
+				{Cluster: "cluster2", Name: "pv2"}:              &Disk{Name: "pv2"},
+				{Cluster: "cluster2", Name: "local-pv-456"}:     &Disk{Name: "local-pv-456"},
+				{Cluster: "cluster3", Name: "not-local-pv-789"}: &Disk{Name: "not-local-pv-789"},
+			},
+			expected: map[DiskIdentifier]*Disk{
+				{Cluster: "cluster1", Name: "pv1"}:              &Disk{Name: "pv1"},
+				{Cluster: "cluster2", Name: "pv2"}:              &Disk{Name: "pv2"},
+				{Cluster: "cluster3", Name: "not-local-pv-789"}: &Disk{Name: "not-local-pv-789"},
+			},
+		},
+		{
+			name: "No local PVs to filter",
+			input: map[DiskIdentifier]*Disk{
+				{Cluster: "cluster1", Name: "pv1"}: &Disk{Name: "pv1"},
+				{Cluster: "cluster2", Name: "pv2"}: &Disk{Name: "pv2"},
+			},
+			expected: map[DiskIdentifier]*Disk{
+				{Cluster: "cluster1", Name: "pv1"}: &Disk{Name: "pv1"},
+				{Cluster: "cluster2", Name: "pv2"}: &Disk{Name: "pv2"},
+			},
+		},
+		{
+			name:     "Empty input",
+			input:    map[DiskIdentifier]*Disk{},
+			expected: map[DiskIdentifier]*Disk{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterSigStorageLocalProvisonerPVs(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
*   sig-storage-local-provisioner is a storage provisioner that provisions a PV in a host node . This shows up as a cost in assets even when ASSET_INCLUDE_LOCAL_DISK_COST is set to false, which was introduced in [PR](https://github.com/opencost/opencost/pull/2441). The current PR fixes this by having a check to exclude creation of the diskMap which eventually is used to create disk asset when it has a prefix of "local-v-*". We are fortunate that the sig-storage-local-provisioner always provisions pv by this prefix . Here is the code reference [ref](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/b6f465027bd059e92c0032c81dd1e1d90e35c909/pkg/discovery/discovery.go#L410-L417)

## Does this PR relate to any other PRs?
* None

## How will this PR impact users?
* Exclude assets from showing up as cost when ASSET_INCLUDE_LOCAL_DISK_COST is set to false

## Does this PR address any GitHub or Zendesk issues?
* Closes ... https://kubecost.atlassian.net/browse/ENG-136

## How was this PR tested?
* Putting it in a cluster that has this local storage with sig-storage-local-provisioner and the asset disk doesnt show up anymore 

Before 

<img width="1016" alt="Screenshot 2024-08-22 at 10 29 31 AM" src="https://github.com/user-attachments/assets/76cf8f23-3f57-4608-8132-c32d739f9704">

After
<img width="1614" alt="Screenshot 2024-08-22 at 10 30 16 AM" src="https://github.com/user-attachments/assets/63cc4aed-dc7b-4d77-9b36-1d458248dcda">


## Does this PR require changes to documentation?
* None

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v2.4 
