### PR TITLE
bump go version 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,4 +195,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-go 1.22.7
+go 1.23.5


### PR DESCRIPTION
Signed-off-by Cliff Colvin<clifford.colvin@ibm.com>

## What does this PR change?
* Bump golang toolchain for CVE fixes
* https://github.com/advisories/GHSA-7wrw-r4p8-38rx
* https://github.com/advisories/GHSA-3f6r-qh9c-x6mm
* https://github.com/advisories/GHSA-3whm-j4xm-rv8x

## Does this PR relate to any other PRs?
* NA

## How will this PR impact users?
* NA

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Local build

## Does this PR require changes to documentation?
* NA

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* LTS
