### PR TITLE
Data model 2.0 - Add UID support to namespace metrics

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Namespace struct {
+	UID         types.UID
 	Name        string
 	Labels      map[string]string
 	Annotations map[string]string
@@ -181,6 +182,7 @@ func GetControllerOfNoCopy(pod *Pod) *metav1.OwnerReference {
 
 func TransformNamespace(input *v1.Namespace) *Namespace {
 	return &Namespace{
+		UID:         input.UID,
 		Name:        input.Name,
 		Annotations: input.Annotations,
 		Labels:      input.Labels,

--- a/pkg/metrics/namespacemetrics_test.go
+++ b/pkg/metrics/namespacemetrics_test.go
@@ -1,0 +1,171 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type mockNamespaceCache struct {
+	clustercache.ClusterCache
+	namespaces []*clustercache.Namespace
+}
+
+func (m mockNamespaceCache) GetAllNamespaces() []*clustercache.Namespace {
+	return m.namespaces
+}
+
+func TestKubecostNamespaceCollector_Collect(t *testing.T) {
+	// Test with namespace that has annotations
+	cache := mockNamespaceCache{
+		namespaces: []*clustercache.Namespace{
+			{
+				Name:        "test-ns",
+				UID:         types.UID("test-uid"),
+				Annotations: map[string]string{"team": "backend"},
+			},
+		},
+	}
+	
+	collector := KubecostNamespaceCollector{
+		KubeClusterCache: cache,
+		metricsConfig:    MetricsConfig{},
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("Expected 1 metric, got %d", count)
+	}
+}
+
+func TestKubeNamespaceCollector_Collect(t *testing.T) {
+	// Test with namespace that has labels
+	cache := mockNamespaceCache{
+		namespaces: []*clustercache.Namespace{
+			{
+				Name:   "test-ns",
+				UID:    types.UID("test-uid"),
+				Labels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+	
+	collector := KubeNamespaceCollector{
+		KubeClusterCache: cache,
+		metricsConfig:    MetricsConfig{},
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("Expected 1 metric, got %d", count)
+	}
+}
+
+func TestNamespaceAnnotationsMetric_Write(t *testing.T) {
+	metric := newNamespaceAnnotationsMetric(
+		"test_metric",
+		"test-ns",
+		"test-uid",
+		[]string{"team"},
+		[]string{"backend"},
+	)
+
+	pbMetric := &dto.Metric{}
+	err := metric.Write(pbMetric)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	if pbMetric.Gauge == nil || *pbMetric.Gauge.Value != 1.0 {
+		t.Error("Expected gauge value 1.0")
+	}
+
+	if len(pbMetric.Label) != 3 { // team + namespace + uid
+		t.Errorf("Expected 3 labels, got %d", len(pbMetric.Label))
+	}
+}
+
+func TestKubeNamespaceLabelsMetric_Write(t *testing.T) {
+	metric := newKubeNamespaceLabelsMetric(
+		"test_metric",
+		"test-ns", 
+		"test-uid",
+		[]string{"env"},
+		[]string{"prod"},
+	)
+
+	pbMetric := &dto.Metric{}
+	err := metric.Write(pbMetric)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	if pbMetric.Gauge == nil || *pbMetric.Gauge.Value != 1.0 {
+		t.Error("Expected gauge value 1.0")
+	}
+
+	if len(pbMetric.Label) != 3 { // env + namespace + uid
+		t.Errorf("Expected 3 labels, got %d", len(pbMetric.Label))
+	}
+}
+
+func TestKubecostNamespaceCollector_Describe(t *testing.T) {
+	collector := KubecostNamespaceCollector{metricsConfig: MetricsConfig{}}
+	
+	ch := make(chan *prometheus.Desc, 1)
+	go func() {
+		collector.Describe(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("Expected 1 descriptor, got %d", count)
+	}
+}
+
+func TestKubeNamespaceCollector_Describe(t *testing.T) {
+	collector := KubeNamespaceCollector{metricsConfig: MetricsConfig{}}
+	
+	ch := make(chan *prometheus.Desc, 1)
+	go func() {
+		collector.Describe(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("Expected 1 descriptor, got %d", count)
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* Updates namespace metric collection and emission to include UID for enhanced  metric identification. Changes include:
- Add UID field to Namespace struct in clustercache
- Update TransformNamespace to capture namespace UID
- Add UID parameter to namespace metric constructors
- Include UID in Prometheus label descriptors
- Add UID to Protocol Buffer label pairs for both annotation and label metrics

This enables unique identification of namespace metrics by UID in addition to namespace name for improved metric tracking and correlation. 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users will be able to see the Namespace UIDs populated in the Namespace metrics.

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Verified correct UID propagation in the relevant metric by Prometheus queries
* Ensured backward compatibility with existing metric consumers

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* It should be part of the next release, however I don't have access to label it.