### PR TITLE
OTC Pricing api 

### DIFF
--- a/pkg/cloud/otc/pricingapi.go
+++ b/pkg/cloud/otc/pricingapi.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/opencost/opencost/core/pkg/log"
 )
@@ -22,18 +21,6 @@ type Product struct {
 	PriceAmount string `json:"priceAmount"`
 	VCpu        string `json:"vCpu,omitempty"`
 	Ram         string `json:"ram,omitempty"`
-}
-
-// Builds query string for serviceName[0]=ecs&serviceName[1]=memo&...
-func buildServiceNameQueryParam(serviceNames []string) string {
-	var sb strings.Builder
-	for i, name := range serviceNames {
-		sb.WriteString(fmt.Sprintf("serviceName[%d]=%s", i, name))
-		if i < len(serviceNames)-1 {
-			sb.WriteString("&")
-		}
-	}
-	return sb.String()
 }
 
 // Fetches and flattens all product entries across multiple services with pagination

--- a/pkg/cloud/otc/pricingapi.go
+++ b/pkg/cloud/otc/pricingapi.go
@@ -9,20 +9,6 @@ import (
 	"github.com/opencost/opencost/core/pkg/log"
 )
 
-type OTCStats struct {
-	CurrentPage    int `json:"currentPage"`
-	MaxPages       int `json:"maxPages"`
-	RecordsPerPage int `json:"recordsPerPage"`
-}
-
-type Product struct {
-	OpiFlavour  string `json:"opiFlavour"`
-	OsUnit      string `json:"osUnit,omitempty"`
-	PriceAmount string `json:"priceAmount"`
-	VCpu        string `json:"vCpu,omitempty"`
-	Ram         string `json:"ram,omitempty"`
-}
-
 // Fetches and flattens all product entries across multiple services with pagination
 func (otc *OTC) fetchPaginatedProducts(serviceNames []string) ([]Product, error) {
 	const baseURL = "https://calculator.otc-service.com/de/open-telekom-price-api/"
@@ -32,8 +18,7 @@ func (otc *OTC) fetchPaginatedProducts(serviceNames []string) ([]Product, error)
 	query := buildServiceNameQueryParam(serviceNames)
 
 	for {
-		url := fmt.Sprintf("%s?%s&columns%%5B1%%5D=opiFlavour&columns%%5B2%%5D=osUnit&columns%%5B3%%5D=vCpu&columns%%5B4%%5D=ram&columns%%5B5%%5D=priceAmount&limitFrom=%d",
-			baseURL, query, limitFrom)
+		url := fmt.Sprintf("%s?%s&columns%%5B0%%5D=productIdParameter&columns%%5B1%%5D=opiFlavour&columns%%5B2%%5D=osUnit&columns%%5B3%%5D=vCpu&columns%%5B4%%5D=ram&columns%%5B5%%5D=priceAmount&limitFrom=%d", baseURL, query, limitFrom)
 
 		resp, err := http.Get(url)
 		if err != nil {

--- a/pkg/cloud/otc/pricingapi.go
+++ b/pkg/cloud/otc/pricingapi.go
@@ -1,0 +1,106 @@
+package otc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/opencost/opencost/core/pkg/log"
+)
+
+type OTCStats struct {
+	CurrentPage    int `json:"currentPage"`
+	MaxPages       int `json:"maxPages"`
+	RecordsPerPage int `json:"recordsPerPage"`
+}
+
+type Product struct {
+	OpiFlavour  string `json:"opiFlavour"`
+	OsUnit      string `json:"osUnit,omitempty"`
+	PriceAmount string `json:"priceAmount"`
+	VCpu        string `json:"vCpu,omitempty"`
+	Ram         string `json:"ram,omitempty"`
+}
+
+// Builds query string for serviceName[0]=ecs&serviceName[1]=memo&...
+func buildServiceNameQueryParam(serviceNames []string) string {
+	var sb strings.Builder
+	for i, name := range serviceNames {
+		sb.WriteString(fmt.Sprintf("serviceName[%d]=%s", i, name))
+		if i < len(serviceNames)-1 {
+			sb.WriteString("&")
+		}
+	}
+	return sb.String()
+}
+
+// Fetches and flattens all product entries across multiple services with pagination
+func (otc *OTC) fetchPaginatedProducts(serviceNames []string) ([]Product, error) {
+	const baseURL = "https://calculator.otc-service.com/de/open-telekom-price-api/"
+	var allProducts []Product
+
+	limitFrom := 0
+	query := buildServiceNameQueryParam(serviceNames)
+
+	for {
+		url := fmt.Sprintf("%s?%s&columns%%5B1%%5D=opiFlavour&columns%%5B2%%5D=osUnit&columns%%5B3%%5D=vCpu&columns%%5B4%%5D=ram&columns%%5B5%%5D=priceAmount&limitFrom=%d",
+			baseURL, query, limitFrom)
+
+		resp, err := http.Get(url)
+		if err != nil {
+			log.Errorf("Error fetching products from OTC API: %v", err)
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		pageData, stats, err := otc.loadPaginatedResponse(resp)
+		if err != nil {
+			log.Errorf("Error loading paginated response: %v", err)
+			return nil, err
+		}
+
+		for _, products := range pageData {
+			allProducts = append(allProducts, products...)
+		}
+
+		if stats.CurrentPage >= stats.MaxPages {
+			log.Infof("Fetched all products for services: %v", serviceNames)
+			break
+		}
+
+		limitFrom += stats.RecordsPerPage
+	}
+
+	return allProducts, nil
+}
+
+// Parses the OTC API response into a map of service → []Product and pagination stats
+func (otc *OTC) loadPaginatedResponse(resp *http.Response) (map[string][]Product, *OTCStats, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("Error reading OTC API response: %v", err)
+		return nil, nil, err
+	}
+
+	var raw map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		log.Errorf("Error unmarshalling OTC API response: %v", err)
+		return nil, nil, err
+	}
+
+	var data map[string][]Product
+	if err := json.Unmarshal(raw["response"]["result"], &data); err != nil {
+		log.Errorf("Error unmarshalling result section: %v", err)
+		return nil, nil, err
+	}
+
+	var stats OTCStats
+	if err := json.Unmarshal(raw["response"]["stats"], &stats); err != nil {
+		log.Errorf("Error unmarshalling stats section: %v", err)
+		return nil, nil, err
+	}
+
+	return data, &stats, nil
+}

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -171,18 +171,6 @@ func (otc *OTC) loadStructFromResponse(resp http.Response, serviceName string) (
 	return data[serviceName], nil
 }
 
-// The product (price) data that is fetched from OTC
-//
-// If OsUnit, VCpu and Ram aren't given, the product
-// is a persistent volume, else it's a node.
-type Product struct {
-	OpiFlavour  string `json:"opiFlavour"`
-	OsUnit      string `json:"osUnit,omitempty"`
-	PriceAmount string `json:"priceAmount"`
-	VCpu        string `json:"vCpu,omitempty"`
-	Ram         string `json:"ram,omitempty"`
-}
-
 /*
 Download the pricing data from the OTC API
 
@@ -253,33 +241,11 @@ func (otc *OTC) DownloadPricingData() error {
 	otc.Pricing = make(map[string]*OTCPricing)
 	otc.ValidPricingKeys = make(map[string]bool)
 
-	// Get pricing data from API.
-	nodePricingURL := "https://calculator.otc-service.com/de/open-telekom-price-api/?serviceName=ecs" /* + "&limitMax=200"*/ + "&columns%5B1%5D=opiFlavour" + "&columns%5B2%5D=osUnit" + "&columns%5B3%5D=vCpu" + "&columns%5B4%5D=ram" + "&columns%5B5%5D=priceAmount"
-	pvPricingURL := "https://calculator.otc-service.com/de/open-telekom-price-api/?serviceName%5B0%5D=evs&columns%5B1%5D=opiFlavour&columns%5B2%5D=priceAmount&limitFrom=0&region%5B3%5D=eu-de"
-
-	log.Info("Started downloading OTC pricing data...")
-	resp, err := http.Get(nodePricingURL)
+	products, err := otc.fetchPaginatedProducts([]string{"ecs", "ecsnoc", "memo", "uhio", "evs"})
 	if err != nil {
+		log.Errorf("Failed to fetch OTC pricing data: %v", err)
 		return err
 	}
-	pvResp, err := http.Get(pvPricingURL)
-	if err != nil {
-		return err
-	}
-	log.Info("Succesfully downloaded OTC pricing data")
-
-	var products []Product
-
-	nodeProducts, err := otc.loadStructFromResponse(*resp, "ecs")
-	if err != nil {
-		return err
-	}
-	products = append(products, nodeProducts...)
-	pvProducts, err := otc.loadStructFromResponse(*pvResp, "evs")
-	if err != nil {
-		return err
-	}
-	products = append(products, pvProducts...)
 
 	// convert the otc-reponse product-structs to opencost-compatible node structs
 	const ClusterRegion = "eu-de"

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -1,13 +1,10 @@
 package otc
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/core/pkg/log"
@@ -16,41 +13,6 @@ import (
 	"github.com/opencost/opencost/pkg/cloud/models"
 	"github.com/opencost/opencost/pkg/env"
 )
-
-// OTC node pricing attributes
-type OTCNodeAttributes struct {
-	Type  string // like s2.large.1
-	OS    string // like windows
-	Price string // (in EUR) like 0.023
-	RAM   string // (in GB) like 2
-	VCPU  string // like 8
-}
-
-type OTCPVAttributes struct {
-	Type  string // like vss.ssd
-	Price string // (in EUR/GB/h) like 0.01
-}
-
-// OTC pricing is either for a node, a persistent volume (or a database, network, cluster, ...)
-type OTCPricing struct {
-	NodeAttributes *OTCNodeAttributes
-	PVAttributes   *OTCPVAttributes
-}
-
-// the main provider struct
-type OTC struct {
-	Clientset               clustercache.ClusterCache
-	Pricing                 map[string]*OTCPricing
-	Config                  models.ProviderConfig
-	ClusterRegion           string
-	projectID               string
-	clusterManagementPrice  float64
-	BaseCPUPrice            string
-	BaseRAMPrice            string
-	BaseGPUPrice            string
-	ValidPricingKeys        map[string]bool
-	DownloadPricingDataLock sync.RWMutex
-}
 
 // Kubernetes to OTC OS conversion
 /* Note:
@@ -140,35 +102,6 @@ func (otc *OTC) GetPVKey(pv *clustercache.PersistentVolume, parameters map[strin
 		RegionID:               defaultRegion,
 		ProviderId:             providerID,
 	}
-}
-
-// Takes a resopnse from the otc api and the respective service name as an input
-// and extracts the resulting data into a product slice.
-func (otc *OTC) loadStructFromResponse(resp http.Response, serviceName string) ([]Product, error) {
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal the first bit of the response.
-	wrapper := make(map[string]map[string]interface{})
-	err = json.Unmarshal(body, &wrapper)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal the second, more specific, bit of the response.
-	data := make(map[string][]Product)
-	tmp, err := json.Marshal(wrapper["response"]["result"])
-	if err != nil {
-		return nil, err
-	}
-	err = json.Unmarshal(tmp, &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data[serviceName], nil
 }
 
 /*

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -185,8 +185,8 @@ func (otc *OTC) DownloadPricingData() error {
 	for _, product := range products {
 		var productPricing *OTCPricing
 		var key string
-		// if os is empty the product must be a persistent volume
-		if product.OsUnit == "" {
+		// if the product is a persistent volume, it has no osUnit and no vCpu
+		if strings.ToLower(strings.TrimSpace(product.ProductIdParameter)) == "evs" {
 			productPricing = &OTCPricing{
 				PVAttributes: &OTCPVAttributes{
 					Type:  product.OpiFlavour,
@@ -216,6 +216,11 @@ func (otc *OTC) DownloadPricingData() error {
 		otc.Pricing[key] = productPricing
 		otc.ValidPricingKeys[key] = true
 	}
+
+	// debug the whole pricing
+	log.Debugf("OTC Pricing Data: %v", otc.Pricing)
+
+	// exit
 
 	return nil
 }
@@ -370,6 +375,7 @@ func (otc *OTC) getClusterName(cfg *models.CustomPricing) string {
 // in the provider's pricing list and return it
 func (otc *OTC) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	pricing, ok := otc.Pricing[pvk.Features()]
+	log.Info("looking for persistent volume pricing for features \"" + pvk.Features() + "\"")
 	if !ok {
 		log.Info("Persistent Volume pricing not found for features \"" + pvk.Features() + "\"")
 		log.Info("continuing with pricing for \"eu-de,vss.ssd\"")

--- a/pkg/cloud/otc/types.go
+++ b/pkg/cloud/otc/types.go
@@ -1,0 +1,57 @@
+package otc
+
+import (
+	"sync"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/opencost/opencost/pkg/cloud/models"
+)
+
+type OTCStats struct {
+	CurrentPage    int `json:"currentPage"`
+	MaxPages       int `json:"maxPages"`
+	RecordsPerPage int `json:"recordsPerPage"`
+}
+
+type Product struct {
+	OpiFlavour  string `json:"opiFlavour"`
+	OsUnit      string `json:"osUnit,omitempty"`
+	PriceAmount string `json:"priceAmount"`
+	VCpu        string `json:"vCpu,omitempty"`
+	Ram         string `json:"ram,omitempty"`
+}
+
+// OTC node pricing attributes
+type OTCNodeAttributes struct {
+	Type  string // like s2.large.1
+	OS    string // like windows
+	Price string // (in EUR) like 0.023
+	RAM   string // (in GB) like 2
+	VCPU  string // like 8
+}
+
+type OTCPVAttributes struct {
+	Type  string // like vss.ssd
+	Price string // (in EUR/GB/h) like 0.01
+}
+
+// OTC pricing is either for a node, a persistent volume (or a database, network, cluster, ...)
+type OTCPricing struct {
+	NodeAttributes *OTCNodeAttributes
+	PVAttributes   *OTCPVAttributes
+}
+
+// the main provider struct
+type OTC struct {
+	Clientset               clustercache.ClusterCache
+	Pricing                 map[string]*OTCPricing
+	Config                  models.ProviderConfig
+	ClusterRegion           string
+	projectID               string
+	clusterManagementPrice  float64
+	BaseCPUPrice            string
+	BaseRAMPrice            string
+	BaseGPUPrice            string
+	ValidPricingKeys        map[string]bool
+	DownloadPricingDataLock sync.RWMutex
+}

--- a/pkg/cloud/otc/types.go
+++ b/pkg/cloud/otc/types.go
@@ -14,11 +14,12 @@ type OTCStats struct {
 }
 
 type Product struct {
-	OpiFlavour  string `json:"opiFlavour"`
-	OsUnit      string `json:"osUnit,omitempty"`
-	PriceAmount string `json:"priceAmount"`
-	VCpu        string `json:"vCpu,omitempty"`
-	Ram         string `json:"ram,omitempty"`
+	ProductIdParameter string `json:"productIdParameter"`
+	OpiFlavour         string `json:"opiFlavour"`
+	OsUnit             string `json:"osUnit,omitempty"`
+	PriceAmount        string `json:"priceAmount"`
+	VCpu               string `json:"vCpu,omitempty"`
+	Ram                string `json:"ram,omitempty"`
 }
 
 // OTC node pricing attributes

--- a/pkg/cloud/otc/utils.go
+++ b/pkg/cloud/otc/utils.go
@@ -1,0 +1,18 @@
+package otc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Builds query string for serviceName[0]=ecs&serviceName[1]=memo&...
+func buildServiceNameQueryParam(serviceNames []string) string {
+	var sb strings.Builder
+	for i, name := range serviceNames {
+		sb.WriteString(fmt.Sprintf("serviceName[%d]=%s", i, name))
+		if i < len(serviceNames)-1 {
+			sb.WriteString("&")
+		}
+	}
+	return sb.String()
+}


### PR DESCRIPTION
## What does this PR change?
* Implements pagination support when fetching OTC pricing data from the Open Telekom Cloud API.
* Adds support for querying multiple OTC services (e.g., `ecs`, `ecsnoc`, `memo`, `uhio`, `evs`) in a single request using array-style query parameters (`serviceName[0]=...`).
* Replaces the previous single-service, single-page logic with a paginated, flattened `[]Product` result.

## Does this PR relate to any other PRs?
* No.

## How will this PR impact users?
* Ensures that all OTC instance types (including compute-optimized, memory-optimized, and high-I/O flavors) are correctly priced and reflected in OpenCost.
* Prevents missing pricing keys and fallback to base pricing for nodes like `c4.xlarge.4`, improving accuracy of cost reporting.

## Does this PR address any GitHub or Zendesk issues?
* Closes https://github.com/opencost/opencost/issues/3216

## How was this PR tested?
* Manually verified that pricing is successfully fetched across multiple OTC services.
* Observed log output to confirm proper pagination traversal and product aggregation.
* Checked that missing node pricing issues (e.g., `c4.xlarge.4`) are resolved in OpenCost metrics.

## Does this PR require changes to documentation?
* No. (But optionally the OTC provider docs could mention support for multi-service pagination.)

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes, this is relevant for the next release as it fixes a critical completeness issue in the OTC provider integration.