### PR TITLE
Fix Typo in build-test-image.yml

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo "IMAGE_TAG=ghcr.io/${{ github.repository_owner }}/opencost:test-${{ steps.sha.outputs.OC_SHORTHASH }}" >> $GITHUB_OUTPUT
       - name: Build and publish container
-        uses: ./github/actions/build-container
+        uses: ./.github/actions/build-container
         with:
           actor: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR change?
* Fixes a typo in `.github/workflows/build-test-image.yml`

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* Fixes the broken GitHub Actions workflow, `build-and-publish-test-image`.

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* This issue was discovered when this workflow was merged: https://github.com/opencost/opencost/commit/ff82178cf212d3a3f6b2ee28c61ba4e6c3481c45

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A
