### PR TITLE
Add application name in diagnostics report file when exporting

### DIFF
--- a/core/pkg/diagnostics/diagnostics.go
+++ b/core/pkg/diagnostics/diagnostics.go
@@ -37,6 +37,9 @@ type DiagnosticResult struct {
 
 // DiagnosticsRunReport is a struct that contains the start time of the diagnostics run, and all of the results.
 type DiagnosticsRunReport struct {
+	// Application contains the name of the application that the diagnostics run belongs to.
+	Application string `json:"application"`
+
 	// StartTime contains the time when the full diagnostics run started
 	StartTime time.Time `json:"startTime"`
 

--- a/core/pkg/diagnostics/exporter/controller.go
+++ b/core/pkg/diagnostics/exporter/controller.go
@@ -14,7 +14,7 @@ func NewDiagnosticsExportController(
 	service diagnostics.DiagnosticService,
 ) *exporter.EventExportController[diagnostics.DiagnosticsRunReport] {
 	return exporter.NewEventExportController(
-		NewDiagnosticSource(service),
+		NewDiagnosticSource(applicationName, service),
 		NewDiagnosticExporter(clusterId, applicationName, store),
 	)
 }

--- a/core/pkg/diagnostics/exporter/source.go
+++ b/core/pkg/diagnostics/exporter/source.go
@@ -9,13 +9,15 @@ import (
 
 // DiagnosticSource is an `export.ExportSource` implementation that provides the basic data for a `DiagnosticResult` payload.
 type DiagnosticSource struct {
+	applicationName string
 	diagnosticService diagnostics.DiagnosticService
 }
 
 // NewDiagnosticSource creates a new `DiagnosticSource` instance. It accepts the `DiagnosticService` implementation
 // that will be used to retrieve the diagnostic results.
-func NewDiagnosticSource(diagnosticService diagnostics.DiagnosticService) *DiagnosticSource {
+func NewDiagnosticSource(applicationName string, diagnosticService diagnostics.DiagnosticService) *DiagnosticSource {
 	return &DiagnosticSource{
+		applicationName: applicationName,
 		diagnosticService: diagnosticService,
 	}
 }
@@ -31,6 +33,7 @@ func (ds *DiagnosticSource) Make(t time.Time) *diagnostics.DiagnosticsRunReport 
 
 	return &diagnostics.DiagnosticsRunReport{
 		StartTime: t,
+		Application: ds.applicationName,
 		Results:   ds.diagnosticService.Run(ctx),
 	}
 }


### PR DESCRIPTION
## What does this PR change?
* Add application name in diagnostics report file when exporting
* This was mainly done to get the application Name while ingested diagnostics in clickhouse table. 
* We could have also asked the cost model ingestor to get the application name from file paths while checking for files to ingest. But that would have required us to separately handle application name in file paths in the main ingestor that ingest allocations, assets, etc too with diagnostics. But we do not have a concept of application name for allocation, etc. Doable but might become messy at the ingestor side. 
* Heartbeat export response already has application name in it so no change required there.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/3624

## How will this PR impact users?
* No

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* Ran locally

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 