### PR TITLE
Update Azure Rate Card Log

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -850,7 +850,7 @@ func (az *Azure) DownloadPricingData() error {
 	rateCardFilter := fmt.Sprintf("OfferDurableId eq '%s' and Currency eq '%s' and Locale eq 'en-US' and RegionInfo eq '%s'", config.AzureOfferDurableID, config.CurrencyCode, config.AzureBillingRegion)
 
 	log.Infof("Using azureRateCard query %s", rateCardFilter)
-	log.Debugf("Using azureRateCard URI %s", rcClient.BaseURI)
+	log.Infof("Using azureRateCard URI %s", rcClient.BaseURI)
 	// rate-card client is old, it can hang indefinitely in some cases
 	// this happens on the main thread, so it may block the whole app
 	// there is can be a better way to set timeout for the client

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -849,8 +849,16 @@ func (az *Azure) DownloadPricingData() error {
 
 	rateCardFilter := fmt.Sprintf("OfferDurableId eq '%s' and Currency eq '%s' and Locale eq 'en-US' and RegionInfo eq '%s'", config.AzureOfferDurableID, config.CurrencyCode, config.AzureBillingRegion)
 
+	// create a preparer (the same way rcClient.Get() does) so that we can log the azureRateCard URL
 	log.Infof("Using azureRateCard query %s", rateCardFilter)
-	log.Infof("Using azureRateCard URI %s", rcClient.BaseURI)
+	rcPreparer, err := rcClient.GetPreparer(context.TODO(), rateCardFilter)
+	if err != nil {
+		// this isn't an error that necessitates a return, as we only need the preparer for an informational log
+		log.Warnf("Failed to get azureRateCard URL: %s", err)
+	} else {
+		log.Infof("Using azureRateCard URL %s", rcPreparer.URL.String())
+	}
+
 	// rate-card client is old, it can hang indefinitely in some cases
 	// this happens on the main thread, so it may block the whole app
 	// there is can be a better way to set timeout for the client

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -854,7 +854,7 @@ func (az *Azure) DownloadPricingData() error {
 	rcPreparer, err := rcClient.GetPreparer(context.TODO(), rateCardFilter)
 	if err != nil {
 		// this isn't an error that necessitates a return, as we only need the preparer for an informational log
-		log.Warnf("Failed to get azureRateCard URL: %s", err)
+		log.Infof("Failed to get azureRateCard URL: %s", err)
 	} else {
 		log.Infof("Using azureRateCard URL %s", rcPreparer.URL.String())
 	}


### PR DESCRIPTION
## What does this PR change?
* Improves logging for Azure rate card requests. This change was motivated by the fact that failing calls to `rcClient.Get()` are difficult to diagnose; this change allows us to know the requested URL that failed, enabling more effective debugging.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* Users will be able to better diagnose rate card request failures

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* Nope.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
