### PR TITLE
return metrics name in name method to avoid overlap of multiple ID with unique names

### DIFF
--- a/modules/collector-source/pkg/collector/datasource.go
+++ b/modules/collector-source/pkg/collector/datasource.go
@@ -116,7 +116,7 @@ func (c *collectorDataSource) RegisterDiagnostics(diagService diagnostics.Diagno
 	diagnosticDefinitions := c.diagnosticsModule.DiagnosticsDefinitions()
 
 	for _, dd := range diagnosticDefinitions {
-		err := diagService.Register(dd.ID, dd.Description, CollectorDiagnosticCategory, func(ctx context.Context) (map[string]any, error) {
+		err := diagService.Register(dd.MetricName, dd.Description, CollectorDiagnosticCategory, func(ctx context.Context) (map[string]any, error) {
 			details, err := c.diagnosticsModule.DiagnosticsDetails(dd.ID)
 			if err != nil {
 				return nil, err

--- a/modules/collector-source/pkg/metric/diagnostics.go
+++ b/modules/collector-source/pkg/metric/diagnostics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubecost/events"
 	"github.com/opencost/opencost/core/pkg/collections"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/util/sliceutil"
 	"github.com/opencost/opencost/modules/collector-source/pkg/event"
 )
@@ -34,6 +35,21 @@ const (
 	KubernetesPodsScraperDiagnosticID         = event.KubernetesClusterScraperName + "-" + event.PodScraperType
 	KubernetesPvsScraperDiagnosticID          = event.KubernetesClusterScraperName + "-" + event.PvScraperType
 	KubernetesPvcsScraperDiagnosticID         = event.KubernetesClusterScraperName + "-" + event.PvcScraperType
+
+	// Metric Names for the diagnostics (used in the UI)
+	DGGMScraperDiagnosticMetricName                   = "DCGM Metrics"
+	OpenCostScraperDiagnosticMetricName               = "Opencost Metrics"
+	NodeStatsScraperDiagnosticMetricName              = "Node Stats Metrics"
+	NetworkCostsScraperDiagnosticMetricName           = "Network Costs Metrics"
+	KubernetesNodesScraperDiagnosticMetricName        = "Kubernetes Nodes Metrics"
+	KubernetesNamespacesScraperDiagnosticMetricName   = "Kubernetes Namespaces Metrics"
+	KubernetesReplicaSetsScraperDiagnosticMetricName  = "Kubernetes Replica Sets Metrics"
+	KubernetesDeploymentsScraperDiagnosticMetricName  = "Kubernetes Deployments Metrics"
+	KubernetesStatefulSetsScraperDiagnosticMetricName = "Kubernetes Stateful Sets Metrics"
+	KubernetesServicesScraperDiagnosticMetricName     = "Kubernetes Services Metrics"
+	KubernetesPodsScraperDiagnosticMetricName         = "Kubernetes Pods Metrics"
+	KubernetesPvsScraperDiagnosticMetricName          = "Kubernetes PVs Metrics"
+	KubernetesPvcsScraperDiagnosticMetricName         = "Kubernetes PVCs Metrics"
 )
 
 // diagnostic defintion is the type used to define a deterministic list of specific diagnostics we _expect_ to collect
@@ -49,91 +65,91 @@ type diagnosticDefinition struct {
 var diagnosticDefinitions map[string]*diagnosticDefinition = map[string]*diagnosticDefinition{
 	DcgmScraperDiagnosticID: {
 		ID:          DcgmScraperDiagnosticID,
-		MetricName:  event.DCGMScraperName,
+		MetricName:  DGGMScraperDiagnosticMetricName,
 		Label:       "DCGM scraper is available and is being scraped.",
 		Description: scraperDiagnosticDescriptionFor(event.DCGMScraperName, ""),
 	},
 
 	OpenCostScraperDiagnosticID: {
 		ID:          OpenCostScraperDiagnosticID,
-		MetricName:  event.OpenCostScraperName,
+		MetricName:  OpenCostScraperDiagnosticMetricName,
 		Label:       "Opencost metrics scraper is available and is being scraped.",
 		Description: scraperDiagnosticDescriptionFor(event.OpenCostScraperName, ""),
 	},
 
 	NodeStatsScraperDiagnosticID: {
 		ID:          NodeStatsScraperDiagnosticID,
-		MetricName:  event.NodeStatsScraperName,
+		MetricName:  NodeStatsScraperDiagnosticMetricName,
 		Label:       "Node stats summary scraper is available and is being scraped.",
 		Description: scraperDiagnosticDescriptionFor(event.NodeStatsScraperName, ""),
 	},
 
 	NetworkCostsScraperDiagnosticID: {
 		ID:          NetworkCostsScraperDiagnosticID,
-		MetricName:  event.NetworkCostsScraperName,
+		MetricName:  NetworkCostsScraperDiagnosticMetricName,
 		Label:       "Network costs daemonset metrics scrapers are available and being scraped.",
 		Description: scraperDiagnosticDescriptionFor(event.NetworkCostsScraperName, ""),
 	},
 
 	KubernetesNodesScraperDiagnosticID: {
 		ID:          KubernetesNodesScraperDiagnosticID,
-		MetricName:  KubernetesNodesScraperDiagnosticID,
+		MetricName:  KubernetesNodesScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.NodeScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.NodeScraperType),
 	},
 
 	KubernetesNamespacesScraperDiagnosticID: {
 		ID:          KubernetesNamespacesScraperDiagnosticID,
-		MetricName:  KubernetesNamespacesScraperDiagnosticID,
+		MetricName:  KubernetesNamespacesScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.NamespaceScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.NamespaceScraperType),
 	},
 
 	KubernetesReplicaSetsScraperDiagnosticID: {
 		ID:          KubernetesReplicaSetsScraperDiagnosticID,
-		MetricName:  KubernetesReplicaSetsScraperDiagnosticID,
+		MetricName:  KubernetesReplicaSetsScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.ReplicaSetScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.ReplicaSetScraperType),
 	},
 
 	KubernetesDeploymentsScraperDiagnosticID: {
 		ID:          KubernetesDeploymentsScraperDiagnosticID,
-		MetricName:  KubernetesDeploymentsScraperDiagnosticID,
+		MetricName:  KubernetesDeploymentsScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.DeploymentScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.DeploymentScraperType),
 	},
 
 	KubernetesStatefulSetsScraperDiagnosticID: {
 		ID:          KubernetesStatefulSetsScraperDiagnosticID,
-		MetricName:  KubernetesStatefulSetsScraperDiagnosticID,
+		MetricName:  KubernetesStatefulSetsScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.StatefulSetScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.StatefulSetScraperType),
 	},
 
 	KubernetesServicesScraperDiagnosticID: {
 		ID:          KubernetesServicesScraperDiagnosticID,
-		MetricName:  KubernetesServicesScraperDiagnosticID,
+		MetricName:  KubernetesServicesScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.ServiceScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.ServiceScraperType),
 	},
 
 	KubernetesPodsScraperDiagnosticID: {
 		ID:          KubernetesPodsScraperDiagnosticID,
-		MetricName:  KubernetesPodsScraperDiagnosticID,
+		MetricName:  KubernetesPodsScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.PodScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.PodScraperType),
 	},
 
 	KubernetesPvsScraperDiagnosticID: {
 		ID:          KubernetesPvsScraperDiagnosticID,
-		MetricName:  KubernetesPvsScraperDiagnosticID,
+		MetricName:  KubernetesPvsScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.PvScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.PvScraperType),
 	},
 
 	KubernetesPvcsScraperDiagnosticID: {
 		ID:          KubernetesPvcsScraperDiagnosticID,
-		MetricName:  KubernetesPvcsScraperDiagnosticID,
+		MetricName:  KubernetesPvcsScraperDiagnosticMetricName,
 		Label:       fmt.Sprintf("Kubernetes cluster resources: %s are available and being scraped", event.PvcScraperType),
 		Description: scraperDiagnosticDescriptionFor(event.KubernetesClusterScraperName, event.PvcScraperType),
 	},
