### PR TITLE
bug: correct inverted boolean logic in Azure spot pricing assignment

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -290,10 +290,12 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	spotPrice := ""
 	for _, item := range pricingPayload.Items {
 		if item.Type == "Consumption" && !strings.Contains(item.ProductName, "Windows") {
-			if !strings.Contains(strings.ToLower(item.SkuName), " spot") {
+			if strings.Contains(strings.ToLower(item.SkuName), " spot") {
 				spotPrice = fmt.Sprintf("%f", item.RetailPrice)
+				log.DedupedInfof(10, "Azure pricing: Assigned spot price %f for SKU %s", item.RetailPrice, item.SkuName)
 			} else {
 				retailPrice = fmt.Sprintf("%f", item.RetailPrice)
+				log.DedupedInfof(10, "Azure pricing: Assigned retail price %f for SKU %s", item.RetailPrice, item.SkuName)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes inverted boolean logic in Azure pricing provider that was incorrectly assigning standard prices to spot instances and vice versa.

## Changes
- **File:** `pkg/cloud/azure/provider.go:292`
- **Fix:** Removed negation operator (`!`) from `strings.Contains(strings.ToLower(item.SkuName), " spot")`
- **Added:** Debug logging for price assignment verification

## Before
```go
if !strings.Contains(strings.ToLower(item.SkuName), " spot") {
    spotPrice = price  // WRONG: standard prices assigned to spot
} else {
    retailPrice = price  // WRONG: spot prices assigned to retail
}
````

## After

```go
if strings.Contains(strings.ToLower(item.SkuName), " spot") {
    spotPrice = price  // CORRECT: spot prices assigned to spot
} else {
    retailPrice = price  // CORRECT: standard prices assigned to retail
}
```

Fixes https://github.com/opencost/opencost/issues/3259