### PR TITLE
refactor(costmodel): Accumulate AllocationSets iteratively

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -38,15 +38,26 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 	}
 
 	// If the duration exceeds the configured MaxPrometheusQueryDuration, then
-	// query for maximum-sized AllocationSets, collect them, and accumulate.
+	// query for maximum-sized AllocationSets, and accumulate as we go.
 
 	// s and e track the coverage of the entire given window over multiple
 	// internal queries.
 	s, e := start, start
 
-	// Collect AllocationSets in a range, then accumulate
-	// TODO optimize by collecting consecutive AllocationSets, accumulating as we go
-	asr := opencost.NewAllocationSetRange()
+	// result is the accumulating AllocationSet
+	var result *opencost.AllocationSet
+
+	// Populate annotations, labels, and services on each Allocation. This is
+	// necessary because AllocationSet.Merge does not propagate any values
+	// stored in maps or slices for performance reasons. In this case, however,
+	// it is both acceptable and necessary to do so.
+	allocationAnnotations := map[string]map[string]string{}
+	allocationLabels := map[string]map[string]string{}
+	allocationServices := map[string]map[string]bool{}
+
+	// Also record errors and warnings, then append them to the results later.
+	errors := []string{}
+	warnings := []string{}
 
 	for e.Before(end) {
 		// By default, query for the full remaining duration. But do not let
@@ -66,26 +77,22 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 			return opencost.NewAllocationSet(start, end), fmt.Errorf("error computing allocation for %s: %s", opencost.NewClosedWindow(s, e), err)
 		}
 
-		// Append to the range
-		asr.Append(as)
+		if as == nil {
+			s = e
+			continue
+		}
 
-		// Set s equal to e to set up the next query, if one exists.
-		s = e
-	}
+		// On the first successful computation, set the result, otherwise accumulate
+		if result == nil {
+			result = as
+		} else {
+			acc, err := result.Accumulate(as)
+			if err != nil {
+				return opencost.NewAllocationSet(start, end), fmt.Errorf("error accumulating allocation sets for %s: %w", opencost.NewClosedWindow(s, e), err)
+			}
+			result = acc
+		}
 
-	// Populate annotations, labels, and services on each Allocation. This is
-	// necessary because Properties.Intersection does not propagate any values
-	// stored in maps or slices for performance reasons. In this case, however,
-	// it is both acceptable and necessary to do so.
-	allocationAnnotations := map[string]map[string]string{}
-	allocationLabels := map[string]map[string]string{}
-	allocationServices := map[string]map[string]bool{}
-
-	// Also record errors and warnings, then append them to the results later.
-	errors := []string{}
-	warnings := []string{}
-
-	for _, as := range asr.Allocations {
 		for k, a := range as.Allocations {
 			if len(a.Properties.Annotations) > 0 {
 				if _, ok := allocationAnnotations[k]; !ok {
@@ -113,26 +120,55 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 					allocationServices[k][val] = true
 				}
 			}
+
+			// Maintain RAM and CPU max usage values by iterating over the range,
+			// computing maximums on a rolling basis, and setting on the result set.
+			// This is necessary because RawAllocationOnly data is cleared when
+			// allocations are added together.
+			resultAlloc := result.Get(k)
+			if resultAlloc == nil {
+				continue
+			}
+
+			if resultAlloc.RawAllocationOnly == nil {
+				resultAlloc.RawAllocationOnly = &opencost.RawAllocationOnlyData{}
+			}
+
+			if a.RawAllocationOnly == nil {
+				// This will happen inevitably for unmounted disks, but should
+				// ideally not happen for any allocation with CPU and RAM data.
+				if !a.IsUnmounted() {
+					log.DedupedWarningf(10, "ComputeAllocation: raw allocation data missing for %s", k)
+				}
+				continue
+			}
+
+			if a.RawAllocationOnly.CPUCoreUsageMax > resultAlloc.RawAllocationOnly.CPUCoreUsageMax {
+				resultAlloc.RawAllocationOnly.CPUCoreUsageMax = a.RawAllocationOnly.CPUCoreUsageMax
+			}
+
+			if a.RawAllocationOnly.RAMBytesUsageMax > resultAlloc.RawAllocationOnly.RAMBytesUsageMax {
+				resultAlloc.RawAllocationOnly.RAMBytesUsageMax = a.RawAllocationOnly.RAMBytesUsageMax
+			}
+
+			if a.RawAllocationOnly.GPUUsageMax != nil && resultAlloc.RawAllocationOnly.GPUUsageMax != nil {
+				if *a.RawAllocationOnly.GPUUsageMax > *resultAlloc.RawAllocationOnly.GPUUsageMax {
+					resultAlloc.RawAllocationOnly.GPUUsageMax = a.RawAllocationOnly.GPUUsageMax
+				}
+			}
 		}
 
 		errors = append(errors, as.Errors...)
 		warnings = append(warnings, as.Warnings...)
+
+		// Set s equal to e to set up the next query, if one exists.
+		s = e
 	}
 
