### PR TITLE
handle aws generated tags

### DIFF
--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -15,6 +15,7 @@ import (
 
 const LabelColumnPrefix = "resource_tags_user_"
 const AWSLabelColumnPrefix = "resource_tags_aws_"
+const AthenaResourceTagPrefix = "resource_tags_"
 
 // athenaDateLayout is the default AWS date format
 const AthenaDateLayout = "2006-01-02 15:04:05.000"
@@ -355,7 +356,7 @@ func (ai *AthenaIntegration) RowToCloudCost(row types.Row, aqi AthenaQueryIndexe
 
 	for _, awsColumnName := range aqi.AWSTagColumns {
 		// partially remove prefix leaving "aws_"
-		labelName := strings.TrimPrefix(awsColumnName, "resource_tags_")
+		labelName := strings.TrimPrefix(awsColumnName, AthenaResourceTagPrefix)
 		value := GetAthenaRowValue(row, aqi.ColumnIndexes, awsColumnName)
 		if value != "" {
 			labels[labelName] = value

--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -14,6 +14,7 @@ import (
 )
 
 const LabelColumnPrefix = "resource_tags_user_"
+const AWSLabelColumnPrefix = "resource_tags_aws_"
 
 // athenaDateLayout is the default AWS date format
 const AthenaDateLayout = "2006-01-02 15:04:05.000"
@@ -52,6 +53,7 @@ type AthenaQueryIndexes struct {
 	Query                  string
 	ColumnIndexes          map[string]int
 	TagColumns             []string
+	AWSTagColumns          []string
 	ListCostColumn         string
 	NetCostColumn          string
 	AmortizedNetCostColumn string
@@ -99,6 +101,10 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.Cloud
 			quotedTag := fmt.Sprintf(`"%s"`, column)
 			groupByColumns = append(groupByColumns, quotedTag)
 			aqi.TagColumns = append(aqi.TagColumns, quotedTag)
+		}
+		if strings.HasPrefix(column, AWSLabelColumnPrefix) {
+			groupByColumns = append(groupByColumns, column)
+			aqi.AWSTagColumns = append(aqi.AWSTagColumns, column)
 		}
 	}
 	var selectColumns []string
@@ -342,6 +348,15 @@ func (ai *AthenaIntegration) RowToCloudCost(row types.Row, aqi AthenaQueryIndexe
 		// remove prefix
 		labelName = strings.TrimPrefix(labelName, LabelColumnPrefix)
 		value := GetAthenaRowValue(row, aqi.ColumnIndexes, tagColumnName)
+		if value != "" {
+			labels[labelName] = value
+		}
+	}
+
+	for _, awsColumnName := range aqi.AWSTagColumns {
+		// partially remove prefix leaving "aws_"
+		labelName := strings.TrimPrefix(awsColumnName, "resource_tags_")
+		value := GetAthenaRowValue(row, aqi.ColumnIndexes, awsColumnName)
 		if value != "" {
 			labels[labelName] = value
 		}

--- a/pkg/cloud/aws/s3selectintegration.go
+++ b/pkg/cloud/aws/s3selectintegration.go
@@ -35,6 +35,7 @@ const S3SelectNetSPCost = `s."savingsPlan/NetSavingsPlanEffectiveCost"`
 
 const S3SelectUserLabelPrefix = "resourceTags/user:"
 const S3SelectAWSLabelPrefix = "resourceTags/aws:"
+const S3SelectResourceTagsPrefix = "resourceTags/"
 
 type S3SelectIntegration struct {
 	S3SelectQuerier
@@ -190,7 +191,7 @@ func (s3si *S3SelectIntegration) GetCloudCost(
 				labelName := strings.TrimPrefix(awsLabelColumnName, `s."`)
 				labelName = strings.TrimSuffix(labelName, `"`)
 				// partially remove prefix leaving "aws:"
-				labelName = strings.TrimPrefix(labelName, "resourceTags/")
+				labelName = strings.TrimPrefix(labelName, S3SelectResourceTagsPrefix)
 				value := GetCSVRowValue(row, columnIndexes, awsLabelColumnName)
 				if value != "" {
 					labels[labelName] = value
@@ -329,24 +330,33 @@ func (s3si *S3SelectIntegration) GetCloudCost(
 	return ccsr, nil
 }
 
+const (
+	TagAWSEKSClusterName     = "aws:eks:cluster-name"
+	TagEKSClusterName        = "eks:cluster-name"
+	TagEKSCtlClusterName     = "alpha.eksctl.io/cluster-name"
+	TagKubernetesServiceName = "kubernetes.io/service-name"
+	TagKubernetesPVCName     = "kubernetes.io/created-for/pvc/name"
+	TagKubernetesPVName      = "kubernetes.io/created-for/pv/name"
+)
+
 // hsK8sLabel checks if the labels contain a k8s label
 func hasK8sLabel(labels opencost.CloudCostLabels) bool {
-	if _, ok := labels["aws:eks:cluster-name"]; ok {
+	if _, ok := labels[TagAWSEKSClusterName]; ok {
 		return true
 	}
-	if _, ok := labels["eks:cluster-name"]; ok {
+	if _, ok := labels[TagEKSClusterName]; ok {
 		return true
 	}
-	if _, ok := labels["alpha.eksctl.io/cluster-name"]; ok {
+	if _, ok := labels[TagEKSCtlClusterName]; ok {
 		return true
 	}
-	if _, ok := labels["kubernetes.io/service-name"]; ok {
+	if _, ok := labels[TagKubernetesServiceName]; ok {
 		return true
 	}
-	if _, ok := labels["kubernetes.io/created-for/pvc/name"]; ok {
+	if _, ok := labels[TagKubernetesPVCName]; ok {
 		return true
 	}
-	if _, ok := labels["kubernetes.io/created-for/pv/name"]; ok {
+	if _, ok := labels[TagKubernetesPVName]; ok {
 		return true
 	}
 	return false


### PR DESCRIPTION
## What does this PR change?
This PR updates AWS CUR integration to ingest AWS generated tags in addition to user generated tags. To do this columns with the AWS label prefix are gathered in a separate slice. With this separate list of columns the prefix can be properly handled and saved to cloud cost labels. This PR includes this addition for both Athena and S3 integrations.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* Users will now be able to see AWS generated labels in Cloud Costs
![Screenshot 2024-08-29 at 1 08 42 PM](https://github.com/user-attachments/assets/621628a4-144d-4f24-afb5-78c7c47647ac)


## Does this PR address any GitHub or Zendesk issues?
* Closes ENG-150

## How was this PR tested?
* This PR was tested by running cloud cost and aggregator locally and ensuring that AWS label `aws_eks_cluster_name` was being populated in cloud cost.
`curl --location --globoff 'http://localhost:9004/cloudCost?window=yesterday&filter=label[aws_eks_cluster_name]%3A%22dev-1%22&aggregate=label%3Aaws_eks_cluster_name'`
```
      "cloudCosts": {
                    "dev-1": {
                        "properties": {
                            "labels": {
                                "aws_created_by": "AssumedRole:AROAUKXXWPGDYLPOEB2GE:AutoScaling",
                                "aws_eks_cluster_name": "dev-1",
                                "eks_cluster_name": "dev-1"
                            }
                        },
                        "window": {
                            "start": "2024-08-27T00:00:00Z",
                            "end": "2024-08-28T00:00:00Z"
                        },
                        "listCost": {
                            "cost": 28.5624505521,
                            "kubernetesPercent": 1
                        },
                        "netCost": {
                            "cost": 28.5624505521,
                            "kubernetesPercent": 1
                        },
                        "amortizedNetCost": {
                            "cost": 28.5624505521,
                            "kubernetesPercent": 1
                        },
                        "invoicedCost": {
                            "cost": 28.5624505521,
                            "kubernetesPercent": 1
                        },
                        "amortizedCost": {
                            "cost": 28.5624505521,
                            "kubernetesPercent": 1
                        }
                    }
                },
                "window": {
                    "start": "2024-08-27T00:00:00Z",
                    "end": "2024-08-28T00:00:00Z"
                },
                "aggregationProperties": [
                    "label:aws_eks_cluster_name"
                ]
            }
```

Because this PR deals with integrations it will need to by pass unit testing gates

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
