### PR TITLE
compress diagnostics data

### DIFF
--- a/core/pkg/diagnostics/exporter/encoder.go
+++ b/core/pkg/diagnostics/exporter/encoder.go
@@ -7,5 +7,5 @@ import (
 
 // NewDiagnosticsEncoder returns a JSON encoder used to encode DiagnosticsRunReport events.
 func NewDiagnosticsEncoder() exporter.Encoder[diagnostics.DiagnosticsRunReport] {
-	return exporter.NewJSONEncoder[diagnostics.DiagnosticsRunReport]()
+	return exporter.NewGZipEncoder(exporter.NewJSONEncoder[diagnostics.DiagnosticsRunReport]())
 }


### PR DESCRIPTION
## What does this PR change?
* Compress diagnostics data in gzip format before exporting it

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/3221

## How will this PR impact users?
* Reduces the cost of ownership for customers

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Ran agent locally and checked cloud storage bucket to see gzip compressed diagnostics data being pushed. The gzip format files are nearly of 50-55% less size than json

## Does this PR require changes to documentation?
* NO

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 