@@ -203,7 +219,7 @@ func (sd *scrapeDiagnostic) Id() string {
 
 // Name returns the name of the scraper the event fired from.
 func (sd *scrapeDiagnostic) Name() string {
-	return sd.scraper
+	return sd.diagnostic.MetricName
 }
 
 // Details generates an exportable detail map for the specific diagnostic, and resets any of its internal
@@ -293,7 +309,10 @@ func (d *DiagnosticsModule) onScrapeEvent(event event.ScrapeEvent) {
 		return
 	}
 
-	d.diagnostics.Insert(newScrapeDiagnostic(event, def))
+	err := d.diagnostics.Insert(newScrapeDiagnostic(event, def))
+	if err != nil {
+		log.Errorf("failed to insert scrape diagnostic: %s", err)
+	}
 }
 
 // DiagnosticDefinitions returns a deterministic mapping of pre-defined diagnostics used with the collector.

--- a/modules/collector-source/pkg/metric/diagnostics.go
+++ b/modules/collector-source/pkg/metric/diagnostics.go
@@ -222,7 +222,7 @@ func (sd *scrapeDiagnostic) Name() string {
 	if sd.diagnostic != nil {
 		return sd.diagnostic.MetricName
 	}
-	return sd.scraper
+	return scraperIdFor(sd.scraper, sd.scrapeType)
 }
 
 // Details generates an exportable detail map for the specific diagnostic, and resets any of its internal

