### PR TITLE
Deep Copy Labels

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -3,6 +3,7 @@ package costmodel
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"regexp"
 	"strconv"
@@ -271,7 +272,7 @@ func (cm *CostModel) ComputeCostData(start, end time.Time) (map[string]*CostData
 			ns := pod.Namespace
 
 			nsLabels := namespaceLabelsMapping[ns+","+clusterID]
-			podLabels := pod.Labels
+			podLabels := maps.Clone(pod.Labels)
 			if podLabels == nil {
 				podLabels = make(map[string]string)
 			}


### PR DESCRIPTION
## What does this PR change?
* Performs a deep clone of pod labels such that [this line](https://github.com/opencost/opencost/blob/68279ce27b84606059a32959c8fbc835cb1f03f1/pkg/costmodel/costmodel.go#L396) can modify the labels, while allowing other goroutines to read them.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* No more concurrent map read/write panics when using cluster cache V2.

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 