### PR TITLE
Fix GCP GPU mapping for A100 40GB/80GB (A2-HighGPU & A2-Ultra) instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.20 AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.3-alpine3.21 AS build-env
 
 WORKDIR /app
 

--- a/pkg/cloud/gcp/gpu.go
+++ b/pkg/cloud/gcp/gpu.go
@@ -1,0 +1,46 @@
+package gcp
+
+import "strings"
+
+// gpuSKUToGpuLabel defines minimal, explicit mappings for common SKUs.
+var gpuSKUToGpuLabel = map[string]string{
+	"nvidia tesla a100 80gb": "nvidia-a100-80gb",   // A2-Ultra
+	"nvidia a100 80gb":       "nvidia-a100-80gb",
+	"nvidia tesla a100":      "nvidia-tesla-a100",  // A2-HighGPU legacy label
+	"nvidia a100":            "nvidia-tesla-a100",
+	"nvidia l4":              "nvidia-l4",          // G2 nodes
+	"tesla t4":               "nvidia-tesla-t4",
+	"nvidia t4":              "nvidia-tesla-t4",
+	"tesla v100":             "nvidia-tesla-v100",
+	"nvidia v100":            "nvidia-tesla-v100",
+}
+
+// NormalizeGPULabel converts a billing SKU description into the GKE/OpenCost GPU label.
+func NormalizeGPULabel(desc string) string {
+	d := strings.ToLower(desc)
+
+	// Fast path: explicit substring matches first
+	for key, model := range gpuSKUToGpuLabel {
+		if strings.Contains(d, key) {
+			return model
+		}
+	}
+
+	// Fallbacks/cleanup (keeps your current behavior)
+	//  - drop packaging suffixes, unify prefix, handle generic A100 40/80GB
+	g := d
+	g = strings.ReplaceAll(g, "-sxm4", "")
+	g = strings.ReplaceAll(g, "  ", " ")
+	g = strings.TrimSpace(g)
+
+	// If we can spot A100 capacity, decide 80GB vs legacy A100 label
+	if strings.Contains(d, "a100") {
+		if strings.Contains(d, "80gb") {
+			return "nvidia-a100-80gb"
+		}
+		// default/40GB
+		return "nvidia-tesla-a100"
+	}
+
+	return ""
+}

