### PR TITLE
fix duplicate labels error in emitted metrics

### DIFF
--- a/.github/workflows/promote-to-demo.yaml
+++ b/.github/workflows/promote-to-demo.yaml
@@ -1,8 +1,8 @@
-name: Build and Publish Develop
+name: Promote to Demo
 
 on:
   workflow_run:
-    workflows: [Build/Test]
+    workflows: [Build and Publish Develop]
     types: [completed]
     branches: [develop]
 
@@ -10,17 +10,12 @@ concurrency:
   group: build-opencost-develop
   cancel-in-progress: false
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-
 jobs:
-  build-and-publish-opencost:
+  prep-image-name:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      image_tag: ${{ steps.tags.outputs.IMAGE_TAG }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -33,13 +28,11 @@ jobs:
         id: tags
         run: |
           echo "IMAGE_TAG=ghcr.io/${{ github.repository_owner }}/opencost:develop-${{ steps.sha.outputs.OC_SHORTHASH }}" >> $GITHUB_OUTPUT
-
-      - name: Build and publish container
-        uses: ./.github/actions/build-container 
-        with:
-          actor: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          image_tag: ${{ steps.tags.outputs.IMAGE_TAG }}
-          release_version: develop-${{ steps.sha.outputs.OC_SHORTHASH }}
-
-
+ 
+  install-on-demo:
+    needs: [prep-image-name]
+    uses: opencost/opencost-infra/.github/workflows/promote-to-oc-demo.yaml@main
+    secrets: inherit
+    with:
+      img-fqdn: ${{ needs.prep-image-name.outputs.image_tag }}
+      is_be: true

--- a/pkg/clustercache/store.go
+++ b/pkg/clustercache/store.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	rt "k8s.io/apimachinery/pkg/runtime"
 )
 
 // GenericStore is a generic store implementation. It converts objects to a different type using a transform function.
@@ -86,9 +87,14 @@ func (s *GenericStore[Input, Output]) Delete(obj any) error {
 func (s *GenericStore[Input, Output]) GetAll() []Output {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
+
+    // Deep copy the stored items to ensure that callers do not modify
+    // the original objects in the store.
 	allItems := make([]Output, 0, len(s.items))
 	for _, item := range s.items {
-		allItems = append(allItems, item)
+		if deepCopyable, ok := any(item).(rt.Object); ok {
+			allItems = append(allItems, deepCopyable.DeepCopyObject().(Output))
+		}
 	}
 	return allItems
 }

--- a/pkg/clustercache/store.go
+++ b/pkg/clustercache/store.go
@@ -88,8 +88,8 @@ func (s *GenericStore[Input, Output]) GetAll() []Output {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-    // Deep copy the stored items to ensure that callers do not modify
-    // the original objects in the store.
+	// Deep copy the stored items to ensure that callers do not modify
+	// the original objects in the store.
 	allItems := make([]Output, 0, len(s.items))
 	for _, item := range s.items {
 		if deepCopyable, ok := any(item).(rt.Object); ok {


### PR DESCRIPTION
## What does this PR change?
* Creates a deep copy of the stored items so the callers do not modify them which was earlier causing duplicate labels to be present when creating and emitting pod annotation metrics. We did similar to what we had in `cachev1` to prevent things like these:
https://github.com/opencost/opencost/blob/66879963f306bd066f9ccbc667936d31553ca00a/pkg/clustercache/watchcontroller.go#L90-L104

## Does this PR relate to any other PRs?
* issue came in: https://github.com/opencost/opencost/pull/2736
* similar issue that was fixed in: https://github.com/opencost/opencost/pull/2998

## How will this PR impact users?
* Prometheus targets that were in failing state are now healthy

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Earlier with the latest 1.114.0 image we are getting
```
 13 error(s) occurred:
* collected metric "kube_pod_annotations" ...
 has two or more labels with the same name: annotation_kubectl_kubernetes_io_last_applied_configuration
 ```
 at `/metrics` endpoint and the prometheus target `opencost` was down

* created an opencost image and tested it in an openshift env. where we were facing the issue earlier with these changes the issue was not present. the `/metrics` endpoint loaded with no error and prometheus target opencost was now up and healthy

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Next release and be included in previors 1.114.0 release
