### PR TITLE
ENG-2837 - Efficiency Calculations

### DIFF
--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -935,7 +935,7 @@ func (a *Allocation) CPUEfficiency() float64 {
 		return a.CPUCoreUsageAverage / a.CPUCoreRequestAverage
 	}
 
-	if a.CPUCoreUsageAverage == 0.0 || a.CPUCost == 0.0 {
+	if a.CPUCoreUsageAverage == 0.0 || a.CPUTotalCost() == 0.0 {
 		return 0.0
 	}
 
@@ -954,7 +954,7 @@ func (a *Allocation) RAMEfficiency() float64 {
 		return a.RAMBytesUsageAverage / a.RAMBytesRequestAverage
 	}
 
-	if a.RAMBytesUsageAverage == 0.0 || a.RAMCost == 0.0 {
+	if a.RAMBytesUsageAverage == 0.0 || a.RAMTotalCost() == 0.0 {
 		return 0.0
 	}
 
@@ -973,7 +973,7 @@ func (a *Allocation) GPUEfficiency() float64 {
 		return a.GPUUsageAverage / a.GPURequestAverage
 	}
 
-	if a.GPUUsageAverage == 0.0 || a.GPUCost == 0.0 {
+	if a.GPUUsageAverage == 0.0 || a.GPUTotalCost() == 0.0 {
 		return 0.0
 	}
 


### PR DESCRIPTION
## What does this PR change?
* Updates `CPUEfficiency()`, `RAMEfficiency()`, and `GPUEfficiency()` to use `*CostTotal()` instead of `*Cost` for Allocations. This it to more closely align cost efficiency logic with that of `TotalEfficiency().

## Does this PR relate to any other PRs?
* [KCM](https://github.com/kubecost/kubecost-cost-model/pull/2832).

## How will this PR impact users?
* Efficiency calculations will now be correct for Allocations.

## Does this PR address any GitHub or Zendesk issues?
* Closes [ENG-2837](https://kubecost.atlassian.net/browse/ENG-2837).

## How was this PR tested?
* Unit and integration tests.

## Does this PR require changes to documentation?
* Nope.