### PR TITLE
initial golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -3,8 +3,6 @@ on: workflow_dispatch
 
 permissions:
   contents: read
-  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on: workflow_dispatch
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1


### PR DESCRIPTION
## What does this PR change?
* add ability to run golangci-lint on demand `workflow_dispatch` using the Action from the GitHub marketplace: https://github.com/golangci/golangci-lint-action
* followed the Simple example guide: https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#how-to-use

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* None - can be manually run to see lint results

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* N/A - can't test GitHub action without first merging a version to main

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A