### PR TITLE
Add ability to configure cloud provider type from env vars

### DIFF
--- a/pkg/cloud/provider/provider.go
+++ b/pkg/cloud/provider/provider.go
@@ -175,6 +175,32 @@ func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.
 	}
 
 	cp := getClusterProperties(nodes[0])
+
+	// If provider is DEFAULT, check for explicitly set cloud provider from environment variable
+	envProvider := env.GetCloudProvider()
+	if cp.provider == "DEFAULT" && envProvider != "" {
+		log.Infof("Using cloud provider from environment variable: %s", envProvider)
+		cp.provider = envProvider
+		switch envProvider {
+		case opencost.AWSProvider:
+			cp.configFileName = "aws.json"
+		case opencost.AzureProvider:
+			cp.configFileName = "azure.json"
+		case opencost.GCPProvider:
+			cp.configFileName = "gcp.json"
+		case opencost.AlibabaProvider:
+			cp.configFileName = "alibaba.json"
+		case opencost.OracleProvider:
+			cp.configFileName = "oracle.json"
+		case opencost.ScalewayProvider:
+			cp.configFileName = "scaleway.json"
+		case opencost.OTCProvider:
+			cp.configFileName = "otc.json"
+		case opencost.CSVProvider:
+			cp.configFileName = "default.json"
+		}
+	}
+
 	providerConfig := NewProviderConfig(config, cp.configFileName)
 	// If ClusterAccount is set apply it to the cluster properties
 	if providerConfig.customPricing != nil && providerConfig.customPricing.ClusterAccountID != "" {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -122,6 +122,9 @@ const (
 	// Deprecated
 	KubecostNamespaceEnvVar    = "KUBECOST_NAMESPACE"
 	KubecostConfigBucketEnvVar = "KUBECOST_CONFIG_BUCKET"
+
+	// Cloud provider override
+	CloudProviderVar = "CLOUD_PROVIDER"
 )
 
 const DefaultConfigMountPath = "/var/configs"
@@ -550,4 +553,9 @@ func GetNodeStatsCertFile() string {
 // GetNodeStatsKeyFile returns the path of the key file
 func GetNodeStatsKeyFile() string {
 	return env.Get(NodeStatsKeyFileEnvVar, "")
+}
+
+// GetCloudProvider returns the explicitly set cloud provider from environment variable
+func GetCloudProvider() string {
+	return env.Get(CloudProviderVar, "")
 }


### PR DESCRIPTION
## What does this PR change?
This PR address the #3117 
Currently the logic to determine the cloud provider type is based on randomly selected node `.spec.ProviderId`. If we have clusters running special node like fargate or virtual kubelet nodes then this logic would fail to correctly determine the provider type.  This fix add an option for user to specify the provider type as env var, so when the actual logic fails to determine the provider type it will fall back to env var.

## Does this PR relate to any other PRs?
N/A

## How will this PR impact users?
Shouldn't impact anyone

## Does this PR address any GitHub or Zendesk issues?
* Closes #3117 

## How was this PR tested?
Testing locally on a cluster with both virtual and eks nodes.

## Does this PR require changes to documentation?
* Yes,  we could capture this configuration option .

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* It should be part of next release