### PR TITLE
Kcm-4679: K8s version information in cluster info meta provider 

### DIFF
--- a/core/pkg/clusters/clusterinfo.go
+++ b/core/pkg/clusters/clusterinfo.go
@@ -31,6 +31,7 @@ type ClusterInfo struct {
 	Project     string `json:"project"`
 	Region      string `json:"region"`
 	Provisioner string `json:"provisioner"`
+	Version     string `json:"version"`
 }
 
 // Clone creates a copy of ClusterInfo and returns it
@@ -48,6 +49,7 @@ func (ci *ClusterInfo) Clone() *ClusterInfo {
 		Project:     ci.Project,
 		Region:      ci.Region,
 		Provisioner: ci.Provisioner,
+		Version:     ci.Version,
 	}
 }
 

--- a/core/pkg/clusters/util.go
+++ b/core/pkg/clusters/util.go
@@ -25,6 +25,7 @@ func MapToClusterInfo(info map[string]string) (*ClusterInfo, error) {
 	var project string
 	var region string
 	var provisioner string
+	var version string
 
 	if cp, ok := info[ClusterInfoProfileKey]; ok {
 		clusterProfile = cp
@@ -50,6 +51,10 @@ func MapToClusterInfo(info map[string]string) (*ClusterInfo, error) {
 		provisioner = pvsr
 	}
 
+	if ver, ok := info[ClusterInfoVersionKey]; ok {
+		version = ver
+	}
+
 	return &ClusterInfo{
 		ID:          id,
 		Name:        name,
@@ -59,5 +64,6 @@ func MapToClusterInfo(info map[string]string) (*ClusterInfo, error) {
 		Project:     project,
 		Region:      region,
 		Provisioner: provisioner,
+		Version:     version,
 	}, nil
 }

--- a/core/pkg/clusters/util_test.go
+++ b/core/pkg/clusters/util_test.go
@@ -1,0 +1,93 @@
+package clusters
+
+import "testing"
+
+const (
+	testClusterInfoIDKey      = "testClusterID"
+	testClusterInfoNameKey    = "testClusterName"
+	testClusterProfileKey     = "testProfile"
+	testClusterProviderKey    = "testProvider"
+	testClusterAccountKey     = "testAccount"
+	testClusterProjectKey     = "testProject"
+	testClusterRegionKey      = "testRegion"
+	testClusterProvisionerKey = "testProvisioner"
+	testClusterVersionKey     = "testVersion"
+)
+
+func TestMapToClusterInfo(t *testing.T) {
+	mapWOVersion := map[string]string{
+		ClusterInfoIdKey:          testClusterInfoIDKey,
+		ClusterInfoNameKey:        testClusterInfoNameKey,
+		ClusterInfoProfileKey:     testClusterProfileKey,
+		ClusterInfoProviderKey:    testClusterProviderKey,
+		ClusterInfoAccountKey:     testClusterAccountKey,
+		ClusterInfoProjectKey:     testClusterProjectKey,
+		ClusterInfoRegionKey:      testClusterRegionKey,
+		ClusterInfoProvisionerKey: testClusterProvisionerKey,
+	}
+	expectedCIwoVersion := ClusterInfo{
+		ID:          testClusterInfoIDKey,
+		Name:        testClusterInfoNameKey,
+		Profile:     testClusterProfileKey,
+		Provider:    testClusterProviderKey,
+		Account:     testClusterAccountKey,
+		Project:     testClusterProjectKey,
+		Region:      testClusterRegionKey,
+		Provisioner: testClusterProvisionerKey,
+	}
+	mapWVersion := map[string]string{
+		ClusterInfoIdKey:          testClusterInfoIDKey,
+		ClusterInfoNameKey:        testClusterInfoNameKey,
+		ClusterInfoProfileKey:     testClusterProfileKey,
+		ClusterInfoProviderKey:    testClusterProviderKey,
+		ClusterInfoAccountKey:     testClusterAccountKey,
+		ClusterInfoProjectKey:     testClusterProjectKey,
+		ClusterInfoRegionKey:      testClusterRegionKey,
+		ClusterInfoProvisionerKey: testClusterProvisionerKey,
+		ClusterInfoVersionKey:     testClusterVersionKey,
+	}
+	expectedCIwVersion := ClusterInfo{
+		ID:          testClusterInfoIDKey,
+		Name:        testClusterInfoNameKey,
+		Profile:     testClusterProfileKey,
+		Provider:    testClusterProviderKey,
+		Account:     testClusterAccountKey,
+		Project:     testClusterProjectKey,
+		Region:      testClusterRegionKey,
+		Provisioner: testClusterProvisionerKey,
+		Version:     testClusterVersionKey,
+	}
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected ClusterInfo
+		wantErr  bool
+	}{
+		{
+			name:     "when version is not in the cluster info map",
+			input:    mapWOVersion,
+			expected: expectedCIwoVersion,
+			wantErr:  false,
+		},
+		{
+			name:     "when version is in the cluster info map",
+			input:    mapWVersion,
+			expected: expectedCIwVersion,
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			returnCI, err := MapToClusterInfo(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("MapToClusterInfo() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if *returnCI != tc.expected {
+				t.Errorf("MapToClusterInfo() expected = %v, got %v", tc.expected, returnCI)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR change?
* allows finops-agent to report K8s version to S3 bucket in heartbeat

## Does this PR relate to any other PRs?
* Will raise a FinopsPR https://github.com/kubecost/ibm-finops-agent/pull/101

## How will this PR impact users?
* No impact

## Does this PR address any GitHub or Zendesk issues?
* Closes ... https://apptio.atlassian.net/browse/KCM-4679

## How was this PR tested?
* Refer finops-PR

## Does this PR require changes to documentation?
* NR

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* Yes next release of Opencost to pin the new version in finops-agent