### PR TITLE
Add io2 support

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -341,12 +341,14 @@ var volTypes = map[string]string{
 	"EBS:VolumeP-IOPS.piops": "io1",
 	"EBS:VolumeUsage.st1":    "st1",
 	"EBS:VolumeUsage.piops":  "io1",
+	"EBS:VolumeUsage.io2":    "io2",
 	"gp2":                    "EBS:VolumeUsage.gp2",
 	"gp3":                    "EBS:VolumeUsage.gp3",
 	"standard":               "EBS:VolumeUsage",
 	"sc1":                    "EBS:VolumeUsage.sc1",
 	"io1":                    "EBS:VolumeUsage.piops",
 	"st1":                    "EBS:VolumeUsage.st1",
+	"io2":                    "EBS:VolumeUsage.io2",
 }
 
 var loadedAWSSecret bool = false


### PR DESCRIPTION


## What does this PR change?
*  Add io2 to the volTypes map of the aws provider

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* io2 volumes should be calculated correctly

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/3054