--- a/pkg/cloud/gcp/gpu.go
+++ b/pkg/cloud/gcp/gpu.go
@@ -1,11 +1,25 @@
 package gcp
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
-// gpuSKUToGpuLabel defines minimal, explicit mappings for common non-A100 SKUs.
-// A100 is handled separately to avoid ambiguous substring matches.
+// ---- Original OpenCost regex fallback ----
+var (
+	nvidiaTeslaGPURegex = regexp.MustCompile(`(?i)nvidia[\s-]*tesla[\s-]*([a-z0-9]+)`)
+	nvidiaGPURegex      = regexp.MustCompile(`(?i)nvidia[\s-]*([a-z0-9]+)`)
+)
+
+// Explicit substring → canonical GPU label
 var gpuSKUToGpuLabel = map[string]string{
-	// L4 (G2)
+	// A100
+	"nvidia tesla a100 80gb": "nvidia-a100-80gb",
+	"nvidia a100 80gb":       "nvidia-a100-80gb",
+	"nvidia tesla a100":      "nvidia-tesla-a100",
+	"nvidia a100":            "nvidia-tesla-a100",
+
+	// L4
 	"nvidia l4": "nvidia-l4",
 
 	// T4
@@ -16,41 +30,43 @@ var gpuSKUToGpuLabel = map[string]string{
 	"tesla v100":  "nvidia-tesla-v100",
 	"nvidia v100": "nvidia-tesla-v100",
 
-	// P100 (reviewer example)
+	// P100 (reviewer case)
 	"tesla p100":  "nvidia-tesla-p100",
 	"nvidia p100": "nvidia-tesla-p100",
 }
 
-// NormalizeGPULabel converts a billing SKU description into the GKE/OpenCost GPU label.
+// ---- Main Normalizer ----
 func NormalizeGPULabel(desc string) string {
 	d := strings.ToLower(desc)
 
-	// ---- 1) Special-case A100 80GB vs 40GB / generic A100 ----
-	// We do this *before* using the map to avoid flaky behavior due to
-	// overlapping substrings ("nvidia a100" vs "nvidia a100 80gb").
+	// --- Step 1: A100 detection first ---
 	if strings.Contains(d, "a100") {
 		has80 := strings.Contains(d, "80gb") || strings.Contains(d, "80 gb")
 		has40 := strings.Contains(d, "40gb") || strings.Contains(d, "40 gb")
 
 		if has80 {
-			// A2-Ultra → nvidia-a100-80gb
 			return "nvidia-a100-80gb"
 		}
 		if has40 {
-			// A2-HighGPU 40GB → legacy label nvidia-tesla-a100
 			return "nvidia-tesla-a100"
 		}
-		// Generic A100 → treat as legacy A2-HighGPU
-		return "nvidia-tesla-a100"
+		return "nvidia-tesla-a100" // generic A100 → legacy
 	}
 
-	// ---- 2) Other GPUs via explicit substring map ----
+	// --- Step 2: explicit substring mapping ---
 	for key, model := range gpuSKUToGpuLabel {
 		if strings.Contains(d, key) {
 			return model
 		}
 	}
 
-	// ---- 3) No known GPU found ----
+	// --- Step 3: regex fallback (original OpenCost behavior) ---
+	if match := nvidiaTeslaGPURegex.FindStringSubmatch(desc); len(match) == 2 {
+		return "nvidia-tesla-" + strings.ToLower(match[1])
+	}
+	if match := nvidiaGPURegex.FindStringSubmatch(desc); len(match) == 2 {
+		return "nvidia-" + strings.ToLower(match[1])
+	}
+
 	return ""
 }

--- a/pkg/cloud/gcp/gpu.go
+++ b/pkg/cloud/gcp/gpu.go
@@ -2,45 +2,55 @@ package gcp
 
 import "strings"
 
-// gpuSKUToGpuLabel defines minimal, explicit mappings for common SKUs.
+// gpuSKUToGpuLabel defines minimal, explicit mappings for common non-A100 SKUs.
+// A100 is handled separately to avoid ambiguous substring matches.
 var gpuSKUToGpuLabel = map[string]string{
-	"nvidia tesla a100 80gb": "nvidia-a100-80gb",   // A2-Ultra
-	"nvidia a100 80gb":       "nvidia-a100-80gb",
-	"nvidia tesla a100":      "nvidia-tesla-a100",  // A2-HighGPU legacy label
-	"nvidia a100":            "nvidia-tesla-a100",
-	"nvidia l4":              "nvidia-l4",          // G2 nodes
-	"tesla t4":               "nvidia-tesla-t4",
-	"nvidia t4":              "nvidia-tesla-t4",
-	"tesla v100":             "nvidia-tesla-v100",
-	"nvidia v100":            "nvidia-tesla-v100",
+	// L4 (G2)
+	"nvidia l4": "nvidia-l4",
+
+	// T4
+	"tesla t4":  "nvidia-tesla-t4",
+	"nvidia t4": "nvidia-tesla-t4",
+
+	// V100
+	"tesla v100":  "nvidia-tesla-v100",
+	"nvidia v100": "nvidia-tesla-v100",
+
+	// P100 (reviewer example)
+	"tesla p100":  "nvidia-tesla-p100",
+	"nvidia p100": "nvidia-tesla-p100",
 }
 
 // NormalizeGPULabel converts a billing SKU description into the GKE/OpenCost GPU label.
 func NormalizeGPULabel(desc string) string {
 	d := strings.ToLower(desc)
 
-	// Fast path: explicit substring matches first
+	// ---- 1) Special-case A100 80GB vs 40GB / generic A100 ----
+	// We do this *before* using the map to avoid flaky behavior due to
+	// overlapping substrings ("nvidia a100" vs "nvidia a100 80gb").
+	if strings.Contains(d, "a100") {
+		has80 := strings.Contains(d, "80gb") || strings.Contains(d, "80 gb")
+		has40 := strings.Contains(d, "40gb") || strings.Contains(d, "40 gb")
+
+		if has80 {
+			// A2-Ultra → nvidia-a100-80gb
+			return "nvidia-a100-80gb"
+		}
+		if has40 {
+			// A2-HighGPU 40GB → legacy label nvidia-tesla-a100
+			return "nvidia-tesla-a100"
+		}
+		// Generic A100 → treat as legacy A2-HighGPU
+		return "nvidia-tesla-a100"
+	}
+
+	// ---- 2) Other GPUs via explicit substring map ----
 	for key, model := range gpuSKUToGpuLabel {
 		if strings.Contains(d, key) {
 			return model
 		}
 	}
 
-	// Fallbacks/cleanup (keeps your current behavior)
-	//  - drop packaging suffixes, unify prefix, handle generic A100 40/80GB
-	g := d
-	g = strings.ReplaceAll(g, "-sxm4", "")
-	g = strings.ReplaceAll(g, "  ", " ")
-	g = strings.TrimSpace(g)
-
-	// If we can spot A100 capacity, decide 80GB vs legacy A100 label
-	if strings.Contains(d, "a100") {
-		if strings.Contains(d, "80gb") {
-			return "nvidia-a100-80gb"
-		}
-		// default/40GB
-		return "nvidia-tesla-a100"
-	}
-
+	// ---- 3) No known GPU found ----
 	return ""
 }

--- a/pkg/cloud/gcp/gpu_test.go
+++ b/pkg/cloud/gcp/gpu_test.go
@@ -3,31 +3,39 @@ package gcp
 import "testing"
 
 func TestNormalizeGPULabel(t *testing.T) {
-    cases := []struct {
-        desc string
-        want string
-    }{
-        // A100 80GB (A2-Ultra)
-        {"Nvidia A100 80GB GPU attached to instance", "nvidia-a100-80gb"},
-        {"Nvidia Tesla A100 80GB GPU (SXM4) in region us-central1", "nvidia-a100-80gb"},
-        // A100 40GB / generic A100 (A2-HighGPU legacy label)
-        {"Nvidia Tesla A100 GPU attached", "nvidia-tesla-a100"},
-        {"Nvidia Tesla A100 40GB GPU", "nvidia-tesla-a100"},
-        // L4 (G2)
-        {"NVIDIA L4 GPU attached", "nvidia-l4"},
-        // T4
-        {"Tesla T4 GPU", "nvidia-tesla-t4"},
-        {"NVIDIA T4 accelerator", "nvidia-tesla-t4"},
-        // V100
-        {"NVIDIA V100 in use", "nvidia-tesla-v100"},
-        // No GPU
-        {"E2 standard instance, no accelerator", ""},
-    }
+	cases := []struct {
+		desc string
+		want string
+	}{
+		// A100 80GB (A2-Ultra)
+		{"Nvidia A100 80GB GPU attached to instance", "nvidia-a100-80gb"},
+		{"Nvidia Tesla A100 80GB GPU (SXM4) in region us-central1", "nvidia-a100-80gb"},
 
-    for i, tc := range cases {
-        got := NormalizeGPULabel(tc.desc)
-        if got != tc.want {
-            t.Fatalf("case %d: desc=%q: got %q, want %q", i, tc.desc, got, tc.want)
-        }
-    }
+		// A100 40GB / generic A100 (A2-HighGPU legacy label)
+		{"Nvidia Tesla A100 GPU attached", "nvidia-tesla-a100"},
+		{"Nvidia Tesla A100 40GB GPU", "nvidia-tesla-a100"},
+
+		// L4 (G2)
+		{"NVIDIA L4 GPU attached", "nvidia-l4"},
+
+		// T4
+		{"Tesla T4 GPU", "nvidia-tesla-t4"},
+		{"NVIDIA T4 accelerator", "nvidia-tesla-t4"},
+
+		// V100
+		{"NVIDIA V100 in use", "nvidia-tesla-v100"},
+
+		// P100 – reviewer example, should be handled by regex fallback.
+		{"Nvidia Tesla P100 GPU running in Melbourne", "nvidia-tesla-p100"},
+
+		// No GPU
+		{"E2 standard instance, no accelerator", ""},
+	}
+
+	for i, tc := range cases {
+		got := NormalizeGPULabel(tc.desc)
+		if got != tc.want {
+			t.Fatalf("case %d: desc=%q: got %q, want %q", i, tc.desc, got, tc.want)
+		}
+	}
 }

--- a/pkg/cloud/gcp/gpu_test.go
+++ b/pkg/cloud/gcp/gpu_test.go
@@ -1,0 +1,33 @@
+package gcp
+
+import "testing"
+
+func TestNormalizeGPULabel(t *testing.T) {
+    cases := []struct {
+        desc string
+        want string
+    }{
+        // A100 80GB (A2-Ultra)
+        {"Nvidia A100 80GB GPU attached to instance", "nvidia-a100-80gb"},
+        {"Nvidia Tesla A100 80GB GPU (SXM4) in region us-central1", "nvidia-a100-80gb"},
+        // A100 40GB / generic A100 (A2-HighGPU legacy label)
+        {"Nvidia Tesla A100 GPU attached", "nvidia-tesla-a100"},
+        {"Nvidia Tesla A100 40GB GPU", "nvidia-tesla-a100"},
+        // L4 (G2)
+        {"NVIDIA L4 GPU attached", "nvidia-l4"},
+        // T4
+        {"Tesla T4 GPU", "nvidia-tesla-t4"},
+        {"NVIDIA T4 accelerator", "nvidia-tesla-t4"},
+        // V100
+        {"NVIDIA V100 in use", "nvidia-tesla-v100"},
+        // No GPU
+        {"E2 standard instance, no accelerator", ""},
+    }
+
+    for i, tc := range cases {
+        got := NormalizeGPULabel(tc.desc)
+        if got != tc.want {
+            t.Fatalf("case %d: desc=%q: got %q, want %q", i, tc.desc, got, tc.want)
+        }
+    }
+}

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -762,55 +762,11 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 					instanceType = "t2astandard"
 				}
 
