### PR TITLE
Sth/kcm 4204

### DIFF
--- a/modules/collector-source/pkg/collector/datasource.go
+++ b/modules/collector-source/pkg/collector/datasource.go
@@ -94,6 +94,7 @@ func NewCollectorDataSource(
 	clusterMap := newCollectorClusterMap(clusterInfo)
 
 	return &collectorDataSource{
+		config:         config,
 		metricsQuerier: metricQuerier,
 		clusterInfo:    clusterInfo,
 		clusterMap:     clusterMap,

--- a/modules/collector-source/pkg/metric/aggregator/avgovertime.go
+++ b/modules/collector-source/pkg/metric/aggregator/avgovertime.go
@@ -49,7 +49,11 @@ func (a *averageOverTimeAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	if a.count == 0 {
-		return []MetricValue{}
+		return []MetricValue{
+			{
+				Value: 0,
+			},
+		}
 	}
 	return []MetricValue{
 		{a.total / float64(a.count), nil},

--- a/modules/collector-source/pkg/metric/aggregator/avgovertime_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/avgovertime_test.go
@@ -20,7 +20,11 @@ func TestAvgOverTimeAggregator_Value(t *testing.T) {
 	}{
 		"no update": {
 			updates: []update{},
-			want:    []MetricValue{},
+			want: []MetricValue{
+				{
+					Value: 0,
+				},
+			},
 		},
 		"single update": {
 			updates: []update{

--- a/modules/collector-source/pkg/metric/aggregator/increase.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase.go
@@ -58,9 +58,6 @@ func (a *increaseAggregator) Update(value float64, timestamp time.Time, addition
 func (a *increaseAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if !a.initialized {
-		return []MetricValue{}
-	}
 	return []MetricValue{
 		{Value: a.current - a.initial},
 	}

--- a/modules/collector-source/pkg/metric/aggregator/increase_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase_test.go
@@ -20,7 +20,11 @@ func TestIncreaseAggregator_Value(t *testing.T) {
 	}{
 		"no update": {
 			updates: []update{},
-			want:    []MetricValue{},
+			want: []MetricValue{
+				{
+					Value: 0,
+				},
+			},
 		},
 		"single update": {
 			updates: []update{

--- a/modules/collector-source/pkg/metric/aggregator/iratemax.go
+++ b/modules/collector-source/pkg/metric/aggregator/iratemax.go
@@ -69,9 +69,6 @@ func (a *iRateMaxAggregator) Update(value float64, timestamp time.Time, addition
 func (a *iRateMaxAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if !a.initialized {
-		return []MetricValue{}
-	}
 	return []MetricValue{
 		{Value: a.max},
 	}

--- a/modules/collector-source/pkg/metric/aggregator/iratemax_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/iratemax_test.go
@@ -22,7 +22,11 @@ func TestIRateMaxAggregator_Value(t *testing.T) {
 	}{
 		"no update": {
 			updates: []update{},
-			want:    []MetricValue{},
+			want: []MetricValue{
+				{
+					Value: 0,
+				},
+			},
 		},
 		"single update": {
 			updates: []update{

--- a/modules/collector-source/pkg/metric/aggregator/maxovertime.go
+++ b/modules/collector-source/pkg/metric/aggregator/maxovertime.go
@@ -43,9 +43,6 @@ func (a *maxOverTimeAggregator) Update(value float64, timestamp time.Time, addit
 func (a *maxOverTimeAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if a.max == 0 {
-		return []MetricValue{}
-	}
 	return []MetricValue{
 		{Value: a.max},
 	}

--- a/modules/collector-source/pkg/metric/aggregator/maxovertime_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/maxovertime_test.go
@@ -19,7 +19,11 @@ func TestMaxOverTimeAggregator_Value(t *testing.T) {
 	}{
 		"no update": {
 			updates: []update{},
-			want:    []MetricValue{},
+			want: []MetricValue{
+				{
+					Value: 0,
+				},
+			},
 		},
 		"single update": {
 			updates: []update{

--- a/modules/collector-source/pkg/metric/aggregator/rate.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate.go
@@ -60,9 +60,6 @@ func (a *rateAggregator) Update(value float64, timestamp time.Time, additionalIn
 func (a *rateAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if !a.initialized {
-		return []MetricValue{}
-	}
 	seconds := a.currentTime.Sub(a.initialTime).Seconds()
 	if seconds == 0 {
 		return []MetricValue{

--- a/modules/collector-source/pkg/metric/aggregator/rate_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate_test.go
@@ -21,7 +21,11 @@ func TestRateAggregator_Value(t *testing.T) {
 	}{
 		"no update": {
 			updates: []update{},
-			want:    []MetricValue{},
+			want: []MetricValue{
+				{
+					Value: 0,
+				},
+			},
 		},
 		"single update": {
 			updates: []update{


### PR DESCRIPTION
## What does this PR change?
This PR addresses this panic
```
panic: runtime error: index out of range [0] with length 0

goroutine 15747 [running]:
github.com/opencost/opencost/pkg/costmodel.applyRAMBytesUsedMax(0xc00909a7b8, {0xc01eba6c88, 0x18d, 0x1?}, 0xc00909a2d0)
	/app/opencost/pkg/costmodel/allocation_helpers.go:606 +0x519
```
This is seems to happen when a metric for a label set returns empty. This should never happen because metric are initialized when a value for their label set appears

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Update unit tests

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 