### PR TITLE
use the query window to refresh costs

### DIFF
--- a/pkg/customcost/ingestor.go
+++ b/pkg/customcost/ingestor.go
@@ -337,14 +337,14 @@ func (ing *CustomCostIngestor) run() {
 			// Wait for next tick
 		}
 
-		// Start from the last covered time, minus the RunWindow
-		start := ing.lastRun
-		start = start.Add(-ing.resolution)
-
 		queryWin := ing.config.DailyQueryWindow
 		if ing.resolution == time.Hour {
 			queryWin = ing.config.HourlyQueryWindow
 		}
+		// Start from the last covered time, minus the query window
+		// this allows re-querying of data as the plugin providers' data may stabilize over time
+		start := ing.lastRun
+		start = start.Add(-1 * queryWin)
 
 		// Round start time back to the nearest Resolution point in the past from the
 		// last update to the QueryWindow


### PR DESCRIPTION
## What does this PR change?
* uses the query window to refresh costs, like the cloud costs ingestor

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* should make custom costs more reliable, since we refresh the data as it gets older and ostensibly more accurate

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* tested locally, confirmed query behavior

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
