### PR TITLE
Azure: prioritize Azure Workload Identity over IMDS authentication

### DIFF
--- a/azure_auth_test.go
+++ b/azure_auth_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "github.com/opencost/opencost/pkg/cloud/azure"
+)
+
+func main() {
+    fmt.Println("Testing Azure authentication...")
+    
+    // Set up Workload Identity environment
+    os.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/test-token")
+    os.Setenv("AZURE_CLIENT_ID", "test-client-id")
+    os.Setenv("AZURE_TENANT_ID", "test-tenant-id")
+    
+    // Try to create credentials (this should trigger our logging)
+    holder := &azure.DefaultAzureCredentialHolder{}
+    _, err := holder.GetCredential()
+    if err != nil {
+        fmt.Printf("Error: %v\n", err)
+    } else {
+        fmt.Println("Credential creation successful")
+    }
+}

--- a/core/pkg/storage/azurestorage.go
+++ b/core/pkg/storage/azurestorage.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -469,8 +470,8 @@ func getContainerClient(conf AzureConfig) (*container.Client, error) {
 		msiOpt.ID = azidentity.ClientID(conf.UserAssignedID)
 		cred, err = azidentity.NewManagedIdentityCredential(msiOpt)
 	} else {
-		// Otherwise use Default Azure Credential
-		cred, err = azidentity.NewDefaultAzureCredential(nil)
+		// Otherwise use custom credential with Workload Identity prioritization
+		cred, err = newAzureCredentialWithWorkloadIdentity()
 	}
 
 	if err != nil {
@@ -483,4 +484,32 @@ func getContainerClient(conf AzureConfig) (*container.Client, error) {
 	}
 
 	return containerClient, nil
+}
+
+// newAzureCredentialWithWorkloadIdentity creates an Azure credential with Workload Identity prioritization
+func newAzureCredentialWithWorkloadIdentity() (azcore.TokenCredential, error) {
+	// Priority 1: Azure Workload Identity
+	if federatedTokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); federatedTokenFile != "" {
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
+		
+		if clientID != "" && tenantID != "" {
+			log.Infof("Azure Storage: Using Workload Identity authentication")
+			
+			return azidentity.NewClientAssertionCredential(tenantID, clientID, 
+				func(ctx context.Context) (string, error) {
+					tokenBytes, err := os.ReadFile(federatedTokenFile)
+					if err != nil {
+						return "", fmt.Errorf("failed to read federated token file: %w", err)
+					}
+					return string(tokenBytes), nil
+				}, nil)
+		} else {
+			log.Warnf("Azure Storage: AZURE_FEDERATED_TOKEN_FILE set but missing AZURE_CLIENT_ID or AZURE_TENANT_ID")
+		}
+	}
+	
+	// Priority 2: Fallback to DefaultAzureCredential
+	log.Infof("Azure Storage: Using DefaultAzureCredential authentication")
+	return azidentity.NewDefaultAzureCredential(nil)
 }

--- a/pkg/cloud/azure/authorizer.go
+++ b/pkg/cloud/azure/authorizer.go
@@ -1,10 +1,13 @@
 package azure
 
 import (
+	"context"
 	"fmt"
+	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/util/json"
 	"github.com/opencost/opencost/pkg/cloud"
 )
@@ -61,6 +64,34 @@ func (dac *DefaultAzureCredentialHolder) Sanitize() cloud.Config {
 }
 
 func (dac *DefaultAzureCredentialHolder) GetCredential() (azcore.TokenCredential, error) {
+	return newAzureCredentialWithWorkloadIdentity()
+}
+
+// newAzureCredentialWithWorkloadIdentity creates an Azure credential with Workload Identity prioritization
+func newAzureCredentialWithWorkloadIdentity() (azcore.TokenCredential, error) {
+	// Priority 1: Azure Workload Identity
+	if federatedTokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); federatedTokenFile != "" {
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
+		
+		if clientID != "" && tenantID != "" {
+			log.Infof("Azure: Using Workload Identity authentication")
+			
+			return azidentity.NewClientAssertionCredential(tenantID, clientID, 
+				func(ctx context.Context) (string, error) {
+					tokenBytes, err := os.ReadFile(federatedTokenFile)
+					if err != nil {
+						return "", fmt.Errorf("failed to read federated token file: %w", err)
+					}
+					return string(tokenBytes), nil
+				}, nil)
+		} else {
+			log.Warnf("Azure: AZURE_FEDERATED_TOKEN_FILE set but missing AZURE_CLIENT_ID or AZURE_TENANT_ID")
+		}
+	}
+	
+	// Priority 2: Fallback to DefaultAzureCredential
+	log.Infof("Azure: Using DefaultAzureCredential authentication")
 	return azidentity.NewDefaultAzureCredential(nil)
 }
 

