### PR TITLE
add cost model image tag to installInfo endpoint, for agent diagnostics

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1193,6 +1193,7 @@ type InstallInfo struct {
 	Containers  []ContainerInfo   `json:"containers"`
 	ClusterInfo map[string]string `json:"clusterInfo"`
 	Version     string            `json:"version"`
+	CostModelImageTag string      `json:"costModelImageTag"`
 }
 
 type ContainerInfo struct {
@@ -1211,10 +1212,19 @@ func (a *Accesses) GetInstallInfo(w http.ResponseWriter, r *http.Request, _ http
 		return
 	}
 
+	costModelImageTag := ""
+	for _, container := range containers {
+		if container.ContainerName != "cost-model" {
+			continue
+		}
+		costModelImageTag = strings.Split(container.Image, ":")[1]
+	}
+
 	info := InstallInfo{
 		Containers:  containers,
 		ClusterInfo: make(map[string]string),
 		Version:     version.FriendlyVersion(),
+		CostModelImageTag: costModelImageTag,
 	}
 
 	nodes := a.ClusterCache.GetAllNodes()


### PR DESCRIPTION
## What does this PR change?
* Adds cost-model image tag in the response of `installInfo` endpoint

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
*

## Does this PR address any GitHub or Zendesk issues?
* Closes https://kubecost.atlassian.net/browse/ENG-2359

## How was this PR tested?
* Ran it locally

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
