### PR TITLE
Export pathing constants to use in ingesters

### DIFF
--- a/core/pkg/exporter/pathing/bingenpath.go
+++ b/core/pkg/exporter/pathing/bingenpath.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultRootDir string = "federated"
-	baseStorageDir string = "etl/bingen"
+	DefaultRootDir string = "federated"
+	BaseStorageDir string = "etl/bingen"
 )
 
 // BingenStoragePathFormatter is an implementation of the StoragePathFormatter interface for
@@ -27,7 +27,7 @@ type BingenStoragePathFormatter struct {
 }
 
 func NewDefaultStoragePathFormatter(clusterId, pipeline string, resolution *time.Duration) (StoragePathFormatter[opencost.Window], error) {
-	return NewBingenStoragePathFormatter(defaultRootDir, clusterId, pipeline, resolution)
+	return NewBingenStoragePathFormatter(DefaultRootDir, clusterId, pipeline, resolution)
 }
 
 // NewBingenStoragePathFormatter creates a StoragePathFormatter for a cluster separated storage path
@@ -65,7 +65,7 @@ func (bsf *BingenStoragePathFormatter) Dir() string {
 	return path.Join(
 		bsf.rootDir,
 		bsf.clusterId,
-		baseStorageDir,
+		BaseStorageDir,
 		bsf.pipeline,
 		bsf.resolution,
 	)
@@ -80,7 +80,7 @@ func (bsf *BingenStoragePathFormatter) ToFullPath(prefix string, window opencost
 	return path.Join(
 		bsf.rootDir,
 		bsf.clusterId,
-		baseStorageDir,
+		BaseStorageDir,
 		bsf.pipeline,
 		bsf.resolution,
 		fileName,

--- a/core/pkg/exporter/pathing/path_test.go
+++ b/core/pkg/exporter/pathing/path_test.go
@@ -25,7 +25,7 @@ func TestBingenPathFormatter(t *testing.T) {
 			pipeline:   "allocation",
 			resolution: nil,
 			prefix:     "",
-			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1704110400-1704114000", defaultRootDir, baseStorageDir),
+			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1704110400-1704114000", DefaultRootDir, BaseStorageDir),
 		},
 		{
 			name:       "with resolution",
@@ -33,7 +33,7 @@ func TestBingenPathFormatter(t *testing.T) {
 			pipeline:   "allocation",
 			resolution: &[]time.Duration{1 * time.Hour}[0],
 			prefix:     "",
-			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1h/1704110400-1704114000", defaultRootDir, baseStorageDir),
+			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1h/1704110400-1704114000", DefaultRootDir, BaseStorageDir),
 		},
 		{
 			name:       "no resolution with prefix",
@@ -41,7 +41,7 @@ func TestBingenPathFormatter(t *testing.T) {
 			pipeline:   "allocation",
 			resolution: nil,
 			prefix:     "test",
-			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/test.1704110400-1704114000", defaultRootDir, baseStorageDir),
+			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/test.1704110400-1704114000", DefaultRootDir, BaseStorageDir),
 		},
 		{
 			name:       "with resolution with prefix",
@@ -49,7 +49,7 @@ func TestBingenPathFormatter(t *testing.T) {
 			pipeline:   "allocation",
 			resolution: &[]time.Duration{1 * time.Hour}[0],
 			prefix:     "test",
-			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1h/test.1704110400-1704114000", defaultRootDir, baseStorageDir),
+			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1h/test.1704110400-1704114000", DefaultRootDir, BaseStorageDir),
 		},
 		{
 			name:       "daily resolution",
@@ -57,7 +57,7 @@ func TestBingenPathFormatter(t *testing.T) {
 			pipeline:   "allocation",
 			resolution: &[]time.Duration{24 * time.Hour}[0],
 			prefix:     "",
-			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1d/1704110400-1704196800", defaultRootDir, baseStorageDir),
+			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1d/1704110400-1704196800", DefaultRootDir, BaseStorageDir),
 		},
 		{
 			name:       "weekly resolution",
@@ -65,7 +65,7 @@ func TestBingenPathFormatter(t *testing.T) {
 			pipeline:   "allocation",
 			resolution: &[]time.Duration{7 * 24 * time.Hour}[0],
 			prefix:     "",
-			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1w/1704110400-1704715200", defaultRootDir, baseStorageDir),
+			expected:   fmt.Sprintf("%s/cluster-a/%s/allocation/1w/1704110400-1704715200", DefaultRootDir, BaseStorageDir),
 		},
 	}
 


### PR DESCRIPTION
## What does this PR change?
* Export pathing constants to use in ingesters

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* https://github.com/kubecost/kubecost-cost-model/pull/3624

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* locally ran aggregator

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 