### PR TITLE
Sth/kcm 4335

### DIFF
--- a/modules/collector-source/pkg/metric/aggregator/increase.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase.go
@@ -21,6 +21,7 @@ func Increase(labelValues []string) MetricAggregator {
 	}
 }
 
+// getIncrease returns the current increase without updating the state
 func (a *increaseAggregator) getIncrease() float64 {
 	increase := a.increase
 	// ignore decreases and do not return increase if only one sample has been recorded
@@ -42,6 +43,7 @@ func (a *increaseAggregator) Update(value float64, timestamp time.Time, addition
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	if timestamp.After(a.currentTime) {
+		// update state and reset current
 		a.increase = a.getIncrease()
 		a.previousTime = a.currentTime
 		a.currentTime = timestamp

--- a/modules/collector-source/pkg/metric/aggregator/increase.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase.go
@@ -8,17 +8,25 @@ import (
 type increaseAggregator struct {
 	lock        sync.Mutex
 	labelValues []string
-	initialized bool
-	initialTime time.Time
 	currentTime time.Time
-	initial     float64
+	previous    float64
 	current     float64
+	increase    float64
 }
 
 func Increase(labelValues []string) MetricAggregator {
 	return &increaseAggregator{
 		labelValues: labelValues,
 	}
+}
+
+func (a *increaseAggregator) getIncrease() float64 {
+	increase := a.increase
+	// ignore decreases
+	if a.previous < a.current && a.previous != 0 {
+		increase += a.current - a.previous
+	}
+	return increase
 }
 
 func (a *increaseAggregator) AdditionInfo() map[string]string {
@@ -32,20 +40,12 @@ func (a *increaseAggregator) LabelValues() []string {
 func (a *increaseAggregator) Update(value float64, timestamp time.Time, additionalInfo map[string]string) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if !a.initialized {
-		a.initialTime = timestamp
+	if timestamp.After(a.currentTime) {
 		a.currentTime = timestamp
-		a.initialized = true
-	}
-	if a.initialTime == timestamp {
-		a.initial += value
-	}
-
-	if a.currentTime.Before(timestamp) {
-		a.currentTime = timestamp
+		a.increase = a.getIncrease()
+		a.previous = a.current
 		a.current = 0
 	}
-
 	a.current += value
 }
 
@@ -53,6 +53,6 @@ func (a *increaseAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	return []MetricValue{
-		{Value: a.current - a.initial},
+		{Value: a.getIncrease()},
 	}
 }

--- a/modules/collector-source/pkg/metric/aggregator/increase.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase.go
@@ -6,12 +6,13 @@ import (
 )
 
 type increaseAggregator struct {
-	lock        sync.Mutex
-	labelValues []string
-	currentTime time.Time
-	previous    float64
-	current     float64
-	increase    float64
+	lock         sync.Mutex
+	labelValues  []string
+	currentTime  time.Time
+	previousTime time.Time
+	previous     float64
+	current      float64
+	increase     float64
 }
 
 func Increase(labelValues []string) MetricAggregator {
@@ -22,8 +23,8 @@ func Increase(labelValues []string) MetricAggregator {
 
 func (a *increaseAggregator) getIncrease() float64 {
 	increase := a.increase
-	// ignore decreases
-	if a.previous < a.current && a.previous != 0 {
+	// ignore decreases and do not return increase if only one sample has been recorded
+	if a.previous < a.current && !a.previousTime.IsZero() {
 		increase += a.current - a.previous
 	}
 	return increase
@@ -41,8 +42,9 @@ func (a *increaseAggregator) Update(value float64, timestamp time.Time, addition
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	if timestamp.After(a.currentTime) {
-		a.currentTime = timestamp
 		a.increase = a.getIncrease()
+		a.previousTime = a.currentTime
+		a.currentTime = timestamp
 		a.previous = a.current
 		a.current = 0
 	}

--- a/modules/collector-source/pkg/metric/aggregator/increase_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestIncreaseAggregator_Value(t *testing.T) {
-	time1 := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
-	time2 := time.Date(1, 1, 1, 0, 15, 0, 0, time.UTC)
-	time3 := time.Date(1, 1, 1, 0, 30, 0, 0, time.UTC)
-	time4 := time.Date(1, 1, 1, 0, 45, 0, 0, time.UTC)
+	time1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	time2 := time.Date(2025, 1, 1, 0, 15, 0, 0, time.UTC)
+	time3 := time.Date(2025, 1, 1, 0, 30, 0, 0, time.UTC)
+	time4 := time.Date(2025, 1, 1, 0, 45, 0, 0, time.UTC)
 	type update struct {
 		value                 float64
 		timestamp             time.Time

--- a/modules/collector-source/pkg/metric/aggregator/increase_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase_test.go
@@ -9,6 +9,8 @@ import (
 func TestIncreaseAggregator_Value(t *testing.T) {
 	time1 := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
 	time2 := time.Date(1, 1, 1, 0, 15, 0, 0, time.UTC)
+	time3 := time.Date(1, 1, 1, 0, 30, 0, 0, time.UTC)
+	time4 := time.Date(1, 1, 1, 0, 45, 0, 0, time.UTC)
 	type update struct {
 		value                 float64
 		timestamp             time.Time
@@ -78,6 +80,31 @@ func TestIncreaseAggregator_Value(t *testing.T) {
 			want: []MetricValue{
 				{
 					Value: 4,
+				},
+			},
+		},
+		"set restart ": {
+			updates: []update{
+				{
+					value:     3,
+					timestamp: time1,
+				},
+				{
+					value:     4,
+					timestamp: time2,
+				},
+				{
+					value:     1,
+					timestamp: time3,
+				},
+				{
+					value:     2,
+					timestamp: time4,
+				},
+			},
+			want: []MetricValue{
+				{
+					Value: 2,
 				},
 			},
 		},

--- a/modules/collector-source/pkg/metric/aggregator/increase_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/increase_test.go
@@ -83,7 +83,7 @@ func TestIncreaseAggregator_Value(t *testing.T) {
 				},
 			},
 		},
-		"set restart ": {
+		"set restart": {
 			updates: []update{
 				{
 					value:     3,

--- a/modules/collector-source/pkg/metric/aggregator/iratemax_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/iratemax_test.go
@@ -125,6 +125,31 @@ func TestIRateMaxAggregator_Value(t *testing.T) {
 				},
 			},
 		},
+		"set restart": {
+			updates: []update{
+				{
+					value:     3,
+					timestamp: time1,
+				},
+				{
+					value:     4,
+					timestamp: time2,
+				},
+				{
+					value:     1,
+					timestamp: time3,
+				},
+				{
+					value:     2,
+					timestamp: time4,
+				},
+			},
+			want: []MetricValue{
+				{
+					Value: 1,
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/modules/collector-source/pkg/metric/aggregator/rate.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate.go
@@ -8,19 +8,30 @@ import (
 // rateAggregator is a MetricAggregator which returns the average rate per second change of the samples that it tracks.
 // to function properly calls to Update must have a timestamp greater than or equal to the last call to update.
 type rateAggregator struct {
-	lock        sync.Mutex
-	labelValues []string
-	initialized bool
-	initialTime time.Time
-	currentTime time.Time
-	initial     float64
-	current     float64
+	lock         sync.Mutex
+	labelValues  []string
+	previousTime time.Time
+	previous     float64
+	currentTime  time.Time
+	current      float64
+	increase     float64
+	seconds      float64
 }
 
 func Rate(labelValues []string) MetricAggregator {
 	return &rateAggregator{
 		labelValues: labelValues,
 	}
+}
+func (a *rateAggregator) getIncreaseSeconds() (float64, float64) {
+	increase := a.increase
+	seconds := a.seconds
+	// ignore decreases
+	if a.previous < a.current && a.previous != 0 {
+		increase += a.current - a.previous
+		seconds += a.currentTime.Sub(a.previousTime).Seconds()
+	}
+	return increase, seconds
 }
 
 func (a *rateAggregator) AdditionInfo() map[string]string {
@@ -34,33 +45,25 @@ func (a *rateAggregator) LabelValues() []string {
 func (a *rateAggregator) Update(value float64, timestamp time.Time, additionalInfo map[string]string) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if !a.initialized {
-		a.initialTime = timestamp
-		a.currentTime = timestamp
-		a.initialized = true
-	}
-	if a.initialTime == timestamp {
-		a.initial += value
-	}
-
-	if a.currentTime.Before(timestamp) {
+	if timestamp.After(a.currentTime) {
+		a.increase, a.seconds = a.getIncreaseSeconds()
+		a.previous = a.current
+		a.previousTime = a.currentTime
 		a.currentTime = timestamp
 		a.current = 0
 	}
-
 	a.current += value
 }
 
 func (a *rateAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	seconds := a.currentTime.Sub(a.initialTime).Seconds()
+	increase, seconds := a.getIncreaseSeconds()
 	if seconds == 0 {
 		return []MetricValue{
 			{Value: 0},
 		}
 	}
-	increase := a.current - a.initial
 	return []MetricValue{
 		{Value: increase / seconds},
 	}

--- a/modules/collector-source/pkg/metric/aggregator/rate.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate.go
@@ -23,12 +23,15 @@ func Rate(labelValues []string) MetricAggregator {
 		labelValues: labelValues,
 	}
 }
-func (a *rateAggregator) getIncreaseSeconds() (float64, float64) {
+
+// getRunningAvgSeconds returns the running average without updating the state
+func (a *rateAggregator) getRunningAvgSeconds() (float64, float64) {
 	runningAvg := a.runningAvg
 	seconds := a.seconds
-	// ignore decreases
+	// ignore decreases and base case where only one sample has been recorded
 	if a.previous < a.current && !a.previousTime.IsZero() {
 		currentSeconds := a.currentTime.Sub(a.previousTime).Seconds()
+		// ratio used to add the rate since the last recorded timestamp into the running average
 		weightingRatio := currentSeconds / (currentSeconds + seconds)
 		currentRate := (a.current - a.previous) / currentSeconds
 		runningAvg = (runningAvg * (1 - weightingRatio)) + (currentRate * weightingRatio)
@@ -50,7 +53,8 @@ func (a *rateAggregator) Update(value float64, timestamp time.Time, additionalIn
 	defer a.lock.Unlock()
 	// If samples from a new timestamp finalize current values by moving them to previous
 	if timestamp.After(a.currentTime) {
-		a.runningAvg, a.seconds = a.getIncreaseSeconds()
+		// update state and reset current
+		a.runningAvg, a.seconds = a.getRunningAvgSeconds()
 		a.previous = a.current
 		a.previousTime = a.currentTime
 		a.currentTime = timestamp
@@ -62,7 +66,7 @@ func (a *rateAggregator) Update(value float64, timestamp time.Time, additionalIn
 func (a *rateAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	average, seconds := a.getIncreaseSeconds()
+	average, seconds := a.getRunningAvgSeconds()
 	if seconds == 0 {
 		return []MetricValue{
 			{Value: 0},

--- a/modules/collector-source/pkg/metric/aggregator/rate.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate.go
@@ -14,7 +14,7 @@ type rateAggregator struct {
 	previous     float64
 	currentTime  time.Time
 	current      float64
-	increase     float64
+	runningAvg   float64
 	seconds      float64
 }
 
@@ -24,14 +24,17 @@ func Rate(labelValues []string) MetricAggregator {
 	}
 }
 func (a *rateAggregator) getIncreaseSeconds() (float64, float64) {
-	increase := a.increase
+	runningAvg := a.runningAvg
 	seconds := a.seconds
 	// ignore decreases
-	if a.previous < a.current && a.previous != 0 {
-		increase += a.current - a.previous
-		seconds += a.currentTime.Sub(a.previousTime).Seconds()
+	if a.previous < a.current && !a.previousTime.IsZero() {
+		currentSeconds := a.currentTime.Sub(a.previousTime).Seconds()
+		weightingRatio := currentSeconds / (currentSeconds + seconds)
+		currentRate := (a.current - a.previous) / currentSeconds
+		runningAvg = (runningAvg * (1 - weightingRatio)) + (currentRate * weightingRatio)
+		seconds += currentSeconds
 	}
-	return increase, seconds
+	return runningAvg, seconds
 }
 
 func (a *rateAggregator) AdditionInfo() map[string]string {
@@ -45,8 +48,9 @@ func (a *rateAggregator) LabelValues() []string {
 func (a *rateAggregator) Update(value float64, timestamp time.Time, additionalInfo map[string]string) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
+	// If samples from a new timestamp finalize current values by moving them to previous
 	if timestamp.After(a.currentTime) {
-		a.increase, a.seconds = a.getIncreaseSeconds()
+		a.runningAvg, a.seconds = a.getIncreaseSeconds()
 		a.previous = a.current
 		a.previousTime = a.currentTime
 		a.currentTime = timestamp
@@ -58,13 +62,13 @@ func (a *rateAggregator) Update(value float64, timestamp time.Time, additionalIn
 func (a *rateAggregator) Value() []MetricValue {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	increase, seconds := a.getIncreaseSeconds()
+	average, seconds := a.getIncreaseSeconds()
 	if seconds == 0 {
 		return []MetricValue{
 			{Value: 0},
 		}
 	}
 	return []MetricValue{
-		{Value: increase / seconds},
+		{Value: average},
 	}
 }

--- a/modules/collector-source/pkg/metric/aggregator/rate_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestRateAggregator_Value(t *testing.T) {
-	time1 := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
-	time2 := time.Date(1, 1, 1, 0, 0, 1, 0, time.UTC)
-	time3 := time.Date(1, 1, 1, 0, 0, 2, 0, time.UTC)
-	time4 := time.Date(1, 1, 1, 0, 0, 3, 0, time.UTC)
+	time1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	time2 := time.Date(2025, 1, 1, 0, 0, 1, 0, time.UTC)
+	time3 := time.Date(2025, 1, 1, 0, 0, 2, 0, time.UTC)
+	time4 := time.Date(2025, 1, 1, 0, 0, 3, 0, time.UTC)
 	type update struct {
 		value                 float64
 		timestamp             time.Time

--- a/modules/collector-source/pkg/metric/aggregator/rate_test.go
+++ b/modules/collector-source/pkg/metric/aggregator/rate_test.go
@@ -10,6 +10,7 @@ func TestRateAggregator_Value(t *testing.T) {
 	time1 := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
 	time2 := time.Date(1, 1, 1, 0, 0, 1, 0, time.UTC)
 	time3 := time.Date(1, 1, 1, 0, 0, 2, 0, time.UTC)
+	time4 := time.Date(1, 1, 1, 0, 0, 3, 0, time.UTC)
 	type update struct {
 		value                 float64
 		timestamp             time.Time
@@ -100,6 +101,31 @@ func TestRateAggregator_Value(t *testing.T) {
 			want: []MetricValue{
 				{
 					Value: 4,
+				},
+			},
+		},
+		"set restart": {
+			updates: []update{
+				{
+					value:     3,
+					timestamp: time1,
+				},
+				{
+					value:     4,
+					timestamp: time2,
+				},
+				{
+					value:     1,
+					timestamp: time3,
+				},
+				{
+					value:     2,
+					timestamp: time4,
+				},
+			},
+			want: []MetricValue{
+				{
+					Value: 1,
 				},
 			},
 		},


### PR DESCRIPTION
## What does this PR change?
* This PR updates the increase and rate aggregators which are meant to track positive increases in a counter to be able to handle counter restarts. To do this negative deltas between sample timestamps are dropped and not included in running totals. Ideally when the counter is reset a new metric aggregator would be initialized as the label set would change but that is not currently the case when dealing with certain things like containers which are part of a statefulset and do not have unique identifiers in their metric label sets.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Added unit tests which simulate the failing scenario.

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 