### PR TITLE
Fix Azure public pricing download

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -810,8 +810,9 @@ func (az *Azure) DownloadPricingData() error {
 	config.AzureClientID = clientID
 	config.AzureClientSecret = clientSecret
 	config.AzureTenantID = tenantID
-
 	var authorizer autorest.Authorizer
+
+	log.Debugf("Fetching azure rate card with credentials: %s:%s:%s:%s", config.AzureSubscriptionID, config.AzureClientID, config.AzureClientSecret, config.AzureTenantID)
 
 	azureEnv := determineCloudByRegion(az.ClusterRegion)
 
@@ -1100,8 +1101,10 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 
 	meta := models.PricingMetadata{}
 
+	azurePricingExists := true
 	if az.Pricing == nil {
-		return nil, meta, fmt.Errorf("Unable to download Azure pricing data")
+		azurePricingExists = false
+		log.DedupedWarningf(5, "Azure pricing data not found")
 	}
 
 	azKey, ok := key.(*azureKey)
@@ -1123,12 +1126,16 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 		featureString = azKey.Features()
 	}
 
-	if n, ok := az.Pricing[featureString]; ok {
-		log.Debugf("Returning pricing for node %s: %+v from key %s", azKey, n, azKey.Features())
-		if azKey.isValidGPUNode() {
-			n.Node.GPU = azKey.GetGPUCount()
+	if azurePricingExists {
+		if n, ok := az.Pricing[featureString]; ok {
+			log.Debugf("Returning pricing for node %s: %+v from key %s", azKey, n, azKey.Features())
+			if azKey.isValidGPUNode() {
+				n.Node.GPU = azKey.GetGPUCount()
+			}
+			return n.Node, meta, nil
+		} else {
+			log.Debugf("Could not find pricing for node %s from key %s", azKey, azKey.Features())
 		}
-		return n.Node, meta, nil
 	}
 
 	cost, err := getRetailPrice(region, instance, config.CurrencyCode, isSpot)

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -810,9 +810,8 @@ func (az *Azure) DownloadPricingData() error {
 	config.AzureClientID = clientID
 	config.AzureClientSecret = clientSecret
 	config.AzureTenantID = tenantID
-	var authorizer autorest.Authorizer
 
-	log.Debugf("Fetching azure rate card with credentials: %s:%s:%s:%s", config.AzureSubscriptionID, config.AzureClientID, config.AzureClientSecret, config.AzureTenantID)
+	var authorizer autorest.Authorizer
 
 	azureEnv := determineCloudByRegion(az.ClusterRegion)
 
@@ -1101,12 +1100,6 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 
 	meta := models.PricingMetadata{}
 
-	azurePricingExists := true
-	if az.Pricing == nil {
-		azurePricingExists = false
-		log.DedupedWarningf(5, "Azure pricing data not found")
-	}
-
 	azKey, ok := key.(*azureKey)
 	if !ok {
 		return nil, meta, fmt.Errorf("azure: NodePricing: key is of type %T", key)
@@ -1126,7 +1119,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 		featureString = azKey.Features()
 	}
 
-	if azurePricingExists {
+	if az.Pricing != nil {
 		if n, ok := az.Pricing[featureString]; ok {
 			log.Debugf("Returning pricing for node %s: %+v from key %s", azKey, n, azKey.Features())
 			if azKey.isValidGPUNode() {


### PR DESCRIPTION
## What does this PR change?
Fixes an issue where Azure would not download public pricing data for configurations where the rate card info failed to download.

## Does this PR relate to any other PRs?
Alters/fixes behavior introduced in https://github.com/opencost/opencost/pull/2978.

## How will this PR impact users?
Fixes an issue where Azure would not download public pricing data.

## Does this PR address any GitHub or Zendesk issues?
https://apptio.atlassian.net/browse/KCM-3373

## How was this PR tested?
Tested on Azure clusters (standard KC install + agent) without the rate card configured. Observed repeated failures to get data. After fix, observed successful data download and no additional failures beyond that.

## Does this PR require changes to documentation?
No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

