### PR TITLE
Fix opencast prometheus tests

### DIFF
--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -480,6 +480,12 @@ func (parcs ProportionalAssetResourceCosts) Insert(parc ProportionalAssetResourc
 			GPUProportionalCost:          curr.GPUProportionalCost + parc.GPUProportionalCost,
 			PVProportionalCost:           curr.PVProportionalCost + parc.PVProportionalCost,
 			LoadBalancerProportionalCost: curr.LoadBalancerProportionalCost + parc.LoadBalancerProportionalCost,
+			// Preserve total costs during aggregation to prevent NaN values in ComputePercentages
+			CPUTotalCost:          curr.CPUTotalCost + parc.CPUTotalCost,
+			RAMTotalCost:          curr.RAMTotalCost + parc.RAMTotalCost,
+			GPUTotalCost:          curr.GPUTotalCost + parc.GPUTotalCost,
+			PVTotalCost:           curr.PVTotalCost + parc.PVTotalCost,
+			LoadBalancerTotalCost: curr.LoadBalancerTotalCost + parc.LoadBalancerTotalCost,
 		}
 
 		ComputePercentages(&toInsert)

--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -1428,9 +1428,28 @@ func (a *Allocation) add(that *Allocation) {
 	// Sum LoadBalancer Allocations
 	a.LoadBalancers = a.LoadBalancers.Add(that.LoadBalancers)
 
-	// Any data that is in a "raw allocation only" is not valid in any
-	// sort of cumulative Allocation (like one that is added).
-	a.RawAllocationOnly = nil
+	// Aggregate RawAllocationOnly data by taking the maximum of max values
+	// Max values represent peak usage at a point in time, so when combining
+	// allocations, we want the highest peak among all combined allocations.
+	if a.RawAllocationOnly != nil && that.RawAllocationOnly != nil {
+		// Both have RawAllocationOnly data, take max of each field
+		if that.RawAllocationOnly.CPUCoreUsageMax > a.RawAllocationOnly.CPUCoreUsageMax {
+			a.RawAllocationOnly.CPUCoreUsageMax = that.RawAllocationOnly.CPUCoreUsageMax
+		}
+		if that.RawAllocationOnly.RAMBytesUsageMax > a.RawAllocationOnly.RAMBytesUsageMax {
+			a.RawAllocationOnly.RAMBytesUsageMax = that.RawAllocationOnly.RAMBytesUsageMax
+		}
+		// Handle GPU max (pointer)
+		if that.RawAllocationOnly.GPUUsageMax != nil {
+			if a.RawAllocationOnly.GPUUsageMax == nil || *that.RawAllocationOnly.GPUUsageMax > *a.RawAllocationOnly.GPUUsageMax {
+				a.RawAllocationOnly.GPUUsageMax = that.RawAllocationOnly.GPUUsageMax
+			}
+		}
+	} else if that.RawAllocationOnly != nil {
+		// Only 'that' has RawAllocationOnly data, adopt it
+		a.RawAllocationOnly = that.RawAllocationOnly.Clone()
+	}
+	// If only 'a' has RawAllocationOnly data, keep it as-is
 }
 
 func (thisLbAllocs LbAllocations) Add(thatLbAllocs LbAllocations) LbAllocations {

--- a/core/pkg/opencost/allocation_test.go
+++ b/core/pkg/opencost/allocation_test.go
@@ -231,8 +231,10 @@ func TestAllocation_Add(t *testing.T) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", 1.279690, act.TotalEfficiency())
 	}
 
