### PR TITLE
Increate timeout for ratecardapi to 5 minutes

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -849,7 +849,7 @@ func (az *Azure) DownloadPricingData() error {
 	// rate-card client is old, it can hang indefinitely in some cases
 	// this happens on the main thread, so it may block the whole app
 	// there is can be a better way to set timeout for the client
-	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 300*time.Second)
 	defer cancel()
 	result, err := rcClient.Get(ctx, rateCardFilter)
 	if err != nil {


### PR DESCRIPTION
Timeout of 1 minute is not enough to complete the ratecardQuery

## What does this PR change?
* Set the timeout of the azure ratecard query to 5 minutes instead of 1. 

## How will this PR impact users?
* Allow azure users to get ratecard query results

related to #2977
closes #2977
