### PR TITLE
 Add comprehensive unit tests for AWS Athena helper functions

### DIFF
--- a/pkg/cloud/aws/athenaconfiguration_test.go
+++ b/pkg/cloud/aws/athenaconfiguration_test.go
@@ -669,3 +669,189 @@ func TestAthenaConfiguration_JSON(t *testing.T) {
 		})
 	}
 }
+
+func TestAthenaConfiguration_Sanitize(t *testing.T) {
+	testCases := map[string]struct {
+		config   AthenaConfiguration
+		expected AthenaConfiguration
+	}{
+		"sanitize with access key": {
+			config: AthenaConfiguration{
+				Bucket:    "test-bucket",
+				Region:    "us-west-2",
+				Database:  "test-db",
+				Catalog:   "test-catalog",
+				Table:     "test-table",
+				Workgroup: "test-workgroup",
+				Account:   "123456789012",
+				Authorizer: &AccessKey{
+					ID:     "test-id",
+					Secret: "test-secret",
+				},
+			},
+			expected: AthenaConfiguration{
+				Bucket:    "test-bucket",
+				Region:    "us-west-2",
+				Database:  "test-db",
+				Catalog:   "test-catalog",
+				Table:     "test-table",
+				Workgroup: "test-workgroup",
+				Account:   "123456789012",
+				Authorizer: &AccessKey{
+					ID:     "test-id",
+					Secret: "test-secret",
+				},
+			},
+		},
+		"sanitize with service account": {
+			config: AthenaConfiguration{
+				Bucket:     "test-bucket",
+				Region:     "us-east-1",
+				Database:   "test-db",
+				Table:      "test-table",
+				Workgroup:  "test-workgroup",
+				Account:    "123456789012",
+				Authorizer: &ServiceAccount{},
+			},
+			expected: AthenaConfiguration{
+				Bucket:     "test-bucket",
+				Region:     "us-east-1",
+				Database:   "test-db",
+				Table:      "test-table",
+				Workgroup:  "test-workgroup",
+				Account:    "123456789012",
+				Authorizer: &ServiceAccount{},
+			},
+		},
+		"sanitize with assume role": {
+			config: AthenaConfiguration{
+				Bucket:    "test-bucket",
+				Region:    "eu-west-1",
+				Database:  "test-db",
+				Table:     "test-table",
+				Workgroup: "test-workgroup",
+				Account:   "123456789012",
+				Authorizer: &AssumeRole{
+					Authorizer: &ServiceAccount{},
+					RoleARN:    "arn:aws:iam::123456789012:role/test-role",
+				},
+			},
+			expected: AthenaConfiguration{
+				Bucket:    "test-bucket",
+				Region:    "eu-west-1",
+				Database:  "test-db",
+				Table:     "test-table",
+				Workgroup: "test-workgroup",
+				Account:   "123456789012",
+				Authorizer: &AssumeRole{
+					Authorizer: &ServiceAccount{},
+					RoleARN:    "arn:aws:iam::123456789012:role/test-role",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := testCase.config.Sanitize()
+			
+			// Type assert the result
+			athenaConfig, ok := result.(*AthenaConfiguration)
+			if !ok {
+				t.Fatalf("expected *AthenaConfiguration, got %T", result)
+			}
+
+			// Compare the sanitized config with expected
+			if athenaConfig.Bucket != testCase.expected.Bucket {
+				t.Errorf("Bucket mismatch: got %s, want %s", athenaConfig.Bucket, testCase.expected.Bucket)
+			}
+			if athenaConfig.Region != testCase.expected.Region {
+				t.Errorf("Region mismatch: got %s, want %s", athenaConfig.Region, testCase.expected.Region)
+			}
+			if athenaConfig.Database != testCase.expected.Database {
+				t.Errorf("Database mismatch: got %s, want %s", athenaConfig.Database, testCase.expected.Database)
+			}
+			if athenaConfig.Catalog != testCase.expected.Catalog {
+				t.Errorf("Catalog mismatch: got %s, want %s", athenaConfig.Catalog, testCase.expected.Catalog)
+			}
+			if athenaConfig.Table != testCase.expected.Table {
+				t.Errorf("Table mismatch: got %s, want %s", athenaConfig.Table, testCase.expected.Table)
+			}
+			if athenaConfig.Workgroup != testCase.expected.Workgroup {
+				t.Errorf("Workgroup mismatch: got %s, want %s", athenaConfig.Workgroup, testCase.expected.Workgroup)
+			}
+			if athenaConfig.Account != testCase.expected.Account {
+				t.Errorf("Account mismatch: got %s, want %s", athenaConfig.Account, testCase.expected.Account)
+			}
+			
+			// Verify that the authorizer was also sanitized
+			if athenaConfig.Authorizer == nil {
+				t.Error("Authorizer should not be nil after sanitization")
+			}
+		})
+	}
+}
+
+func TestAthenaConfiguration_Provider(t *testing.T) {
+	config := AthenaConfiguration{
+		Bucket:     "test-bucket",
+		Region:     "us-west-2",
+		Database:   "test-db",
+		Table:      "test-table",
+		Workgroup:  "test-workgroup",
+		Account:    "123456789012",
+		Authorizer: &ServiceAccount{},
+	}
+
+	provider := config.Provider()
+	expectedProvider := "AWS"
+	
+	if provider != expectedProvider {
+		t.Errorf("Provider() returned %s, expected %s", provider, expectedProvider)
+	}
+}
+
+func TestAthenaConfiguration_Key(t *testing.T) {
+	testCases := map[string]struct {
+		config   AthenaConfiguration
+		expected string
+	}{
+		"standard key": {
+			config: AthenaConfiguration{
+				Account: "123456789012",
+				Bucket:  "test-bucket",
+			},
+			expected: "123456789012/test-bucket",
+		},
+		"empty account": {
+			config: AthenaConfiguration{
+				Account: "",
+				Bucket:  "test-bucket",
+			},
+			expected: "/test-bucket",
+		},
+		"empty bucket": {
+			config: AthenaConfiguration{
+				Account: "123456789012",
+				Bucket:  "",
+			},
+			expected: "123456789012/",
+		},
+		"both empty": {
+			config: AthenaConfiguration{
+				Account: "",
+				Bucket:  "",
+			},
+			expected: "/",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := testCase.config.Key()
+			if result != testCase.expected {
+				t.Errorf("Key() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/cloud/aws/athenaintegration_test.go
+++ b/pkg/cloud/aws/athenaintegration_test.go
@@ -388,6 +388,387 @@ func Test_athenaRowToCloudCost(t *testing.T) {
 	}
 }
 
+func TestAthenaIntegration_GetListCostColumn(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	result := ai.GetListCostColumn()
+
+	expected := "SUM(CASE line_item_line_item_type WHEN 'EdpDiscount' THEN 0 WHEN 'PrivateRateDiscount' THEN 0 ELSE line_item_unblended_cost END) as list_cost"
+
+	if result != expected {
+		t.Errorf("GetListCostColumn() returned %s, expected %s", result, expected)
+	}
+}
+
+func TestAthenaIntegration_GetNetCostColumn(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		allColumns map[string]bool
+		expected   string
+	}{
+		"with net pricing column": {
+			allColumns: map[string]bool{
+				"line_item_net_unblended_cost": true,
+			},
+			expected: "SUM(COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0)) as net_cost",
+		},
+		"without net pricing column": {
+			allColumns: map[string]bool{
+				"line_item_net_unblended_cost": false,
+			},
+			expected: "SUM(line_item_unblended_cost) as net_cost",
+		},
+		"empty columns map": {
+			allColumns: map[string]bool{},
+			expected:   "SUM(line_item_unblended_cost) as net_cost",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := ai.GetNetCostColumn(testCase.allColumns)
+			if result != testCase.expected {
+				t.Errorf("GetNetCostColumn() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestAthenaIntegration_GetAmortizedCostColumn(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		allColumns map[string]bool
+		expected   string
+	}{
+		"with RI and SP columns": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               true,
+				"savings_plan_savings_plan_effective_cost": true,
+			},
+			expected: "SUM(CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN reservation_effective_cost WHEN 'SavingsPlanCoveredUsage' THEN savings_plan_savings_plan_effective_cost ELSE line_item_unblended_cost END) as amortized_cost",
+		},
+		"with only RI column": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               true,
+				"savings_plan_savings_plan_effective_cost": false,
+			},
+			expected: "SUM(CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN reservation_effective_cost ELSE line_item_unblended_cost END) as amortized_cost",
+		},
+		"with only SP column": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               false,
+				"savings_plan_savings_plan_effective_cost": true,
+			},
+			expected: "SUM(CASE line_item_line_item_type WHEN 'SavingsPlanCoveredUsage' THEN savings_plan_savings_plan_effective_cost ELSE line_item_unblended_cost END) as amortized_cost",
+		},
+		"without RI or SP columns": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               false,
+				"savings_plan_savings_plan_effective_cost": false,
+			},
+			expected: "SUM(line_item_unblended_cost) as amortized_cost",
+		},
+		"empty columns map": {
+			allColumns: map[string]bool{},
+			expected:   "SUM(line_item_unblended_cost) as amortized_cost",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := ai.GetAmortizedCostColumn(testCase.allColumns)
+			if result != testCase.expected {
+				t.Errorf("GetAmortizedCostColumn() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestAthenaIntegration_GetAmortizedNetCostColumn(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		allColumns map[string]bool
+		expected   string
+	}{
+		"with net pricing and RI/SP columns": {
+			allColumns: map[string]bool{
+				"line_item_net_unblended_cost":                 true,
+				"reservation_net_effective_cost":               true,
+				"savings_plan_net_savings_plan_effective_cost": true,
+			},
+			expected: "SUM(CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN COALESCE(reservation_net_effective_cost, reservation_effective_cost, 0) WHEN 'SavingsPlanCoveredUsage' THEN COALESCE(savings_plan_net_savings_plan_effective_cost, savings_plan_savings_plan_effective_cost, 0) ELSE COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0) END) as amortized_net_cost",
+		},
+		"with net pricing but no RI/SP columns": {
+			allColumns: map[string]bool{
+				"line_item_net_unblended_cost":                 true,
+				"reservation_net_effective_cost":               false,
+				"savings_plan_net_savings_plan_effective_cost": false,
+			},
+			expected: "SUM(COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0)) as amortized_net_cost",
+		},
+		"without net pricing": {
+			allColumns: map[string]bool{
+				"line_item_net_unblended_cost": false,
+			},
+			expected: "SUM(line_item_unblended_cost) as amortized_net_cost",
+		},
+		"empty columns map": {
+			allColumns: map[string]bool{},
+			expected:   "SUM(line_item_unblended_cost) as amortized_net_cost",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := ai.GetAmortizedNetCostColumn(testCase.allColumns)
+			if result != testCase.expected {
+				t.Errorf("GetAmortizedNetCostColumn() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestAthenaIntegration_GetAmortizedCostCase(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		allColumns map[string]bool
+		expected   string
+	}{
+		"with RI and SP columns": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               true,
+				"savings_plan_savings_plan_effective_cost": true,
+			},
+			expected: "CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN reservation_effective_cost WHEN 'SavingsPlanCoveredUsage' THEN savings_plan_savings_plan_effective_cost ELSE line_item_unblended_cost END",
+		},
+		"with only RI column": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               true,
+				"savings_plan_savings_plan_effective_cost": false,
+			},
+			expected: "CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN reservation_effective_cost ELSE line_item_unblended_cost END",
+		},
+		"with only SP column": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               false,
+				"savings_plan_savings_plan_effective_cost": true,
+			},
+			expected: "CASE line_item_line_item_type WHEN 'SavingsPlanCoveredUsage' THEN savings_plan_savings_plan_effective_cost ELSE line_item_unblended_cost END",
+		},
+		"without RI or SP columns": {
+			allColumns: map[string]bool{
+				"reservation_effective_cost":               false,
+				"savings_plan_savings_plan_effective_cost": false,
+			},
+			expected: "line_item_unblended_cost",
+		},
+		"empty columns map": {
+			allColumns: map[string]bool{},
+			expected:   "line_item_unblended_cost",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := ai.GetAmortizedCostCase(testCase.allColumns)
+			if result != testCase.expected {
+				t.Errorf("GetAmortizedCostCase() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestAthenaIntegration_GetAmortizedNetCostCase(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		allColumns map[string]bool
+		expected   string
+	}{
+		"with net RI and SP columns": {
+			allColumns: map[string]bool{
+				"reservation_net_effective_cost":               true,
+				"savings_plan_net_savings_plan_effective_cost": true,
+			},
+			expected: "CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN COALESCE(reservation_net_effective_cost, reservation_effective_cost, 0) WHEN 'SavingsPlanCoveredUsage' THEN COALESCE(savings_plan_net_savings_plan_effective_cost, savings_plan_savings_plan_effective_cost, 0) ELSE COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0) END",
+		},
+		"with only net RI column": {
+			allColumns: map[string]bool{
+				"reservation_net_effective_cost":               true,
+				"savings_plan_net_savings_plan_effective_cost": false,
+			},
+			expected: "CASE line_item_line_item_type WHEN 'DiscountedUsage' THEN COALESCE(reservation_net_effective_cost, reservation_effective_cost, 0) ELSE COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0) END",
+		},
+		"with only net SP column": {
+			allColumns: map[string]bool{
+				"reservation_net_effective_cost":               false,
+				"savings_plan_net_savings_plan_effective_cost": true,
+			},
+			expected: "CASE line_item_line_item_type WHEN 'SavingsPlanCoveredUsage' THEN COALESCE(savings_plan_net_savings_plan_effective_cost, savings_plan_savings_plan_effective_cost, 0) ELSE COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0) END",
+		},
+		"without net RI or SP columns": {
+			allColumns: map[string]bool{
+				"reservation_net_effective_cost":               false,
+				"savings_plan_net_savings_plan_effective_cost": false,
+			},
+			expected: "COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0)",
+		},
+		"empty columns map": {
+			allColumns: map[string]bool{},
+			expected:   "COALESCE(line_item_net_unblended_cost, line_item_unblended_cost, 0)",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := ai.GetAmortizedNetCostCase(testCase.allColumns)
+			if result != testCase.expected {
+				t.Errorf("GetAmortizedNetCostCase() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestAthenaIntegration_RemoveColumnAliases(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		input    []string
+		expected []string
+	}{
+		"columns with aliases": {
+			input: []string{
+				"SUM(cost) as total_cost",
+				"COUNT(*) as count",
+				"AVG(price) as avg_price",
+			},
+			expected: []string{
+				"SUM(cost)",
+				"COUNT(*)",
+				"AVG(price)",
+			},
+		},
+		"columns without aliases": {
+			input: []string{
+				"SUM(cost)",
+				"COUNT(*)",
+				"AVG(price)",
+			},
+			expected: []string{
+				"SUM(cost)",
+				"COUNT(*)",
+				"AVG(price)",
+			},
+		},
+		"mixed columns": {
+			input: []string{
+				"SUM(cost) as total_cost",
+				"COUNT(*)",
+				"AVG(price) as avg_price",
+				"MAX(value)",
+			},
+			expected: []string{
+				"SUM(cost)",
+				"COUNT(*)",
+				"AVG(price)",
+				"MAX(value)",
+			},
+		},
+		"empty slice": {
+			input:    []string{},
+			expected: []string{},
+		},
+		"single column with alias": {
+			input: []string{
+				"SUM(cost) as total_cost",
+			},
+			expected: []string{
+				"SUM(cost)",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Create a copy of the input slice to avoid modifying the original
+			columns := make([]string, len(testCase.input))
+			copy(columns, testCase.input)
+
+			ai.RemoveColumnAliases(columns)
+
+			if len(columns) != len(testCase.expected) {
+				t.Errorf("RemoveColumnAliases() returned slice of length %d, expected %d", len(columns), len(testCase.expected))
+				return
+			}
+
+			for i, expected := range testCase.expected {
+				if columns[i] != expected {
+					t.Errorf("RemoveColumnAliases() at index %d returned %s, expected %s", i, columns[i], expected)
+				}
+			}
+		})
+	}
+}
+
+func TestAthenaIntegration_ConvertLabelToAWSTag(t *testing.T) {
+	ai := &AthenaIntegration{}
+
+	testCases := map[string]struct {
+		label    string
+		expected string
+	}{
+		"already has prefix": {
+			label:    "resource_tags_user_kubernetes_io_app_name",
+			expected: "resource_tags_user_kubernetes_io_app_name",
+		},
+		"simple label": {
+			label:    "app",
+			expected: "resource_tags_user_app",
+		},
+		"label with dots": {
+			label:    "kubernetes.io/app.name",
+			expected: "resource_tags_user_kubernetes_io_app_name",
+		},
+		"label with slashes": {
+			label:    "kubernetes/io/app/name",
+			expected: "resource_tags_user_kubernetes_io_app_name",
+		},
+		"label with colons": {
+			label:    "kubernetes:io:app:name",
+			expected: "resource_tags_user_kubernetes_io_app_name",
+		},
+		"label with hyphens": {
+			label:    "kubernetes-io-app-name",
+			expected: "resource_tags_user_kubernetes_io_app_name",
+		},
+		"label with mixed separators": {
+			label:    "kubernetes.io/app-name:test",
+			expected: "resource_tags_user_kubernetes_io_app_name_test",
+		},
+		"empty label": {
+			label:    "",
+			expected: "resource_tags_user_",
+		},
+		"label with multiple consecutive separators": {
+			label:    "app..name",
+			expected: "resource_tags_user_app__name",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := ai.ConvertLabelToAWSTag(testCase.label)
+			if result != testCase.expected {
+				t.Errorf("ConvertLabelToAWSTag() returned %s, expected %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
 func stringsToRow(strings []string) types.Row {
 	var data []types.Datum
 	for _, str := range strings {


### PR DESCRIPTION
# Add comprehensive unit tests for AWS Athena helper functions

## Description
This PR significantly improves test coverage for the pkg/cloud/aws package by adding comprehensive unit tests for 10 critical AWS Athena helper functions that previously had 0% coverage.

## Related Issue
fixes #3311 

## Changes Made
- Added 11 new test functions with comprehensive table-driven test cases
- Achieved 100% coverage for all targeted functions
- Improved overall package coverage from ~4% to 30.58%

## Functions Tested
- AthenaConfiguration.Sanitize() — tests for different authorizer types
- AthenaConfiguration.Provider() — validates AWS provider identification
- AthenaConfiguration.Key() — tests account/bucket key generation
- AthenaIntegration.GetListCostColumn() — tests list cost column generation
- AthenaIntegration.GetNetCostColumn() — tests net cost column logic
- AthenaIntegration.GetAmortizedCostColumn() — tests amortized cost calculations
- AthenaIntegration.GetAmortizedNetCostColumn() — tests net amortized cost logic
- AthenaIntegration.GetAmortizedCostCase() — tests CASE statement generation
- AthenaIntegration.GetAmortizedNetCostCase() — tests net cost CASE statements
- AthenaIntegration.RemoveColumnAliases() — tests column alias removal
- AthenaIntegration.ConvertLabelToAWSTag() — tests label to AWS tag conversion

## Test Coverage
- Multiple scenarios for each function including edge cases
- Empty inputs, missing data, various column combinations
- Real-world AWS Athena query patterns
- Comprehensive validation of SQL generation logic

## Benefits
- Improved reliability of AWS pricing logic
- Better maintainability through comprehensive testing
- Edge case validation for robust error handling
- No production code changes — tests only

## Testing
All tests pass with 100% coverage for targeted functions.
<img width="892" height="716" alt="Screenshot 2025-08-16 015601" src="https://github.com/user-attachments/assets/a504f6dd-7da6-41f6-afb2-977570473dbd" />
