### PR TITLE
add Thomas E to emeritus maintainer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,6 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 | Matt Bolt | @​mbolt35 | Kubecost | <matt@kubecost.com> |
 | Niko Kovacevic | @nikovacevic | Kubecost | <niko@kubecost.com> |
 | Sean Holcomb | @Sean-Holcomb | Kubecost | <Sean@kubecost.com> |
-| Thomas Evans | @teevans | Kubecost | <thomas@kubecost.com> |
 
 ## Opencost Emeritus Committers
 We would like to acknowledge previous committers and their huge contributions to our collective success:
@@ -22,3 +21,4 @@ We would like to acknowledge previous committers and their huge contributions to
 | --------------- | --------- | ----------- | ----------- |
 | Michael Dresser | @michaelmdresser | Kubecost (former) | <michaelmdresser@gmail.com> |
 | Matt Ray | @mattray | Kubecost (former) | <mattray@kubecost.com> |
+| Thomas Evans | @teevans | Kubecost (former) | <thomas@kubecost.com> |


### PR DESCRIPTION
Signed-off-by: Cliff Colvin <ccolvin@kubecost.com>

## What does this PR change?
* Updates maintainers list to move Thomas Evans to emeritus maintainers list as he's stepping away from the project.

## Does this PR relate to any other PRs?
* NA

## How will this PR impact users?
* NA

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* NA

## Does this PR require changes to documentation?
* NA

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* NA
