### PR TITLE
Add Azure Disk Sku Nil Check

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,6 +24,7 @@ test-collector-source:
 # run the opencost unit tests 
 test-opencost: 
     {{commonenv}} go test ./... -coverprofile=coverage.out
+    {{commonenv}} go tool cover -html=coverage.out -o coverage.html
     {{commonenv}} go vet ./...
 
 # Run unit tests, merge coverage reports, remove old reports 

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1450,6 +1450,11 @@ func (az *Azure) findCostForDisk(d *compute.Disk) (float64, error) {
 	if d == nil {
 		return 0.0, fmt.Errorf("disk is empty")
 	}
+
+	if d.Sku == nil {
+		return 0.0, fmt.Errorf("disk sku is nil")
+	}
+
 	storageClass := string(d.Sku.Name)
 	if strings.EqualFold(storageClass, "Premium_LRS") {
 		storageClass = AzureDiskPremiumSSDStorageClass

--- a/pkg/cloud/azure/provider_test.go
+++ b/pkg/cloud/azure/provider_test.go
@@ -223,6 +223,16 @@ func TestAzure_findCostForDisk(t *testing.T) {
 			730.0,
 			nil,
 		},
+		{
+			"nil sku",
+			&compute.Disk{
+				Location:       nil,
+				Sku:            nil,
+				DiskProperties: nil,
+			},
+			0.0,
+			fmt.Errorf("disk sku is nil"),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What does this PR change?
*  This PR addresses a bug where Azure can return a nil Sku for a disk, resulting in the cost-model crashing

## Does this PR relate to any other PRs?
* no

## How will this PR impact users?
* minimal impact to users

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* PR tested via additional unit test to check for a nil Sku

Code Coverage around the issue
![image](https://github.com/user-attachments/assets/a83ea319-3e0f-48e1-95f6-9d124a2862df)


## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 