### PR TITLE
New Authorizer type

### DIFF
--- a/pkg/cloud/azure/authorizer.go
+++ b/pkg/cloud/azure/authorizer.go
@@ -9,8 +9,10 @@ import (
 	"github.com/opencost/opencost/pkg/cloud"
 )
 
-const DefaultCredentialAuthorizerType = "AzureDefaultCredential"
-const ClientSecretCredentialType = "AzureClientSecretCredential"
+const (
+	DefaultCredentialAuthorizerType = "AzureDefaultCredential"
+	ClientSecretCredentialType      = "AzureClientSecretCredential"
+)
 
 // Authorizer configs provide credentials from azidentity to connect to Azure services.
 type Authorizer interface {
@@ -68,28 +70,28 @@ type ClientSecretCredential struct {
 	ClientSecret string `json:"clientSecret"`
 }
 
-func (c *ClientSecretCredential) Validate() error {
-	if c.TenantID == "" {
+func (csc *ClientSecretCredential) Validate() error {
+	if csc.TenantID == "" {
 		return fmt.Errorf("ClientSecretCredential: missing Tenant ID")
 	}
-	if c.ClientID == "" {
+	if csc.ClientID == "" {
 		return fmt.Errorf("ClientSecretCredential: missing Client ID")
 	}
-	if c.ClientSecret == "" {
+	if csc.ClientSecret == "" {
 		return fmt.Errorf("ClientSecretCredential: missing Client Secret")
 	}
 	return nil
 }
 
-func (c *ClientSecretCredential) Sanitize() cloud.Config {
+func (csc *ClientSecretCredential) Sanitize() cloud.Config {
 	return &ClientSecretCredential{
-		TenantID:     c.TenantID,
-		ClientID:     c.ClientID,
+		TenantID:     csc.TenantID,
+		ClientID:     csc.ClientID,
 		ClientSecret: cloud.Redacted,
 	}
 }
 
-func (c *ClientSecretCredential) Equals(config cloud.Config) bool {
+func (csc *ClientSecretCredential) Equals(config cloud.Config) bool {
 	if config == nil {
 		return false
 	}
@@ -98,29 +100,29 @@ func (c *ClientSecretCredential) Equals(config cloud.Config) bool {
 		return false
 	}
 
-	if c.TenantID != thatConfig.TenantID {
+	if csc.TenantID != thatConfig.TenantID {
 		return false
 	}
-	if c.ClientID != thatConfig.ClientID {
+	if csc.ClientID != thatConfig.ClientID {
 		return false
 	}
-	if c.ClientSecret != thatConfig.ClientSecret {
+	if csc.ClientSecret != thatConfig.ClientSecret {
 		return false
 	}
 	return true
 }
 
-func (c *ClientSecretCredential) MarshalJSON() ([]byte, error) {
+func (csc *ClientSecretCredential) MarshalJSON() ([]byte, error) {
 	fmap := make(map[string]any, 1)
 	fmap[cloud.AuthorizerTypeProperty] = ClientSecretCredentialType
-	fmap["tenantID"] = c.TenantID
-	fmap["clientID"] = c.ClientID
-	fmap["clientSecret"] = c.ClientSecret
+	fmap["tenantID"] = csc.TenantID
+	fmap["clientID"] = csc.ClientID
+	fmap["clientSecret"] = csc.ClientSecret
 	return json.Marshal(fmap)
 }
 
-func (c *ClientSecretCredential) GetCredential() (azcore.TokenCredential, error) {
-	cred, err := azidentity.NewClientSecretCredential(c.TenantID, c.ClientID, c.ClientSecret, nil)
+func (csc *ClientSecretCredential) GetCredential() (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewClientSecretCredential(csc.TenantID, csc.ClientID, csc.ClientSecret, nil)
 	if err != nil {
 		return nil, fmt.Errorf("ClientSecretCredential: failed to retrieve credentials: %w", err)
 	}

--- a/pkg/cloud/azure/authorizer.go
+++ b/pkg/cloud/azure/authorizer.go
@@ -10,6 +10,7 @@ import (
 )
 
 const DefaultCredentialAuthorizerType = "AzureDefaultCredential"
+const ClientSecretCredentialType = "AzureClientSecretCredential"
 
 // Authorizer configs provide credentials from azidentity to connect to Azure services.
 type Authorizer interface {
@@ -22,6 +23,8 @@ func SelectAuthorizerByType(typeStr string) (Authorizer, error) {
 	switch typeStr {
 	case DefaultCredentialAuthorizerType:
 		return &DefaultAzureCredentialHolder{}, nil
+	case ClientSecretCredentialType:
+		return &ClientSecretCredential{}, nil
 	default:
 		return nil, fmt.Errorf("azure: provider authorizer type '%s' is not valid", typeStr)
 	}
@@ -57,4 +60,69 @@ func (dac *DefaultAzureCredentialHolder) Sanitize() cloud.Config {
 
 func (dac *DefaultAzureCredentialHolder) GetCredential() (azcore.TokenCredential, error) {
 	return azidentity.NewDefaultAzureCredential(nil)
+}
+
+type ClientSecretCredential struct {
+	TenantID     string `json:"tenantID"`
+	ClientID     string `json:"clientID"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+func (c *ClientSecretCredential) Validate() error {
+	if c.TenantID == "" {
+		return fmt.Errorf("ClientSecretCredential: missing Tenant ID")
+	}
+	if c.ClientID == "" {
+		return fmt.Errorf("ClientSecretCredential: missing Client ID")
+	}
+	if c.ClientSecret == "" {
+		return fmt.Errorf("ClientSecretCredential: missing Client Secret")
+	}
+	return nil
+}
+
+func (c *ClientSecretCredential) Sanitize() cloud.Config {
+	return &ClientSecretCredential{
+		TenantID:     c.TenantID,
+		ClientID:     c.ClientID,
+		ClientSecret: cloud.Redacted,
+	}
+}
+
+func (c *ClientSecretCredential) Equals(config cloud.Config) bool {
+	if config == nil {
+		return false
+	}
+	thatConfig, ok := config.(*ClientSecretCredential)
+	if !ok {
+		return false
+	}
+
+	if c.TenantID != thatConfig.TenantID {
+		return false
+	}
+	if c.ClientID != thatConfig.ClientID {
+		return false
+	}
+	if c.ClientSecret != thatConfig.ClientSecret {
+		return false
+	}
+	return true
+}
+
+func (c *ClientSecretCredential) MarshalJSON() ([]byte, error) {
+	fmap := make(map[string]any, 1)
+	fmap[cloud.AuthorizerTypeProperty] = ClientSecretCredentialType
+	fmap["tenantID"] = c.TenantID
+	fmap["clientID"] = c.ClientID
+	fmap["clientSecret"] = c.ClientSecret
+	return json.Marshal(fmap)
+}
+
+func (c *ClientSecretCredential) GetCredential() (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewClientSecretCredential(c.TenantID, c.ClientID, c.ClientSecret, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ClientSecretCredential: failed to retrieve credentials: %w", err)
+	}
+	return cred, nil
 }

--- a/pkg/cloud/azure/authorizer_test.go
+++ b/pkg/cloud/azure/authorizer_test.go
@@ -1,0 +1,169 @@
+package azure
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opencost/opencost/pkg/cloud"
+)
+
+func TestClientSecretCredential_Validate(t *testing.T) {
+	tests := map[string]struct {
+		csc     *ClientSecretCredential
+		wantErr bool
+	}{
+		"missing TenantID": {
+			csc: &ClientSecretCredential{
+				TenantID:     "",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			wantErr: true,
+		},
+		"missing ClientID": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "",
+				ClientSecret: "clientSecret",
+			},
+			wantErr: true,
+		},
+		"missing ClientSecret": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "",
+			},
+			wantErr: true,
+		},
+		"valid": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			wantErr: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := tt.csc.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClientSecretCredential_Sanitize(t *testing.T) {
+
+	tests := map[string]struct {
+		csc  *ClientSecretCredential
+		want cloud.Config
+	}{
+		"Plain integration": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			want: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: cloud.Redacted,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.csc.Sanitize(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Sanitize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientSecretCredential_Equals(t *testing.T) {
+	tests := map[string]struct {
+		csc    *ClientSecretCredential
+		config cloud.Config
+		want   bool
+	}{
+		"compare nil": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			config: nil,
+			want:   false,
+		},
+		"different config": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			config: &DefaultAzureCredentialHolder{},
+			want:   false,
+		},
+		"different TenantID": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			config: &ClientSecretCredential{
+				TenantID:     "tenantID2",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			want: false,
+		},
+		"different ClientID": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			config: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID2",
+				ClientSecret: "clientSecret",
+			},
+			want: false,
+		},
+		"different ClientSecret": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret2",
+			},
+			config: &ClientSecretCredential{
+				TenantID:     "tenantID2",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			want: false,
+		},
+		"equal": {
+			csc: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			config: &ClientSecretCredential{
+				TenantID:     "tenantID",
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			want: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.csc.Equals(tt.config); got != tt.want {
+				t.Errorf("Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloud/azure/storageauthorizer.go
+++ b/pkg/cloud/azure/storageauthorizer.go
@@ -122,3 +122,8 @@ func (ah *AuthorizerHolder) GetBlobClient(serviceURL string) (*azblob.Client, er
 	client, err := azblob.NewClient(serviceURL, cred, nil)
 	return client, err
 }
+
+// UnmarshalJSON passes the contained Authorizer to be unmarshalled into
+func (ah *AuthorizerHolder) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, ah.Authorizer)
+}

--- a/pkg/cloud/azure/storageconfiguration_test.go
+++ b/pkg/cloud/azure/storageconfiguration_test.go
@@ -480,6 +480,22 @@ func TestStorageConfiguration_JSON(t *testing.T) {
 				},
 			},
 		},
+		"ClientSecretCredential Authorizer": {
+			config: StorageConfiguration{
+				SubscriptionID: "subscriptionID",
+				Account:        "account",
+				Container:      "container",
+				Path:           "path",
+				Cloud:          "cloud",
+				Authorizer: &AuthorizerHolder{
+					Authorizer: &ClientSecretCredential{
+						TenantID:     "tenantID",
+						ClientID:     "clientID",
+						ClientSecret: "clientSecret",
+					},
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
## What does this PR change?
This PR adds an explicit authorization method for client secret credentials. This can be configured with a `cloud-integration.json` in this format
```
{
  "azure": {
    "storage": [
      {
        "subscriptionID": "subID",
        "account": "storageAccount",
        "container": "storageContainer",
	"path": "export/some/path",
        "cloud": "public",
        "authorizer": {
          "authorizerType": "AzureClientSecretCredential",
          "tenantID": "Tenant ID",
          "clientID": "Client ID",
          "clientSecret": "Client Secret"
        }
      }
    ]
  }
}
```

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 