### PR TITLE
Data Model 2.0 - Add UID support to Job metrics

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -116,6 +116,7 @@ type StorageClass struct {
 }
 
 type Job struct {
+	UID       types.UID
 	Name      string
 	Namespace string
 	Status    batchv1.JobStatus
@@ -328,6 +329,7 @@ func TransformStorageClass(input *stv1.StorageClass) *StorageClass {
 
 func TransformJob(input *batchv1.Job) *Job {
 	return &Job{
+		UID:       input.UID,
 		Name:      input.Name,
 		Namespace: input.Namespace,
 		Status:    input.Status,

--- a/pkg/metrics/jobmetrics_test.go
+++ b/pkg/metrics/jobmetrics_test.go
@@ -1,0 +1,91 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type mockJobCache struct {
+	clustercache.ClusterCache
+	jobs []*clustercache.Job
+}
+
+func (m mockJobCache) GetAllJobs() []*clustercache.Job {
+	return m.jobs
+}
+
+func TestKubeJobCollector_Collect(t *testing.T) {
+	// Test with job that has no failures
+	cache := mockJobCache{
+		jobs: []*clustercache.Job{
+			{
+				Name:      "test-job",
+				Namespace: "default",
+				UID:       types.UID("test-job-uid"),
+				Status:    batchv1.JobStatus{Failed: 0},
+			},
+		},
+	}
+
+	collector := KubeJobCollector{
+		KubeClusterCache: cache,
+		metricsConfig:    MetricsConfig{},
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("Expected 1 metric, got %d", count)
+	}
+}
+
+func TestKubeJobStatusFailedMetric_Write(t *testing.T) {
+	metric := newKubeJobStatusFailedMetric(
+		"test-job",
+		"default",
+		"test-job-uid",
+		"kube_job_status_failed",
+		"",
+		0.0,
+	)
+
+	pbMetric := &dto.Metric{}
+	err := metric.Write(pbMetric)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	if pbMetric.Gauge == nil || *pbMetric.Gauge.Value != 0.0 {
+		t.Error("Expected gauge value 0.0")
+	}
+
+	if len(pbMetric.Label) != 4 { // job_name + namespace + uid + reason
+		t.Errorf("Expected 4 labels, got %d", len(pbMetric.Label))
+	}
+
+	// Verify UID label is present
+	foundUID := false
+	for _, label := range pbMetric.Label {
+		if *label.Name == "uid" && *label.Value == "test-job-uid" {
+			foundUID = true
+			break
+		}
+	}
+	if !foundUID {
+		t.Error("Expected uid label not found")
+	}
+}


### PR DESCRIPTION
## What does this PR change?
- Add UID field to clustercache Job struct and TransformJob function
- Update KubeJobStatusFailedMetric to include UID in metric labels
- Modify job metric collection to extract and propagate job UID
- Add comprehensive unit tests for job metrics UID functionality
- Ensure job metrics now include uid label for better tracking and correlation 

## Does this PR relate to any other PRs?
* No 

## How will this PR impact users?
*   Users can now uniquely identify and correlate job metrics using the new uid label, enabling better tracking across job lifecycles and more precise alerting. This is a backward-compatible additive change that doesn't break existing queries or dashboards.

## Does this PR address any GitHub or Zendesk issues?
* No

## How was this PR tested?
* Added comprehensive unit tests in jobmetrics_test.go to verify UID extraction, metric collection, and label serialization functionality. Confirmed all existing metrics package tests continue to pass and the package builds successfully.

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* It should be part of the next release, however I don't have access to label it.