### PR TITLE
[KCM-3403] Remove node label allow-list so all node labels can be shown in Allocation workloads

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
-	"github.com/opencost/opencost/core/pkg/util/promutil"
 	"github.com/opencost/opencost/core/pkg/util/timeutil"
 	"github.com/opencost/opencost/pkg/cloud/provider"
 	"github.com/opencost/opencost/pkg/env"
@@ -912,23 +911,11 @@ func resToNodeLabels(resNodeLabels []*prom.QueryResult) map[nodeKey]map[string]s
 			nodeLabels[nodeKey] = map[string]string{}
 		}
 
-		for _, rawK := range env.GetAllocationNodeLabelsIncludeList() {
-			labels := res.GetLabels()
-
-			// Sanitize the given label name to match Prometheus formatting
-			// e.g. topology.kubernetes.io/zone => topology_kubernetes_io_zone
-			k := promutil.SanitizeLabelName(rawK)
-			if v, ok := labels[k]; ok {
-				nodeLabels[nodeKey][k] = v
-				continue
-			}
-
-			// Try with the "label_" prefix, if not found
-			// e.g. topology_kubernetes_io_zone => label_topology_kubernetes_io_zone
-			k = fmt.Sprintf("label_%s", k)
-			if v, ok := labels[k]; ok {
-				nodeLabels[nodeKey][k] = v
-			}
+		labels := res.GetLabels()
+		// labels are retrieved from prometheus here so it will be in prometheus sanitized state
+		// e.g. topology.kubernetes.io/zone => topology_kubernetes_io_zone
+		for labelKey, labelValue := range labels {
+			nodeLabels[nodeKey][labelKey] = labelValue
 		}
 	}
 

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -71,7 +71,7 @@ const (
 	MultiClusterBasicAuthPassword = "MC_BASIC_AUTH_PW"
 	MultiClusterBearerToken       = "MC_BEARER_TOKEN"
 
-	InsecureSkipVerify = "INSECURE_SKIP_VERIFY"
+	InsecureSkipVerify   = "INSECURE_SKIP_VERIFY"
 	KubeRbacProxyEnabled = "KUBE_RBAC_PROXY_ENABLED"
 
 	KubeConfigPathEnvVar = "KUBECONFIG_PATH"
@@ -106,8 +106,7 @@ const (
 
 	ETLReadOnlyMode = "ETL_READ_ONLY"
 
-	AllocationNodeLabelsEnabled     = "ALLOCATION_NODE_LABELS_ENABLED"
-	AllocationNodeLabelsIncludeList = "ALLOCATION_NODE_LABELS_INCLUDE_LIST"
+	AllocationNodeLabelsEnabled = "ALLOCATION_NODE_LABELS_ENABLED"
 
 	AssetIncludeLocalDiskCostEnvVar = "ASSET_INCLUDE_LOCAL_DISK_COST"
 
@@ -622,31 +621,6 @@ func IsIngestingPodUID() bool {
 
 func GetAllocationNodeLabelsEnabled() bool {
 	return env.GetBool(AllocationNodeLabelsEnabled, true)
-}
-
-var defaultAllocationNodeLabelsIncludeList []string = []string{
-	"cloud.google.com/gke-nodepool",
-	"eks.amazonaws.com/nodegroup",
-	"kubernetes.azure.com/agentpool",
-	"node.kubernetes.io/instance-type",
-	"topology.kubernetes.io/region",
-	"topology.kubernetes.io/zone",
-}
-
-func GetAllocationNodeLabelsIncludeList() []string {
-	// If node labels are not enabled, return an empty list.
-	if !GetAllocationNodeLabelsEnabled() {
-		return []string{}
-	}
-
-	list := env.GetList(AllocationNodeLabelsIncludeList, ",")
-
-	// If node labels are enabled, but the white list is empty, use defaults.
-	if len(list) == 0 {
-		return defaultAllocationNodeLabelsIncludeList
-	}
-
-	return list
 }
 
 func GetAssetIncludeLocalDiskCost() bool {


### PR DESCRIPTION
## What does this PR change?
* Remove node label allow-list options so all the node labels can be shown with allocation workloads

## Does this PR relate to any other PRs?
* [HELM PR](https://github.com/kubecost/cost-analyzer-helm-chart/pull/3892)

## How will this PR impact users?
* Allocation bingen will have all the node labels on which the workload resides for all workload rather than a predetermined set of node labels that was configurable.

## Does this PR address any GitHub or Zendesk issues?
* Closes ... https://apptio.atlassian.net/browse/KCM-3403

## How was this PR tested?
* Ran KCM locally. The generated allocation bingen was investigated. 

For example: This is the below allocation of cert-manager-cainjector-86b8557d49-nnd4w pod.

`"cluster-localrun-default/ip-192-168-11-47.us-east-2.compute.internal/cert-manager/cert-manager-cainjector-86b8557d49-nnd4w/cert-manager-cainjector": {
      "name": "cluster-localrun-default/ip-192-168-11-47.us-east-2.compute.internal/cert-manager/cert-manager-cainjector-86b8557d49-nnd4w/cert-manager-cainjector",
      "properties": {
        "cluster": "cluster-localrun-default",
        "node": "ip-192-168-11-47.us-east-2.compute.internal",
        "container": "cert-manager-cainjector",
        "controller": "cert-manager-cainjector",
        "controllerKind": "deployment",
        "namespace": "cert-manager",
        "pod": "cert-manager-cainjector-86b8557d49-nnd4w",
        "providerID": "i-0a6dce4247665072e",
        "labels": {
          "app": "cainjector",
          "app_kubernetes_io_component": "cainjector",
          "app_kubernetes_io_instance": "cert-manager",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "cainjector",
          "app_kubernetes_io_version": "v1.15.1",
          "beta_kubernetes_io_arch": "amd64",
          "beta_kubernetes_io_instance_type": "g4dn.xlarge",
          "beta_kubernetes_io_os": "linux",
          "costgroup": "engineering",
          "eks_amazonaws_com_capacityType": "ON_DEMAND",
          "eks_amazonaws_com_nodegroup": "shared-gpu-alan-rodrigues-pranav-bhat",
          "eks_amazonaws_com_nodegroup_image": "ami-06577ac4cff2ce049",
          "expire": "202410102359",
          "failure_domain_beta_kubernetes_io_region": "us-east-2",
          "failure_domain_beta_kubernetes_io_zone": "us-east-2b",
          "feature_node_kubernetes_io_cpu_cpuid_ADX": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AESNI": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX2": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX512BW": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX512CD": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX512DQ": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX512F": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX512VL": "true",
          "feature_node_kubernetes_io_cpu_cpuid_AVX512VNNI": "true",
          "feature_node_kubernetes_io_cpu_cpuid_CMPXCHG8": "true",
          "feature_node_kubernetes_io_cpu_cpuid_FMA3": "true",
          "feature_node_kubernetes_io_cpu_cpuid_FXSR": "true",
          "feature_node_kubernetes_io_cpu_cpuid_FXSROPT": "true",
          "feature_node_kubernetes_io_cpu_cpuid_HYPERVISOR": "true",
          "feature_node_kubernetes_io_cpu_cpuid_LAHF": "true",
          "feature_node_kubernetes_io_cpu_cpuid_MOVBE": "true",
          "feature_node_kubernetes_io_cpu_cpuid_MPX": "true",
          "feature_node_kubernetes_io_cpu_cpuid_OSXSAVE": "true",
          "feature_node_kubernetes_io_cpu_cpuid_SYSCALL": "true",
          "feature_node_kubernetes_io_cpu_cpuid_SYSEE": "true",
          "feature_node_kubernetes_io_cpu_cpuid_X87": "true",
          "feature_node_kubernetes_io_cpu_cpuid_XGETBV1": "true",
          "feature_node_kubernetes_io_cpu_cpuid_XSAVE": "true",
          "feature_node_kubernetes_io_cpu_cpuid_XSAVEC": "true",
          "feature_node_kubernetes_io_cpu_cpuid_XSAVEOPT": "true",
          "feature_node_kubernetes_io_cpu_cpuid_XSAVES": "true",
          "feature_node_kubernetes_io_cpu_hardware_multithreading": "true",
          "feature_node_kubernetes_io_cpu_model_family": "6",
          "feature_node_kubernetes_io_cpu_model_id": "85",
          "feature_node_kubernetes_io_cpu_model_vendor_id": "Intel",
          "feature_node_kubernetes_io_kernel_config_NO_HZ": "true",
          "feature_node_kubernetes_io_kernel_config_NO_HZ_IDLE": "true",
          "feature_node_kubernetes_io_kernel_version_full": "5.10.225-213.878.amzn2.x86_64",
          "feature_node_kubernetes_io_kernel_version_major": "5",
          "feature_node_kubernetes_io_kernel_version_minor": "10",
          "feature_node_kubernetes_io_kernel_version_revision": "225",
          "feature_node_kubernetes_io_pci_10de_present": "true",
          "feature_node_kubernetes_io_pci_1d0f_present": "true",
          "feature_node_kubernetes_io_storage_nonrotationaldisk": "true",
          "feature_node_kubernetes_io_system_os_release_ID": "amzn",
          "feature_node_kubernetes_io_system_os_release_VERSION_ID": "2",
          "feature_node_kubernetes_io_system_os_release_VERSION_ID_major": "2",
          "helm_sh_chart": "cert-manager-v1.15.1",
          "k8s_io_cloud_provider_aws": "659b6cdec8c90e1f2729fd59c20d9a9d",
          "kubernetes_io_arch": "amd64",
          "kubernetes_io_hostname": "ip-192-168-11-47.us-east-2.compute.internal",
          "kubernetes_io_metadata_name": "cert-manager",
          "kubernetes_io_os": "linux",
          "maintainer": "alanr",
          "name": "cert-manager",
          "node_kubernetes_io_instance_type": "g4dn.xlarge",
          "nvidia_com_cuda_driver_major": "550",
          "nvidia_com_cuda_driver_minor": "90",
          "nvidia_com_cuda_driver_rev": "12",
          "nvidia_com_cuda_driver_version_full": "550.90.12",
          "nvidia_com_cuda_driver_version_major": "550",
          "nvidia_com_cuda_driver_version_minor": "90",
          "nvidia_com_cuda_driver_version_revision": "12",
          "nvidia_com_cuda_runtime_major": "12",
          "nvidia_com_cuda_runtime_minor": "4",
          "nvidia_com_cuda_runtime_version_full": "12.4",
          "nvidia_com_cuda_runtime_version_major": "12",
          "nvidia_com_cuda_runtime_version_minor": "4",
          "nvidia_com_device_plugin_config": "test-sharing",
          "nvidia_com_gfd_timestamp": "1728425372",
          "nvidia_com_gpu_compute_major": "7",
          "nvidia_com_gpu_compute_minor": "5",
          "nvidia_com_gpu_count": "1",
          "nvidia_com_gpu_family": "turing",
          "nvidia_com_gpu_machine": "g4dn.xlarge",
          "nvidia_com_gpu_memory": "15360",
          "nvidia_com_gpu_mode": "compute",
          "nvidia_com_gpu_product": "Tesla-T4",
          "nvidia_com_gpu_replicas": "4",
          "nvidia_com_gpu_sharing_strategy": "time-slicing",
          "nvidia_com_mig_capable": "false",
          "nvidia_com_mps_capable": "false",
          "nvidia_com_vgpu_present": "false",
          "pod_template_hash": "86b8557d49",
          "topology_ebs_csi_aws_com_zone": "us-east-2b",
          "topology_k8s_aws_zone_id": "use2-az2",
          "topology_kubernetes_io_region": "us-east-2",
          "topology_kubernetes_io_zone": "us-east-2b"
        },
        "namespaceLabels": {
          "kubernetes_io_metadata_name": "cert-manager",
          "name": "cert-manager"
        }
      },
      "window": {
        "start": "2025-02-18T00:00:00Z",
        "end": "2025-02-19T00:00:00Z"
      },
      "start": "2025-02-18T00:00:00Z",
      "end": "2025-02-18T23:50:00Z",
      "minutes": 1430,
      "cpuCores": 0.01,
      "cpuCoreRequestAverage": 0.01,
      "cpuCoreUsageAverage": 0.00079,
      "cpuCoreHours": 0.23833,
      "cpuCost": 0.00347,
      "cpuCostAdjustment": 0,
      "cpuCostIdle": 0,
      "cpuEfficiency": 0.07868,
      "gpuCount": 0,
      "gpuHours": 0,
      "gpuCost": 0,
      "gpuCostAdjustment": 0,
      "gpuCostIdle": 0,
      "gpuEfficiency": 0,
      "networkTransferBytes": 7951711.48018,
      "networkReceiveBytes": 10062789.98989,
      "networkCost": 0,
      "networkCrossZoneCost": 0,
      "networkCrossRegionCost": 0,
      "networkInternetCost": 0,
      "networkCostAdjustment": 0,
      "loadBalancerCost": 0,
      "loadBalancerCostAdjustment": 0,
      "pvBytes": 0,
      "pvByteHours": 0,
      "pvCost": 0,
      "pvs": null,
      "pvCostAdjustment": 0,
      "ramBytes": 83886080,
      "ramByteRequestAverage": 83886080,
      "ramByteUsageAverage": 56303690.31682,
      "ramByteHours": 1999284906.66667,
      "ramCost": 0.00364,
      "ramCostAdjustment": 0,
      "ramCostIdle": 0,
      "ramEfficiency": 0.67119,
      "externalCost": 0,
      "sharedCost": 0,
      "totalCost": 0.00711,
      "totalEfficiency": 0.38179,
      "rawAllocationOnly": {
        "cpuCoreUsageMax": 0.0014965769564496791,
        "ramByteUsageMax": 58425344,
        "gpuUsageMax": null
      },
      "lbAllocations": null,
      "gpuAllocation": {
        "isGPUShared": null,
        "gpuUsageAverage": null,
        "gpuRequestAverage": 0
      }
    },`

The associated label are aggregation of labels of the pod and the associated node label on which the pod resides

![Screenshot 2025-02-19 at 3 04 59 PM](https://github.com/user-attachments/assets/37627eed-5a98-41f7-bc2a-3b0245ab0fb7)
![Screenshot 2025-02-19 at 3 05 07 PM](https://github.com/user-attachments/assets/72fc5972-4bbe-4214-82c9-dad773215d26)



## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v2.7 of KCM
