### PR TITLE
use empty structs, pre-size array during dedupe

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1628,8 +1628,8 @@ func pruneDuplicates(s []string) []string {
 	for _, v := range s {
 		if strings.Contains(v, "_") {
 			name := strings.Replace(v, "_", "-", -1)
-			if !m[name] {
-				m[name] = true
+			if _, found := m[name]; !found {
+				m[name] = struct{}{}
 			}
 			delete(m, v)
 		}
@@ -1638,16 +1638,16 @@ func pruneDuplicates(s []string) []string {
 	return setToSlice(m)
 }
 
-// Creates a map[string]bool containing the slice values as keys
-func sliceToSet(s []string) map[string]bool {
-	m := make(map[string]bool)
+// Creates a map[string]struct{} containing the slice values as keys
+func sliceToSet(s []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(s))
 	for _, v := range s {
-		m[v] = true
+		m[v] = struct{}{}
 	}
 	return m
 }
 
-func setToSlice(m map[string]bool) []string {
+func setToSlice(m map[string]struct{}) []string {
 	var result []string
 	for k := range m {
 		result = append(result, k)


### PR DESCRIPTION
## What does this PR change?
* for the deduplication code, this pre-sizes the array and switches to empty structs from bools to reduce space requirements 

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* we are hoping this should reduce memory consumption for large users 

## How was this PR tested?
* unit test was added

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
