### PR TITLE
Fix: fetching for azure nodes that are not spot instances  

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -291,7 +291,7 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	spotPrice := ""
 	for _, item := range pricingPayload.Items {
 		if item.Type == "Consumption" && !strings.Contains(item.ProductName, "Windows") {
-			if  !strings.Contains(strings.ToLower(item.SkuName), " spot") {
+			if !strings.Contains(strings.ToLower(item.SkuName), " spot") {
 				spotPrice = fmt.Sprintf("%f", item.RetailPrice)
 			} else {
 				retailPrice = fmt.Sprintf("%f", item.RetailPrice)
@@ -300,6 +300,10 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	}
 
 	log.DedupedInfof(5, "done parsing retail price payload from \"%s\"\n", pricingURL)
+
+	if spot && spotPrice != "" {
+		return spotPrice, nil
+	}
 
 	if retailPrice == "" {
 		return retailPrice, fmt.Errorf("Couldn't find price for product \"%s\" in \"%s\" region", skuName, region)

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1112,9 +1112,10 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 	instance := features[1]
 	var featureString string
 	if isSpot {
+		features := strings.Split(featureString, ",")
+		region := features[0]
+		instance := features[1]
 		featureString = fmt.Sprintf("%s,%s,spot", region, instance)
-	} else {
-		featureString = azKey.Features()
 	}
 
 	if n, ok := az.Pricing[featureString]; ok {

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -290,7 +290,6 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	retailPrice := ""
 	for _, item := range pricingPayload.Items {
 		if item.Type == "Consumption" && !strings.Contains(item.ProductName, "Windows") {
-			// if spot is true SkuName should contain "spot, if it is false it should not
 			if spot == strings.Contains(strings.ToLower(item.SkuName), " spot") {
 				retailPrice = fmt.Sprintf("%f", item.RetailPrice)
 			} else {
@@ -938,11 +937,6 @@ func convertMeterToPricings(info commerce.MeterInfo, regions map[string]string, 
 		return nil, nil
 	}
 
-	if strings.Contains(meterSubCategory, "Cloud Services") || strings.Contains(meterSubCategory, "CloudServices") {
-		// This meter doesn't correspond to any pricings.
-		return nil, nil
-	}
-
 	if strings.Contains(meterCategory, "Storage") {
 		if strings.Contains(meterSubCategory, "HDD") || strings.Contains(meterSubCategory, "SSD") || strings.Contains(meterSubCategory, "Premium Files") {
 			var storageClass string = ""
@@ -1145,7 +1139,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 			}
 		}
 
-		az.addPricing(azKey.Features(), &AzurePricing{
+		az.addPricing(featureString, &AzurePricing{
 			Node: node,
 		})
 		return node, meta, nil

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1114,12 +1114,14 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 	slv, ok := azKey.Labels[config.SpotLabel]
 	isSpot := ok && slv == config.SpotLabelValue && config.SpotLabel != "" && config.SpotLabelValue != ""
 
-	featureString := azKey.Features()
+	features := strings.Split(azKey.Features(), ",")
+	region := features[0]
+	instance := features[1]
+	var featureString string
 	if isSpot {
-		features := strings.Split(featureString, ",")
-		region := features[0]
-		instance := features[1]
 		featureString = fmt.Sprintf("%s,%s,spot", region, instance)
+	} else {
+		featureString = azKey.Features()
 	}
 
 	if n, ok := az.Pricing[featureString]; ok {

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -288,6 +288,7 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	}
 
 	retailPrice := ""
+	spotPrice := ""
 	for _, item := range pricingPayload.Items {
 		if item.Type == "Consumption" && !strings.Contains(item.ProductName, "Windows") {
 			if spot == strings.Contains(strings.ToLower(item.SkuName), " spot") {

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -291,7 +291,9 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	spotPrice := ""
 	for _, item := range pricingPayload.Items {
 		if item.Type == "Consumption" && !strings.Contains(item.ProductName, "Windows") {
-			if spot == strings.Contains(strings.ToLower(item.SkuName), " spot") {
+			if  !strings.Contains(strings.ToLower(item.SkuName), " spot") {
+				spotPrice = fmt.Sprintf("%f", item.RetailPrice)
+			} else {
 				retailPrice = fmt.Sprintf("%f", item.RetailPrice)
 			}
 		}

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -290,6 +290,7 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	retailPrice := ""
 	for _, item := range pricingPayload.Items {
 		if item.Type == "Consumption" && !strings.Contains(item.ProductName, "Windows") {
+			// if spot is true SkuName should contain "spot, if it is false it should not
 			if spot == strings.Contains(strings.ToLower(item.SkuName), " spot") {
 				retailPrice = fmt.Sprintf("%f", item.RetailPrice)
 			} else {
@@ -933,6 +934,11 @@ func convertMeterToPricings(info commerce.MeterInfo, regions map[string]string, 
 	}
 
 	if strings.Contains(meterSubCategory, "Windows") {
+		// This meter doesn't correspond to any pricings.
+		return nil, nil
+	}
+
+	if strings.Contains(meterSubCategory, "Cloud Services") || strings.Contains(meterSubCategory, "CloudServices") {
 		// This meter doesn't correspond to any pricings.
 		return nil, nil
 	}

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1107,10 +1107,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 	slv, ok := azKey.Labels[config.SpotLabel]
 	isSpot := ok && slv == config.SpotLabelValue && config.SpotLabel != "" && config.SpotLabelValue != ""
 
-	features := strings.Split(azKey.Features(), ",")
-	region := features[0]
-	instance := features[1]
-	var featureString string
+	featureString := azKey.Features()
 	if isSpot {
 		features := strings.Split(featureString, ",")
 		region := features[0]


### PR DESCRIPTION
## What does this PR change?
* It enables to fetch non spot node instance costs from azure
* It refactors the `NodePricing` function of the azure provider, make it easier to read.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* It will enable to fetch non spot node instance from azure. So less errors containing `failed to retrieve spot retail pricing` 

## Does this PR address any GitHub or Zendesk issues?
* No, I thought instead of opening a issue i can fix it directly ;) 

## How was this PR tested?
* I let it run on my cluster, the produced metrics corresponded to the metrics read by opencost. An example, where the fetch before didn't work was for me [this resource](https://prices.azure.com/api/retail/prices?$skip=0&currencyCode=%27USD%27&$filter=armRegionName+eq+%27switzerlandnorth%27+and+armSkuName+eq+%27Standard_D8d_v5%27). 
* I let the existing test run -> and they worked well. I think they worked well, because they didn't covered this usecase. 

## Does this PR require changes to documentation?
* It does not.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Should be included into the next release
