### PR TITLE
rev golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.5


### PR DESCRIPTION
## What does this PR change?
* rev golangci-lint to 2.5 from 2.1

## Does this PR relate to any other PRs?
* https://github.com/opencost/opencost/pull/3410

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* N/A

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A