### PR TITLE
feat(gcp): add explicit GCP_CLOUD_COST_PROJECT_ID config for multi-project setups and improve troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ Visit the full documentation for [recommended installation options](https://www.
 - [Prometheus Metrics](https://www.opencost.io/docs/integrations/prometheus)
 - [User Interface](https://www.opencost.io/docs/installation/ui)
 
+## GCP Multi-Project Setup and Troubleshooting
+
+If your GKE cluster, service account, and billing dataset are in different GCP projects, set the `GCP_CLOUD_COST_PROJECT_ID` environment variable to the project ID that should be used for cloud cost API calls. This ensures OpenCost can access billing and commitment data correctly.
+
+Example (Helm values.yaml):
+
+```yaml
+opencost:
+  exporter:
+    env:
+      - name: GCP_CLOUD_COST_PROJECT_ID
+        value: "your-billing-project-id"
+```
+
+If not set, OpenCost will attempt to infer the project ID, but this may fail in multi-project setups.
+
+### Troubleshooting
+- Ensure your service account has access to the billing dataset and required APIs in the target project.
+- Increase memory requests/limits for the OpenCost pod (e.g., 4GiB or more).
+- For GCP Managed Prometheus, check for relabeling issues (namespace label may be renamed to `exported_namespace`).
+- Check OpenCost logs for errors like `RESOURCE_PROJECT_INVALID` or "No Cloud Cost integrations currently configured."
+- Try a longer time window (e.g., 1d or more) if you see zeroed-out values.
+
 ## Contributing
 
 We :heart: pull requests! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for information on building the project from source and contributing changes.

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1059,7 +1059,14 @@ func (gcp *GCP) DownloadPricingData() error {
 	gcp.loadGCPAuthSecret()
 
 	gcp.BaseCPUPrice = c.CPU
-	gcp.ProjectID = c.ProjectID
+	// --- PATCH: allow explicit override of ProjectID for cloud cost API calls ---
+	explicitProjectID := os.Getenv("GCP_CLOUD_COST_PROJECT_ID")
+	if explicitProjectID != "" {
+		log.Infof("Using explicit GCP_CLOUD_COST_PROJECT_ID for cloud cost API calls: %s", explicitProjectID)
+		gcp.ProjectID = explicitProjectID
+	} else {
+		gcp.ProjectID = c.ProjectID
+	}
 	gcp.BillingDataDataset = c.BillingDataDataset
 
 	nodeList := gcp.Clientset.GetAllNodes()
@@ -1345,8 +1352,12 @@ func (gcp *GCP) getReservedInstances() ([]*GCPReservedInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	commitments, err := computeService.RegionCommitments.AggregatedList(gcp.ProjectID).Do()
+	// --- PATCH: use explicit ProjectID if set ---
+	projectID := gcp.ProjectID
+	if projectID == "" {
+		log.Warn("GCP ProjectID is empty for reserved instance lookup. Set GCP_CLOUD_COST_PROJECT_ID or check your config.")
+	}
+	commitments, err := computeService.RegionCommitments.AggregatedList(projectID).Do()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/costmodel/moq_allocation_model_test.go
+++ b/pkg/costmodel/moq_allocation_model_test.go
@@ -63,11 +63,11 @@ func (mock *AllocationModelMock) ComputeAllocation(start time.Time, end time.Tim
 		panic("AllocationModelMock.ComputeAllocationFunc: method is nil but AllocationModel.ComputeAllocation was just called")
 	}
 	callInfo := struct {
-		Start      time.Time
-		End        time.Time
+		Start time.Time
+		End   time.Time
 	}{
-		Start:      start,
-		End:        end,
+		Start: start,
+		End:   end,
 	}
 	mock.lockComputeAllocation.Lock()
 	mock.calls.ComputeAllocation = append(mock.calls.ComputeAllocation, callInfo)
@@ -80,12 +80,12 @@ func (mock *AllocationModelMock) ComputeAllocation(start time.Time, end time.Tim
 //
 //	len(mockedAllocationModel.ComputeAllocationCalls())
 func (mock *AllocationModelMock) ComputeAllocationCalls() []struct {
-	Start      time.Time
-	End        time.Time
+	Start time.Time
+	End   time.Time
 } {
 	var calls []struct {
-		Start      time.Time
-		End        time.Time
+		Start time.Time
+		End   time.Time
 	}
 	mock.lockComputeAllocation.RLock()
 	calls = mock.calls.ComputeAllocation


### PR DESCRIPTION
fixes: #2777

### What does this pr solve:
Adds support for the GCP_CLOUD_COST_PROJECT_ID environment variable to explicitly set the project ID for GCP cloud cost API calls. Updates documentation with configuration and troubleshooting guidance for multi-project GCP environments.

why we need it 
Fixes issues with zeroed-out values and RESOURCE_PROJECT_INVALID errors when cluster, service account, and billing dataset are in different GCP projects.