### PR TITLE
Remove superfluous write header

### DIFF
--- a/core/pkg/protocol/http.go
+++ b/core/pkg/protocol/http.go
@@ -121,8 +121,6 @@ func (hp HTTPProtocol) WriteRawNoContent(w http.ResponseWriter) {
 // xss CWE as well as backwards compatibility to exisitng FE expectations
 func (hp HTTPProtocol) WriteJSONData(w http.ResponseWriter, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
-	status := http.StatusOK
-	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		log.Error("Failed to encode JSON response: " + err.Error())
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## What does this PR change?
* This PR removes a superflous call to write header which was causing logs such as these
<img width="2338" height="462" alt="image" src="https://github.com/user-attachments/assets/4a20fca3-2e95-4104-81ca-0c35eb5eef96" />
When json encoding fails write header is called twice.
The description for WriteHeader in the interface definition states that 

> If WriteHeader is not called explicitly, the first call to Write
will trigger an implicit WriteHeader(http.StatusOK). 
thus explicit calls to WriteHeader are mainly used to
send error codes or 1xx informational responses.

There is a call to `Write` in the decode so writing the 200 code is unnecessary.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 