### PR TITLE
feat: Customizable cluster management cost

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -874,6 +874,10 @@ func (aws *AWS) DownloadPricingData() error {
 	aws.SpotDataPrefix = c.SpotDataPrefix
 	aws.ProjectID = c.ProjectID
 	aws.SpotDataRegion = c.SpotDataRegion
+	clusterManagementCost, hasCustomClusterManagementCost := c.GetClusterManagementCost()
+	if hasCustomClusterManagementCost {
+		aws.clusterManagementPrice = clusterManagementCost
+	}
 
 	aws.ConfigureAuthWith(c) // load aws authentication from configuration or secret
 
@@ -886,7 +890,9 @@ func (aws *AWS) DownloadPricingData() error {
 	for _, n := range nodeList {
 
 		if _, ok := n.Labels["eks.amazonaws.com/nodegroup"]; ok {
-			aws.clusterManagementPrice = 0.10
+			if !hasCustomClusterManagementCost {
+				aws.clusterManagementPrice = 0.10 // Default to 0.10 if not set by custom pricing
+			}
 			aws.clusterProvisioner = "EKS"
 		} else if _, ok := n.Labels["kops.k8s.io/instancegroup"]; ok {
 			aws.clusterProvisioner = "KOPS"

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1739,7 +1739,14 @@ func (az *Azure) PricingSourceStatus() map[string]*models.PricingSource {
 	return sources
 }
 
-func (*Azure) ClusterManagementPricing() (string, float64, error) {
+func (az *Azure) ClusterManagementPricing() (string, float64, error) {
+	config, err := az.GetConfig()
+	if err != nil {
+		return "", 0.0, err
+	}
+	if clusterManagementCost, ok := config.GetClusterManagementCost(); ok {
+		return "AKS", clusterManagementCost, nil
+	}
 	return "", 0.0, nil
 }
 

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1045,6 +1045,11 @@ func (gcp *GCP) DownloadPricingData() error {
 	gcp.ProjectID = c.ProjectID
 	gcp.BillingDataDataset = c.BillingDataDataset
 
+	clusterManagementCost, hasCustomClusterManagementCost := c.GetClusterManagementCost()
+	if hasCustomClusterManagementCost {
+		gcp.clusterManagementPrice = clusterManagementCost
+	}
+
 	nodeList := gcp.Clientset.GetAllNodes()
 	inputkeys := make(map[string]models.Key)
 
@@ -1052,7 +1057,9 @@ func (gcp *GCP) DownloadPricingData() error {
 	for _, n := range nodeList {
 		labels := n.Labels
 		if _, ok := labels["cloud.google.com/gke-nodepool"]; ok { // The node is part of a GKE nodepool, so you're paying a cluster management cost
-			gcp.clusterManagementPrice = 0.10
+			if !hasCustomClusterManagementCost {
+				gcp.clusterManagementPrice = 0.10 // Default to 0.10 if not set by custom pricing
+			}
 			gcp.clusterProvisioner = "GKE"
 		}
 		r, _ := util.GetRegion(labels)

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/pkg/config"
 )
 
@@ -142,6 +143,7 @@ type CustomPricing struct {
 	FirstFiveForwardingRulesCost string `json:"firstFiveForwardingRulesCost"`
 	AdditionalForwardingRuleCost string `json:"additionalForwardingRuleCost"`
 	LBIngressDataCost            string `json:"LBIngressDataCost"`
+	ClusterManagementCost        string `json:"clusterManagementCost,omitempty"`
 	SpotLabel                    string `json:"spotLabel,omitempty"`
 	SpotLabelValue               string `json:"spotLabelValue,omitempty"`
 	GpuLabel                     string `json:"gpuLabel,omitempty"`
@@ -187,6 +189,21 @@ type CustomPricing struct {
 	DefaultLBPrice               string `json:"defaultLBPrice"`
 }
 
+// GetClusterManagementCost parses and returns a float64 representation
+// of the configured hourly cluster management cost. If the string version cannot
+// be parsed into a float, an error is logged and 0.0 is returned.
+// Also returns a boolean indicating whether a value was configured.
+func (cp *CustomPricing) GetClusterManagementCost() (float64, bool) {
+	if cp.ClusterManagementCost == "" {
+		return 0.0, false
+	}
+	clusterManagementCost, err := strconv.ParseFloat(cp.ClusterManagementCost, 64)
+	if err != nil {
+		log.Warnf("ClusterManagementCost: failed to parse cluster management cost \"%s\": %s", cp.ClusterManagementCost, err)
+		return 0.0, false
+	}
+	return clusterManagementCost, true
+}
 func sanitizeFloatString(number string, allowNaN bool) (string, error) {
 	num, err := strconv.ParseFloat(number, 64)
 	if err != nil {
@@ -217,7 +234,7 @@ func SetCustomPricingField(obj *CustomPricing, name string, value string) error 
 	// validation work in order to prevent "NaN" and other invalid strings
 	// from getting set here.
 	switch strings.ToLower(name) {
-	case "cpu", "gpu", "ram", "spotcpu", "spotgpu", "spotram", "storage", "zonenetworkegress", "regionnetworkegress", "internetnetworkegress", "natgatewayegress", "natgatewayingress":
+	case "cpu", "gpu", "ram", "spotcpu", "spotgpu", "spotram", "storage", "zonenetworkegress", "regionnetworkegress", "internetnetworkegress", "natgatewayegress", "natgatewayingress", "clustermanagementcost":
 		// If we are sent an empty string, ignore the key and don't change the value
 		if value == "" {
 			return nil

--- a/pkg/cloud/models/models_test.go
+++ b/pkg/cloud/models/models_test.go
@@ -68,6 +68,7 @@ func TestSetSetCustomPricingField(t *testing.T) {
 		"InternetNetworkEgress",
 		"NatGatewayEgress",
 		"NatGatewayIngress",
+		"ClusterManagementCost",
 	}
 
 	testCases := []testCase{}
@@ -102,6 +103,7 @@ func TestSetSetCustomPricingField(t *testing.T) {
 				InternetNetworkEgress: defaultValue,
 				NatGatewayEgress:      defaultValue,
 				NatGatewayIngress:     defaultValue,
+				ClusterManagementCost: defaultValue,
 			}
 			err := SetCustomPricingField(cp, tc.fieldName, tc.fieldValue)
 			if err != nil && tc.expError == nil {
@@ -116,6 +118,50 @@ func TestSetSetCustomPricingField(t *testing.T) {
 			actValue := structFieldValue.String()
 			if actValue != tc.expValue {
 				t.Errorf("expected field '%s' to be '%s'; actual value is '%s'", tc.fieldName, tc.expValue, actValue)
+			}
+		})
+	}
+}
+
+func TestCustomPricing_GetClusterManagementCost(t *testing.T) {
+	testCases := map[string]struct {
+		input     string
+		expCost   float64
+		expExists bool
+	}{
+		"empty string returns false": {
+			input:     "",
+			expCost:   0.0,
+			expExists: false,
+		},
+		"valid cost": {
+			input:     "0.10",
+			expCost:   0.10,
+			expExists: true,
+		},
+		"zero cost": {
+			input:     "0",
+			expCost:   0.0,
+			expExists: true,
+		},
+		"invalid string returns false": {
+			input:     "not-a-number",
+			expCost:   0.0,
+			expExists: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cp := &CustomPricing{
+				ClusterManagementCost: tc.input,
+			}
+			cost, exists := cp.GetClusterManagementCost()
+			if cost != tc.expCost {
+				t.Errorf("expected cost %f, got %f", tc.expCost, cost)
+			}
+			if exists != tc.expExists {
+				t.Errorf("expected exists=%v, got %v", tc.expExists, exists)
 			}
 		})
 	}

--- a/pkg/cloud/provider/customprovider.go
+++ b/pkg/cloud/provider/customprovider.go
@@ -76,7 +76,14 @@ type customProviderKey struct {
 	Labels         map[string]string
 }
 
-func (*CustomProvider) ClusterManagementPricing() (string, float64, error) {
+func (cp *CustomProvider) ClusterManagementPricing() (string, float64, error) {
+	c, err := cp.GetConfig()
+	if err != nil {
+		return "", 0.0, err
+	}
+	if clusterManagementCost, ok := c.GetClusterManagementCost(); ok {
+		return "Custom", clusterManagementCost, nil
+	}
 	return "", 0.0, nil
 }
 


### PR DESCRIPTION
## What does this PR change?
* Adds `clusterManagementCost` to the custom pricing model.

## Does this PR relate to any other PRs?

## How will this PR impact users?
* Allows `clusterManagementCost` to be configurable, even if OpenCost fails to detect the cluster provisioner.

## Does this PR address any GitHub or Zendesk issues?
* Closes #3339

## How was this PR tested?
* I have added unit tests, but I haven't tested it on a real environment yet.

## Does this PR require changes to documentation?
* Preferably, add `clusterManagementCost` to the list of fields in the [On-Premises](https://opencost.io/docs/configuration/on-prem/#on-prem-configuration) page.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* I don't have the permission to set labels