-	// Accumulate to yield the result AllocationSet. After this step, we will
-	// be nearly complete, but without the raw allocation data, which must be
-	// recomputed.
-	resultASR, err := asr.Accumulate(opencost.AccumulateOptionAll)
-	if err != nil {
-		return opencost.NewAllocationSet(start, end), fmt.Errorf("error accumulating data for %s: %s", opencost.NewClosedWindow(s, e), err)
-	}
-	if resultASR != nil && len(resultASR.Allocations) == 0 {
+	// If there were no results, return an empty AllocationSet
+	if result == nil {
 		return opencost.NewAllocationSet(start, end), nil
 	}
-	if length := len(resultASR.Allocations); length != 1 {
-		return opencost.NewAllocationSet(start, end), fmt.Errorf("expected 1 accumulated allocation set, found %d sets", length)
-	}
-	result := resultASR.Allocations[0]
 
 	// Apply the annotations, labels, and services to the post-accumulation
 	// results. (See above for why this is necessary.)
@@ -156,45 +192,6 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 		// to match the Window of the AllocationSet, which gets expanded
 		// at the end of this function.
 		a.Window = a.Window.ExpandStart(start).ExpandEnd(end)
-	}
-
-	// Maintain RAM and CPU max usage values by iterating over the range,
-	// computing maximums on a rolling basis, and setting on the result set.
-	for _, as := range asr.Allocations {
-		for key, alloc := range as.Allocations {
-			resultAlloc := result.Get(key)
-			if resultAlloc == nil {
-				continue
-			}
-
-			if resultAlloc.RawAllocationOnly == nil {
-				resultAlloc.RawAllocationOnly = &opencost.RawAllocationOnlyData{}
-			}
-
-			if alloc.RawAllocationOnly == nil {
-				// This will happen inevitably for unmounted disks, but should
-				// ideally not happen for any allocation with CPU and RAM data.
-				if !alloc.IsUnmounted() {
-					log.DedupedWarningf(10, "ComputeAllocation: raw allocation data missing for %s", key)
-				}
-				continue
-			}
-
-			if alloc.RawAllocationOnly.CPUCoreUsageMax > resultAlloc.RawAllocationOnly.CPUCoreUsageMax {
-				resultAlloc.RawAllocationOnly.CPUCoreUsageMax = alloc.RawAllocationOnly.CPUCoreUsageMax
-			}
-
-			if alloc.RawAllocationOnly.RAMBytesUsageMax > resultAlloc.RawAllocationOnly.RAMBytesUsageMax {
-				resultAlloc.RawAllocationOnly.RAMBytesUsageMax = alloc.RawAllocationOnly.RAMBytesUsageMax
-			}
-
-			if alloc.RawAllocationOnly.GPUUsageMax != nil && resultAlloc.RawAllocationOnly.GPUUsageMax != nil {
-				if *alloc.RawAllocationOnly.GPUUsageMax > *resultAlloc.RawAllocationOnly.GPUUsageMax {
-					resultAlloc.RawAllocationOnly.GPUUsageMax = alloc.RawAllocationOnly.GPUUsageMax
-				}
-			}
-
-		}
 	}
 
 	// Expand the window to match the queried time range.

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -37,7 +37,7 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 		return as, err
 	}
 
-	// If the duration exceeds the configured MaxPrometheusQueryDuration, then
+	// If the duration exceeds the configured BatchDuration, then
 	// query for maximum-sized AllocationSets, and accumulate as we go.
 
 	// s and e track the coverage of the entire given window over multiple

