### PR TITLE
use string method instead of adding Name method in storage interface

### DIFF
--- a/core/pkg/storage/azurestorage.go
+++ b/core/pkg/storage/azurestorage.go
@@ -191,8 +191,8 @@ func NewAzureStorageWith(conf AzureConfig) (*AzureStorage, error) {
 	}, nil
 }
 
-// Name returns the bucket name for azure storage.
-func (as *AzureStorage) Name() string {
+// String returns the bucket name for azure storage.
+func (as *AzureStorage) String() string {
 	return as.name
 }
 

--- a/core/pkg/storage/clusterstorage.go
+++ b/core/pkg/storage/clusterstorage.go
@@ -164,7 +164,8 @@ func (c *ClusterStorage) check() error {
 	return nil
 }
 
-func (c *ClusterStorage) Name() string {
+// String returns the host and port for the cluster storage.
+func (c *ClusterStorage) String() string {
 	return fmt.Sprintf("%s:%d", c.host, c.port)
 }
 

--- a/core/pkg/storage/filestorage.go
+++ b/core/pkg/storage/filestorage.go
@@ -22,7 +22,8 @@ func NewFileStorage(baseDir string) Storage {
 	return &FileStorage{baseDir}
 }
 
-func (fs *FileStorage) Name() string {
+// String returns the base directory for the file storage.
+func (fs *FileStorage) String() string {
 	return fs.baseDir
 }
 

--- a/core/pkg/storage/gcsstorage.go
+++ b/core/pkg/storage/gcsstorage.go
@@ -71,8 +71,8 @@ func NewGCSStorageWith(gc GCSConfig) (*GCSStorage, error) {
 	}, nil
 }
 
-// Name returns the bucket name for gcs.
-func (gs *GCSStorage) Name() string {
+// String returns the bucket name for gcs.
+func (gs *GCSStorage) String() string {
 	return gs.name
 }
 

--- a/core/pkg/storage/memorystorage.go
+++ b/core/pkg/storage/memorystorage.go
@@ -25,6 +25,11 @@ func NewMemoryStorage() *MemoryStorage {
 	}
 }
 
+// String returns the storage type as a string for logging purposes.
+func (ms *MemoryStorage) String() string {
+	return string(ms.StorageType())
+}
+
 // StorageType returns a string identifier for the type of storage used by the implementation.
 func (ms *MemoryStorage) StorageType() StorageType {
 	return StorageTypeMemory

--- a/core/pkg/storage/memorystorage.go
+++ b/core/pkg/storage/memorystorage.go
@@ -25,10 +25,6 @@ func NewMemoryStorage() *MemoryStorage {
 	}
 }
 
-func (ms *MemoryStorage) Name() string {
-	return "memory"
-}
-
 // StorageType returns a string identifier for the type of storage used by the implementation.
 func (ms *MemoryStorage) StorageType() StorageType {
 	return StorageTypeMemory

--- a/core/pkg/storage/prefixedbucketstorage.go
+++ b/core/pkg/storage/prefixedbucketstorage.go
@@ -5,6 +5,7 @@ package storage
 // https://github.com/thanos-io/objstore/blob/main/prefixed_bucket.go
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -43,8 +44,12 @@ func withPrefix(prefix, name string) string {
 	return prefix + DirDelim + name
 }
 
-func (pbs *PrefixedBucketStorage) Name() string {
-	return pbs.storage.Name()
+// String returns the string representation of the prefixed bucket storage.
+func (pbs *PrefixedBucketStorage) String() string {
+	if stringer, ok := pbs.storage.(fmt.Stringer); ok {
+		return stringer.String()
+	}
+	return ""
 }
 
 func (pbs *PrefixedBucketStorage) StorageType() StorageType {

--- a/core/pkg/storage/s3storage.go
+++ b/core/pkg/storage/s3storage.go
@@ -230,8 +230,8 @@ func NewS3StorageWith(config S3Config) (*S3Storage, error) {
 	return bkt, nil
 }
 
-// Name returns the bucket name for s3.
-func (s3 *S3Storage) Name() string {
+// String returns the bucket name for s3.
+func (s3 *S3Storage) String() string {
 	return s3.name
 }
 

--- a/core/pkg/storage/storage.go
+++ b/core/pkg/storage/storage.go
@@ -24,7 +24,6 @@ type StorageInfo struct {
 
 // Storage provides an API for storing binary data
 type Storage interface {
-	Name() string
 	// StorageType returns a string identifier for the type of storage used by the implementation.
 	StorageType() StorageType
 


### PR DESCRIPTION
## What does this PR change?
* Add a String method in multiple storage types to return their storage names like s3 bucket name, gcp bucket name, etc that can be used for logging.

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/3308

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Ran go test ./... and ran locally with cost-model changes

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 