### PR TITLE
update Kubecost committer contact info

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,13 +6,13 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 
 | Maintainer | GitHub ID | Affiliation | Email |
 | --------------- | --------- | ----------- | ----------- |
-| Ajay Tripathy | @AjayTripathy | Kubecost | <Ajay@kubecost.com> |
-| Alex Meijer | @ameijer | Kubecost | <ameijer@kubecost.com> |
+| Ajay Tripathy | @AjayTripathy | IBM | <ajay.tripathy@ibm.com> |
+| Alex Meijer | @ameijer | IBM | <alexander.meijer@ibm.com> |
 | Artur Khantimirov | @r2k1 | Microsoft | <akhantimirov@microsoft.com> |
-| Cliff Colvin | @cliffcolvin | Kubecost | <ccolvin@kubecost.com> |
-| Matt Bolt | @​mbolt35 | Kubecost | <matt@kubecost.com> |
-| Niko Kovacevic | @nikovacevic | Kubecost | <niko@kubecost.com> |
-| Sean Holcomb | @Sean-Holcomb | Kubecost | <Sean@kubecost.com> |
+| Cliff Colvin | @cliffcolvin | IBM | <clifford.colvin@ibm.com> |
+| Matt Bolt | @​mbolt35 | IBM | <matthew.bolt@ibm.com> |
+| Niko Kovacevic | @nikovacevic | IBM | <Nicholas.Kovacevic@ibm.com> |
+| Sean Holcomb | @Sean-Holcomb | IBM | <sean.holcomb@ibm.com> |
 
 ## Opencost Emeritus Committers
 We would like to acknowledge previous committers and their huge contributions to our collective success:


### PR DESCRIPTION
## What does this PR change?
* updates contact info to IBM contacts for former Kubecost maintainers 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* no impact

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* N/A

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
