### PR TITLE
feat: Introduce configurable metrics emitter query window

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -477,7 +477,8 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 			}
 
 			end := time.Now()
-			start := end.Add(-time.Minute * 2)
+			queryWindow := env.GetMetricsEmitterQueryWindow()
+			start := end.Add(-queryWindow)
 
 			data, err := cmme.Model.ComputeCostData(start, end)
 			if err != nil {

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -1,6 +1,8 @@
 package env
 
 import (
+	"time"
+
 	"github.com/opencost/opencost/core/pkg/env"
 )
 
@@ -91,6 +93,9 @@ const (
 	// MCP Server
 	MCPServerEnabledEnvVar = "MCP_SERVER_ENABLED"
 	MCPHTTPPortEnvVar      = "MCP_HTTP_PORT"
+
+	// Metrics Emitter
+	MetricsEmitterQueryWindowEnvVar = "METRICS_EMITTER_QUERY_WINDOW"
 )
 
 func GetGCPAuthSecretFilePath() string {
@@ -382,4 +387,11 @@ func IsMCPServerEnabled() bool {
 // the HTTP port for the MCP server.
 func GetMCPHTTPPort() int {
 	return env.GetInt(MCPHTTPPortEnvVar, 8081)
+}
+
+// GetMetricsEmitterQueryWindow returns the time window for the metrics emitter
+// to query historical data. This controls the time range used in ComputeCostData queries.
+// Default is 2m.
+func GetMetricsEmitterQueryWindow() time.Duration {
+	return env.GetDuration(MetricsEmitterQueryWindowEnvVar, 2*time.Minute)
 }


### PR DESCRIPTION
Added a new environment variable to set the metrics emitter query window in minutes, allowing for dynamic adjustment of the time range used in ComputeCostData queries. Default is set to 2 minutes.

## What does this PR change?

* Adds a new environment variable `METRICS_EMITTER_QUERY_WINDOW` to configure the time window for CostModelMetricsEmitter queries
* Replaces hardcoded 2-minute query window in `CostModelMetricsEmitter.Start()` with a configurable value from environment variable
* Adds `GetMetricsEmitterQueryWindow()` helper function in `pkg/env/costmodel.go` with a default value of 2 minutes

## Does this PR relate to any other PRs?

* No

## How will this PR impact users?

* **Positive Impact**: Users with non-standard Prometheus scrape intervals can now adjust the metrics emitter query window to match their setup, improving data accuracy and reducing query errors
* **No Breaking Changes**: Default behavior remains unchanged (2 minutes), existing deployments will continue to work without modification
* **Use Case**: Particularly beneficial for users with scrape intervals > 1 minute (e.g., 3 minutes), who can now set the query window to 6-8 minutes to ensure sufficient data points for reliable metrics

## Does this PR address any GitHub or Zendesk issues?

* Closes ... *(if applicable)*

## How was this PR tested?

* Code builds successfully without linter errors
* Manual testing recommended: Deploy with different `METRICS_EMITTER_QUERY_WINDOW` values (e.g., 2, 3, 5) and verify:
  - Metrics are emitted correctly
  - Prometheus queries complete without errors
  - No increase in query failures for longer time windows

## Does this PR require changes to documentation?

* **Yes** - The new environment variable `METRICS_EMITTER_QUERY_WINDOW` should be documented in:
  - Environment variables reference documentation
  - Configuration guide (with recommendations on how to set it based on scrape interval)
  - Suggested guidance: Set to at least 2× the Prometheus scrape interval

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

* Yes, this should be labeled as "next release" as it's a new configuration feature that improves flexibility for different deployment scenarios

---

### Additional Notes

Recommended values based on Prometheus scrape interval:
- 30s scrape → 2 minutes (default)
- 1m scrape → 3 minutes  
- 3m scrape → 6-8 minutes