### PR TITLE
feat: Add cluster label filtering to Prometheus queries via OPENCOST_CLUSTER_FILTER

### DIFF
--- a/modules/prometheus-source/pkg/prom/query.go
+++ b/modules/prometheus-source/pkg/prom/query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
 
@@ -223,9 +224,17 @@ func runQuery(query string, ctx *Context, resCh source.QueryResultsChan, t time.
 
 // RawQuery is a direct query to the prometheus client and returns the body of the response
 func (ctx *Context) RawQuery(query string, t time.Time) ([]byte, error) {
-	u := ctx.Client.URL(epQuery, nil)
-	q := u.Query()
-	q.Set("query", query)
+
+       // Inject cluster label filter if OPENCOST_CLUSTER_FILTER is set
+       clusterFilter := ""
+       if val := os.Getenv("OPENCOST_CLUSTER_FILTER"); val != "" {
+	       clusterFilter = val
+       }
+       filteredQuery := injectClusterLabelFilter(query, clusterFilter)
+
+       u := ctx.Client.URL(epQuery, nil)
+       q := u.Query()
+       q.Set("query", filteredQuery)
 
 	if t.IsZero() {
 		t = time.Now()
@@ -244,7 +253,7 @@ func (ctx *Context) RawQuery(query string, t time.Time) ([]byte, error) {
 	if ctx.name != "" {
 		req = httputil.SetName(req, ctx.name)
 	}
-	req = httputil.SetQuery(req, query)
+	req = httputil.SetQuery(req, filteredQuery)
 
 	// Note that the warnings return value from client.Do() is always nil using this
 	// version of the prometheus client library. We parse the warnings out of the response
@@ -377,9 +386,16 @@ func runQueryRange(query string, start, end time.Time, step time.Duration, ctx *
 
 // RawQuery is a direct query to the prometheus client and returns the body of the response
 func (ctx *Context) RawQueryRange(query string, start, end time.Time, step time.Duration) ([]byte, error) {
-	u := ctx.Client.URL(epQueryRange, nil)
-	q := u.Query()
-	q.Set("query", query)
+       // Inject cluster label filter if OPENCOST_CLUSTER_FILTER is set
+       clusterFilter := ""
+       if val := os.Getenv("OPENCOST_CLUSTER_FILTER"); val != "" {
+	       clusterFilter = val
+       }
+       filteredQuery := injectClusterLabelFilter(query, clusterFilter)
+
+       u := ctx.Client.URL(epQueryRange, nil)
+       q := u.Query()
+       q.Set("query", filteredQuery)
 	q.Set("start", start.Format(time.RFC3339Nano))
 	q.Set("end", end.Format(time.RFC3339Nano))
 	q.Set("step", strconv.FormatFloat(step.Seconds(), 'f', 3, 64))
@@ -394,8 +410,7 @@ func (ctx *Context) RawQueryRange(query string, start, end time.Time, step time.
 	if ctx.name != "" {
 		req = httputil.SetName(req, ctx.name)
 	}
-	req = httputil.SetQuery(req, query)
-
+       req = httputil.SetQuery(req, filteredQuery)
 	// Note that the warnings return value from client.Do() is always nil using this
 	// version of the prometheus client library. We parse the warnings out of the response
 	// body after json decodidng completes.
@@ -418,6 +433,35 @@ func (ctx *Context) RawQueryRange(query string, start, end time.Time, step time.
 	return body, err
 }
 
+// injectClusterLabelFilter adds {cluster="..."} to all metric queries if not already present
+func injectClusterLabelFilter(query, cluster string) string {
+	if cluster == "" {
+		return query
+	}
+	// Simple heuristic: inject into first {...} or add {...} if none
+	inBraces := false
+	out := ""
+	for _, c := range query {
+		if c == '{' && !inBraces {
+			inBraces = true
+			out += string(c)
+			out += "cluster=\"" + cluster + "\"," // inject at start of label matchers
+		} else {
+			out += string(c)
+		}
+	}
+	if !inBraces {
+		// No braces found, add {cluster="..."}
+		for idx, c := range query {
+			if c == '(' || c == '[' {
+				return query[:idx] + "{cluster=\"" + cluster + "\"}" + query[idx:]
+			}
+		}
+		// Otherwise, just append
+		return query + "{cluster=\"" + cluster + "\"}"
+	}
+	return out
+}
 func (ctx *Context) queryRange(query string, start, end time.Time, step time.Duration) (interface{}, v1.Warnings, error) {
 	body, err := ctx.RawQueryRange(query, start, end, step)
 
@@ -470,3 +514,4 @@ func warningsFrom(result interface{}) v1.Warnings {
 
 	return warnings
 }
+


### PR DESCRIPTION
## What does this PR change?

This PR introduces a mechanism to **filter all Prometheus queries in OpenCost by a specific cluster label**, enabling proper multi-cluster separation when using backends such as **Mimir** that store metrics from multiple clusters under a single `OrgID`.

In our environment, we operate **hundreds of clusters**, all reporting metrics into a **single Mimir OrgID**. Creating and maintaining a separate OrgID for each cluster is not practical at our scale.
This change injects a **cluster label filter** into every Prometheus query so that OpenCost only retrieves metrics for the selected cluster.

#### Why `PROMETHEUS_HEADER_X_SCOPE_ORGID` isn’t sufficient

`PROMETHEUS_HEADER_X_SCOPE_ORGID` allows setting a custom HTTP header (`X-Scope-OrgID`) to select the Mimir tenant. However, in our setup, **all clusters share the same OrgID**, so this header only selects the tenant, not the cluster.
As a result, OpenCost receives metrics for all clusters under that OrgID, making it impossible to isolate costs per cluster.

#### What this PR does instead

This PR enables a new environment variable, `OPENCOST_CLUSTER_FILTER`, which injects a label matcher (e.g., `{cluster="stage-cluster"}`) into all Prometheus queries.
This ensures OpenCost retrieves metrics only for the specified cluster, even when multiple clusters share a single OrgID.

---

## Does this PR relate to any other PRs?

No.

---

## How will this PR impact users?

In environments where multiple clusters share one Mimir OrgID, OpenCost previously queried and displayed data for all clusters combined.
With this change, users can now isolate metrics and costs for a specific cluster, improving accuracy and usability in **multi-cluster, single-tenant setups**.

---

## Code changes

* Added logic in `query.go` to check for the `OPENCOST_CLUSTER_FILTER` environment variable.
* If set, all Prometheus queries (instant and range) are automatically modified to include `{cluster="<value>"}` as a label matcher.
* Introduced a helper function `injectClusterLabelFilter` to correctly apply the label filter, whether or not existing matchers are present.

---
## Does this PR address any GitHub or Zendesk issues?
* Closes ...

---

## How was this PR tested?
Testing was performed in a local OpenCost setup using **Mimir** as the Prometheus backend.

### Steps:

1. Set the environment variable:

   ```bash
   export OPENCOST_CLUSTER_FILTER=stage-cluster
   ```
2. Queried the following OpenCost endpoints:

   * `http://localhost:9003/allocation?window=today&aggregate=namespace`
   * `http://localhost:9003/allocation?window=today`

### Results:

* **Before the change:**

  * The `/allocation` API returned namespaces and metrics from **all clusters**, even though OpenCost was installed on only one.
  * The total core count reflected **aggregate usage across all clusters**.

* **After the change:**

  * The same APIs now correctly return data **only for the specified cluster (`stage-cluster`)**.
  * The core count and namespace-level data now reflect **single-cluster metrics**, confirming that the cluster label filter works as expected.

---

---

## Does this PR require changes to documentation?

If merged, this feature will require a small documentation update describing the new `OPENCOST_CLUSTER_FILTER` environment variable.

---

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
Marked for next release if accepted.