### PR TITLE
update go.mod for golang cve

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencost/opencost/core
 
-go 1.22.0
+go 1.22.7
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -195,6 +195,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.22.7


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
* Bump go version for CVE-2024-34156

## Does this PR relate to any other PRs?
* NA

## How will this PR impact users?
* NA

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* local build

## Does this PR require changes to documentation?
* NA

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v2.4 and v1.112