--- a/modules/collector-source/pkg/metric/diagnostics.go
+++ b/modules/collector-source/pkg/metric/diagnostics.go
@@ -219,7 +219,10 @@ func (sd *scrapeDiagnostic) Id() string {
 
 // Name returns the name of the scraper the event fired from.
 func (sd *scrapeDiagnostic) Name() string {
-	return sd.diagnostic.MetricName
+	if sd.diagnostic != nil {
+		return sd.diagnostic.MetricName
+	}
+	return sd.scraper
 }
 
 // Details generates an exportable detail map for the specific diagnostic, and resets any of its internal


### PR DESCRIPTION
## What does this PR change?
* return `diagnostic.MetricName` in `Name` method for scraper diagnostics to avoid overlap of a multiple IDs with unique name. 
Ref: https://github.com/opencost/opencost/blob/0ea2743e1e3b4112f559bee253a990094d7c1cb4/core/pkg/collections/idnamemap.go#L43-L45
and
https://github.com/opencost/opencost/blob/0ea2743e1e3b4112f559bee253a990094d7c1cb4/core/pkg/collections/idnamemap.go#L80-L89
* Update metric names for diagnostics to make them UI friendly.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* No failing diagnostics with error `diagnostic not available` for same diagnostics scraper name

## Does this PR address any GitHub or Zendesk issues?
* Closes https://apptio.atlassian.net/browse/KCM-4601

## How was this PR tested?
* Ran agent locally and checked the uploaded diagnostics files:
```json
{
    "application": "Opencost",
    "startTime": "2025-09-19T18:28:52Z",
    "results": [
        {
            "id": "0199633c-7abd-7687-9c5e-ffadeb62f62a",
            "name": "Kubernetes Nodes Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: nodes",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.02946Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: nodes are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 1,
                    "total": 1
                }
            }
        },
        {
            "id": "0199633c-7abd-7728-847d-c7aca5fe0d18",
            "name": "Kubernetes Stateful Sets Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: statefulsets",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029478Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: statefulsets are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 7,
                    "total": 7
                }
            }
        },
        {
            "id": "0199633c-7abd-768b-9266-d0edbccf384b",
            "name": "Kubernetes Deployments Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: deployments",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029467Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: deployments are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 29,
                    "total": 29
                }
            }
        },
        {
            "id": "0199633c-7abd-7753-9b93-fc76510ebac8",
            "name": "DCGM Metrics",
            "description": "Determine if the scraper for: dcgm-metrics is correctly reporting data",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029489Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "DCGM scraper is available and is being scraped.",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 0,
                    "total": 0
                }
            }
        },
        {
            "id": "0199633c-7abd-770c-aa2c-5412e3106354",
            "name": "Kubernetes Replica Sets Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: replicasets",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029478Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: replicasets are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 66,
                    "total": 66
                }
            }
        },
        {
            "id": "0199633c-7abd-7704-811c-31af46cf73ec",
            "name": "Kubernetes PVs Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: pvs",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029483Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: pvs are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 4,
                    "total": 4
                }
            }
        },
        {
            "id": "0199633c-7abd-777e-9b48-c71f5118094a",
            "name": "Kubernetes Services Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: services",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029493Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: services are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 99,
                    "total": 99
                }
            }
        },
        {
            "id": "0199633c-7abd-7766-b3ea-5f962de98f46",
            "name": "Opencost Metrics",
            "description": "Determine if the scraper for: opencost-metrics is correctly reporting data",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.02949Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Opencost metrics scraper is available and is being scraped.",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 1,
                    "total": 1
                }
            }
        },
        {
            "id": "0199633c-7abd-76ca-9c80-2bf68c6dcee5",
            "name": "Network Costs Metrics",
            "description": "Determine if the scraper for: network-costs-metrics is correctly reporting data",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029488Z",
            "details": {
                "docLink": "",
                "errors": [
                    "failed to fetch URL: Get \"http://10.0.144.194:3001/metrics\": dial tcp 10.0.144.194:3001: i/o timeout"
                ],
                "label": "Network costs daemonset metrics scrapers are available and being scraped.",
                "passed": false,
                "stats": {
                    "fail": 1,
                    "success": 0,
                    "total": 1
                }
            }
        },
        {
            "id": "0199633c-7abd-777d-abab-4f174d3844cf",
            "name": "Kubernetes Namespaces Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: namespaces",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029493Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: namespaces are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 17,
                    "total": 17
                }
            }
        },
        {
            "id": "0199633c-7abd-774f-90b0-1a4e24adb656",
            "name": "Kubernetes Pods Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: pods",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029504Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: pods are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 56,
                    "total": 56
                }
            }
        },
        {
            "id": "0199633c-7abd-777a-8052-e841f1215cd8",
            "name": "Kubernetes PVCs Metrics",
            "description": "Determine if the scraper for: kubernetes-metrics is correctly report data for type: pvcs",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029506Z",
            "details": {
                "docLink": "",
                "errors": [],
                "label": "Kubernetes cluster resources: pvcs are available and being scraped",
                "passed": true,
                "stats": {
                    "fail": 0,
                    "success": 4,
                    "total": 4
                }
            }
        },
        {
            "id": "0199633c-7abd-76c6-be12-66b966278b14",
            "name": "Node Stats Metrics",
            "description": "Determine if the scraper for: nodestats-metrics is correctly reporting data",
            "category": "collector",
            "timestamp": "2025-09-19T18:28:52.029518Z",
            "details": {
                "docLink": "",
                "errors": [
                    "error retrieving node data: problem getting node address: stats/summary. Use DEBUG log level for individual connection method errors"
                ],
                "label": "Node stats summary scraper is available and is being scraped.",
                "passed": false,
                "stats": {
                    "fail": 1,
                    "success": 0,
                    "total": 1
                }
            }
        }
    ]
}
```

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 