### PR TITLE
update log when unable to find pricing key for node

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1445,8 +1445,9 @@ func (aws *AWS) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 		}
 		return aws.createNode(terms, usageType, k)
 	} else { // Fall back to base pricing if we can't find the key. Base pricing is handled at the costmodel level.
+		// we seem to have an issue where this error gets thrown during app start.
+		// somehow the ValidPricingKeys map is being accessed before all the pricing data has been downloaded
 		return nil, meta, fmt.Errorf("Invalid Pricing Key \"%s\"", key)
-
 	}
 }
 

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -886,7 +886,8 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 
 		cnode, _, err := cp.NodePricing(cp.GetKey(nodeLabels, n))
 		if err != nil {
-			log.Infof("Error getting node pricing. Error: %s", err.Error())
+			log.Infof("Could not get node pricing for node %s. Falling back to default pricing", name)
+			log.Debugf("Error getting node pricing: %s", err.Error())
 			if cnode != nil {
 				nodes[name] = cnode
 				continue


### PR DESCRIPTION
## What does this PR change?
* Updates logs for when node pricing is not found

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* Better messaging around when we are unable to find pricing data for a node

## Does this PR address any GitHub or Zendesk issues?
* Closes https://apptio.atlassian.net/browse/KCM-4389

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* v3.0