### PR TITLE
update validate func used by aggregator to not check for write and delete

### DIFF
--- a/core/pkg/storage/bucketstorage_test.go
+++ b/core/pkg/storage/bucketstorage_test.go
@@ -92,3 +92,28 @@ func TestBucketStorage_Stat(t *testing.T) {
 
 	TestStorageStat(t, store)
 }
+
+// We should be able to call validate function with and without write and delete check without any errors
+func TestBucketStorage_Validate(t *testing.T) {
+	configPath := os.Getenv("TEST_BUCKET_CONFIG")
+	if configPath == "" {
+		t.Skip("skipping integration test, set environment variable TEST_BUCKET_CONFIG")
+	}
+	store, err := createStorage(configPath)
+	if err != nil {
+		t.Errorf("failed to create storage: %s", err.Error())
+		return
+	}
+
+	// Validate BucketStorage with write and delete check
+	err = Validate(store, true)
+	if err != nil {
+		t.Errorf("failed to validate storage: %s", err.Error())
+	}
+
+	// Validate BucketStorage without write and delete check (should not fail)
+	err = Validate(store, false)
+	if err != nil {
+		t.Errorf("failed to validate storage: %s", err.Error())
+	}
+}

--- a/core/pkg/storage/storage.go
+++ b/core/pkg/storage/storage.go
@@ -78,12 +78,6 @@ func Validate(storage Storage) error {
 		return errors.Wrap(err, "Failed to list path")
 	}
 
-	// attempt to write a path
-	err = storage.Write(testPath, []byte(testContent))
-	if err != nil {
-		return errors.Wrap(err, "Failed to write data to storage")
-	}
-
 	// attempt to read the path
 	data, err := storage.Read(testPath)
 	if err != nil {
@@ -91,12 +85,6 @@ func Validate(storage Storage) error {
 	}
 	if string(data) != testContent {
 		return errors.New("Failed to read the expected data from storage")
-	}
-
-	// delete the path
-	err = storage.Remove(testPath)
-	if err != nil {
-		return errors.Wrap(err, "Failed to remove data from storage")
 	}
 
 	return nil

--- a/core/pkg/storage/storage.go
+++ b/core/pkg/storage/storage.go
@@ -60,8 +60,9 @@ type Storage interface {
 }
 
 // Validate uses the provided storage implementation to write a test file to the store, followed by a removal.
-func Validate(storage Storage) error {
+func Validate(storage Storage, validateWriteDelete bool) error {
 	const testPath = "tmp/test.txt"
+	const testContent = "test"
 
 	log.Debug("validating storage")
 
@@ -77,11 +78,32 @@ func Validate(storage Storage) error {
 		return errors.Wrap(err, "Failed to list path")
 	}
 
+	if validateWriteDelete {
+		// attempt to write a path
+		err = storage.Write(testPath, []byte(testContent))
+		if err != nil {
+			return errors.Wrap(err, "Failed to write data to storage")
+		}
+	}
+
 	// attempt to read the path
-	_, err = storage.Read(testPath)
+	data, err := storage.Read(testPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to read data from storage")
 	}
+
+	if validateWriteDelete {
+		if string(data) != testContent {
+			return errors.New("Failed to read the expected data from storage")
+		}
+
+		// delete the path
+		err = storage.Remove(testPath)
+		if err != nil {
+			return errors.Wrap(err, "Failed to remove data from storage")
+		}
+	}
+
 	return nil
 }
 

--- a/core/pkg/storage/storage.go
+++ b/core/pkg/storage/storage.go
@@ -62,7 +62,6 @@ type Storage interface {
 // Validate uses the provided storage implementation to write a test file to the store, followed by a removal.
 func Validate(storage Storage) error {
 	const testPath = "tmp/test.txt"
-	const testContent = "test"
 
 	log.Debug("validating storage")
 
@@ -79,14 +78,10 @@ func Validate(storage Storage) error {
 	}
 
 	// attempt to read the path
-	data, err := storage.Read(testPath)
+	_, err = storage.Read(testPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to read data from storage")
 	}
-	if string(data) != testContent {
-		return errors.New("Failed to read the expected data from storage")
-	}
-
 	return nil
 }
 

--- a/core/pkg/storage/storage.go
+++ b/core/pkg/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/log"
@@ -87,8 +88,10 @@ func Validate(storage Storage, validateWriteDelete bool) error {
 	}
 
 	// attempt to read the path
+	// If we are not validating write and delete, the file won't exist since we never wrote it.
+	// We only want to check read permissions, so ignore errors with "exist" and "404" in the error message to bypass the file not exist error.
 	data, err := storage.Read(testPath)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "exist") && !strings.Contains(err.Error(), "404") {
 		return errors.Wrap(err, "Failed to read data from storage")
 	}
 


### PR DESCRIPTION
## What does this PR change?
* Aggregator uses this validate func. to check for fed bucket permissions but as aggregator does not need write and delete permissions we are removing them from validate func
* Validate fun is not used anywhere except in cost-model

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/3604

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 