### PR TITLE
add name method for storage

### DIFF
--- a/core/pkg/storage/clusterstorage.go
+++ b/core/pkg/storage/clusterstorage.go
@@ -164,6 +164,10 @@ func (c *ClusterStorage) check() error {
 	return nil
 }
 
+func (c *ClusterStorage) Name() string {
+	return fmt.Sprintf("%s:%d", c.host, c.port)
+}
+
 func (c *ClusterStorage) StorageType() StorageType {
 	return StorageTypeCluster
 }

--- a/core/pkg/storage/filestorage.go
+++ b/core/pkg/storage/filestorage.go
@@ -22,6 +22,10 @@ func NewFileStorage(baseDir string) Storage {
 	return &FileStorage{baseDir}
 }
 
+func (fs *FileStorage) Name() string {
+	return fs.baseDir
+}
+
 // StorageType returns a string identifier for the type of storage used by the implementation.
 func (fs *FileStorage) StorageType() StorageType {
 	return StorageTypeFile

--- a/core/pkg/storage/memorystorage.go
+++ b/core/pkg/storage/memorystorage.go
@@ -25,6 +25,10 @@ func NewMemoryStorage() *MemoryStorage {
 	}
 }
 
+func (ms *MemoryStorage) Name() string {
+	return "memory"
+}
+
 // StorageType returns a string identifier for the type of storage used by the implementation.
 func (ms *MemoryStorage) StorageType() StorageType {
 	return StorageTypeMemory

--- a/core/pkg/storage/prefixedbucketstorage.go
+++ b/core/pkg/storage/prefixedbucketstorage.go
@@ -43,6 +43,10 @@ func withPrefix(prefix, name string) string {
 	return prefix + DirDelim + name
 }
 
+func (pbs *PrefixedBucketStorage) Name() string {
+	return pbs.storage.Name()
+}
+
 func (pbs *PrefixedBucketStorage) StorageType() StorageType {
 	return pbs.storage.StorageType()
 }

--- a/core/pkg/storage/storage.go
+++ b/core/pkg/storage/storage.go
@@ -24,6 +24,7 @@ type StorageInfo struct {
 
 // Storage provides an API for storing binary data
 type Storage interface {
+	Name() string
 	// StorageType returns a string identifier for the type of storage used by the implementation.
 	StorageType() StorageType
 
@@ -70,6 +71,12 @@ func Validate(storage Storage) error {
 	_, err := storage.Exists(testPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to check if path exists")
+	}
+
+	// attempt to list a path
+	_, err = storage.List(testPath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to list path")
 	}
 
 	// attempt to write a path


### PR DESCRIPTION
## What does this PR change?
* Few of the storage types like s3, gcs already have Name method. I have added it for all storage types. 
* We would be able to log the name of the storage present at the start 

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/3604

## How will this PR impact users?
* We would be able to log storage name like the s3 or GCS bucket name.

## Does this PR address any GitHub or Zendesk issues?
* https://apptio.atlassian.net/browse/KCM-4388

## How was this PR tested?
* Ran go test ./... locally

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 