### PR TITLE
Introducing OpenCost Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6219/badge)](https://www.bestpractices.dev/projects/6219)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OpenCost%20Guru-006BFF)](https://gurubase.io/g/opencost)
 
 ![](./opencost-header.png)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [OpenCost Guru](https://gurubase.io/g/opencost) to Gurubase. OpenCost Guru uses the data from this repo and data from the [docs](https://www.opencost.io/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "OpenCost Guru", which highlights that OpenCost now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable OpenCost Guru in Gurubase, just let me know that's totally fine.
