### PR TITLE
feat(aws): Use AmazonECS price list to calculate Fargate nodes price

### DIFF
--- a/pkg/cloud/aws/fargate.go
+++ b/pkg/cloud/aws/fargate.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/opencost/opencost/core/pkg/log"
+	"github.com/opencost/opencost/pkg/env"
+)
+
+const (
+	usageTypeFargateLinuxX86CPU    = "Fargate-vCPU-Hours:perCPU"
+	usageTypeFargateLinuxX86RAM    = "Fargate-GB-Hours"
+	usageTypeFargateLinuxArmCPU    = "Fargate-ARM-vCPU-Hours:perCPU"
+	usageTypeFargateLinuxArmRAM    = "Fargate-ARM-GB-Hours"
+	usageTypeFargateWindowsCPU     = "Fargate-Windows-vCPU-Hours:perCPU"
+	usageTypeFargateWindowsLicense = "Fargate-Windows-OS-Hours:perCPU"
+	usageTypeFargateWindowsRAM     = "Fargate-Windows-GB-Hours"
+)
+
+var fargateUsageTypes = []string{
+	usageTypeFargateLinuxX86CPU,
+	usageTypeFargateLinuxX86RAM,
+	usageTypeFargateLinuxArmCPU,
+	usageTypeFargateLinuxArmRAM,
+	usageTypeFargateWindowsCPU,
+	usageTypeFargateWindowsLicense,
+	usageTypeFargateWindowsRAM,
+}
+
+type FargateRegionPricing map[string]float64
+
+func (f FargateRegionPricing) Validate() error {
+	for _, usageType := range fargateUsageTypes {
+		if _, ok := f[usageType]; !ok {
+			return fmt.Errorf("missing pricing for usageType %s", usageType)
+		}
+	}
+	return nil
+}
+
+type FargatePricing struct {
+	regions map[string]FargateRegionPricing
+}
+
+func NewFargatePricing() *FargatePricing {
+	return &FargatePricing{
+		regions: make(map[string]FargateRegionPricing),
+	}
+}
+
+func (f *FargatePricing) Initialize(nodeList []*clustercache.Node) error {
+	url := f.getPricingURL(nodeList)
+
+	log.Infof("Downloading Fargate pricing data from %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("downloading pricing data: %s", err)
+	}
+
+	var pricing AWSPricing
+	err = json.NewDecoder(resp.Body).Decode(&pricing)
+	if err != nil {
+		return fmt.Errorf("parsing pricing data: %s", err)
+	}
+
+	return f.populatePricing(&pricing)
+}
+
+func (f *FargatePricing) getPricingURL(nodeList []*clustercache.Node) string {
+	// Allow override of pricing URL for air-gapped environments
+	if override := env.GetAWSECSPricingURL(); override != "" {
+		return override
+	}
+	return getPricingListURL("AmazonECS", nodeList)
+}
+
+func (f *FargatePricing) populatePricing(pricing *AWSPricing) error {
+	// Populate pricing for each region
+productLoop:
+	for sku, product := range pricing.Products {
+		for _, usageType := range fargateUsageTypes {
+			if strings.HasSuffix(product.Attributes.UsageType, usageType) {
+				region := product.Attributes.RegionCode
+				if _, ok := f.regions[region]; !ok {
+					f.regions[region] = make(FargateRegionPricing)
+				}
+
+				skuPrice, err := f.getPricingOfSKU(sku, &pricing.Terms)
+				if err != nil {
+					return fmt.Errorf("error getting pricing for sku %s: %s", sku, err)
+				}
+				f.regions[region][usageType] = skuPrice
+				continue productLoop
+			}
+		}
+	}
+
+	// Validate pricing - do we have all the pricing we need?
+	for region, regionPricing := range f.regions {
+		err := regionPricing.Validate()
+		if err != nil {
+			// Be failsafe here and just log warnings
+			log.Warnf("Fargate pricing data is (partially) missing pricing for %s: %s", region, err)
+		}
+	}
+	return nil
+}
+
+func (f *FargatePricing) getPricingOfSKU(sku string, allTerms *AWSPricingTerms) (float64, error) {
+	skuTerm, ok := allTerms.OnDemand[sku]
+	if !ok {
+		return 0, fmt.Errorf("missing pricing for sku %s", sku)
+	}
+	for _, offerTerm := range skuTerm {
+		if _, isMatch := OnDemandRateCodes[offerTerm.OfferTermCode]; isMatch {
+			priceDimensionKey := strings.Join([]string{sku, offerTerm.OfferTermCode, HourlyRateCode}, ".")
+			if dimension, ok := offerTerm.PriceDimensions[priceDimensionKey]; ok {
+				return strconv.ParseFloat(dimension.PricePerUnit.USD, 64)
+			}
+		} else if _, isMatch := OnDemandRateCodesCn[offerTerm.OfferTermCode]; isMatch {
+			priceDimensionKey := strings.Join([]string{sku, offerTerm.OfferTermCode, HourlyRateCodeCn}, ".")
+			if dimension, ok := offerTerm.PriceDimensions[priceDimensionKey]; ok {
+				return strconv.ParseFloat(dimension.PricePerUnit.CNY, 64)
+			}
+		}
+	}
+	return 0, fmt.Errorf("missing pricing for sku %s", sku)
+}
+
+func (f *FargatePricing) GetHourlyPricing(region string, os, arch string) (cpu, memory float64, err error) {
+	regionPricing, ok := f.regions[region]
+	if !ok {
+		return 0, 0, fmt.Errorf("missing pricing for region %s", region)
+	}
+
+	switch os {
+	case "linux":
+		switch arch {
+		case "amd64":
+			cpu = regionPricing[usageTypeFargateLinuxX86CPU]
+			memory = regionPricing[usageTypeFargateLinuxX86RAM]
+			return
+		case "arm64":
+			cpu = regionPricing[usageTypeFargateLinuxArmCPU]
+			memory = regionPricing[usageTypeFargateLinuxArmRAM]
+			return
+		}
+	case "windows":
+		cpuOnly := regionPricing[usageTypeFargateWindowsCPU]
+		cpuLicense := regionPricing[usageTypeFargateWindowsLicense]
+		cpu = cpuOnly + cpuLicense
+		memory = regionPricing[usageTypeFargateWindowsRAM]
+		return
+	}
+
+	return 0, 0, fmt.Errorf("unknown os/arch combination: %s/%s", os, arch)
+}

