### PR TITLE
Fix inconsistency in timestamp usage within metric repository

### DIFF
--- a/modules/collector-source/pkg/metric/repository.go
+++ b/modules/collector-source/pkg/metric/repository.go
@@ -75,7 +75,7 @@ func (r *MetricRepository) Coverage() map[string][]time.Time {
 	for resKey, resCollector := range r.resolutionStores {
 		var windowStarts []time.Time
 		for _, key := range resCollector.getKeys() {
-			windowStarts = append(windowStarts, time.Unix(key, 0).UTC())
+			windowStarts = append(windowStarts, time.UnixMilli(key).UTC())
 		}
 		result[resKey] = windowStarts
 	}


### PR DESCRIPTION
## What does this PR change?
* Coverage method was incorrectly building times in seconds from a millis representation

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* N/A?

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Ran aspects of this locally, valid timestamps are now generated

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 