### PR TITLE
Data Model 2.0 - Add UID support to PersistentVolumeClaim metrics

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -98,6 +98,7 @@ type StatefulSet struct {
 }
 
 type PersistentVolumeClaim struct {
+	UID         types.UID
 	Name        string
 	Namespace   string
 	Spec        v1.PersistentVolumeClaimSpec
@@ -306,6 +307,7 @@ func TransformPersistentVolume(input *v1.PersistentVolume) *PersistentVolume {
 
 func TransformPersistentVolumeClaim(input *v1.PersistentVolumeClaim) *PersistentVolumeClaim {
 	return &PersistentVolumeClaim{
+		UID:         input.UID,
 		Name:        input.Name,
 		Namespace:   input.Namespace,
 		Spec:        input.Spec,

--- a/pkg/metrics/pvcmetrics_test.go
+++ b/pkg/metrics/pvcmetrics_test.go
@@ -1,0 +1,130 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func collectMetrics(collector KubePVCCollector) []prometheus.Metric {
+	ch := make(chan prometheus.Metric, 10)
+	go func() {
+		defer close(ch)
+		collector.Collect(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	return metrics
+}
+
+
+func TestKubePVCCollector_Describe(t *testing.T) {
+	collector := KubePVCCollector{metricsConfig: MetricsConfig{}}
+	ch := make(chan *prometheus.Desc, 5)
+	go func() {
+		defer close(ch)
+		collector.Describe(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 2 {
+		t.Errorf("Expected 2 metrics described, got %d", count)
+	}
+}
+
+
+func TestKubePVCCollector_Collect(t *testing.T) {
+	storageSize := resource.MustParse("1Gi")
+	pvc := &clustercache.PersistentVolumeClaim{
+		UID:       types.UID("test-uid"),
+		Name:      "test-pvc",
+		Namespace: "default",
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceStorage: storageSize},
+			},
+		},
+	}
+
+	cache := NewFakePVCCache([]*clustercache.PersistentVolumeClaim{pvc})
+	collector := KubePVCCollector{
+		KubeClusterCache: cache,
+		metricsConfig:    MetricsConfig{},
+	}
+
+	metrics := collectMetrics(collector)
+	if len(metrics) != 2 {
+		t.Errorf("Expected 2 metrics, got %d", len(metrics))
+	}
+
+	// Verify UID label exists in metrics
+	for _, metric := range metrics {
+		var m dto.Metric
+		if err := metric.Write(&m); err != nil {
+			t.Errorf("Error writing metric: %v", err)
+		}
+
+		hasUID := false
+		for _, label := range m.Label {
+			if *label.Name == "uid" && *label.Value == "test-uid" {
+				hasUID = true
+				break
+			}
+		}
+		if !hasUID {
+			t.Error("Metric missing UID label")
+		}
+	}
+}
+
+
+func TestKubePVCMetrics_UIDLabel(t *testing.T) {
+	metric := newKubePVCResourceRequestsStorageBytesMetric(
+		"test_metric", "test-pvc", "test-namespace", "test-uid", 1000.0,
+	)
+
+	var m dto.Metric
+	if err := metric.Write(&m); err != nil {
+		t.Fatalf("Error writing metric: %v", err)
+	}
+
+	// Verify UID label exists
+	for _, label := range m.Label {
+		if *label.Name == "uid" && *label.Value == "test-uid" {
+			return
+		}
+	}
+	t.Error("UID label not found in metric")
+}
+
+
+
+
+
+
+type FakePVCCache struct {
+	clustercache.ClusterCache
+	pvcs []*clustercache.PersistentVolumeClaim
+}
+
+func (f FakePVCCache) GetAllPersistentVolumeClaims() []*clustercache.PersistentVolumeClaim {
+	return f.pvcs
+}
+
+func NewFakePVCCache(pvcs []*clustercache.PersistentVolumeClaim) FakePVCCache {
+	return FakePVCCache{
+		pvcs: pvcs,
+	}
+}


### PR DESCRIPTION
## What does this PR change?
This PR adds UID (Unique Identifier) support to PersistentVolumeClaim metrics in OpenCost. Specifically:
  - Adds UID field to the PersistentVolumeClaim struct in clustercache.go:101
  - Updates the transform function to capture the UID from Kubernetes PVC objects in clustercache.go:310
  - Enhances both PVC metrics (kube_persistentvolumeclaim_info and kube_persistentvolumeclaim_resource_requests_storage_bytes) to include the UID as a label

This enables proper tracking and identification of PVC resources in metrics data. 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Users will now have access to the PVC UID in their metrics, which provides:
* Better resource tracking: UIDs are immutable and unique across the cluster lifetime, unlike names which can be reuse
* Enhanced observability: Users can correlate PVC metrics with other Kubernetes resources using the UID
* Improved debugging: UIDs help distinguish between different PVC instances that may have had the same name over time
* Backward compatibility: Existing metrics continue to work as before, with the UID being an additional label

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
This PR was tested by:
* Verifying that PVC metrics now include the uid label in Prometheus output
* Confirming that existing functionality remains intact (metrics still collect name, namespace, storage class, etc.)
* Comprehensive unit tests that verify UID label inclusion in both PVC metrics and validate end-to-end metric collection from PVC objects to Prometheus output. 
* The tests use a fake cache to simulate cluster data and confirm the UID field is correctly extracted, transformed, and included in metric labels without breaking existing functionality.


## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* It should be part of the next release, however I don't have access to label it.