### PR TITLE
Cross-Zone and Cross-Region Network Costs Labels

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -228,8 +228,8 @@ const (
 	queryPodDaemonsets        = `sum(kube_pod_owner{owner_kind="DaemonSet", %s}) by (namespace,pod,owner_name,%s)`
 	queryPodJobs              = `sum(kube_pod_owner{owner_kind="Job", %s}) by (namespace,pod,owner_name,%s)`
 	queryServiceLabels        = `avg_over_time(service_selector_labels{%s}[%s])`
-	queryZoneNetworkUsage     = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", sameZone="false", sameRegion="true", %s}[%s] %s)) by (namespace,pod_name,%s) / 1024 / 1024 / 1024`
-	queryRegionNetworkUsage   = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", sameZone="false", sameRegion="false", %s}[%s] %s)) by (namespace,pod_name,%s) / 1024 / 1024 / 1024`
+	queryZoneNetworkUsage     = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", same_zone="false", same_region="true", %s}[%s] %s)) by (namespace,pod_name,%s) / 1024 / 1024 / 1024`
+	queryRegionNetworkUsage   = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="false", same_zone="false", same_region="false", %s}[%s] %s)) by (namespace,pod_name,%s) / 1024 / 1024 / 1024`
 	queryInternetNetworkUsage = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="true", %s}[%s] %s)) by (namespace,pod_name,%s) / 1024 / 1024 / 1024`
 	normalizationStr          = `max(count_over_time(kube_pod_container_resource_requests{resource="memory", unit="byte", %s}[%s] %s))`
 )


### PR DESCRIPTION
## What does this PR change?
* This PR updates the labels queried in opencost to match the updated network-costs deployment. This fixes a bug that has been outstanding since the network-costs 0.17.0 release.
* The previous PR only addressed labels for the `allocations.go` string templates which corrected the OpenCost-specific endpoints for `/allocations` and `/allocations/summary`. This one also addresses the label mismatch in `costmodel.go`.
* This should fix the cost-model metrics for network traffic on containers and pods being reported as zero bytes for endpoints such as `/costDataModelRange`.

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/2478

## How will this PR impact users?
* Metrics that were reported as zero should now be reported correctly.

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* Local deployment

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Fist time contributor, unsure of what to do here.
