### PR TITLE
fix: Apply allocation filters before aggregation to ensure AND operator order independence

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -227,11 +227,11 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// Get allocation filter if provided
 	allocationFilter := qp.Get("filter", "")
 
-	// Query allocations WITHOUT aggregation/accumulation first, so we can filter
-	// on individual allocations before they are aggregated. This ensures filters
-	// can match on all allocation properties (like cluster, node, etc.) before
-	// they are potentially lost or merged during aggregation.
-	asr, err := a.Model.QueryAllocation(window, step, nil, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, opencost.AccumulateOptionNone, shareIdle)
+	// Query allocations with filtering, aggregation, and accumulation.
+	// Filtering is done BEFORE aggregation inside QueryAllocation to ensure
+	// filters can match on all allocation properties (like cluster, node, etc.)
+	// before they are potentially lost or merged during aggregation.
+	asr, err := a.Model.QueryAllocation(window, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, accumulateBy, shareIdle, allocationFilter)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "bad request") {
 			proto.WriteError(w, proto.BadRequest(err.Error()))
@@ -240,53 +240,6 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 		}
 
 		return
-	}
-
-	// Apply allocation filter BEFORE aggregation if provided
-	if allocationFilter != "" {
-		parser := allocation.NewAllocationFilterParser()
-		filterNode, err := parser.Parse(allocationFilter)
-		if err != nil {
-			proto.WriteError(w, proto.BadRequest(fmt.Sprintf("Invalid filter: %s", err)))
-			return
-		}
-		compiler := opencost.NewAllocationMatchCompiler(nil)
-		matcher, err := compiler.Compile(filterNode)
-		if err != nil {
-			proto.WriteError(w, proto.BadRequest(fmt.Sprintf("Failed to compile filter: %s", err)))
-			return
-		}
-		filteredASR := opencost.NewAllocationSetRange()
-		for _, as := range asr.Slice() {
-			filteredAS := opencost.NewAllocationSet(as.Start(), as.End())
-			for _, alloc := range as.Allocations {
-				if matcher.Matches(alloc) {
-					filteredAS.Set(alloc)
-				}
-			}
-			if filteredAS.Length() > 0 {
-				filteredASR.Append(filteredAS)
-			}
-		}
-		asr = filteredASR
-	}
-
-	// Apply aggregation if requested
-	if len(aggregateBy) > 0 {
-		err = asr.AggregateBy(aggregateBy, nil)
-		if err != nil {
-			proto.WriteError(w, proto.InternalServerError(err.Error()))
-			return
-		}
-	}
-
-	// Apply accumulation if requested
-	if accumulateBy != opencost.AccumulateOptionNone {
-		asr, err = asr.Accumulate(accumulateBy)
-		if err != nil {
-			proto.WriteError(w, proto.InternalServerError(err.Error()))
-			return
-		}
 	}
 
 	WriteData(w, asr, nil)

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -227,7 +227,11 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// Get allocation filter if provided
 	allocationFilter := qp.Get("filter", "")
 
-	asr, err := a.Model.QueryAllocation(window, step, aggregateBy, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, accumulateBy, shareIdle)
+	// Query allocations WITHOUT aggregation/accumulation first, so we can filter
+	// on individual allocations before they are aggregated. This ensures filters
+	// can match on all allocation properties (like cluster, node, etc.) before
+	// they are potentially lost or merged during aggregation.
+	asr, err := a.Model.QueryAllocation(window, step, nil, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, opencost.AccumulateOptionNone, shareIdle)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "bad request") {
 			proto.WriteError(w, proto.BadRequest(err.Error()))
@@ -238,7 +242,7 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Apply allocation filter if provided
+	// Apply allocation filter BEFORE aggregation if provided
 	if allocationFilter != "" {
 		parser := allocation.NewAllocationFilterParser()
 		filterNode, err := parser.Parse(allocationFilter)
@@ -265,6 +269,24 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 			}
 		}
 		asr = filteredASR