-	if act.RawAllocationOnly != nil {
-		t.Errorf("Allocation.Add: Raw only data must be nil after an add")
+	// RawAllocationOnly should be preserved (taking max of max values) after Add
+	// since both a1 and a2 have RawAllocationOnly data
+	if act.RawAllocationOnly == nil {
+		t.Errorf("Allocation.Add: RawAllocationOnly should be preserved when both allocations have it")
 	}
 }
 

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2054,6 +2054,11 @@ func computeIdleAllocations(allocSet *opencost.AllocationSet, assetSet *opencost
 		gpuIdleCost := assetTotal.TotalGPUCost() - allocTotal.TotalGPUCost()
 		ramIdleCost := assetTotal.TotalRAMCost() - allocTotal.TotalRAMCost()
 
+		// Calculate idle resource hours
+		cpuIdleCoreHours := assetTotal.CPUCoreHours - allocTotal.CPUCoreHours
+		gpuIdleHours := assetTotal.GPUHours - allocTotal.GPUHours
+		ramIdleByteHours := assetTotal.RAMByteHours - allocTotal.RAMByteHours
+
 		// Clamp idle costs to zero to prevent negative idle allocations
 		if cpuIdleCost < 0 {
 			log.Warnf("Negative CPU idle cost detected for %s: asset total (%.4f) < allocation total (%.4f), clamping to 0",
@@ -2071,6 +2076,23 @@ func computeIdleAllocations(allocSet *opencost.AllocationSet, assetSet *opencost
 			ramIdleCost = 0
 		}
 
+		// Clamp idle resource hours to zero to prevent negative values
+		if cpuIdleCoreHours < 0 {
+			log.Warnf("Negative CPU idle core hours detected for %s: asset total (%.4f) < allocation total (%.4f), clamping to 0",
+				key, assetTotal.CPUCoreHours, allocTotal.CPUCoreHours)
+			cpuIdleCoreHours = 0
+		}
+		if gpuIdleHours < 0 {
+			log.Warnf("Negative GPU idle hours detected for %s: asset total (%.4f) < allocation total (%.4f), clamping to 0",
+				key, assetTotal.GPUHours, allocTotal.GPUHours)
+			gpuIdleHours = 0
+		}
+		if ramIdleByteHours < 0 {
+			log.Warnf("Negative RAM idle byte hours detected for %s: asset total (%.4f) < allocation total (%.4f), clamping to 0",
+				key, assetTotal.RAMByteHours, allocTotal.RAMByteHours)
+			ramIdleByteHours = 0
+		}
+
 		err := idleSet.Insert(&opencost.Allocation{
 			Name:   name,
 			Window: idleSet.Window.Clone(),
@@ -2079,11 +2101,14 @@ func computeIdleAllocations(allocSet *opencost.AllocationSet, assetSet *opencost
 				Node:       assetTotal.Node,
 				ProviderID: assetTotal.ProviderID,
 			},
-			Start:   assetTotal.Start,
-			End:     assetTotal.End,
-			CPUCost: cpuIdleCost,
-			GPUCost: gpuIdleCost,
-			RAMCost: ramIdleCost,
+			Start:        assetTotal.Start,
+			End:          assetTotal.End,
+			CPUCost:      cpuIdleCost,
+			GPUCost:      gpuIdleCost,
+			RAMCost:      ramIdleCost,
+			CPUCoreHours: cpuIdleCoreHours,
+			GPUHours:     gpuIdleHours,
+			RAMByteHours: ramIdleByteHours,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to insert idle allocation %s: %w", name, err)


### PR DESCRIPTION
## Summary

Fixes integration test failures where OpenCost allocation results showed significant discrepancies compared to Prometheus queries. Two critical bugs were identified and fixed:

1. **Missing resource hour tracking in idle allocations** (~8% CPUCoreHours difference)
2. **Max usage values discarded during aggregation** (89% RAMUsageMax difference)

## Problem

Integration tests comparing Prometheus mode vs Promless mode were failing with significant differences:

RAMUsageMax[Fail]: DifferencePercent 89.05 Prometheus: 1,335,345,152 bytes (1.24 GB) Allocation API: 146,219,008 bytes (139 MB)
CPUCoreHours[Fail]: DifferencePercent: 7.81 Prometheus: 0.93 Allocation API: 1.01

## Root Causes

### Issue 1: Idle Allocations Missing Resource Hours

Following the recent addition of resource hour fields to `AllocationTotals` and `AssetTotals` (#3393), idle allocations were computing idle costs but not tracking the corresponding resource hours:
- Missing: `CPUCoreHours`, `GPUHours`, `RAMByteHours`
- Impact: Totals were incorrect when comparing Prometheus vs allocation API

**Location**: `pkg/costmodel/costmodel.go:2074-2087`

### Issue 2: Max Usage Values Discarded During Aggregation

In `core/pkg/opencost/allocation.go:1433`, when allocations were aggregated, all peak usage data was discarded:

```go
// Old code:
a.RawAllocationOnly = nil  // ❌ Lost all max usage data!
This was based on the incorrect assumption that "raw allocation only data is not valid in cumulative allocations." However, max values ARE valid - they represent the highest peak among all combined allocations.
Solution
Fix 1: Add Resource Hour Tracking to Idle Allocations
Calculate idle resource hours as the difference between asset and allocation totals, with clamping to prevent negative values:
cpuIdleCoreHours := assetTotal.CPUCoreHours - allocTotal.CPUCoreHours
gpuIdleHours := assetTotal.GPUHours - allocTotal.GPUHours
ramIdleByteHours := assetTotal.RAMByteHours - allocTotal.RAMByteHours

// Clamp to zero (matching existing idle cost behavior)
if cpuIdleCoreHours < 0 {
    cpuIdleCoreHours = 0
}
// ... include in idle allocation
Fix 2: Preserve Max Usage Values During Aggregation
When aggregating allocations, take the maximum of max values instead of discarding them:
if a.RawAllocationOnly != nil && that.RawAllocationOnly != nil {
    // Take max of each field
    if that.RawAllocationOnly.CPUCoreUsageMax > a.RawAllocationOnly.CPUCoreUsageMax {
        a.RawAllocationOnly.CPUCoreUsageMax = that.RawAllocationOnly.CPUCoreUsageMax
    }
    if that.RawAllocationOnly.RAMBytesUsageMax > a.RawAllocationOnly.RAMBytesUsageMax {
        a.RawAllocationOnly.RAMBytesUsageMax = that.RawAllocationOnly.RAMBytesUsageMax
    }
    // Handle GPUUsageMax similarly
}

````
## Testing
These fixes address the failing integration tests:
✅ prometheus: RAMUsageMax ground truth - Should now show <5% difference
✅ prometheus: CPUCores, CPUCoreHours and CPUCoreRequestAverage Costs - Should now pass
The changes ensure that:
Idle allocations properly track resource hours
Aggregated allocations preserve peak usage metrics
Prometheus and Allocation API comparisons are accurate
Related Issues
Follows up on #3393 (fix: Negative idle cost on promless mode) which added resource hour tracking to totals
Addresses integration test failures in opencost-integration-tests
Checklist

✅  Code follows project style guidelines

✅  Changes are focused and minimal

✅  Commit messages are clear and descriptive

        Integration tests pass (pending CI run)

Details above

## What does this PR change?
* 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 