### PR TITLE
field parser for diagnostics

### DIFF
--- a/core/pkg/filter/diagnostics/fields.go
+++ b/core/pkg/filter/diagnostics/fields.go
@@ -1,0 +1,15 @@
+package diagnostics
+
+import (
+	"github.com/opencost/opencost/core/pkg/filter/fieldstrings"
+)
+
+// DiagnosticsField is an enum that represents Diagnostics-specific fields that can be
+// filtered on (cluster)
+type DiagnosticsField string
+
+// If you add a DiagnosticsField, make sure to update field maps to return the correct
+// Diagnostic value does not enforce exhaustive pattern matching on "enum" types.
+const (
+	FieldClusterID  DiagnosticsField = DiagnosticsField(fieldstrings.FieldClusterID)
+)

--- a/core/pkg/filter/diagnostics/parser.go
+++ b/core/pkg/filter/diagnostics/parser.go
@@ -1,0 +1,36 @@
+package diagnostics
+
+import "github.com/opencost/opencost/core/pkg/filter/ast"
+
+// a slice of all the diagnostics field instances the lexer should recognize as
+// valid left-hand comparators
+var diagnosticsFilterFields []*ast.Field = []*ast.Field{
+	ast.NewField(FieldClusterID),
+}
+
+// fieldMap is a lazily loaded mapping from DiagnosticsField to ast.Field
+var fieldMap map[DiagnosticsField]*ast.Field
+
+func init() {
+	fieldMap = make(map[DiagnosticsField]*ast.Field, len(diagnosticsFilterFields))
+	for _, f := range diagnosticsFilterFields {
+		ff := *f
+		fieldMap[DiagnosticsField(ff.Name)] = &ff
+	}
+}
+
+// DefaultFieldByName returns only default diagnostics filter fields by name.
+func DefaultFieldByName(field DiagnosticsField) *ast.Field {
+	if af, ok := fieldMap[field]; ok {
+		afcopy := *af
+		return &afcopy
+	}
+
+	return nil
+}
+
+// NewDiagnosticFilterParser creates a new `ast.FilterParser` implementation
+// which uses diagnostics specific fields
+func NewDiagnosticsFilterParser() ast.FilterParser {
+	return ast.NewFilterParser(diagnosticsFilterFields)
+}


### PR DESCRIPTION
## What does this PR change?
* Adds filter parser for diagnostics api
* filtering by cluster is enabled for diagnostics

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/3527

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Locally ran aggregator to test filter for diagnostics multicluster endpoint

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 