### PR TITLE
Add MCP Struct Definitions to Support AI Integration for Allocation, Asset, and Cloud Cost Queries

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -1,0 +1,42 @@
+package mcp
+
+type QueryContext struct {
+    QueryType    string          `json:"queryType"`
+    TimeWindow   string          `json:"timeWindow,omitempty"`
+    Aggregations []string        `json:"aggregations,omitempty"`
+    Filters      map[string]string `json:"filters,omitempty"`
+    Granularity  string          `json:"granularity,omitempty"`
+    Step         string          `json:"step,omitempty"`
+    ResponseHint string          `json:"responseHint,omitempty"`
+}
+
+type AllocationResponse struct {
+    TotalCost     float64            `json:"totalCost"`
+    CostBreakdown map[string]float64 `json:"costBreakdown"`
+    TimeSeries    []TimeSeriesPoint  `json:"timeSeries,omitempty"`
+}
+
+type AssetResponse struct {
+    AssetType     string             `json:"assetType"`
+    TotalCost     float64            `json:"totalCost"`
+    CostPerAsset  map[string]float64 `json:"costPerAsset"`
+    Region        string             `json:"region,omitempty"`
+}
+
+type CloudCostResponse struct {
+    Provider        string             `json:"provider"`
+    Services        map[string]float64 `json:"services"`
+    TotalCloudCost  float64            `json:"totalCloudCost"`
+}
+
+type TimeSeriesPoint struct {
+    Timestamp string  `json:"timestamp"`
+    Value     float64 `json:"value"`
+}
+
+type ConversationState struct {
+    LastQuery      QueryContext `json:"lastQuery"`
+    LastIntent     string       `json:"lastIntent"`
+    FollowUpNeeded bool         `json:"followUpNeeded"`
+    Summary        string       `json:"summary,omitempty"`
+}


### PR DESCRIPTION
This PR introduces Go struct definitions in the package mcp to facilitate seamless AI agent interaction with OpenCost, as part of the LFX Mentorship Coding Challenge.

These structs are designed to align with the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/go-sdk), enabling structured conversation and query representation for allocation, asset, and cloud cost data through an MCP server.

🔧 Added Structs:
QueryContext:
Captures the user query intent and context such as query type (allocations, assets, cloud costs), time window, filters, granularity, and more. This provides flexible representation for natural language-based cost inquiries.

AllocationResponse:
Structures the response for allocation-related queries. Includes total cost, cost breakdown, and optional time series data.

AssetResponse:
Structures the asset-level cost breakdown. Includes asset type, per-asset cost map, and optional region.

CloudCostResponse:
Captures cloud provider-level cost distribution across services and total cloud cost.

TimeSeriesPoint:
Represents a single data point in a time series response.

ConversationState:
Maintains the state of conversation with the AI agent. Includes previous query, current intent, flags for follow-up, and summary data if available.

🧠 Motivation:
These data models are intended to power an MCP server that enables AI agents (like ChatGPT or internal assistants) to fetch OpenCost data conversationally. The ConversationState structure provides continuity between interactions, while the QueryContext offers flexibility for complex queries.

This PR aligns with the mentorship challenge requirements to:

Create conversation and response data structures,

Anticipate AI-specific needs like follow-up capability and summarization,

Enable seamless backend interaction with OpenCost APIs via MCP protocol.

📹 Demo and Testing (Next Steps):
Integration with MCP server endpoints using the go-sdk.

Create integration tests in the OpenCost Integration Tests repo.

Record a demo showing an AI-agent-style conversation using this setup.

🖊️ **Signed-off-by:** Muskan Rathore <muskanrathoregwl9@gmail.com>