### PR TITLE
Fix idleByNode parameter ignored in allocation API

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1608,7 +1608,7 @@ func (cm *CostModel) QueryAllocation(window opencost.Window, step time.Duration,
 				}
 			}
 
-			idleSet, err := computeIdleAllocations(allocSet, assetSet, true)
+			idleSet, err := computeIdleAllocations(allocSet, assetSet, idleByNode)
 			if err != nil {
 				return nil, fmt.Errorf("error computing idle allocations for %s: %w", opencost.NewClosedWindow(stepStart, stepEnd), err)
 			}


### PR DESCRIPTION
# Bug Report: idleByNode Query Parameter Not Working

## Summary

The `idleByNode` query parameter in the `/allocation` API endpoint is not functioning as documented. When set to `true`, it should return separate idle allocations for each node, but instead always returns a single cluster-level idle allocation regardless of the parameter value.

## Expected Behavior

When calling `/allocation?window=1d&includeIdle=true&idleByNode=true`, the API should return:
- Multiple idle allocations, one per node
- Each idle allocation should have `node` and `providerID` properties set
- Idle costs should be broken down by individual nodes

## Actual Behavior

The API returns:
- Single cluster-level idle allocation with key `__idle__`
- No `node` or `providerID` properties
- All idle costs aggregated at cluster level
- Identical results whether `idleByNode=true` or `idleByNode=false`

## Reproduction Steps

1. Start OpenCost connected to a Kubernetes cluster with multiple nodes
2. Query the allocation API with node-level idle:
   ```bash
   curl "http://your-opencost-endpoint:9003/allocation?window=1d&includeIdle=true&idleByNode=true"
   ```
3. Observe single `__idle__` allocation with no node association
4. Query with cluster-level idle:
   ```bash
   curl "http://your-opencost-endpoint:9003/allocation?window=1d&includeIdle=true&idleByNode=false"
   ```
5. Observe identical results

## Root Cause

**File:** `pkg/costmodel/costmodel.go`
**Line:** 1611 (as of develop branch commit 78a8f1cf)
**URL:** https://github.com/opencost/opencost/blob/develop/pkg/costmodel/costmodel.go#L1611

The `idleByNode` parameter from the API request is not passed through to the `computeIdleAllocations` function. Instead, the value is hardcoded to `true`:

```go
idleSet, err := computeIdleAllocations(allocSet, assetSet, true)  // BUG: hardcoded
```

This should be:

```go
idleSet, err := computeIdleAllocations(allocSet, assetSet, idleByNode)
```

## Git Blame Analysis

The bug was introduced in commit `c8e9cf474` on 2023-03-22 as part of the ProportionalAssetResourceCosts (PARC) feature implementation.

**Original correct implementation** (commit `b6c14f58d` from 2021-09-14):
```go
idleSet, err := computeIdleAllocations(allocSet, assetSet, idleByNode)
```

**Breaking change** (commit `c8e9cf474` from 2023-03-22):
```go
idleSet, err := computeIdleAllocations(allocSet, assetSet, true)
```

The parameter was accidentally hardcoded during the PARC refactoring.

## Impact

- Users cannot obtain node-level idle cost breakdowns via the API
- Idle costs cannot be matched to specific nodes for capacity planning
- Rightsizing decisions cannot be made based on per-node idle metrics
- Cost allocation strategies that depend on node-level idle data are blocked

## Environment

- OpenCost version: **v2.5.3 (latest stable release)** and develop branch (verified as of 2025-10-13)
- Kubernetes version: Any
- Cloud provider: Any

**This bug affects all released versions since v1.102.0 (March 2023) when the PARC feature was introduced.**

## Additional Context

The `computeIdleAllocations` function correctly handles the `idleByNode` parameter when it receives it (lines 1746-1808). The function uses this parameter to determine whether to call:
- `ComputeAssetTotals(assetSet, true)` for node-level totals
- `ComputeAssetTotals(assetSet, false)` for cluster-level totals

The issue is purely that line 1610 never passes the user's requested value to this function.

## Proposed Fix

Change line 1610 from:
```go
idleSet, err := computeIdleAllocations(allocSet, assetSet, true)
```

To:
```go
idleSet, err := computeIdleAllocations(allocSet, assetSet, idleByNode)
```

This is a one-line fix that restores the original behavior and respects the user's API parameter.



Fixes #3400
