### PR TITLE
remove needs run-comparison-tests

### DIFF
--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -238,7 +238,7 @@ jobs:
             namespace: "${{ needs.wait_for_image_ready.outputs.NAMESPACE }}-promless"
 
     check-success:
-        needs: [noop-tests, run-tests, run-comparison-tests]
+        needs: [noop-tests, run-tests]
         permissions: {}
         runs-on: ubuntu-latest
         if: ${{ always() }}


### PR DESCRIPTION
## What does this PR change?
* https://github.com/opencost/opencost/pull/3181 allowed for tests to fail but still forces PR's to wait on comparison test completion

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/3181

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 