### PR TITLE
Data Model 2.0 - Add UID support to ReplicaSet resources

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -144,6 +144,7 @@ type PodDisruptionBudget struct {
 }
 
 type ReplicaSet struct {
+	UID             types.UID
 	Name            string
 	Namespace       string
 	OwnerReferences []metav1.OwnerReference
@@ -353,6 +354,7 @@ func TransformPodDisruptionBudget(input *policyv1.PodDisruptionBudget) *PodDisru
 
 func TransformReplicaSet(input *appsv1.ReplicaSet) *ReplicaSet {
 	return &ReplicaSet{
+		UID:             input.UID,
 		Name:            input.Name,
 		Namespace:       input.Namespace,
 		OwnerReferences: input.OwnerReferences,


### PR DESCRIPTION
## What does this PR change?
Updates ReplicaSet struct and transformation function to include UID field for enhanced resource identification. Changes include:

- Add UID field to ReplicaSet struct in clustercache
- Update TransformReplicaSet to capture ReplicaSet UID from Kubernetes input

This enables unique identification of ReplicaSet resources by UID in addition to name and namespace for improved resource tracking and correlation. Provides foundation for future ReplicaSet-specific metrics and maintains consistency with other Kubernetes object types.

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
*  No immediate impact on end users. This PR is an internal infrastructure change for the Data Model 2.0 project.
*  Users will not notice any difference in OpenCost behavior, performance, or output

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Manual verification of struct compilation and TransformReplicaSet function. 
* No functional testing needed since this only adds internal data fields without changing user-facing 
  behavior.

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* It should be part of the next release, however I don't have access to label it.
* It's a low-risk infrastructure change that completes UID support across Kubernetes objects and enables future ReplicaSet metrics development.