-				// --- BEGIN: GPU parsing block ---
-				var gpuType string
-				descLower := strings.ToLower(product.Description)
-							
-				// Try "Nvidia Tesla ..."
-				for matchnum, group := range nvidiaTeslaGPURegex.FindStringSubmatch(product.Description) {
-				    if matchnum == 1 {
-				        gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
-				        log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
-				    }
-				}
-				
-				// If a 'Nvidia Tesla' is not found, try 'Nvidia'
-				if gpuType == "" {
-				    for matchnum, group := range nvidiaGPURegex.FindStringSubmatch(product.Description) {
-				        if matchnum == 1 {
-				            gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
-				            log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
-				        }
-				    }
-				}
-				
-				// Normalize to GKE/OpenCost-friendly forms
+				gpuType := NormalizeGPULabel(product.Description)
 				if gpuType != "" {
-				    // drop packaging variants like SXM4
-				    gpuType = strings.ReplaceAll(gpuType, "-sxm4", "")
-				
-				    // canonical NVIDIA prefix; drop "tesla-" if present
-				    gpuType = strings.TrimPrefix(gpuType, "nvidia-tesla-")
-				    gpuType = strings.TrimPrefix(gpuType, "tesla-")
-				    if !strings.HasPrefix(gpuType, "nvidia-") {
-				        gpuType = "nvidia-" + gpuType
-				    }
-				
-				    // Generic A100 handling (covers both highgpu and ultragpu):
-				    // - If the SKU explicitly says 80GB -> nvidia-a100-80gb (A2-Ultra)
-				    // - Else if it says 40GB OR just "A100" -> normalize to legacy label "nvidia-tesla-a100" (A2-HighGPU)
-				    if strings.Contains(descLower, "a100") {
-				        if strings.Contains(descLower, "80gb") {
-				            gpuType = "nvidia-a100-80gb"
-				        } else if strings.Contains(descLower, "40gb") || !strings.Contains(descLower, "gb") {
-				            // a2-highgpu nodes often use cloud.google.com/gke-accelerator=nvidia-tesla-a100
-				            gpuType = "nvidia-tesla-a100"
-				        }
-				    }
-				
-				    log.Debugf("GCP Billing API: normalized GPU type: '%s'", gpuType)
+				    log.Debugf("GCP Billing API: normalized GPU type: %q", gpuType)
 				}
