### PR TITLE
Add AppVersion to pkg/version

### DIFF
--- a/core/pkg/version/version.go
+++ b/core/pkg/version/version.go
@@ -3,8 +3,9 @@ package version
 import "fmt"
 
 var (
-	Version   = "dev"
-	GitCommit = "HEAD"
+	Version    = "dev"
+	GitCommit  = "HEAD"
+	AppVersion = "unknown"
 )
 
 func FriendlyVersion() string {


### PR DESCRIPTION
## What does this PR change?
Adds `AppVersion` to `pkg/version`, intended to be used to identify the `major.minor` version of a built image.

## Does this PR relate to any other PRs?
* https://github.com/kubecost/kubecost-cost-model/pull/3817

## How will this PR impact users?
No impact to OC users.

## Does this PR address any GitHub or Zendesk issues?
https://apptio.atlassian.net/browse/KCM-4695

## How was this PR tested?
Tested by building an image with correct flag set and observing set variable.

## Does this PR require changes to documentation?
No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
Yes