### PR TITLE
KCM-4123 - InstallInfo Null

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -408,7 +408,7 @@ func GetKubecostContainers(kubeClientSet kubernetes.Interface) ([]ContainerInfo,
 
 	// If we have zero pods either something is weird with the install since the app selector is not exposed in the helm
 	// chart or more likely we are running locally - in either case Images field will return as null
-	var containers []ContainerInfo
+	containers := make([]ContainerInfo, 0)
 	if len(pods.Items) > 0 {
 		for _, pod := range pods.Items {
 			for _, container := range pod.Spec.Containers {


### PR DESCRIPTION
## What does this PR change?
* Explicitly initializes a slice in a function called by `/installInfo` such that, in the event that no pods/containers are found, we don't send a `null` value in the response (see below).

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* The settings page should no longer crash when no pods or containers are found.

## Does this PR address any GitHub or Zendesk issues?
* Closes [KCM-4123](https://apptio.atlassian.net/browse/KCM-4123).

## How was this PR tested?
* Local testing against `/installInfo`.

## Does this PR require changes to documentation?
* Nope.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 

## Before
```
{
    "containers": null,
    "clusterInfo": {},
    "version": "dev (HEAD)"
}
```

## Now
```
{
    "containers": [],
    "clusterInfo": {},
    "version": "dev (HEAD)"
}
```