### PR TITLE
fix(aws): retain all Savings Plan data when paginating Athena results

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -2039,6 +2039,11 @@ func (aws *AWS) GetSavingsPlanDataFromAthena() error {
 	}
 	if aws.SavingsPlanDataByInstanceID == nil {
 		aws.SavingsPlanDataByInstanceID = make(map[string]*SavingsPlanData)
+	} else {
+		// Always clear the map at the start of the query
+		for k := range aws.SavingsPlanDataByInstanceID {
+			delete(aws.SavingsPlanDataByInstanceID, k)
+		}
 	}
 	tNow := time.Now()
 	tOneDayAgo := tNow.Add(time.Duration(-25) * time.Hour) // Also get files from one day ago to avoid boundary conditions
@@ -2066,7 +2071,7 @@ func (aws *AWS) GetSavingsPlanDataFromAthena() error {
 			return false
 		}
 		aws.SavingsPlanDataLock.Lock()
-		aws.SavingsPlanDataByInstanceID = make(map[string]*SavingsPlanData) // Clean out the old data and only report a savingsplan price if its in the most recent run.
+		// Do NOT clear the map here! Only accumulate results.
 		mostRecentDate := ""
 		iter := op.ResultSet.Rows
 		if page == 0 && len(iter) > 0 {


### PR DESCRIPTION
### Problem
When querying Savings Plan data from AWS Athena, if the results span multiple pages, only the data from the last page was retained. This was due to the SavingsPlanDataByInstanceID map being cleared on each page of results, causing all previously collected data to be lost. As a result, users with large datasets or multi-page Athena queries would see incomplete or incorrect Savings Plan cost reporting in OpenCost.

### what does PR do:
Fixes data loss for multi-page Athena Savings Plan queries.
Ensures accurate and complete Savings Plan cost calculations in OpenCost reports for all AWS users.
No regressions observed in related AWS or Athena functionality.

### issue being Fixed #3131

Previously, when querying Savings Plan data from Athena, if the results spanned multiple pages, only the data from the last page was retained. This was because the SavingsPlanDataByInstanceID map was being cleared on every page of results, causing all previously collected data to be lost.

would like to know ur views on it.
