### PR TITLE
fix: handle processing of multi page athena query results

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -2061,6 +2061,7 @@ func (aws *AWS) GetSavingsPlanDataFromAthena() error {
 	line_item_usage_start_date DESC`
 
 	page := 0
+	mostRecentDate := ""
 	processResults := func(op *athena.GetQueryResultsOutput) bool {
 		if op == nil {
 			log.Errorf("GetSavingsPlanDataFromAthena: Athena page is nil")
@@ -2070,8 +2071,11 @@ func (aws *AWS) GetSavingsPlanDataFromAthena() error {
 			return false
 		}
 		aws.SavingsPlanDataLock.Lock()
-		aws.SavingsPlanDataByInstanceID = make(map[string]*SavingsPlanData) // Clean out the old data and only report a savingsplan price if its in the most recent run.
-		mostRecentDate := ""
+		defer aws.SavingsPlanDataLock.Unlock()
+		if page == 0 {
+			aws.SavingsPlanDataByInstanceID = make(map[string]*SavingsPlanData) // Clean out the old data and only report a savingsplan price if its in the most recent run.
+		}
+
 		iter := op.ResultSet.Rows
 		if page == 0 && len(iter) > 0 {
 			iter = op.ResultSet.Rows[1:len(op.ResultSet.Rows)]
@@ -2100,7 +2104,6 @@ func (aws *AWS) GetSavingsPlanDataFromAthena() error {
 		for k, r := range aws.SavingsPlanDataByInstanceID {
 			log.DedupedInfof(5, "Savings Plan Instance Data found for node %s : %f at time %s", k, r.EffectiveCost, r.MostRecentDate)
 		}
-		aws.SavingsPlanDataLock.Unlock()
 		return true
 	}
 
@@ -2163,6 +2166,7 @@ func (aws *AWS) GetReservationDataFromAthena() error {
 	line_item_usage_start_date DESC`
 
 	page := 0
+	mostRecentDate := ""
 	processResults := func(op *athena.GetQueryResultsOutput) bool {
 		if op == nil {
 			log.Errorf("GetReservationDataFromAthena: Athena page is nil")
@@ -2172,8 +2176,10 @@ func (aws *AWS) GetReservationDataFromAthena() error {
 			return false
 		}
 		aws.RIDataLock.Lock()
-		aws.RIPricingByInstanceID = make(map[string]*RIData) // Clean out the old data and only report a RI price if its in the most recent run.
-		mostRecentDate := ""
+		defer aws.RIDataLock.Unlock()
+		if page == 0 {
+			aws.RIPricingByInstanceID = make(map[string]*RIData) // Clean out the old data and only report a RI price if its in the most recent run.
+		}
 		iter := op.ResultSet.Rows
 		if page == 0 && len(iter) > 0 {
 			iter = op.ResultSet.Rows[1:len(op.ResultSet.Rows)]
@@ -2202,7 +2208,6 @@ func (aws *AWS) GetReservationDataFromAthena() error {
 		for k, r := range aws.RIPricingByInstanceID {
 			log.DedupedInfof(5, "Reserved Instance Data found for node %s : %f at time %s", k, r.EffectiveCost, r.MostRecentDate)
 		}
-		aws.RIDataLock.Unlock()
 		return true
 	}
 


### PR DESCRIPTION
## What does this PR change?
*  This PR fixes #3131 

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* This PR address a existing bug while handling multi-page athena query results.

## Does this PR address any GitHub or Zendesk issues?
* Closes #3131 

## How was this PR tested?
* Tested the PR running locally, my setup makes athena queries that results in multi-page results and made sure the map doesn't get reset until all the results are processed and stored in memory.

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Since, this is a bug we should have this in next release