### PR TITLE
Cherry Pick: Add Azure Disk Sku Nil Check (#3165)

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ test-core:
 # Run unit tests
 test: test-core
     {{commonenv}} go test ./... -coverprofile=coverage.out
+    {{commonenv}} go tool cover -html=coverage.out -o coverage.html
     {{commonenv}} go vet ./...
 
 # Run unit tests and integration tests

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1450,6 +1450,11 @@ func (az *Azure) findCostForDisk(d *compute.Disk) (float64, error) {
 	if d == nil {
 		return 0.0, fmt.Errorf("disk is empty")
 	}
+
+	if d.Sku == nil {
+		return 0.0, fmt.Errorf("disk sku is nil")
+	}
+
 	storageClass := string(d.Sku.Name)
 	if strings.EqualFold(storageClass, "Premium_LRS") {
 		storageClass = AzureDiskPremiumSSDStorageClass

--- a/pkg/cloud/azure/provider_test.go
+++ b/pkg/cloud/azure/provider_test.go
@@ -223,6 +223,16 @@ func TestAzure_findCostForDisk(t *testing.T) {
 			730.0,
 			nil,
 		},
+		{
+			"nil sku",
+			&compute.Disk{
+				Location:       nil,
+				Sku:            nil,
+				DiskProperties: nil,
+			},
+			0.0,
+			fmt.Errorf("disk sku is nil"),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What does this PR change?
* Cherry pick of https://github.com/opencost/opencost/pull/3165 into kc-2.8

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Fix a situation where Azure Sku for Disk is nil

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Unit Test

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A