+	}
+
+	// Apply aggregation if requested
+	if len(aggregateBy) > 0 {
+		err = asr.AggregateBy(aggregateBy, nil)
+		if err != nil {
+			proto.WriteError(w, proto.InternalServerError(err.Error()))
+			return
+		}
+	}
+
+	// Apply accumulation if requested
+	if accumulateBy != opencost.AccumulateOptionNone {
+		asr, err = asr.Accumulate(accumulateBy)
+		if err != nil {
+			proto.WriteError(w, proto.InternalServerError(err.Error()))
+			return
+		}
 	}
 
 	WriteData(w, asr, nil)

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/core/pkg/clusters"
 	coreenv "github.com/opencost/opencost/core/pkg/env"
+	"github.com/opencost/opencost/core/pkg/filter/allocation"
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/source"
@@ -1553,7 +1554,7 @@ func measureTime(start time.Time, threshold time.Duration, name string) {
 	}
 }
 
-func (cm *CostModel) QueryAllocation(window opencost.Window, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer bool, accumulateBy opencost.AccumulateOption, shareIdle bool) (*opencost.AllocationSetRange, error) {
+func (cm *CostModel) QueryAllocation(window opencost.Window, step time.Duration, aggregate []string, includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer bool, accumulateBy opencost.AccumulateOption, shareIdle bool, filterString string) (*opencost.AllocationSetRange, error) {
 	// Validate window is legal
 	if window.IsOpen() || window.IsNegative() {
 		return nil, fmt.Errorf("illegal window: %s", window)
@@ -1621,6 +1622,33 @@ func (cm *CostModel) QueryAllocation(window opencost.Window, step time.Duration,
 
 		stepStart = stepEnd
 		stepEnd = stepStart.Add(step)
+	}
+
+	// Apply allocation filter BEFORE aggregation if provided
+	if filterString != "" {
+		parser := allocation.NewAllocationFilterParser()
+		filterNode, err := parser.Parse(filterString)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filter: %w", err)
+		}
+		compiler := opencost.NewAllocationMatchCompiler(nil)
+		matcher, err := compiler.Compile(filterNode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile filter: %w", err)
+		}
+		filteredASR := opencost.NewAllocationSetRange()
+		for _, as := range asr.Slice() {
+			filteredAS := opencost.NewAllocationSet(as.Start(), as.End())
+			for _, alloc := range as.Allocations {
+				if matcher.Matches(alloc) {
+					filteredAS.Set(alloc)
+				}
+			}
+			if filteredAS.Length() > 0 {
+				filteredASR.Append(filteredAS)
+			}
+		}
+		asr = filteredASR
 	}
 
 	// Set aggregation options and aggregate


### PR DESCRIPTION
## What does this PR change?
* The AND operator (+) in v2 allocation filters was order-dependent, causing filters like `namespace:"ns1"+cluster:"non-existent"` to behave differently than `cluster:"non-existent"+namespace:"ns1"`.

* Root cause: Aggregation was happening before filtering, which could merge or lose allocation properties (like cluster), making them unavailable for filter matching. This caused the first filter condition to match while subsequent conditions had incomplete data.

* Solution: Reordered operations to filter -> aggregate -> accumulate. Filtering now happens on individual allocations with all properties intact, ensuring consistent AND behavior regardless of filter order. 

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
*  Users experiencing incorrect results with AND filters (+) in v2 allocation API will now get correct behavior. Previously, filters like namespace:"ns1"+cluster:"non-existent" could incorrectly return data, while reversing the order would correctly return nothing. 
* After this fix, AND filters work consistently regardless of order - both conditions must match for allocations to be included. Users who may have worked around this bug by ordering their filters specifically will need to update their queries.

## Does this PR address any GitHub or Zendesk issues?
* Fixes #3371 

## How was this PR tested?
* Added unit test Test_AllocationFilterAnd_OrderIndependence in core/pkg/opencost/allocationfilter_test.go:745-820 that validates:
  - AND filters produce identical results regardless of filter order
  - The specific bug scenario (namespace matches, cluster doesn't) correctly returns false
  - Both matching conditions return true
  - All allocation properties remain available for filtering before aggregation

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* This should be labeled for next release but I don't have the access to label it.