--- a/pkg/cloud/aws/fargate_test.go
+++ b/pkg/cloud/aws/fargate_test.go
@@ -1,0 +1,269 @@
+package aws
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+var testRegionPricing = FargateRegionPricing{
+	usageTypeFargateLinuxX86CPU:    0.0404800000,
+	usageTypeFargateLinuxX86RAM:    0.0044450000,
+	usageTypeFargateLinuxArmCPU:    0.0323800000,
+	usageTypeFargateLinuxArmRAM:    0.0035600000,
+	usageTypeFargateWindowsCPU:     0.0465520000,
+	usageTypeFargateWindowsLicense: 0.0460000000,
+	usageTypeFargateWindowsRAM:     0.0051117500,
+}
+
+func TestFargatePricing_populatePricing(t *testing.T) {
+	// Load test data
+	testDataPath := "testdata/ecs-pricing-us-east-1.json"
+	data, err := os.ReadFile(testDataPath)
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
+
+	var pricing AWSPricing
+	err = json.Unmarshal(data, &pricing)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal test data: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		pricing *AWSPricing
+		wantErr bool
+	}{
+		{
+			name:    "valid pricing data",
+			pricing: &pricing,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewFargatePricing()
+
+			err := f.populatePricing(tt.pricing)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("populatePricing() expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("populatePricing() unexpected error: %v", err)
+				return
+			}
+
+			// Verify that regions were populated
+			if len(f.regions) == 0 {
+				t.Error("populatePricing() did not populate any regions")
+				return
+			}
+
+			// Check that us-east-1 pricing was populated (from test data)
+			usEast1, ok := f.regions["us-east-1"]
+			if !ok {
+				t.Error("populatePricing() did not populate us-east-1 region")
+				return
+			}
+
+			// Verify all required usage types are present
+			for _, usageType := range fargateUsageTypes {
+				if price, ok := usEast1[usageType]; !ok {
+					t.Errorf("populatePricing() missing usage type %s", usageType)
+				} else if price <= 0 {
+					t.Errorf("populatePricing() invalid price %f for usage type %s", price, usageType)
+				}
+			}
+
+			// Test specific pricing values from test data
+			for usageType, expectedPrice := range testRegionPricing {
+				if actualPrice, ok := usEast1[usageType]; ok {
+					if actualPrice != expectedPrice {
+						t.Errorf("populatePricing() price mismatch for %s: expected %f, got %f", usageType, expectedPrice, actualPrice)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFargatePricing_GetHourlyPricing(t *testing.T) {
+	// Create a Fargate pricing instance with test data
+	f := NewFargatePricing()
+
+	// Populate test pricing data for us-east-1
+	f.regions["us-east-1"] = testRegionPricing
+
+	tests := []struct {
+		name        string
+		region      string
+		os          string
+		arch        string
+		expectedCPU float64
+		expectedRAM float64
+		expectedErr bool
+	}{
+		{
+			name:        "linux amd64",
+			region:      "us-east-1",
+			os:          "linux",
+			arch:        "amd64",
+			expectedCPU: 0.0404800000,
+			expectedRAM: 0.0044450000,
+			expectedErr: false,
+		},
+		{
+			name:        "linux arm64",
+			region:      "us-east-1",
+			os:          "linux",
+			arch:        "arm64",
+			expectedCPU: 0.0323800000,
+			expectedRAM: 0.0035600000,
+			expectedErr: false,
+		},
+		{
+			name:        "windows (any arch)",
+			region:      "us-east-1",
+			os:          "windows",
+			arch:        "amd64",
+			expectedCPU: 0.0925520000, // CPU + License: 0.0465520000 + 0.0460000000
+			expectedRAM: 0.0051117500,
+			expectedErr: false,
+		},
+		{
+			name:        "unknown region",
+			region:      "unknown-region",
+			os:          "linux",
+			arch:        "amd64",
+			expectedCPU: 0,
+			expectedRAM: 0,
+			expectedErr: true,
+		},
+		{
+			name:        "unknown os",
+			region:      "us-east-1",
+			os:          "macos",
+			arch:        "amd64",
+			expectedCPU: 0,
+			expectedRAM: 0,
+			expectedErr: true,
+		},
+		{
+			name:        "unknown arch for linux",
+			region:      "us-east-1",
+			os:          "linux",
+			arch:        "unknown",
+			expectedCPU: 0,
+			expectedRAM: 0,
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpu, memory, err := f.GetHourlyPricing(tt.region, tt.os, tt.arch)
+
+			if tt.expectedErr {
+				if err == nil {
+					t.Errorf("GetHourlyPricing() expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("GetHourlyPricing() unexpected error: %v", err)
+				return
+			}
+
+			if cpu != tt.expectedCPU {
+				t.Errorf("GetHourlyPricing() CPU price mismatch: expected %f, got %f", tt.expectedCPU, cpu)
+			}
+
+			if memory != tt.expectedRAM {
+				t.Errorf("GetHourlyPricing() RAM price mismatch: expected %f, got %f", tt.expectedRAM, memory)
+			}
+		})
+	}
+}
+
+func TestFargateRegionPricing_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pricing FargateRegionPricing
+		wantErr bool
+	}{
+		{
+			name: "valid complete pricing",
+			pricing: FargateRegionPricing{
+				usageTypeFargateLinuxX86CPU:    0.04048,
+				usageTypeFargateLinuxX86RAM:    0.004445,
+				usageTypeFargateLinuxArmCPU:    0.03238,
+				usageTypeFargateLinuxArmRAM:    0.00356,
+				usageTypeFargateWindowsCPU:     0.046552,
+				usageTypeFargateWindowsLicense: 0.046,
+				usageTypeFargateWindowsRAM:     0.00511175,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing linux x86 CPU",
+			pricing: FargateRegionPricing{
+				usageTypeFargateLinuxX86RAM:    0.004445,
+				usageTypeFargateLinuxArmCPU:    0.03238,
+				usageTypeFargateLinuxArmRAM:    0.00356,
+				usageTypeFargateWindowsCPU:     0.046552,
+				usageTypeFargateWindowsLicense: 0.046,
+				usageTypeFargateWindowsRAM:     0.00511175,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing linux x86 RAM",
+			pricing: FargateRegionPricing{
+				usageTypeFargateLinuxX86CPU:    0.04048,
+				usageTypeFargateLinuxArmCPU:    0.03238,
+				usageTypeFargateLinuxArmRAM:    0.00356,
+				usageTypeFargateWindowsCPU:     0.046552,
+				usageTypeFargateWindowsLicense: 0.046,
+				usageTypeFargateWindowsRAM:     0.00511175,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing windows license",
+			pricing: FargateRegionPricing{
+				usageTypeFargateLinuxX86CPU: 0.04048,
+				usageTypeFargateLinuxX86RAM: 0.004445,
+				usageTypeFargateLinuxArmCPU: 0.03238,
+				usageTypeFargateLinuxArmRAM: 0.00356,
+				usageTypeFargateWindowsCPU:  0.046552,
+				usageTypeFargateWindowsRAM:  0.00511175,
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty pricing",
+			pricing: FargateRegionPricing{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.pricing.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -54,6 +54,7 @@ const (
 	APIPricingSource              = "Public API"
 	SpotPricingSource             = "Spot Data Feed"
 	ReservedInstancePricingSource = "Savings Plan, Reserved Instance, and Out-Of-Cluster"
+	FargatePricingSource          = "Fargate"
 
 	InUseState    = "in-use"
 	AttachedState = "attached"
@@ -120,6 +121,18 @@ func (aws *AWS) PricingSourceStatus() map[string]*models.PricingSource {
 		rps.Available = true
 	}
 	sources[ReservedInstancePricingSource] = rps
+
+	fs := &models.PricingSource{
+		Name:      FargatePricingSource,
+		Enabled:   true,
+		Available: true,
+	}
+	if aws.FargatePricingError != nil {
+		fs.Error = aws.FargatePricingError.Error()
+		fs.Available = false
+	}
+	sources[FargatePricingSource] = fs
+
 	return sources
 
 }
@@ -172,6 +185,8 @@ type AWS struct {
 	SavingsPlanDataByInstanceID map[string]*SavingsPlanData
 	SavingsPlanDataRunning      bool
 	SavingsPlanDataLock         sync.RWMutex
+	FargatePricing              *FargatePricing
+	FargatePricingError         error
 	ValidPricingKeys            map[string]bool
 	Clientset                   clustercache.ClusterCache
 	BaseCPUPrice                string
@@ -597,6 +612,7 @@ func (aws *AWS) UpdateConfig(r io.Reader, updateType string) (*models.CustomPric
 }
 
 type awsKey struct {
+	Name           string
 	SpotLabelName  string
 	SpotLabelValue string
 	Labels         map[string]string
@@ -643,6 +659,16 @@ func (k *awsKey) Features() string {
 		return spotKey
 	}
 	return key
+}
+
+const eksComputeTypeLabel = "eks.amazonaws.com/compute-type"
+
+func (k *awsKey) isFargateNode() bool {
+	v := k.Labels[eksComputeTypeLabel]
+	if v == "fargate" {
+		return true
+	}
+	return false
 }
 
 // getUsageType returns the usage type of the instance
@@ -752,6 +778,7 @@ func getStorageClassTypeFrom(provisioner string) string {
 // GetKey maps node labels to information needed to retrieve pricing data
 func (aws *AWS) GetKey(labels map[string]string, n *clustercache.Node) models.Key {
 	return &awsKey{
+		Name:           n.Name,
 		SpotLabelName:  aws.SpotLabelName,
 		SpotLabelValue: aws.SpotLabelValue,
 		Labels:         labels,
@@ -771,10 +798,9 @@ func (aws *AWS) ClusterManagementPricing() (string, float64, error) {
 	return aws.clusterProvisioner, aws.clusterManagementPrice, nil
 }
 
-// Use the pricing data from the current region. Fall back to using all region data if needed.
-func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response, string, error) {
-
-	pricingURL := "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/"
+func getPricingListURL(serviceCode string, nodeList []*clustercache.Node) string {
+	// See https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-the-aws-price-list-bulk-api-fetching-price-list-files-manually.html
+	pricingURL := "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/" + serviceCode + "/current/"
 	region := ""
 	multiregion := false
 	for _, n := range nodeList {
@@ -784,7 +810,7 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 			currentNodeRegion = r
 			// Switch to Chinese endpoint for regions with the Chinese prefix
 			if strings.HasPrefix(currentNodeRegion, "cn-") {
-				pricingURL = "https://pricing.cn-north-1.amazonaws.com.cn/offers/v1.0/cn/AmazonEC2/current/"
+				pricingURL = "https://pricing.cn-north-1.amazonaws.com.cn/offers/v1.0/cn/" + serviceCode + "/current/"
 			}
 		} else {
 			multiregion = true // We weren't able to detect the node's region, so pull all data.
@@ -802,11 +828,16 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 	if region != "" && !multiregion {
 		pricingURL += region + "/"
 	}
+	return pricingURL + "index.json"
+}
 
-	pricingURL += "index.json"
-
+// Use the pricing data from the current region. Fall back to using all region data if needed.
+func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response, string, error) {
+	var pricingURL string
 	if env.GetAWSPricingURL() != "" { // Allow override of pricing URL
 		pricingURL = env.GetAWSPricingURL()
+	} else {
+		pricingURL = getPricingListURL("AmazonEC2", nodeList)
 	}
 
 	log.Infof("starting download of \"%s\", which is quite large ...", pricingURL)
@@ -933,6 +964,15 @@ func (aws *AWS) DownloadPricingData() error {
 					}
 				}
 			}()
+		}
+	}
+
+	// Initialize fargate pricing if it's not initialized yet
+	if aws.FargatePricing == nil {
+		aws.FargatePricing = NewFargatePricing()
+		aws.FargatePricingError = aws.FargatePricing.Initialize(nodeList)
+		if aws.FargatePricingError != nil {
+			log.Errorf("Failed to initialize fargate pricing: %s", aws.FargatePricingError.Error())
 		}
 	}
 
@@ -1399,6 +1439,72 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 	}, meta, nil
 }
 
+func (aws *AWS) getFargatePod(awsKey *awsKey) (*clustercache.Pod, bool) {
+	pods := aws.Clientset.GetAllPods()
+	for _, pod := range pods {
+		if pod.Spec.NodeName == awsKey.Name {
+			return pod, true
+		}
+	}
+	return nil, false
+}
+
+const (
+	nodeOSLabel   = "kubernetes.io/os"
+	nodeArchLabel = "kubernetes.io/arch"
+
+	fargatePodCapacityAnnotation = "CapacityProvisioned"
+)
+
+// e.g. "0.25vCPU 0.5GB"
+var fargatePodCapacityRegex = regexp.MustCompile("^([0-9.]+)vCPU ([0-9.]+)GB$")
+
+func (aws *AWS) createFargateNode(awsKey *awsKey, usageType string) (*models.Node, models.PricingMetadata, error) {
+	pod, ok := aws.getFargatePod(awsKey)
+	if !ok {
+		return nil, models.PricingMetadata{}, fmt.Errorf("could not find pod for fargate node %s", awsKey.Name)
+	}
+	capacity := pod.Annotations[fargatePodCapacityAnnotation]
+	match := fargatePodCapacityRegex.FindStringSubmatch(capacity)
+	if len(match) == 0 {
+		return nil, models.PricingMetadata{}, fmt.Errorf("could not parse pod capacity for fargate node %s", awsKey.Name)
+	}
+
+	vCPU, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return nil, models.PricingMetadata{}, fmt.Errorf("could not parse vCPU capacity for fargate node %s: %v", awsKey.Name, err)
+	}
+	memory, err := strconv.ParseFloat(match[2], 64)
+	if err != nil {
+		return nil, models.PricingMetadata{}, fmt.Errorf("could not parse memory capacity for fargate node %s: %v", awsKey.Name, err)
+	}
+
+	region, ok := util.GetRegion(awsKey.Labels)
+	if !ok {
+		return nil, models.PricingMetadata{}, fmt.Errorf("could not get region for fargate node %s", awsKey.Name)
+	}
+	nodeOS := awsKey.Labels[nodeOSLabel]
+	nodeArch := awsKey.Labels[nodeArchLabel]
+	hourlyCPU, hourlyRAM, err := aws.FargatePricing.GetHourlyPricing(region, nodeOS, nodeArch)
+	if err != nil {
+		return nil, models.PricingMetadata{}, fmt.Errorf("could not get hourly pricing for fargate node %s: %v", awsKey.Name, err)
+	}
+
+	cost := hourlyCPU*vCPU + hourlyRAM*memory
+	return &models.Node{
+		Cost:         strconv.FormatFloat(cost, 'f', -1, 64),
+		VCPU:         strconv.FormatFloat(vCPU, 'f', -1, 64),
+		RAM:          strconv.FormatFloat(memory, 'f', -1, 64),
+		RAMBytes:     strconv.FormatFloat(memory*1024*1024*1024, 'f', -1, 64),
+		VCPUCost:     strconv.FormatFloat(hourlyCPU, 'f', -1, 64),
+		RAMCost:      strconv.FormatFloat(hourlyRAM, 'f', -1, 64),
+		BaseCPUPrice: aws.BaseCPUPrice,
+		BaseRAMPrice: aws.BaseRAMPrice,
+		BaseGPUPrice: aws.BaseGPUPrice,
+		UsageType:    usageType,
+	}, models.PricingMetadata{}, nil
+}
+
 // NodePricing takes in a key from GetKey and returns a Node object for use in building the cost model.
 func (aws *AWS) NodePricing(k models.Key) (*models.Node, models.PricingMetadata, error) {
 	aws.DownloadPricingDataLock.RLock()
@@ -1444,6 +1550,9 @@ func (aws *AWS) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 			}, meta, fmt.Errorf("Unable to find any Pricing data for \"%s\"", key)
 		}
 		return aws.createNode(terms, usageType, k)
+	} else if awsKey, ok := k.(*awsKey); ok && awsKey.isFargateNode() {
+		// Since Fargate pricing is listed at AmazonECS and is different from AmazonEC2, we handle it separately here
+		return aws.createFargateNode(awsKey, usageType)
 	} else { // Fall back to base pricing if we can't find the key. Base pricing is handled at the costmodel level.
 		// we seem to have an issue where this error gets thrown during app start.
 		// somehow the ValidPricingKeys map is being accessed before all the pricing data has been downloaded

--- a/pkg/cloud/aws/testdata/ecs-pricing-us-east-1.json
+++ b/pkg/cloud/aws/testdata/ecs-pricing-us-east-1.json
@@ -1,0 +1,462 @@
+{
+  "formatVersion" : "v1.0",
+  "disclaimer" : "This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/",
+  "offerCode" : "AmazonECS",
+  "version" : "20250828172723",
+  "publicationDate" : "2025-08-28T17:27:23Z",
+  "products" : {
+    "74HXSAMY4YHFPXQQ" : {
+      "sku" : "74HXSAMY4YHFPXQQ",
+      "productFamily" : "Compute Metering",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "usagetype" : "USE1-ECS-EC2-GB-Hours",
+        "operation" : "",
+        "memorytype" : "perGB",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "RF2BUTAD289DREDC" : {
+      "sku" : "RF2BUTAD289DREDC",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "operatingSystem" : "Windows",
+        "usagetype" : "USE1-Fargate-Windows-vCPU-Hours:perCPU",
+        "operation" : "",
+        "cputype" : "perCPU",
+        "regionCode" : "us-east-1",
+        "resource" : "per vCPU per hour",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "9D3ZWXRS2VXMZET6" : {
+      "sku" : "9D3ZWXRS2VXMZET6",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "operatingSystem" : "Windows",
+        "usagetype" : "USE1-Fargate-Windows-OS-Hours:perCPU",
+        "operation" : "",
+        "cputype" : "perCPU OS License Fee",
+        "regionCode" : "us-east-1",
+        "resource" : "OS License Fee per vCPU per hour",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "WTG8RAG79KP7K3N8" : {
+      "sku" : "WTG8RAG79KP7K3N8",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "usagetype" : "USE1-ECS-Anywhere-Instance-hours",
+        "operation" : "AddExternalInstance",
+        "externalInstanceType" : "Default",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "7KPDPTDSCT4J3Z64" : {
+      "sku" : "7KPDPTDSCT4J3Z64",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "usagetype" : "USE1-Fargate-EphemeralStorage-GB-Hours",
+        "operation" : "",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service",
+        "storagetype" : "default"
+      }
+    },
+    "UNH9KPQP7W7C66C9" : {
+      "sku" : "UNH9KPQP7W7C66C9",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "usagetype" : "USE1-Fargate-ARM-GB-Hours",
+        "operation" : "",
+        "cpuArchitecture" : "ARM",
+        "memorytype" : "perGB",
+        "regionCode" : "us-east-1",
+        "resource" : "per GB per hour",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "8QDMJPGQCM368Z6X" : {
+      "sku" : "8QDMJPGQCM368Z6X",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "operatingSystem" : "Windows",
+        "usagetype" : "USE1-Fargate-Windows-GB-Hours",
+        "operation" : "",
+        "memorytype" : "perGB",
+        "regionCode" : "us-east-1",
+        "resource" : "per GB per hour",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "PBZNQUSEXZUC34C9" : {
+      "sku" : "PBZNQUSEXZUC34C9",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "usagetype" : "USE1-Fargate-GB-Hours",
+        "operation" : "",
+        "memorytype" : "perGB",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "XSZATS4VYMDC9CYN" : {
+      "sku" : "XSZATS4VYMDC9CYN",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "usagetype" : "USE1-Fargate-ARM-vCPU-Hours:perCPU",
+        "operation" : "",
+        "cpuArchitecture" : "ARM",
+        "cputype" : "perCPU",
+        "regionCode" : "us-east-1",
+        "resource" : "per vCPU per hour",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "VUZADW4HBG7NT6R7" : {
+      "sku" : "VUZADW4HBG7NT6R7",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "usagetype" : "USE1-ECS-Anywhere-Instance-hours-WithFree",
+        "operation" : "AddExternalInstance",
+        "externalInstanceType" : "With Free",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "DQ8NT47B7YY2CGC5" : {
+      "sku" : "DQ8NT47B7YY2CGC5",
+      "productFamily" : "Compute Metering",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "usagetype" : "USE1-ECS-EC2-vCPU-Hours",
+        "operation" : "",
+        "cputype" : "perCPU",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    },
+    "8CESGAFWKAJ98PME" : {
+      "sku" : "8CESGAFWKAJ98PME",
+      "productFamily" : "Compute",
+      "attributes" : {
+        "servicecode" : "AmazonECS",
+        "location" : "US East (N. Virginia)",
+        "locationType" : "AWS Region",
+        "tenancy" : "Shared",
+        "usagetype" : "USE1-Fargate-vCPU-Hours:perCPU",
+        "operation" : "",
+        "cputype" : "perCPU",
+        "regionCode" : "us-east-1",
+        "servicename" : "Amazon Elastic Container Service"
+      }
+    }
+  },
+  "terms" : {
+    "OnDemand" : {
+      "RF2BUTAD289DREDC" : {
+        "RF2BUTAD289DREDC.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "RF2BUTAD289DREDC",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "RF2BUTAD289DREDC.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "RF2BUTAD289DREDC.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - Windows - vCPU - US East (N.Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0465520000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "74HXSAMY4YHFPXQQ" : {
+        "74HXSAMY4YHFPXQQ.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "74HXSAMY4YHFPXQQ",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "74HXSAMY4YHFPXQQ.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "74HXSAMY4YHFPXQQ.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "USD 0.0 per GB-Hours for ECS-EC2-GB-Hours in US East (N. Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "GB-Hours",
+              "pricePerUnit" : {
+                "USD" : "0.0000000000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "XSZATS4VYMDC9CYN" : {
+        "XSZATS4VYMDC9CYN.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "XSZATS4VYMDC9CYN",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "XSZATS4VYMDC9CYN.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "XSZATS4VYMDC9CYN.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - ARM - vCPU - US East (N. Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0323800000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "UNH9KPQP7W7C66C9" : {
+        "UNH9KPQP7W7C66C9.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "UNH9KPQP7W7C66C9",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "UNH9KPQP7W7C66C9.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "UNH9KPQP7W7C66C9.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - ARM - Memory - US East (N. Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0035600000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "WTG8RAG79KP7K3N8" : {
+        "WTG8RAG79KP7K3N8.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "WTG8RAG79KP7K3N8",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "WTG8RAG79KP7K3N8.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "WTG8RAG79KP7K3N8.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "$0.01025 per hour for ECS-Anywhere-Instance-Hours",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0102500000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "VUZADW4HBG7NT6R7" : {
+        "VUZADW4HBG7NT6R7.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "VUZADW4HBG7NT6R7",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "VUZADW4HBG7NT6R7.JRTCKXETXF.4TES4JTS8Q" : {
+              "rateCode" : "VUZADW4HBG7NT6R7.JRTCKXETXF.4TES4JTS8Q",
+              "description" : "$0 per hour for ECS-Anywhere-Instance-Hours",
+              "beginRange" : "0",
+              "endRange" : "2200",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0000000000"
+              },
+              "appliesTo" : [ ]
+            },
+            "VUZADW4HBG7NT6R7.JRTCKXETXF.2A2Z7VTUXW" : {
+              "rateCode" : "VUZADW4HBG7NT6R7.JRTCKXETXF.2A2Z7VTUXW",
+              "description" : "$0.01025 per hour for ECS-Anywhere-Instance-Hours",
+              "beginRange" : "2200",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0102500000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "9D3ZWXRS2VXMZET6" : {
+        "9D3ZWXRS2VXMZET6.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "9D3ZWXRS2VXMZET6",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "9D3ZWXRS2VXMZET6.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "9D3ZWXRS2VXMZET6.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - Windows - OS - US East (N.Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0460000000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "DQ8NT47B7YY2CGC5" : {
+        "DQ8NT47B7YY2CGC5.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "DQ8NT47B7YY2CGC5",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "DQ8NT47B7YY2CGC5.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "DQ8NT47B7YY2CGC5.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "USD 0.0 per vCPU-Hours for ECS-EC2-vCPU-Hours in US East (N. Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "vCPU-Hours",
+              "pricePerUnit" : {
+                "USD" : "0.0000000000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "PBZNQUSEXZUC34C9" : {
+        "PBZNQUSEXZUC34C9.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "PBZNQUSEXZUC34C9",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "PBZNQUSEXZUC34C9.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "PBZNQUSEXZUC34C9.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - Memory  - US East (N.Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0044450000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "7KPDPTDSCT4J3Z64" : {
+        "7KPDPTDSCT4J3Z64.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "7KPDPTDSCT4J3Z64",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "7KPDPTDSCT4J3Z64.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "7KPDPTDSCT4J3Z64.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - Ephemeral Storage - US East (N. Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "GB-Hours",
+              "pricePerUnit" : {
+                "USD" : "0.0001110000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "8CESGAFWKAJ98PME" : {
+        "8CESGAFWKAJ98PME.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "8CESGAFWKAJ98PME",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "8CESGAFWKAJ98PME.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "8CESGAFWKAJ98PME.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - vCPU - US East (N.Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0404800000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      },
+      "8QDMJPGQCM368Z6X" : {
+        "8QDMJPGQCM368Z6X.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "8QDMJPGQCM368Z6X",
+          "effectiveDate" : "2025-08-01T00:00:00Z",
+          "priceDimensions" : {
+            "8QDMJPGQCM368Z6X.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "8QDMJPGQCM368Z6X.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "AWS Fargate - Windows - Memory  - US East (N.Virginia)",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "hours",
+              "pricePerUnit" : {
+                "USD" : "0.0051117500"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      }
+    }
+  },
+  "attributesList" : { }
+}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -934,17 +934,17 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 			cpu = 0
 		}
 
-		var ram float64
 		if newCnode.RAM == "" {
 			newCnode.RAM = n.Status.Capacity.Memory().String()
 		}
-		ram = float64(n.Status.Capacity.Memory().Value())
+		if newCnode.RAMBytes == "" {
+			newCnode.RAMBytes = fmt.Sprintf("%v", n.Status.Capacity.Memory().Value())
+		}
+		ram, _ := strconv.ParseFloat(newCnode.RAMBytes, 64)
 		if math.IsNaN(ram) {
 			log.Warnf("ram parsed as NaN. Setting to 0.")
 			ram = 0
 		}
-
-		newCnode.RAMBytes = fmt.Sprintf("%f", ram)
 
 		gpuc, err := strconv.ParseFloat(newCnode.GPU, 64)
 		if err != nil {

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -25,6 +25,7 @@ const (
 	AWSAccessKeySecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	AWSClusterIDEnvVar       = "AWS_CLUSTER_ID"
 	AWSPricingURL            = "AWS_PRICING_URL"
+	AWSECSPricingURL         = "AWS_ECS_PRICING_URL"
 
 	AlibabaAccessKeyIDEnvVar     = "ALIBABA_ACCESS_KEY_ID"
 	AlibabaAccessKeySecretEnvVar = "ALIBABA_SECRET_ACCESS_KEY"
@@ -183,6 +184,11 @@ func GetAWSClusterID() string {
 // GetAWSPricingURL returns an optional alternative URL to fetch AWS pricing data from; for use in airgapped environments
 func GetAWSPricingURL() string {
 	return env.Get(AWSPricingURL, "")
+}
+
+// GetAWSECSPricingURL returns an optional alternative URL to fetch AmazonECS pricing data from; for use in airgapped environments
+func GetAWSECSPricingURL() string {
+	return env.Get(AWSECSPricingURL, "")
 }
 
 // GetAlibabaAccessKeyID returns the environment variable value for AlibabaAccessKeyIDEnvVar which represents


### PR DESCRIPTION
## What does this PR change?
* Downloads and parses `AmazonECS` pricing data to correctly populate Amazon Fargate nodes pricing on EKS.

## Does this PR relate to any other PRs?
* No as far as I'm aware of

## How will this PR impact users?
* No action is required on user-side. Fargate nodes will now get correct pricing.

## Does this PR address any GitHub or Zendesk issues?
* Closes #1622

## How was this PR tested?
* I've published snapshot images at [ghcr.io/motoki317/opencost](https://github.com/motoki317/opencost/pkgs/container/opencost) and tested it on a real environment, and it is working fine at least for my cluster.
`patch-eks-fargate` includes this PR, and `patch-eks` includes both this PR and #3348.

Prometheus metrics `node_total_hourly_cost`, `node_cpu_hourly_cost`, and `node_ram_hourly_cost` match the actual fargate node cost.
For example, in ap-northeast-1, `node_cpu_hourly_cost` is `0.05056` and `node_ram_hourly_cost` is `0.00553`.
If we have a Fargate node with `ProvisionedCapacity` of `0.25vCPU 1GB`, we have `node_total_hourly_cost` equal to `0.05056 * 0.25 + 0.00553 * 1 = 0.01817`.
https://aws.amazon.com/fargate/pricing/

<img width="1464" height="755" alt="image" src="https://github.com/user-attachments/assets/5221e87a-2f90-4afa-ae70-fcff859410a7" />

## Does this PR require changes to documentation?
* Probably not?

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Not sure yet