--- a/pkg/filemanager/filemanager.go
+++ b/pkg/filemanager/filemanager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/opencost/opencost/core/pkg/log"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -60,12 +61,40 @@ type AzureBlobFile struct {
 }
 
 func NewAzureBlobFile(blobURL string) (*AzureBlobFile, error) {
-	credential, err := azidentity.NewDefaultAzureCredential(nil)
+	credential, err := newAzureCredentialWithWorkloadIdentity()
 	if err != nil {
 		return nil, err
 	}
 	client, err := blockblob.NewClient(blobURL, credential, nil)
 	return &AzureBlobFile{client: client}, err
+}
+
+// newAzureCredentialWithWorkloadIdentity creates an Azure credential with Workload Identity prioritization
+func newAzureCredentialWithWorkloadIdentity() (azcore.TokenCredential, error) {
+	// Priority 1: Azure Workload Identity
+	if federatedTokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); federatedTokenFile != "" {
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
+		
+		if clientID != "" && tenantID != "" {
+			log.Infof("Azure FileManager: Using Workload Identity authentication")
+			
+			return azidentity.NewClientAssertionCredential(tenantID, clientID, 
+				func(ctx context.Context) (string, error) {
+					tokenBytes, err := os.ReadFile(federatedTokenFile)
+					if err != nil {
+						return "", fmt.Errorf("failed to read federated token file: %w", err)
+					}
+					return string(tokenBytes), nil
+				}, nil)
+		} else {
+			log.Warnf("Azure FileManager: AZURE_FEDERATED_TOKEN_FILE set but missing AZURE_CLIENT_ID or AZURE_TENANT_ID")
+		}
+	}
+	
+	// Priority 2: Fallback to DefaultAzureCredential
+	log.Infof("Azure FileManager: Using DefaultAzureCredential authentication")
+	return azidentity.NewDefaultAzureCredential(nil)
 }
 
 func (a *AzureBlobFile) Download(ctx context.Context, f *os.File) error {


### PR DESCRIPTION
Fixes Azure Workload Identity authentication not being prioritized over IMDS, resolving "Identity not found" errors in AKS deployments.

## Problem
OpenCost ignores Workload Identity configuration and falls back to IMDS, causing:
adal: Refresh request failed. Status Code = '400'
Response body: {"error":"invalid_request","error_description":"Identity not found"}
Endpoint http://169.254.169.254/metadata/identity/oauth2/token

## Solution
- Check for Workload Identity env vars (`AZURE_FEDERATED_TOKEN_FILE`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`) first
- Use `ClientAssertionCredential` when available, fallback to `DefaultAzureCredential`
- Applied across authorizer, filemanager, and storage components

## Testing ✅
**Workload Identity Path ✅:**
```
$ # With Workload Identity environment variables set
$ go run azure_auth_check.go
Testing Azure authentication...
{"level":"info","time":"2025-07-31T19:27:07+05:30","message":"Azure: Using Workload Identity authentication"}
Credential creation successful
```
**Fallback Path ✅:**
```
$ # Without Workload Identity environment variables
$ go run azure_auth_fallback.go
Testing Azure authentication fallback...
{"level":"info","time":"2025-07-31T19:27:37+05:30","message":"Azure: Using DefaultAzureCredential authentication"}
Credential creation successful
```

## Impact
✅ Resolves IMDS fallback: No more 169.254.169.254 endpoint errors when Workload Identity is configured
✅ Maintains backward compatibility: Existing auth methods continue working
✅ Comprehensive logging: Clear visibility into which authentication method is selected
✅ Consistent implementation: Applied across all Azure authentication points (authorizer, filemanager, storage)

## Result
AKS deployments with Workload Identity will show `"Azure: Using Workload Identity authentication"` and authenticate successfully without IMDS fallback.

Fixes [#3188](https://github.com/opencost/opencost/issues/3188#issue-3129963184)