### PR TITLE
lfx-pretask : OpenCost Data Model 2.0 (#3240)

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -15,6 +15,8 @@ import (
 )
 
 type Namespace struct {
+	// Add UID
+	UID         types.UID
 	Name        string
 	Labels      map[string]string
 	Annotations map[string]string
@@ -51,6 +53,8 @@ type Container struct {
 }
 
 type Node struct {
+	// Add UID
+	UID            types.UID
 	Name           string
 	Labels         map[string]string
 	Annotations    map[string]string
@@ -181,6 +185,7 @@ func GetControllerOfNoCopy(pod *Pod) *metav1.OwnerReference {
 
 func TransformNamespace(input *v1.Namespace) *Namespace {
 	return &Namespace{
+		UID:         input.UID, // Emit UID
 		Name:        input.Name,
 		Annotations: input.Annotations,
 		Labels:      input.Labels,
@@ -241,6 +246,7 @@ func TransformPod(input *v1.Pod) *Pod {
 
 func TransformNode(input *v1.Node) *Node {
 	return &Node{
+		UID:            input.UID, // Emit UID
 		Name:           input.Name,
 		Labels:         input.Labels,
 		Annotations:    input.Annotations,

--- a/pkg/metrics/kubemetrics.go
+++ b/pkg/metrics/kubemetrics.go
@@ -44,6 +44,48 @@ func DefaultKubeMetricsOpts() *KubeMetricsOpts {
 	}
 }
 
+// Collector to emit UID metrics
+
+type KubeUIDCollector struct {
+	KubeClusterCache clustercache.ClusterCache
+}
+
+func (c KubeUIDCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- prometheus.NewDesc("opencost_kube_pod_uid", "Kubernetes Pod UID", []string{"namespace", "pod", "uid"}, nil)
+	ch <- prometheus.NewDesc("opencost_kube_node_uid", "Kubernetes Node UID", []string{"node", "uid"}, nil)
+	ch <- prometheus.NewDesc("opencost_kube_namespace_uid", "Kubernetes Namespace UID", []string{"namespace", "uid"}, nil)
+}
+
+func (c KubeUIDCollector) Collect(ch chan<- prometheus.Metric) {
+	// Pod UIDs
+	for _, pod := range c.KubeClusterCache.GetAllPods() {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc("opencost_kube_pod_uid", "Kubernetes Pod UID", []string{"namespace", "pod", "uid"}, nil),
+			prometheus.GaugeValue,
+			1,
+			pod.Namespace, pod.Name, string(pod.UID),
+		)
+	}
+	// Node UIDs
+	for _, node := range c.KubeClusterCache.GetAllNodes() {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc("opencost_kube_node_uid", "Kubernetes Node UID", []string{"node", "uid"}, nil),
+			prometheus.GaugeValue,
+			1,
+			node.Name, string(node.UID),
+		)
+	}
+	// Namespace UIDs
+	for _, ns := range c.KubeClusterCache.GetAllNamespaces() {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc("opencost_kube_namespace_uid", "Kubernetes Namespace UID", []string{"namespace", "uid"}, nil),
+			prometheus.GaugeValue,
+			1,
+			ns.Name, string(ns.UID),
+		)
+	}
+}
+
 // InitKubeMetrics initializes kubernetes metric emission using the provided options.
 func InitKubeMetrics(clusterCache clustercache.ClusterCache, metricsConfig *MetricsConfig, opts *KubeMetricsOpts) {
 	if opts == nil {
@@ -152,6 +194,11 @@ func InitKubeMetrics(clusterCache clustercache.ClusterCache, metricsConfig *Metr
 				metricsConfig:    *metricsConfig,
 			})
 		}
+
+		// Register UID collector for pods, nodes & namespaces
+		prometheus.MustRegister(KubeUIDCollector{
+			KubeClusterCache: clusterCache,
+		})
 	})
 }
 


### PR DESCRIPTION
This submission is part of the LFX pretask for #3240 [OpenCost Data Model 2.0]

### What does this PR change?
- Added UID fields to 3 Kubernetes objects [Pods, Nodes, Namespaces]
- UID propogation added to transformation metrics
- Added Prometheus collector for UIDs
- Registered collector to make it queryable