### PR TITLE
Add filters for diagnostics summary

### DIFF
--- a/core/pkg/filter/diagnostics/fields.go
+++ b/core/pkg/filter/diagnostics/fields.go
@@ -5,7 +5,7 @@ import (
 )
 
 // DiagnosticsField and DiagnosticsSummaryField are enums that represent Diagnostics-specific fields that can be
-// filtered on (cluster) and summary (cluster, provider, region, agent version)
+// filtered on (cluster for diagnostics	, cluster, provider, region, agent version for summary)
 type DiagnosticsField string
 type DiagnosticsSummaryField string
 
@@ -20,5 +20,5 @@ const (
 	FieldSummaryClusterID DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldClusterID)
 	FieldSummaryProvider  DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldProvider)
 	FieldSummaryRegion    DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldRegion)
-	FieldSummaryVersion   DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldAgentVersion)
+	FieldSummaryAgentVersion   DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldAgentVersion)
 )

--- a/core/pkg/filter/diagnostics/fields.go
+++ b/core/pkg/filter/diagnostics/fields.go
@@ -4,12 +4,21 @@ import (
 	"github.com/opencost/opencost/core/pkg/filter/fieldstrings"
 )
 
-// DiagnosticsField is an enum that represents Diagnostics-specific fields that can be
-// filtered on (cluster)
+// DiagnosticsField and DiagnosticsSummaryField are enums that represent Diagnostics-specific fields that can be
+// filtered on (cluster) and summary (cluster, provider, region, agent version)
 type DiagnosticsField string
+type DiagnosticsSummaryField string
 
 // If you add a DiagnosticsField, make sure to update field maps to return the correct
 // Diagnostic value does not enforce exhaustive pattern matching on "enum" types.
 const (
-	FieldClusterID  DiagnosticsField = DiagnosticsField(fieldstrings.FieldClusterID)
+	FieldClusterID DiagnosticsField = DiagnosticsField(fieldstrings.FieldClusterID)
+)
+
+// Field used for Diagnostics Summary filtering
+const (
+	FieldSummaryClusterID DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldClusterID)
+	FieldSummaryProvider  DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldProvider)
+	FieldSummaryRegion    DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldRegion)
+	FieldSummaryVersion   DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldAgentVersion)
 )

--- a/core/pkg/filter/diagnostics/fields.go
+++ b/core/pkg/filter/diagnostics/fields.go
@@ -20,5 +20,5 @@ const (
 	FieldSummaryClusterID DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldClusterID)
 	FieldSummaryProvider  DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldProvider)
 	FieldSummaryRegion    DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldRegion)
-	FieldSummaryAgentVersion   DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldAgentVersion)
+	FieldSummaryVersion   DiagnosticsSummaryField = DiagnosticsSummaryField(fieldstrings.FieldVersion)
 )