-				// --- END: GPU parsing block -
+
 
 				candidateKeys := []string{}
 				if gcp.ValidPricingKeys == nil {

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -96,8 +96,6 @@ var gcpRegions = []string{
 }
 
 var (
-	nvidiaTeslaGPURegex = regexp.MustCompile("(Nvidia Tesla [^ ]+) ")
-	nvidiaGPURegex      = regexp.MustCompile("(Nvidia [^ ]+) ")
 	// gce://guestbook-12345/...
 	//  => guestbook-12345
 	gceRegex = regexp.MustCompile("gce://([^/]*)/*")

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -762,23 +762,55 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 					instanceType = "t2astandard"
 				}
 
+				// --- BEGIN: GPU parsing block ---
 				var gpuType string
+				descLower := strings.ToLower(product.Description)
+							
+				// Try "Nvidia Tesla ..."
 				for matchnum, group := range nvidiaTeslaGPURegex.FindStringSubmatch(product.Description) {
-					if matchnum == 1 {
-						gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
-						log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
-					}
+				    if matchnum == 1 {
+				        gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
+				        log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
+				    }
 				}
-
+				
 				// If a 'Nvidia Tesla' is not found, try 'Nvidia'
 				if gpuType == "" {
-					for matchnum, group := range nvidiaGPURegex.FindStringSubmatch(product.Description) {
-						if matchnum == 1 {
-							gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
-							log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
-						}
-					}
+				    for matchnum, group := range nvidiaGPURegex.FindStringSubmatch(product.Description) {
+				        if matchnum == 1 {
+				            gpuType = strings.ToLower(strings.Join(strings.Split(group, " "), "-"))
+				            log.Debugf("GCP Billing API: GPU type found: '%s'", gpuType)
+				        }
+				    }
 				}
+				
+				// Normalize to GKE/OpenCost-friendly forms
+				if gpuType != "" {
+				    // drop packaging variants like SXM4
+				    gpuType = strings.ReplaceAll(gpuType, "-sxm4", "")
+				
+				    // canonical NVIDIA prefix; drop "tesla-" if present
+				    gpuType = strings.TrimPrefix(gpuType, "nvidia-tesla-")
+				    gpuType = strings.TrimPrefix(gpuType, "tesla-")
+				    if !strings.HasPrefix(gpuType, "nvidia-") {
+				        gpuType = "nvidia-" + gpuType
+				    }
+				
+				    // Generic A100 handling (covers both highgpu and ultragpu):
+				    // - If the SKU explicitly says 80GB -> nvidia-a100-80gb (A2-Ultra)
+				    // - Else if it says 40GB OR just "A100" -> normalize to legacy label "nvidia-tesla-a100" (A2-HighGPU)
+				    if strings.Contains(descLower, "a100") {
+				        if strings.Contains(descLower, "80gb") {
+				            gpuType = "nvidia-a100-80gb"
+				        } else if strings.Contains(descLower, "40gb") || !strings.Contains(descLower, "gb") {
+				            // a2-highgpu nodes often use cloud.google.com/gke-accelerator=nvidia-tesla-a100
+				            gpuType = "nvidia-tesla-a100"
+				        }
+				    }
+				
+				    log.Debugf("GCP Billing API: normalized GPU type: '%s'", gpuType)
+				}
+				// --- END: GPU parsing block -
 
 				candidateKeys := []string{}
 				if gcp.ValidPricingKeys == nil {


### PR DESCRIPTION
# Fix GCP GPU Mapping for A100 40GB & 80GB Instances (A2-HighGPU / A2-Ultra)

## What does this PR change?
This PR fixes incorrect GPU price mapping in GCP provider where A100 80GB (A2-Ultra) instances failed to match node labels like nvidia-a100-80gb.
Previously, OpenCost parsed the SKU description (e.g., “Nvidia Tesla A100 80GB GPU…”) into "nvidia-tesla-a100-80gb", which didn’t align with GKE’s GPU label format, causing:
```
ERR Could not parse default gpu price
```
1) Fixes GPU SKU-to-label mapping for Google Cloud A100 40GB and 80GB families in provider.go.

2) Normalizes GPU names returned from the GCP Billing API so they match GKE node labels.

