### PR TITLE
Fix: Update TLS MinVersion in nodeclientconfig.go

### DIFF
--- a/pkg/costmodel/nodeclientconfig.go
+++ b/pkg/costmodel/nodeclientconfig.go
@@ -59,12 +59,14 @@ func NewNodeClientConfigFromEnv() (*nodes.NodeClientConfig, error) {
 			tlsConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				RootCAs:      caCertPool,
+				MinVersion:   tls.VersionTLS12,
 			}
 
 			transport = &http.Transport{TLSClientConfig: tlsConfig}
 		} else {
 			tlsConfig := &tls.Config{
 				RootCAs: caCertPool,
+				MinVersion:   tls.VersionTLS12,
 			}
 			transport = &http.Transport{TLSClientConfig: tlsConfig}
 		}


### PR DESCRIPTION
Updated TLS configurations in pkg/costmodel/nodeclientconfig.go to enforce a minimum TLS version of 1.2. This addresses security vulnerabilities related to using outdated TLS protocols.

Closes https://github.com/opencost/opencost/issues/3291