### PR TITLE
add support for adding local to the response objects

### DIFF
--- a/core/pkg/opencost/asset_json.go
+++ b/core/pkg/opencost/asset_json.go
@@ -275,6 +275,7 @@ func (d *Disk) MarshalJSON() ([]byte, error) {
 	jsonEncodeString(buffer, "storageClass", d.StorageClass, ",")
 	jsonEncodeString(buffer, "volumeName", d.VolumeName, ",")
 	jsonEncodeString(buffer, "claimName", d.ClaimName, ",")
+	jsonEncodeFloat64(buffer, "local", d.Local, ",")
 	jsonEncodeString(buffer, "claimNamespace", d.ClaimNamespace, "")
 	buffer.WriteString("}")
 	return buffer.Bytes(), nil
@@ -375,10 +376,9 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 		d.ClaimNamespace = ClaimNamespace.(string)
 	}
 
-	// d.Local is not marhsaled, and cannot be calculated from marshaled values.
-	// Currently, it is just ignored and not set in the resulting unmarshal to Disk
-	//  be aware that this means a resulting Disk from an unmarshal is therefore NOT
-	// equal to the originally marshaled Disk.
+	if local, err := getTypedVal(fmap["local"]); err == nil {
+		d.Local = local.(float64)
+	}
 
 	return nil
 


### PR DESCRIPTION
## What does this PR change?
* fixes an issue where we weren't encoding Local properly. Rather than have that be the sole exception, we add support for it here 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Makes the JSON representation more consistent with the golang one

## How was this PR tested?
* tested via downstream unit tests 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