--- a/core/pkg/filter/diagnostics/parser.go
+++ b/core/pkg/filter/diagnostics/parser.go
@@ -13,7 +13,7 @@ var diagnosticsFilterFields []*ast.Field = []*ast.Field{
 
 // a slice of all the diagnostics summary field instances the lexer should recognize as
 // valid left-hand comparators
-var diagnosticsSummaryField []*ast.Field = []*ast.Field{
+var diagnosticsSummaryFilterFields []*ast.Field = []*ast.Field{
 	ast.NewField(FieldSummaryClusterID),
 	ast.NewField(FieldSummaryProvider),
 	ast.NewField(FieldSummaryRegion),
@@ -30,8 +30,8 @@ func init() {
 		ff := *f
 		fieldMap[DiagnosticsField(ff.Name)] = &ff
 	}
-	diagnosticsSummaryFieldMap = make(map[DiagnosticsSummaryField]*ast.Field, len(diagnosticsSummaryField))
-	for _, f := range diagnosticsSummaryField {
+	diagnosticsSummaryFieldMap = make(map[DiagnosticsSummaryField]*ast.Field, len(diagnosticsSummaryFilterFields))
+	for _, f := range diagnosticsSummaryFilterFields {
 		ff := *f
 		diagnosticsSummaryFieldMap[DiagnosticsSummaryField(ff.Name)] = &ff
 	}
@@ -62,7 +62,7 @@ func NewDiagnosticsFilterParser() ast.FilterParser {
 }
 
 func NewDiagnosticsSummaryFilterParser() ast.FilterParser {
-	return ast.NewFilterParser(diagnosticsSummaryField)
+	return ast.NewFilterParser(diagnosticsSummaryFilterFields)
 }
 
 // use initialization function to assign field types to the ops package helper for programatically

--- a/core/pkg/filter/diagnostics/parser.go
+++ b/core/pkg/filter/diagnostics/parser.go
@@ -17,7 +17,7 @@ var diagnosticsSummaryFilterFields []*ast.Field = []*ast.Field{
 	ast.NewField(FieldSummaryClusterID),
 	ast.NewField(FieldSummaryProvider),
 	ast.NewField(FieldSummaryRegion),
-	ast.NewField(FieldSummaryAgentVersion),
+	ast.NewField(FieldSummaryVersion),
 }
 
 // fieldMap is a lazily loaded mapping from DiagnosticsField to ast.Field

--- a/core/pkg/filter/diagnostics/parser.go
+++ b/core/pkg/filter/diagnostics/parser.go
@@ -1,6 +1,9 @@
 package diagnostics
 
-import "github.com/opencost/opencost/core/pkg/filter/ast"
+import (
+	"github.com/opencost/opencost/core/pkg/filter/ast"
+	"github.com/opencost/opencost/core/pkg/filter/ops"
+)
 
 // a slice of all the diagnostics field instances the lexer should recognize as
 // valid left-hand comparators
@@ -8,14 +11,29 @@ var diagnosticsFilterFields []*ast.Field = []*ast.Field{
 	ast.NewField(FieldClusterID),
 }
 
+// a slice of all the diagnostics summary field instances the lexer should recognize as
+// valid left-hand comparators
+var diagnosticsSummaryField []*ast.Field = []*ast.Field{
+	ast.NewField(FieldSummaryClusterID),
+	ast.NewField(FieldSummaryProvider),
+	ast.NewField(FieldSummaryRegion),
+	ast.NewField(FieldSummaryAgentVersion),
+}
+
 // fieldMap is a lazily loaded mapping from DiagnosticsField to ast.Field
 var fieldMap map[DiagnosticsField]*ast.Field
+var diagnosticsSummaryFieldMap map[DiagnosticsSummaryField]*ast.Field
 
 func init() {
 	fieldMap = make(map[DiagnosticsField]*ast.Field, len(diagnosticsFilterFields))
 	for _, f := range diagnosticsFilterFields {
 		ff := *f
 		fieldMap[DiagnosticsField(ff.Name)] = &ff
+	}
+	diagnosticsSummaryFieldMap = make(map[DiagnosticsSummaryField]*ast.Field, len(diagnosticsSummaryField))
+	for _, f := range diagnosticsSummaryField {
+		ff := *f
+		diagnosticsSummaryFieldMap[DiagnosticsSummaryField(ff.Name)] = &ff
 	}
 }
 
@@ -29,8 +47,27 @@ func DefaultFieldByName(field DiagnosticsField) *ast.Field {
 	return nil
 }
 
+func DefaultSummaryFieldByName(field DiagnosticsSummaryField) *ast.Field {
+	if af, ok := diagnosticsSummaryFieldMap[field]; ok {
+		afcopy := *af
+		return &afcopy
+	}
+	return nil
+}
+
 // NewDiagnosticFilterParser creates a new `ast.FilterParser` implementation
 // which uses diagnostics specific fields
 func NewDiagnosticsFilterParser() ast.FilterParser {
 	return ast.NewFilterParser(diagnosticsFilterFields)
+}
+
+func NewDiagnosticsSummaryFilterParser() ast.FilterParser {
+	return ast.NewFilterParser(diagnosticsSummaryField)
+}
+
+// use initialization function to assign field types to the ops package helper for programatically
+// building v2.1 filters
+func init() {
+	ops.RegisterDefaultFieldLookup(DefaultFieldByName)
+	ops.RegisterDefaultFieldLookup(DefaultSummaryFieldByName)
 }

--- a/core/pkg/filter/fieldstrings/fieldstrings.go
+++ b/core/pkg/filter/fieldstrings/fieldstrings.go
@@ -34,8 +34,8 @@ const (
 	FieldRegionID          string = "regionID"
 	FieldAvailabilityZone  string = "availabilityZone"
 
-	FieldAgentVersion string = "agentVersion"
-	FieldRegion       string = "region"
+	FieldVersion string = "version"
+	FieldRegion  string = "region"
 
 	AliasDepartment  string = "department"
 	AliasEnvironment string = "environment"

--- a/core/pkg/filter/fieldstrings/fieldstrings.go
+++ b/core/pkg/filter/fieldstrings/fieldstrings.go
@@ -34,6 +34,9 @@ const (
 	FieldRegionID          string = "regionID"
 	FieldAvailabilityZone  string = "availabilityZone"
 
+	FieldAgentVersion string = "agentVersion"
+	FieldRegion       string = "region"
+
 	AliasDepartment  string = "department"
 	AliasEnvironment string = "environment"
 	AliasOwner       string = "owner"


### PR DESCRIPTION
## What does this PR change?
* Add diagnostics summary filter
* add missing `ops.RegisterDefaultFieldLookup`

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* users will have access to filtering diagnostics summary by cluster, agentVersion, region and provider

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Locally runng the aggregator with these opencost changes

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 