### PR TITLE
KCM-3828 - Prevent duplicate Prometheus metric labels

### DIFF
--- a/core/pkg/util/promutil/promutil.go
+++ b/core/pkg/util/promutil/promutil.go
@@ -75,16 +75,22 @@ func LabelNamesFrom(labels map[string]string) []string {
 
 // Prepends a qualifier string to the keys provided in the m map and returns the new keys and values.
 func KubePrependQualifierToLabels(m map[string]string, qualifier string) ([]string, []string) {
-	keys := make([]string, 0, len(m))
-	for k := range m {
+	// sanitize the keys in m to prevent duplicate output keys
+	sanitizedM := make(map[string]string)
+	for k, v := range m {
+		sanitizedM[SanitizeLabelName(k)] = v
+	}
+
+	keys := make([]string, 0, len(sanitizedM))
+	for k := range sanitizedM {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	values := make([]string, 0, len(m))
+	values := make([]string, 0, len(sanitizedM))
 	for i, k := range keys {
-		keys[i] = qualifier + SanitizeLabelName(k)
-		values = append(values, m[k])
+		keys[i] = qualifier + k
+		values = append(values, sanitizedM[k])
 	}
 
 	return keys, values

--- a/core/pkg/util/promutil/promutil_test.go
+++ b/core/pkg/util/promutil/promutil_test.go
@@ -96,6 +96,7 @@ func TestKubeLabelsToPromLabels(t *testing.T) {
 }
 
 func TestKubePrependQualifierToLabelsDuplicates(t *testing.T) {
+	// 7 expected labels/values
 	expectedLabels := []string{
 		"label_app_",
 		"label_chart",
@@ -115,6 +116,7 @@ func TestKubePrependQualifierToLabelsDuplicates(t *testing.T) {
 		"gatekeeper",
 	}
 
+	// 8 input labels/values, with one duplicate label
 	kubeLabels := map[string]string{
 		// app$ will be sanitized to app_
 		"app$":                    "gatekeeper",

--- a/core/pkg/util/promutil/promutil_test.go
+++ b/core/pkg/util/promutil/promutil_test.go
@@ -95,6 +95,51 @@ func TestKubeLabelsToPromLabels(t *testing.T) {
 	}
 }
 
+func TestKubePrependQualifierToLabelsDuplicates(t *testing.T) {
+	expectedLabels := []string{
+		"label_app_",
+		"label_chart",
+		"label_control_plane",
+		"label_gatekeeper_sh_operation",
+		"label_heritage",
+		"label_pod_template_hash",
+		"label_release",
+	}
+	expectedValues := []string{
+		"gatekeeper",
+		"gatekeeper",
+		"audit-controller",
+		"audit",
+		"Helm",
+		"5599859cd4",
+		"gatekeeper",
+	}
+
+	kubeLabels := map[string]string{
+		// app$ will be sanitized to app_
+		"app$":                    "gatekeeper",
+		"app_":                    "gatekeeper",
+		"chart":                   "gatekeeper",
+		"control-plane":           "audit-controller",
+		"gatekeeper.sh/operation": "audit",
+		"heritage":                "Helm",
+		"pod-template-hash":       "5599859cd4",
+		"release":                 "gatekeeper",
+	}
+
+	labels, values := KubePrependQualifierToLabels(kubeLabels, "label_")
+
+	// Check to make sure we get expected labels and values returned
+	err := checkSlice(labels, expectedLabels)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	err = checkSlice(values, expectedValues)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 func TestSanitizeLabels(t *testing.T) {
 	type testCase struct {
 		in  map[string]string

--- a/core/pkg/util/promutil/promutil_test.go
+++ b/core/pkg/util/promutil/promutil_test.go
@@ -118,8 +118,8 @@ func TestKubePrependQualifierToLabelsDuplicates(t *testing.T) {
 
 	// 8 input labels/values, with one duplicate label
 	kubeLabels := map[string]string{
-		// app$ will be sanitized to app_
-		"app$":                    "gatekeeper",
+		// app- will be sanitized to app_
+		"app-":                    "gatekeeper",
 		"app_":                    "gatekeeper",
 		"chart":                   "gatekeeper",
 		"control-plane":           "audit-controller",


### PR DESCRIPTION
## What does this PR change?
* Updates the annotation/label parser to remove duplicate labels. Duplicates can occur when we have two annotations or labels with names that become equivalent post-sanitization (e.g. `app-` and `app_`).
* Note, the following behavior changes when we have labels that become duplicates post-sanitization:
  * Previously, metric emission would fail, as Prometheus doesn't allow duplicate labels.
  * Now, exactly one of the duplicate labels will remain, and the rest will be dropped. Exactly which one gets dropped is non-deterministic.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* Users will now be able to enable `kubecostMetrics.emitNamespaceAnnotations` and `kubecostMetrics.emitPodAnnotations` together.

## Does this PR address any GitHub or Zendesk issues?
* Closes [KCM-3828](https://apptio.atlassian.net/browse/KCM-3828).

## How was this PR tested?
* Unit tests.
* Tested by Jesse, validated that the error presented in the ticket no longer occurs.

## Does this PR require changes to documentation?
* Nope.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
