### PR TITLE
Remove requirement for SpecProviderID for node stats

### DIFF
--- a/core/pkg/nodestats/nodestats.go
+++ b/core/pkg/nodestats/nodestats.go
@@ -65,11 +65,6 @@ func (nssc *NodeStatsSummaryClient) GetNodeData() ([]*stats.Summary, error) {
 	var errs []error
 
 	work := func(n *clustercache.Node) *stats.Summary {
-		if n.SpecProviderID == "" {
-			log.Warnf("node ProviderID not set, skipping for %s", n.Name)
-			return nil
-		}
-
 		connections := nssc.connectionOptions(n)
 
 		resp, err := requestNodeData(connections, nssc.endpoint, bearerToken)


### PR DESCRIPTION
Many onprem installations of kubernetes do not have ProviderID set on `Node` specs. This removes that requirement, as it's unnecessary for the function of the node stats client. 