### PR TITLE
feat: add MCP server for OpenCost allocation and asset queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,76 @@ Visit the full documentation for [recommended installation options](https://www.
 - [Prometheus Metrics](https://www.opencost.io/docs/integrations/prometheus)
 - [User Interface](https://www.opencost.io/docs/installation/ui)
 
+## MCP Server
+
+The OpenCost MCP (Model Context Protocol) server provides AI agents with access to cost allocation and asset data through a standardized interface.
+
+### Features
+
+- **Allocation Queries**: Retrieve cost allocation data with filtering and aggregation
+- **Asset Queries**: Access detailed asset information including nodes, disks, load balancers, and more
+- **Type-Specific Fields**: Full support for asset-specific parameters (GPU details, storage classes, etc.)
+- **Dynamic Session Management**: Unique session and query ID generation
+- **Request Validation**: Built-in validation using go-playground/validator
+
+### Prerequisites
+
+- Prometheus server running and accessible
+- OpenCost configured to connect to your Prometheus instance
+- MCP client that supports stdio transport (e.g., Cursor, Claude Desktop)
+
+### Building the MCP Server
+
+```bash
+# Build the MCP server binary
+go build -o mcp-server cmd/mcp-server/main.go
+```
+
+### Configuration
+
+Add the following configuration to your MCP client (e.g., Cursor's `mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "opencost": {
+      "type": "stdio",
+      "command": "/path/to/opencost/mcp-server",
+      "env": {
+        "PROMETHEUS_SERVER_ENDPOINT": "https://your-prometheus-endpoint"
+      },
+      "args": []
+    }
+  }
+}
+```
+
+### Available Tools
+
+- **`get_allocation_costs`**: Retrieve allocation cost data with parameters:
+  - `window`: Time window (e.g., "7d", "1h", "30m")
+  - `aggregate`: Aggregation properties (e.g., "namespace", "pod", "node")
+  - `step`: Resolution step size
+  - `accumulate`: Whether to accumulate over time
+  - `share_idle`: Whether to share idle costs
+  - `include_idle`: Whether to include idle resources
+  - `idle_by_node`: Whether to calculate idle by node
+  - `include_proportional_asset_resource_costs`: Include proportional asset costs
+  - `include_aggregated_metadata`: Include aggregated metadata
+  - `share_lb`: Whether to share load balancer costs
+
+- **`get_asset_costs`**: Retrieve asset cost data with parameters:
+  - `window`: Time window (e.g., "7d", "1h", "30m")
+
+### Supported Asset Types
+
+- **Node**: Compute instances with CPU, RAM, GPU details
+- **Disk**: Storage volumes with usage and cost breakdown
+- **LoadBalancer**: Load balancer instances with IP and private status
+- **Network**: Network-related costs and usage
+- **Cloud**: Cloud service costs with credit information
+- **ClusterManagement**: Kubernetes cluster management costs
+
 ## Contributing
 
 We :heart: pull requests! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for information on building the project from source and contributing changes.

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	opencost_mcp "github.com/opencost/opencost/pkg/mcp"
+	"github.com/rs/zerolog/log"
+
+	mcp_sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Tool argument structures
+type AllocationArgs struct {
+	Window    string `json:"window"`
+	Aggregate string `json:"aggregate"`
+
+	// Allocation query parameters
+	Step                                  string `json:"step,omitempty"`                                      // Duration string (e.g., "1h", "30m")
+	Resolution                            string `json:"resolution,omitempty"`                                // Duration string (e.g., "1h", "30m")
+	Accumulate                            bool   `json:"accumulate,omitempty"`                                // Whether to accumulate over time
+	ShareIdle                             bool   `json:"share_idle,omitempty"`                                // Whether to share idle costs
+	IncludeIdle                           bool   `json:"include_idle,omitempty"`                              // Whether to include idle resources
+	IdleByNode                            bool   `json:"idle_by_node,omitempty"`                              // Whether to calculate idle by node
+	IncludeProportionalAssetResourceCosts bool   `json:"include_proportional_asset_resource_costs,omitempty"` // Whether to include proportional asset costs
+	IncludeAggregatedMetadata             bool   `json:"include_aggregated_metadata,omitempty"`               // Whether to include aggregated metadata
+	ShareLB                               bool   `json:"share_lb,omitempty"`                                  // Whether to share load balancer costs
+}
+
+type AssetArgs struct {
+	Window string `json:"window"`
+}
+
+// generateSessionID creates a unique session ID based on timestamp and process ID
+func generateSessionID() string {
+	return fmt.Sprintf("session-%d-%d", time.Now().UnixNano(), os.Getpid())
+}
+
+func main() {
+	log.Logger = log.Output(os.Stderr)
+
+	log.Info().Msg("Initializing OpenCost server dependencies...")
+	opencost_server, err := opencost_mcp.Initialize() // Initialize the OpenCost MCP server
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to initialize OpenCost server dependencies")
+	}
+	log.Info().Msg("OpenCost server initialized successfully.")
+
+	// Define handlers as closures to capture the opencost_server instance
+	handleAllocationCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args AllocationArgs) (*mcp_sdk.CallToolResult, interface{}, error) {
+		// Parse duration strings to time.Duration
+		var step time.Duration
+		var err error
+
+		if args.Step != "" {
+			step, err = time.ParseDuration(args.Step)
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid step duration '%s': %w", args.Step, err)
+			}
+		}
+
+		queryRequest := &opencost_mcp.OpenCostQueryRequest{
+			QueryType: opencost_mcp.AllocationQueryType,
+			Window:    args.Window,
+			AllocationParams: &opencost_mcp.AllocationQuery{
+				Step:                                  step,
+				Accumulate:                            args.Accumulate,
+				ShareIdle:                             args.ShareIdle,
+				Aggregate:                             args.Aggregate,
+				IncludeIdle:                           args.IncludeIdle,
+				IdleByNode:                            args.IdleByNode,
+				IncludeProportionalAssetResourceCosts: args.IncludeProportionalAssetResourceCosts,
+				IncludeAggregatedMetadata:             args.IncludeAggregatedMetadata,
+				ShareLB:                               args.ShareLB,
+			},
+		}
+
+		mcpReq := &opencost_mcp.MCPRequest{
+			SessionID: generateSessionID(),
+			Query:     queryRequest,
+		}
+
+		mcpResp, err := opencost_server.ProcessMCPRequest(mcpReq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to process allocation request: %w", err)
+		}
+
+		return nil, mcpResp, nil
+	}
+
+	handleAssetCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args AssetArgs) (*mcp_sdk.CallToolResult, interface{}, error) {
+		queryRequest := &opencost_mcp.OpenCostQueryRequest{
+			QueryType: opencost_mcp.AssetQueryType,
+			Window:    args.Window,
+
+			AssetParams: &opencost_mcp.AssetQuery{},
+		}
+
+		mcpReq := &opencost_mcp.MCPRequest{
+			SessionID: generateSessionID(),
+			Query:     queryRequest,
+		}
+
+		mcpResp, err := opencost_server.ProcessMCPRequest(mcpReq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to process asset request: %w", err)
+		}
+
+		return nil, mcpResp, nil
+	}
+
+	// Initialize the SDK server
+	sdkServer := mcp_sdk.NewServer(&mcp_sdk.Implementation{
+		Name:    "opencost-mcp-server",
+		Version: "v1.0.0",
+	}, nil)
+
+	// Register tools with the new typed handlers
+	mcp_sdk.AddTool(sdkServer, &mcp_sdk.Tool{
+		Name:        "get_allocation_costs",
+		Description: "Retrieves allocation cost data.",
+	}, handleAllocationCosts)
+
+	mcp_sdk.AddTool(sdkServer, &mcp_sdk.Tool{
+		Name:        "get_asset_costs",
+		Description: "Retrieves asset cost data.",
+	}, handleAssetCosts)
+
+	log.Info().Msg("MCP SDK server initialized. About to run...")
+
+	// Run the SDK server over stdin/stdout
+	if err := sdkServer.Run(context.Background(), &mcp_sdk.StdioTransport{}); err != nil {
+		log.Fatal().Err(err).Msg("Failed to run MCP SDK server")
+	}
+	log.Info().Msg("MCP SDK server finished running.")
+}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17
 	github.com/aws/smithy-go v1.22.2
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/go-playground/validator/v10 v10.27.0
 	github.com/google/martian v2.1.0+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-hclog v1.6.2
@@ -37,6 +38,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kubecost/events v0.0.8
 	github.com/microcosm-cc/bluemonday v1.0.23
+	github.com/modelcontextprotocol/go-sdk v1.0.0
 	github.com/opencost/opencost/core v0.0.0-20250521155634-81d2b597d1bc
 	github.com/opencost/opencost/modules/collector-source v0.0.0-00010101000000-000000000000
 	github.com/opencost/opencost/modules/prometheus-source v0.0.0-00010101000000-000000000000
@@ -72,9 +74,14 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/minio/crc64nvme v1.0.1 // indirect
 	github.com/minio/minio-go/v7 v7.0.88 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -83,6 +90,7 @@ require (
 	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.36.0 // indirect
@@ -141,7 +149,6 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,10 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
+github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -258,6 +260,14 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
+github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
+github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
+github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
+github.com/go-playground/validator/v10 v10.27.0 h1:w8+XrWVMhGkxOaaowyKH35gFydVHOvC0/uWoy2Fzwn4=
+github.com/go-playground/validator/v10 v10.27.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
@@ -274,8 +284,6 @@ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -328,6 +336,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -443,6 +453,8 @@ github.com/kubecost/events v0.0.8 h1:FEglMSOGkjiSZT2FnSYM99s2M4DMiBOgHVheM7Vnurs
 github.com/kubecost/events v0.0.8/go.mod h1:PXnE7CSZs3OulOLcB8baQENploBp4NM7ERZVBCqNi4A=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
+github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -481,6 +493,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/modelcontextprotocol/go-sdk v1.0.0 h1:Z4MSjLi38bTgLrd/LjSmofqRqyBiVKRyQSJgw8q8V74=
+github.com/modelcontextprotocol/go-sdk v1.0.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -596,6 +610,8 @@ github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVK
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/mcp/dependencies.go
+++ b/pkg/mcp/dependencies.go
@@ -1,0 +1,98 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/clusters"
+	"github.com/opencost/opencost/core/pkg/kubeconfig"
+	"github.com/opencost/opencost/pkg/clustercache"
+	"github.com/opencost/opencost/pkg/env"
+
+	"github.com/opencost/opencost/core/pkg/source"
+	"github.com/opencost/opencost/core/pkg/util/retry"
+	"github.com/opencost/opencost/modules/prometheus-source/pkg/prom"
+	"github.com/opencost/opencost/pkg/cloud/provider"
+	"github.com/opencost/opencost/pkg/config"
+	"github.com/opencost/opencost/pkg/costmodel"
+	"github.com/opencost/opencost/pkg/metrics"
+	"github.com/opencost/opencost/pkg/util/watcher"
+)
+
+// Initialize creates a new MCPServer with all its dependencies initialized.
+func Initialize() (*MCPServer, error) {
+	// Kubernetes API setup
+	kubeClientset, err := kubeconfig.LoadKubeClient("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Kubernetes client: %w", err)
+	}
+
+	// Create Kubernetes Cluster Cache + Watchers
+	k8sCache := clustercache.NewKubernetesClusterCache(kubeClientset)
+	k8sCache.Run()
+
+	// Create ConfigFileManager for synchronization of shared configuration
+	confManager := config.NewConfigFileManager(nil)
+
+	cloudProviderKey := env.GetCloudProviderAPIKey()
+	cloudProvider, err := provider.NewProvider(k8sCache, cloudProviderKey, confManager)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cloud provider: %w", err)
+	}
+
+	// ClusterInfo Provider to provide the cluster map with local and remote cluster data
+	var clusterInfoProvider clusters.ClusterInfoProvider
+	if env.IsClusterInfoFileEnabled() {
+		clusterInfoFile := confManager.ConfigFileAt(env.GetClusterInfoFilePath())
+		clusterInfoProvider = costmodel.NewConfiguredClusterInfoProvider(clusterInfoFile)
+	} else {
+		clusterInfoProvider = costmodel.NewLocalClusterInfoProvider(kubeClientset, cloudProvider)
+	}
+
+	const maxRetries = 10
+	const retryInterval = 10 * time.Second
+
+	var fatalErr error
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fn := func() (source.OpenCostDataSource, error) {
+		ds, e := prom.NewDefaultPrometheusDataSource(clusterInfoProvider)
+		if e != nil {
+			if source.IsRetryable(e) {
+				return nil, e
+			}
+			fatalErr = e
+			cancel()
+		}
+
+		return ds, e
+	}
+
+	dataSource, _ := retry.Retry(
+		ctx,
+		fn,
+		maxRetries,
+		retryInterval,
+	)
+
+	if fatalErr != nil {
+		return nil, fmt.Errorf("failed to create Prometheus data source: %w", fatalErr)
+	}
+
+	// Append the pricing config watcher
+	installNamespace := env.GetOpencostNamespace()
+
+	configWatchers := watcher.NewConfigMapWatchers(kubeClientset, installNamespace)
+	configWatchers.AddWatcher(provider.ConfigWatcherFor(cloudProvider))
+	configWatchers.AddWatcher(metrics.GetMetricsConfigWatcher())
+	configWatchers.Watch()
+
+	clusterMap := dataSource.ClusterMap()
+
+	cm := costmodel.NewCostModel(dataSource, cloudProvider, k8sCache, clusterMap, dataSource.BatchDuration())
+
+	mcpServer := NewMCPServer(cm, cloudProvider)
+
+	return mcpServer, nil
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,0 +1,292 @@
+package mcp
+
+import (
+	"time"
+	models "github.com/opencost/opencost/pkg/cloud/models"
+	"github.com/opencost/opencost/pkg/cloudcost"
+	"github.com/opencost/opencost/pkg/costmodel"
+)
+
+// QueryType defines the type of query to be executed.
+type QueryType string
+
+const (
+	AllocationQueryType QueryType = "allocation"
+	AssetQueryType      QueryType = "asset"
+	CloudCostQueryType  QueryType = "cloudcost"
+)
+
+// MCPRequest represents a single turn in a conversation with the OpenCost MCP server.
+type MCPRequest struct {
+	SessionID string                `json:"sessionId"`
+	Query     *OpenCostQueryRequest `json:"query"`
+}
+
+// MCPResponse is the response from the OpenCost MCP server for a single turn.
+type MCPResponse struct {
+	Data      interface{}   `json:"data"`
+	QueryInfo QueryMetadata `json:"queryInfo"`
+	Summary   *DataSummary  `json:"summary,omitempty"`
+}
+
+// QueryMetadata contains metadata about the query execution.
+type QueryMetadata struct {
+	QueryID        string        `json:"queryId"`
+	Timestamp      time.Time     `json:"timestamp"`
+	ProcessingTime time.Duration `json:"processingTime"`
+}
+
+// DataSummary provides a summary of the data.
+type DataSummary struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+// OpenCostQueryRequest provides a unified interface for all OpenCost query types.
+type OpenCostQueryRequest struct {
+	QueryType QueryType `json:"queryType" validate:"required,oneof=allocation asset cloudcost"`
+
+	Window string `json:"window" validate:"required"`
+
+	AllocationParams *AllocationQuery `json:"allocationParams,omitempty"`
+	AssetParams      *AssetQuery      `json:"assetParams,omitempty"`
+	CloudCostParams  *CloudCostQuery  `json:"cloudCostParams,omitempty"`
+}
+
+// AllocationQuery contains the parameters for an allocation query.
+type AllocationQuery struct {
+	Step                                  time.Duration `json:"step,omitempty"`
+	Accumulate                            bool          `json:"accumulate,omitempty"`
+	ShareIdle                             bool          `json:"shareIdle,omitempty"`
+	Aggregate                             string        `json:"aggregate,omitempty"`
+	IncludeIdle                           bool          `json:"includeIdle,omitempty"`
+	IdleByNode                            bool          `json:"idleByNode,omitempty"`
+	IncludeProportionalAssetResourceCosts bool          `json:"includeProportionalAssetResourceCosts,omitempty"`
+	IncludeAggregatedMetadata             bool          `json:"includeAggregatedMetadata,omitempty"`
+	ShareLB                               bool          `json:"sharelb,omitempty"`
+}
+
+// AssetQuery contains the parameters for an asset query.
+type AssetQuery struct {
+	// Currently no specific parameters needed for asset queries as it only takes window as parameter
+}
+
+// CloudCostQuery contains the parameters for a cloud cost query.
+type CloudCostQuery struct {
+	Aggregate  string `json:"aggregate,omitempty"`  // Comma-separated list of aggregation properties
+	Accumulate string `json:"accumulate,omitempty"` // e.g., "week", "day", "month"
+	Filter     string `json:"filter,omitempty"`     // Filter expression for cloud costs
+	Provider   string `json:"provider,omitempty"`   // Cloud provider filter (aws, gcp, azure, etc.)
+	Service    string `json:"service,omitempty"`    // Service filter (ec2, s3, compute, etc.)
+	Category   string `json:"category,omitempty"`   // Category filter (compute, storage, network, etc.)
+	Region     string `json:"region,omitempty"`     // Region filter
+	Account    string `json:"account,omitempty"`    // Account filter
+}
+
+// AllocationResponse represents the allocation data returned to the AI agent.
+type AllocationResponse struct {
+	// The allocation data, as a map of allocation sets.
+	Allocations map[string]*AllocationSet `json:"allocations"`
+}
+
+// AllocationSet represents a set of allocation data.
+type AllocationSet struct {
+	// The name of the allocation set.
+	Name        string            `json:"name"`
+	Properties  map[string]string `json:"properties"`
+	Allocations []*Allocation     `json:"allocations"`
+}
+
+// TotalCost calculates the total cost of all allocations in the set.
+func (as *AllocationSet) TotalCost() float64 {
+	var total float64
+	for _, alloc := range as.Allocations {
+		total += alloc.TotalCost
+	}
+	return total
+}
+
+// Allocation represents a single allocation data point.
+
+type Allocation struct {
+	Name string `json:"name"` // Allocation key (namespace, cluster, etc.)
+
+	CPUCost      float64 `json:"cpuCost"`      // Cost of CPU usage
+	GPUCost      float64 `json:"gpuCost"`      // Cost of GPU usage
+	RAMCost      float64 `json:"ramCost"`      // Cost of memory usage
+	PVCost       float64 `json:"pvCost"`       // Cost of persistent volumes
+	NetworkCost  float64 `json:"networkCost"`  // Cost of network usage
+	SharedCost   float64 `json:"sharedCost"`   // Shared/unallocated costs assigned here
+	ExternalCost float64 `json:"externalCost"` // External costs (cloud services, etc.)
+	TotalCost    float64 `json:"totalCost"`    // Sum of all costs above
+
+	CPUCoreHours float64 `json:"cpuCoreHours"` // Usage metrics: CPU core-hours
+	RAMByteHours float64 `json:"ramByteHours"` // Usage metrics: RAM byte-hours
+	GPUHours     float64 `json:"gpuHours"`     // Usage metrics: GPU-hours
+	PVByteHours  float64 `json:"pvByteHours"`  // Usage metrics: PV byte-hours
+
+	Start time.Time `json:"start"` // Start timestamp for this allocation
+	End   time.Time `json:"end"`   // End timestamp for this allocation
+}
+
+// AssetResponse represents the asset data returned to the AI agent.
+type AssetResponse struct {
+	// The asset data, as a map of asset sets.
+	Assets map[string]*AssetSet `json:"assets"`
+}
+
+// AssetSet represents a set of asset data.
+type AssetSet struct {
+	// The name of the asset set.
+	Name string `json:"name"`
+
+	// The asset data for the set.
+	Assets []*Asset `json:"assets"`
+}
+
+// Asset represents a single asset data point.
+type Asset struct {
+	Type       string            `json:"type"`
+	Properties AssetProperties   `json:"properties"`
+	Labels     map[string]string `json:"labels,omitempty"`
+
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+
+	Minutes    float64 `json:"minutes"`
+	Adjustment float64 `json:"adjustment"`
+	TotalCost  float64 `json:"totalCost"`
+
+	// Disk-specific fields
+	ByteHours      float64  `json:"byteHours,omitempty"`
+	ByteHoursUsed  *float64 `json:"byteHoursUsed,omitempty"`
+	ByteUsageMax   *float64 `json:"byteUsageMax,omitempty"`
+	StorageClass   string   `json:"storageClass,omitempty"`
+	VolumeName     string   `json:"volumeName,omitempty"`
+	ClaimName      string   `json:"claimName,omitempty"`
+	ClaimNamespace string   `json:"claimNamespace,omitempty"`
+	Local          float64  `json:"local,omitempty"`
+
+	// Node-specific fields
+	NodeType     string  `json:"nodeType,omitempty"`
+	CPUCoreHours float64 `json:"cpuCoreHours,omitempty"`
+	RAMByteHours float64 `json:"ramByteHours,omitempty"`
+	GPUHours     float64 `json:"gpuHours,omitempty"`
+	GPUCount     float64 `json:"gpuCount,omitempty"`
+	CPUCost      float64 `json:"cpuCost,omitempty"`
+	GPUCost      float64 `json:"gpuCost,omitempty"`
+	RAMCost      float64 `json:"ramCost,omitempty"`
+	Discount     float64 `json:"discount,omitempty"`
+	Preemptible  float64 `json:"preemptible,omitempty"`
+
+	// Breakdown fields (can be used for different types)
+	Breakdown    *AssetBreakdown `json:"breakdown,omitempty"`
+	CPUBreakdown *AssetBreakdown `json:"cpuBreakdown,omitempty"`
+	RAMBreakdown *AssetBreakdown `json:"ramBreakdown,omitempty"`
+
+	// Overhead (Node-specific)
+	Overhead *NodeOverhead `json:"overhead,omitempty"`
+}
+
+// NodeOverhead represents node overhead information
+type NodeOverhead struct {
+	RamOverheadFraction  float64 `json:"ramOverheadFraction"`
+	CpuOverheadFraction  float64 `json:"cpuOverheadFraction"`
+	OverheadCostFraction float64 `json:"overheadCostFraction"`
+}
+type AssetProperties struct {
+	Category   string `json:"category,omitempty"`
+	Provider   string `json:"provider,omitempty"`
+	Account    string `json:"account,omitempty"`
+	Project    string `json:"project,omitempty"`
+	Service    string `json:"service,omitempty"`
+	Cluster    string `json:"cluster,omitempty"`
+	Name       string `json:"name,omitempty"`
+	ProviderID string `json:"providerID,omitempty"`
+}
+
+type AssetBreakdown struct {
+	Idle   float64 `json:"idle"`
+	Other  float64 `json:"other"`
+	System float64 `json:"system"`
+	User   float64 `json:"user"`
+}
+
+// CloudCostResponse represents the cloud cost data returned to the AI agent.
+type CloudCostResponse struct {
+	// The cloud cost data, as a map of cloud cost sets.
+	CloudCosts map[string]*CloudCostSet `json:"cloudCosts"`
+	// Summary information
+	Summary *CloudCostSummary `json:"summary,omitempty"`
+}
+
+// CloudCostSummary provides summary information about cloud costs
+type CloudCostSummary struct {
+	TotalNetCost       float64            `json:"totalNetCost"`
+	TotalAmortizedCost float64            `json:"totalAmortizedCost"`
+	TotalInvoicedCost  float64            `json:"totalInvoicedCost"`
+	KubernetesPercent  float64            `json:"kubernetesPercent"`
+	ProviderBreakdown  map[string]float64 `json:"providerBreakdown,omitempty"`
+	ServiceBreakdown   map[string]float64 `json:"serviceBreakdown,omitempty"`
+	RegionBreakdown    map[string]float64 `json:"regionBreakdown,omitempty"`
+}
+
+// CloudCostSet represents a set of cloud cost data.
+type CloudCostSet struct {
+	// The name of the cloud cost set.
+	Name string `json:"name"`
+
+	// The cloud cost data for the set.
+	CloudCosts []*CloudCost `json:"cloudCosts"`
+
+	// Aggregation information
+	AggregationProperties []string `json:"aggregationProperties,omitempty"`
+
+	// Time window
+	Window *TimeWindow `json:"window,omitempty"`
+}
+
+// TimeWindow represents a time range
+type TimeWindow struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// CloudCostProperties defines the properties of a cloud cost item.
+type CloudCostProperties struct {
+	ProviderID        string            `json:"providerID,omitempty"`
+	Provider          string            `json:"provider,omitempty"`
+	AccountID         string            `json:"accountID,omitempty"`
+	AccountName       string            `json:"accountName,omitempty"`
+	InvoiceEntityID   string            `json:"invoiceEntityID,omitempty"`
+	InvoiceEntityName string            `json:"invoiceEntityName,omitempty"`
+	RegionID          string            `json:"regionID,omitempty"`
+	AvailabilityZone  string            `json:"availabilityZone,omitempty"`
+	Service           string            `json:"service,omitempty"`
+	Category          string            `json:"category,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+}
+
+// CloudCost represents a single cloud cost data point.
+type CloudCost struct {
+	Properties       CloudCostProperties `json:"properties"`
+	Window           TimeWindow          `json:"window"`
+	ListCost         CostMetric          `json:"listCost"`
+	NetCost          CostMetric          `json:"netCost"`
+	AmortizedNetCost CostMetric          `json:"amortizedNetCost"`
+	InvoicedCost     CostMetric          `json:"invoicedCost"`
+	AmortizedCost    CostMetric          `json:"amortizedCost"`
+}
+
+// CostMetric represents a cost value with Kubernetes percentage
+type CostMetric struct {
+	Cost              float64 `json:"cost"`
+	KubernetesPercent float64 `json:"kubernetesPercent"`
+}
+
+// MCPServer holds the dependencies for the MCP API server.
+type MCPServer struct {
+	costModel   *costmodel.CostModel
+	provider    models.Provider
+	integration cloudcost.CloudCostIntegration
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,9 +1,15 @@
 package mcp
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"time"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/opencost/opencost/core/pkg/opencost"
 	models "github.com/opencost/opencost/pkg/cloud/models"
-	"github.com/opencost/opencost/pkg/cloudcost"
 	"github.com/opencost/opencost/pkg/costmodel"
 )
 
@@ -13,7 +19,6 @@ type QueryType string
 const (
 	AllocationQueryType QueryType = "allocation"
 	AssetQueryType      QueryType = "asset"
-	CloudCostQueryType  QueryType = "cloudcost"
 )
 
 // MCPRequest represents a single turn in a conversation with the OpenCost MCP server.
@@ -44,13 +49,12 @@ type DataSummary struct {
 
 // OpenCostQueryRequest provides a unified interface for all OpenCost query types.
 type OpenCostQueryRequest struct {
-	QueryType QueryType `json:"queryType" validate:"required,oneof=allocation asset cloudcost"`
+	QueryType QueryType `json:"queryType" validate:"required,oneof=allocation asset"`
 
 	Window string `json:"window" validate:"required"`
 
 	AllocationParams *AllocationQuery `json:"allocationParams,omitempty"`
 	AssetParams      *AssetQuery      `json:"assetParams,omitempty"`
-	CloudCostParams  *CloudCostQuery  `json:"cloudCostParams,omitempty"`
 }
 
 // AllocationQuery contains the parameters for an allocation query.
@@ -186,6 +190,13 @@ type Asset struct {
 
 	// Overhead (Node-specific)
 	Overhead *NodeOverhead `json:"overhead,omitempty"`
+
+	// LoadBalancer-specific fields
+	Private bool   `json:"private,omitempty"`
+	Ip      string `json:"ip,omitempty"`
+
+	// Cloud-specific fields
+	Credit float64 `json:"credit,omitempty"`
 }
 
 // NodeOverhead represents node overhead information
@@ -286,7 +297,354 @@ type CostMetric struct {
 
 // MCPServer holds the dependencies for the MCP API server.
 type MCPServer struct {
-	costModel   *costmodel.CostModel
-	provider    models.Provider
-	integration cloudcost.CloudCostIntegration
+	costModel *costmodel.CostModel
+	provider  models.Provider
+}
+
+// NewMCPServer creates a new MCP Server.
+func NewMCPServer(costModel *costmodel.CostModel, provider models.Provider) *MCPServer {
+	return &MCPServer{
+		costModel: costModel,
+		provider:  provider,
+	}
+}
+
+// ProcessMCPRequest processes an MCP request and returns an MCP response.
+
+func (s *MCPServer) summarizeAllocationData(request *OpenCostQueryRequest, resp *AllocationResponse) *DataSummary {
+	// Basic summary implementation
+	var totalCost float64
+	for _, allocationSet := range resp.Allocations {
+		totalCost += allocationSet.TotalCost()
+	}
+
+	return &DataSummary{
+		Title:   fmt.Sprintf("Total Cost Over '%s'", request.Window),
+		Content: fmt.Sprintf("The total cost for the selected window is $%.2f.", totalCost),
+	}
+}
+
+func (s *MCPServer) ProcessMCPRequest(request *MCPRequest) (*MCPResponse, error) {
+	// 1. Validate Request
+	if err := validate.Struct(request); err != nil {
+		return nil, fmt.Errorf("validation failed: %w", err)
+	}
+
+	// 3. Query Dispatching
+	var data interface{}
+	var err error
+	var summary *DataSummary
+
+	queryStart := time.Now()
+
+	switch request.Query.QueryType {
+	case AllocationQueryType:
+		allocationResponse, err := s.QueryAllocations(request.Query)
+		if err != nil {
+			return nil, err // Propagate error
+		}
+		data = allocationResponse
+
+		summary = s.summarizeAllocationData(request.Query, allocationResponse)
+	case AssetQueryType:
+		data, err = s.QueryAssets(request.Query)
+	default:
+		return nil, fmt.Errorf("unsupported query type: %s", request.Query.QueryType)
+	}
+
+	if err != nil {
+		// Handle error appropriately, maybe return a JSON-RPC error response
+		return nil, err
+	}
+
+	processingTime := time.Since(queryStart)
+
+	// 5. Construct Final Response
+	mcpResponse := &MCPResponse{
+		Data: data,
+		QueryInfo: QueryMetadata{
+			QueryID:        generateQueryID(),
+			Timestamp:      time.Now(),
+			ProcessingTime: processingTime,
+		},
+		Summary: summary,
+	}
+	return mcpResponse, nil
+}
+
+// validate is the singleton validator instance.
+var validate = validator.New()
+
+// generateQueryID creates a unique query ID using crypto/rand
+func generateQueryID() string {
+	bytes := make([]byte, 8) // 16 hex characters
+	if _, err := rand.Read(bytes); err != nil {
+		// Fallback to timestamp-based ID if crypto/rand fails
+		return fmt.Sprintf("query-%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("query-%s", hex.EncodeToString(bytes))
+}
+
+func (s *MCPServer) QueryAllocations(query *OpenCostQueryRequest) (*AllocationResponse, error) {
+	// 1. Parse Window
+	window, err := opencost.ParseWindowWithOffset(query.Window, 0) // 0 offset for UTC
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse window '%s': %w", query.Window, err)
+	}
+
+	// 2. Set default parameters
+	var step time.Duration
+	var aggregateBy []string
+	var includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, shareIdle bool
+	var accumulateBy opencost.AccumulateOption
+
+	// 3. Parse allocation parameters if provided
+	if query.AllocationParams != nil {
+		// Set step duration (default to window duration if not specified)
+		if query.AllocationParams.Step > 0 {
+			step = query.AllocationParams.Step
+		} else {
+			step = window.Duration()
+		}
+
+		// Parse aggregation properties
+		if query.AllocationParams.Aggregate != "" {
+			aggregateBy = strings.Split(query.AllocationParams.Aggregate, ",")
+		}
+
+		// Set boolean parameters
+		includeIdle = query.AllocationParams.IncludeIdle
+		idleByNode = query.AllocationParams.IdleByNode
+		includeProportionalAssetResourceCosts = query.AllocationParams.IncludeProportionalAssetResourceCosts
+		includeAggregatedMetadata = query.AllocationParams.IncludeAggregatedMetadata
+		sharedLoadBalancer = query.AllocationParams.ShareLB
+		shareIdle = query.AllocationParams.ShareIdle
+
+		// Set accumulation option
+		if query.AllocationParams.Accumulate {
+			accumulateBy = opencost.AccumulateOptionAll
+		} else {
+			accumulateBy = opencost.AccumulateOptionNone
+		}
+	} else {
+		// Default values when no parameters provided
+		step = window.Duration()
+		accumulateBy = opencost.AccumulateOptionNone
+	}
+
+	// 4. Call the existing QueryAllocation function with all parameters
+	asr, err := s.costModel.QueryAllocation(
+		window,
+		step,
+		aggregateBy,
+		includeIdle,
+		idleByNode,
+		includeProportionalAssetResourceCosts,
+		includeAggregatedMetadata,
+		sharedLoadBalancer,
+		accumulateBy,
+		shareIdle,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query allocations: %w", err)
+	}
+
+	// 5. Handle the AllocationSetRange result
+	if asr == nil || len(asr.Allocations) == 0 {
+		return &AllocationResponse{
+			Allocations: make(map[string]*AllocationSet),
+		}, nil
+	}
+
+	// 6. Transform the result to MCP format
+	// If we have multiple sets, we'll combine them or return the first one
+	// For now, let's return the first allocation set
+	firstSet := asr.Allocations[0]
+	return transformAllocationSet(firstSet), nil
+}
+
+// transformAllocationSet converts an opencost.AllocationSet into the MCP's AllocationResponse format.
+func transformAllocationSet(allocSet *opencost.AllocationSet) *AllocationResponse {
+	if allocSet == nil {
+		return &AllocationResponse{Allocations: make(map[string]*AllocationSet)}
+	}
+
+	mcpAllocations := make(map[string]*AllocationSet)
+
+	// Create a single set for all allocations
+	mcpSet := &AllocationSet{
+		Name:        "allocations",
+		Allocations: []*Allocation{},
+	}
+
+	// Convert each allocation
+	for _, alloc := range allocSet.Allocations {
+		if alloc == nil {
+			continue
+		}
+
+		mcpAlloc := &Allocation{
+			Name:         alloc.Name,
+			CPUCost:      alloc.CPUCost,
+			GPUCost:      alloc.GPUCost,
+			RAMCost:      alloc.RAMCost,
+			PVCost:       alloc.PVCost(), // Call the method
+			NetworkCost:  alloc.NetworkCost,
+			SharedCost:   alloc.SharedCost,
+			ExternalCost: alloc.ExternalCost,
+			TotalCost:    alloc.TotalCost(),
+			CPUCoreHours: alloc.CPUCoreHours,
+			RAMByteHours: alloc.RAMByteHours,
+			GPUHours:     alloc.GPUHours,
+			PVByteHours:  alloc.PVBytes(), // Use the method directly
+			Start:        alloc.Start,
+			End:          alloc.End,
+		}
+		mcpSet.Allocations = append(mcpSet.Allocations, mcpAlloc)
+	}
+
+	mcpAllocations["allocations"] = mcpSet
+
+	return &AllocationResponse{
+		Allocations: mcpAllocations,
+	}
+}
+
+func (s *MCPServer) QueryAssets(query *OpenCostQueryRequest) (*AssetResponse, error) {
+	// 1. Parse Window
+	window, err := opencost.ParseWindowWithOffset(query.Window, 0) // 0 offset for UTC
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse window '%s': %w", query.Window, err)
+	}
+
+	// 2. Set Query Options
+	start := *window.Start()
+	end := *window.End()
+
+	// 3. Call CostModel to get the asset set
+	assetSet, err := s.costModel.ComputeAssets(start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute assets: %w", err)
+	}
+
+	// 4. Transform Response for the MCP API
+	return transformAssetSet(assetSet), nil
+}
+
+// transformAssetSet converts a opencost.AssetSet into the MCP's AssetResponse format.
+func transformAssetSet(assetSet *opencost.AssetSet) *AssetResponse {
+	if assetSet == nil {
+		return &AssetResponse{Assets: make(map[string]*AssetSet)}
+	}
+
+	mcpAssets := make(map[string]*AssetSet)
+
+	// Create a single set for all assets
+	mcpSet := &AssetSet{
+		Name:   "assets",
+		Assets: []*Asset{},
+	}
+
+	for _, asset := range assetSet.Assets {
+		if asset == nil {
+			continue
+		}
+
+		properties := asset.GetProperties()
+		labels := asset.GetLabels()
+
+		mcpAsset := &Asset{
+			Type: asset.Type().String(),
+			Properties: AssetProperties{
+				Category:   properties.Category,
+				Provider:   properties.Provider,
+				Account:    properties.Account,
+				Project:    properties.Project,
+				Service:    properties.Service,
+				Cluster:    properties.Cluster,
+				Name:       properties.Name,
+				ProviderID: properties.ProviderID,
+			},
+			Labels:     labels,
+			Start:      asset.GetStart(),
+			End:        asset.GetEnd(),
+			Minutes:    asset.Minutes(),
+			Adjustment: asset.GetAdjustment(),
+			TotalCost:  asset.TotalCost(),
+		}
+
+		// Handle type-specific fields
+		switch a := asset.(type) {
+		case *opencost.Disk:
+			mcpAsset.ByteHours = a.ByteHours
+			mcpAsset.ByteHoursUsed = a.ByteHoursUsed
+			mcpAsset.ByteUsageMax = a.ByteUsageMax
+			mcpAsset.StorageClass = a.StorageClass
+			mcpAsset.VolumeName = a.VolumeName
+			mcpAsset.ClaimName = a.ClaimName
+			mcpAsset.ClaimNamespace = a.ClaimNamespace
+			mcpAsset.Local = a.Local
+			if a.Breakdown != nil {
+				mcpAsset.Breakdown = &AssetBreakdown{
+					Idle:   a.Breakdown.Idle,
+					Other:  a.Breakdown.Other,
+					System: a.Breakdown.System,
+					User:   a.Breakdown.User,
+				}
+			}
+		case *opencost.Node:
+			mcpAsset.NodeType = a.NodeType
+			mcpAsset.CPUCoreHours = a.CPUCoreHours
+			mcpAsset.RAMByteHours = a.RAMByteHours
+			mcpAsset.GPUHours = a.GPUHours
+			mcpAsset.GPUCount = a.GPUCount
+			mcpAsset.CPUCost = a.CPUCost
+			mcpAsset.GPUCost = a.GPUCost
+			mcpAsset.RAMCost = a.RAMCost
+			mcpAsset.Discount = a.Discount
+			mcpAsset.Preemptible = a.Preemptible
+			if a.CPUBreakdown != nil {
+				mcpAsset.CPUBreakdown = &AssetBreakdown{
+					Idle:   a.CPUBreakdown.Idle,
+					Other:  a.CPUBreakdown.Other,
+					System: a.CPUBreakdown.System,
+					User:   a.CPUBreakdown.User,
+				}
+			}
+			if a.RAMBreakdown != nil {
+				mcpAsset.RAMBreakdown = &AssetBreakdown{
+					Idle:   a.RAMBreakdown.Idle,
+					Other:  a.RAMBreakdown.Other,
+					System: a.RAMBreakdown.System,
+					User:   a.RAMBreakdown.User,
+				}
+			}
+			if a.Overhead != nil {
+				mcpAsset.Overhead = &NodeOverhead{
+					RamOverheadFraction:  a.Overhead.RamOverheadFraction,
+					CpuOverheadFraction:  a.Overhead.CpuOverheadFraction,
+					OverheadCostFraction: a.Overhead.OverheadCostFraction,
+				}
+			}
+		case *opencost.LoadBalancer:
+			mcpAsset.Private = a.Private
+			mcpAsset.Ip = a.Ip
+		case *opencost.Network:
+			// Network assets have no specific fields beyond the base asset structure
+			// All relevant data is in Properties, Labels, Cost, etc.
+		case *opencost.Cloud:
+			mcpAsset.Credit = a.Credit
+		case *opencost.ClusterManagement:
+			// ClusterManagement assets have no specific fields beyond the base asset structure
+			// All relevant data is in Properties, Labels, Cost, etc.
+		}
+
+		mcpSet.Assets = append(mcpSet.Assets, mcpAsset)
+	}
+
+	mcpAssets["assets"] = mcpSet
+
+	return &AssetResponse{
+		Assets: mcpAssets,
+	}
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,16 +1,17 @@
 package mcp
 
 import (
+	"time"
+	models "github.com/opencost/opencost/pkg/cloud/models"
+	"github.com/opencost/opencost/pkg/cloudcost"
+	"github.com/opencost/opencost/pkg/costmodel"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"time"
-
 	"github.com/go-playground/validator/v10"
 	"github.com/opencost/opencost/core/pkg/opencost"
-	models "github.com/opencost/opencost/pkg/cloud/models"
-	"github.com/opencost/opencost/pkg/costmodel"
+	
 )
 
 // QueryType defines the type of query to be executed.
@@ -19,6 +20,7 @@ type QueryType string
 const (
 	AllocationQueryType QueryType = "allocation"
 	AssetQueryType      QueryType = "asset"
+	CloudCostQueryType  QueryType = "cloudcost"
 )
 
 // MCPRequest represents a single turn in a conversation with the OpenCost MCP server.
@@ -49,12 +51,13 @@ type DataSummary struct {
 
 // OpenCostQueryRequest provides a unified interface for all OpenCost query types.
 type OpenCostQueryRequest struct {
-	QueryType QueryType `json:"queryType" validate:"required,oneof=allocation asset"`
+	QueryType QueryType `json:"queryType" validate:"required,oneof=allocation asset cloudcost"`
 
 	Window string `json:"window" validate:"required"`
 
 	AllocationParams *AllocationQuery `json:"allocationParams,omitempty"`
 	AssetParams      *AssetQuery      `json:"assetParams,omitempty"`
+	CloudCostParams  *CloudCostQuery  `json:"cloudCostParams,omitempty"`
 }
 
 // AllocationQuery contains the parameters for an allocation query.
@@ -299,6 +302,7 @@ type CostMetric struct {
 type MCPServer struct {
 	costModel *costmodel.CostModel
 	provider  models.Provider
+	integration cloudcost.CloudCostIntegration
 }
 
 // NewMCPServer creates a new MCP Server.


### PR DESCRIPTION

## What does this PR change?
* Adds a new Model Context Protocol (MCP) server implementation for OpenCost
* Introduces `cmd/mcp-server/main.go` - MCP server entry point with tool handlers
* Adds `pkg/mcp/server.go` - Core server logic with allocation and asset query processing
* Adds `pkg/mcp/dependencies.go` - OpenCost dependency initialization for MCP server
* Implements two MCP tools: `get_allocation_costs` and `get_asset_costs`
* Adds comprehensive type-specific field mapping for all asset types (Node, Disk, LoadBalancer, Network, Cloud, ClusterManagement)
* Introduces request validation using go-playground/validator
* Adds dynamic session and query ID generation
* Updates dependencies: `github.com/go-playground/validator/v10` and `github.com/modelcontextprotocol/go-sdk`

## Does this PR relate to any other PRs?
* No, this is a standalone feature addition


## Does this PR require changes to documentation?
* **Yes** - Updated `README.md` with comprehensive MCP server documentation including:
  - Features overview and prerequisites
  - Build instructions and configuration examples
  - Complete parameter documentation for both tools
  - Supported asset types with descriptions
  - MCP client configuration examples