--- a/pkg/costmodel/allocation_bench_test.go
+++ b/pkg/costmodel/allocation_bench_test.go
@@ -1,0 +1,209 @@
+package costmodel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+// createTestAllocationSets creates N AllocationSets for benchmarking
+func createTestAllocationSets(n int, allocsPerSet int) []*opencost.AllocationSet {
+	sets := make([]*opencost.AllocationSet, n)
+	baseTime := time.Now().Truncate(time.Hour)
+
+	for i := 0; i < n; i++ {
+		start := baseTime.Add(time.Duration(i) * time.Hour)
+		end := start.Add(time.Hour)
+		as := opencost.NewAllocationSet(start, end)
+
+		// Create multiple allocations within each set
+		for j := 0; j < allocsPerSet; j++ {
+			podName := fmt.Sprintf("pod-%d", j)
+			alloc := &opencost.Allocation{
+				Name: podName,
+				Properties: &opencost.AllocationProperties{
+					Cluster:   "cluster-1",
+					Namespace: "namespace-1",
+					Pod:       podName,
+				},
+				Start:  start,
+				End:    end,
+				Window: opencost.NewClosedWindow(start, end),
+			}
+
+			// Set some cost values
+			hours := end.Sub(start).Hours()
+			cpuCost := float64(j+1) * 0.05 * hours
+			ramCost := float64(j+1) * 0.03 * hours
+			alloc.CPUCost = cpuCost
+			alloc.RAMCost = ramCost
+			alloc.CPUCoreHours = float64(j+1) * 0.5 * hours
+			alloc.RAMByteHours = float64(j+1) * 1024 * 1024 * 100 * hours
+
+			// Set raw allocation data for max usage tracking
+			alloc.RawAllocationOnly = &opencost.RawAllocationOnlyData{
+				CPUCoreUsageMax:  float64(j+1) * 0.5,
+				RAMBytesUsageMax: float64(j+1) * 1024 * 1024 * 100, // 100MB base
+			}
+
+			as.Insert(alloc)
+		}
+
+		sets[i] = as
+	}
+
+	return sets
+}
+
+// accumulateIteratively simulates the new approach: accumulate as we go
+func accumulateIteratively(sets []*opencost.AllocationSet) (*opencost.AllocationSet, error) {
+	var result *opencost.AllocationSet
+
+	for _, as := range sets {
+		if as == nil {
+			continue
+		}
+
+		if result == nil {
+			result = as
+		} else {
+			acc, err := result.Accumulate(as)
+			if err != nil {
+				return nil, err
+			}
+			result = acc
+		}
+	}
+
+	return result, nil
+}
+
+// accumulateViaRange simulates the old approach: collect in range, then accumulate
+func accumulateViaRange(sets []*opencost.AllocationSet) (*opencost.AllocationSet, error) {
+	asr := opencost.NewAllocationSetRange(sets...)
+
+	resultASR, err := asr.Accumulate(opencost.AccumulateOptionAll)
+	if err != nil {
+		return nil, err
+	}
+
+	if resultASR == nil || len(resultASR.Allocations) == 0 {
+		return nil, nil
+	}
+
+	return resultASR.Allocations[0], nil
+}
+
+// BenchmarkAccumulateIteratively_10Sets benchmarks the new iterative approach with 10 sets
+func BenchmarkAccumulateIteratively_10Sets(b *testing.B) {
+	sets := createTestAllocationSets(10, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateIteratively(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateViaRange_10Sets benchmarks the old range-based approach with 10 sets
+func BenchmarkAccumulateViaRange_10Sets(b *testing.B) {
+	sets := createTestAllocationSets(10, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateViaRange(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateIteratively_50Sets benchmarks the new iterative approach with 50 sets
+func BenchmarkAccumulateIteratively_50Sets(b *testing.B) {
+	sets := createTestAllocationSets(50, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateIteratively(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateViaRange_50Sets benchmarks the old range-based approach with 50 sets
+func BenchmarkAccumulateViaRange_50Sets(b *testing.B) {
+	sets := createTestAllocationSets(50, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateViaRange(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateIteratively_100Sets benchmarks the new iterative approach with 100 sets
+func BenchmarkAccumulateIteratively_100Sets(b *testing.B) {
+	sets := createTestAllocationSets(100, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateIteratively(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateViaRange_100Sets benchmarks the old range-based approach with 100 sets
+func BenchmarkAccumulateViaRange_100Sets(b *testing.B) {
+	sets := createTestAllocationSets(100, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateViaRange(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateIteratively_500Sets benchmarks the new iterative approach with 500 sets (large time range)
+func BenchmarkAccumulateIteratively_500Sets(b *testing.B) {
+	sets := createTestAllocationSets(500, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateIteratively(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAccumulateViaRange_500Sets benchmarks the old range-based approach with 500 sets (large time range)
+func BenchmarkAccumulateViaRange_500Sets(b *testing.B) {
+	sets := createTestAllocationSets(500, 50)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := accumulateViaRange(sets)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* Refactored to accumulate objects iteratively, reducing memory usage for large time ranges.

The previous implementation collected all objects into a slice before accumulating them. This change processes each object within the loop, avoiding the need to store all sets in memory at once.

This optimization has also been applied to the same function in the build for consistency.


## How will this PR impact users?
* Users will experience reduced memory usage when handling large time ranges.
* Improves performance and stability in scenarios with high data volume.
* No breaking changes to the API or output.


## How was this PR tested?
* Ran `go test ./...` to execute all tests recursively and confirm no regressions.