3) Adds handling for:

- A100-80GB → nvidia-a100-80gb (A2-Ultra)

- A100-40GB → nvidia-tesla-a100 (A2-HighGPU legacy)

4) Retains compatibility with existing GPU families such as L4 (G2) and other Tesla series.

5) Resolves repeated ERR Could not parse default gpu price for A2-Ultra nodes.

## Does this PR relate to any other PRs?
No direct relation. This is a standalone fix within the GCP pricing provider.

## How will this PR impact users?
Users running A2-Ultra (A100-80GB) or A2-HighGPU (A100-40GB) GKE nodes will now see correct GPU pricing in OpenCost.

Eliminates fallback to default GPU pricing for these families.

Improves accuracy of cost allocation and GPU cost visibility for GCP users.

No behavior change for non-GPU node types (e.g. E2, N2) or existing GPU mappings (L4, T4, V100).

## Does this PR address any GitHub or Zendesk issues?
[* Closes ...](https://github.com/opencost/opencost/issues/3444)

## How was this PR tested?
Deployed locally with multiple node types:

✅ a2-ultragpu-1g → parsed as nvidia-a100-80gb, correct GPUCost.

✅ a2-highgpu-1g → parsed as nvidia-tesla-a100, correct GPUCost.

✅ g2-standard-4 (L4) → unchanged, correct GPUCost.

✅ e2-standard-4 → unaffected (CPU-only).

Verified via OpenCost logs that normalized GPU names map correctly to SKUs and prices are applied as expected.

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
Yes — this resolves a user-visible GPU pricing issue and should be included in the next release.
