### PR TITLE
Enable the use of mTLS with the prometheus backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ pkg/cloud/oracle/cloud-integration.json
 
 # tilt
 tilt_config.json
+
+# Test reports
+coverage.html
+coverage.out

--- a/modules/prometheus-source/pkg/env/promenv.go
+++ b/modules/prometheus-source/pkg/env/promenv.go
@@ -34,9 +34,9 @@ const (
 	DBBasicAuthPassword = "DB_BASIC_AUTH_PW"
 	DBBearerToken       = "DB_BEARER_TOKEN"
 
-	DBmTLSAuthCAFile  = "DB_MTLS_AUTH_CA_FILE"
-	DBmTLSAuthCrtFile = "DB_MTLS_AUTH_CRT_FILE"
-	DBmTLSAuthKeyFile = "DB_MTLS_AUTH_KEY_FILE"
+	PromMtlsAuthCAFile  = "PROM_MTLS_AUTH_CA_FILE"
+	PromMtlsAuthCrtFile = "PROM_MTLS_AUTH_CRT_FILE"
+	PromMtlsAuthKeyFile = "PROM_MTLS_AUTH_KEY_FILE"
 
 	CurrentClusterIdFilterEnabledVar = "CURRENT_CLUSTER_ID_FILTER_ENABLED"
 
@@ -140,29 +140,29 @@ func GetDBBearerToken() string {
 	return env.Get(DBBearerToken, "")
 }
 
-func IsDBmTLSAuthEnabled() bool {
-	if GetDBmTLSAuthCAFile() == "" {
+func IsPromMtlsAuthEnabled() bool {
+	if GetPromMtlsAuthCAFile() == "" {
 		return false
 	}
-	if GetDBmTLSAuthCrtFile() == "" {
+	if GetPromMtlsAuthCrtFile() == "" {
 		return false
 	}
-	if GetDBmTLSAuthKeyFile() == "" {
+	if GetPromMtlsAuthKeyFile() == "" {
 		return false
 	}
 	return true
 }
 
-func GetDBmTLSAuthCAFile() string {
-	return env.Get(DBmTLSAuthCAFile, "")
+func GetPromMtlsAuthCAFile() string {
+	return env.Get(PromMtlsAuthCAFile, "")
 }
 
-func GetDBmTLSAuthCrtFile() string {
-	return env.Get(DBmTLSAuthCrtFile, "")
+func GetPromMtlsAuthCrtFile() string {
+	return env.Get(PromMtlsAuthCrtFile, "")
 }
 
-func GetDBmTLSAuthKeyFile() string {
-	return env.Get(DBmTLSAuthKeyFile, "")
+func GetPromMtlsAuthKeyFile() string {
+	return env.Get(PromMtlsAuthKeyFile, "")
 }
 
 func GetPrometheusMaxQueryDuration() time.Duration {

--- a/modules/prometheus-source/pkg/env/promenv.go
+++ b/modules/prometheus-source/pkg/env/promenv.go
@@ -34,6 +34,10 @@ const (
 	DBBasicAuthPassword = "DB_BASIC_AUTH_PW"
 	DBBearerToken       = "DB_BEARER_TOKEN"
 
+	DBmTLSAuthCAFile  = "DB_MTLS_AUTH_CA_FILE"
+	DBmTLSAuthCrtFile = "DB_MTLS_AUTH_CRT_FILE"
+	DBmTLSAuthKeyFile = "DB_MTLS_AUTH_KEY_FILE"
+
 	CurrentClusterIdFilterEnabledVar = "CURRENT_CLUSTER_ID_FILTER_ENABLED"
 
 	KubecostJobNameEnvVar = "KUBECOST_JOB_NAME"
@@ -134,6 +138,31 @@ func GetDBBasicAuthUserPassword() string {
 
 func GetDBBearerToken() string {
 	return env.Get(DBBearerToken, "")
+}
+
+func IsDBmTLSAuthEnabled() bool {
+	if GetDBmTLSAuthCAFile() == "" {
+		return false
+	}
+	if GetDBmTLSAuthCrtFile() == "" {
+		return false
+	}
+	if GetDBmTLSAuthKeyFile() == "" {
+		return false
+	}
+	return true
+}
+
+func GetDBmTLSAuthCAFile() string {
+	return env.Get(DBmTLSAuthCAFile, "")
+}
+
+func GetDBmTLSAuthCrtFile() string {
+	return env.Get(DBmTLSAuthCrtFile, "")
+}
+
+func GetDBmTLSAuthKeyFile() string {
+	return env.Get(DBmTLSAuthKeyFile, "")
 }
 
 func GetPrometheusMaxQueryDuration() time.Duration {

--- a/modules/prometheus-source/pkg/env/promenv_test.go
+++ b/modules/prometheus-source/pkg/env/promenv_test.go
@@ -1,0 +1,30 @@
+package env
+
+import "testing"
+
+func TestIsDBmTLSAuthEnabled(t *testing.T) {
+	t.Run("IsDBmTLSAuthEnabled returns false if all mTLS env vars are not set", func(t *testing.T) {
+		got := IsDBmTLSAuthEnabled()
+		if got == true {
+			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, false)
+		}
+
+		t.Setenv("DB_MTLS_AUTH_CA_FILE", "some/client.ca")
+		got = IsDBmTLSAuthEnabled()
+		if got == true {
+			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, false)
+		}
+
+		t.Setenv("DB_MTLS_AUTH_CRT_FILE", "some/client.crt")
+		got = IsDBmTLSAuthEnabled()
+		if got == true {
+			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, false)
+		}
+
+		t.Setenv("DB_MTLS_AUTH_KEY_FILE", "some/client.key")
+		got = IsDBmTLSAuthEnabled()
+		if got == false {
+			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, true)
+		}
+	})
+}

--- a/modules/prometheus-source/pkg/env/promenv_test.go
+++ b/modules/prometheus-source/pkg/env/promenv_test.go
@@ -2,27 +2,27 @@ package env
 
 import "testing"
 
-func TestIsDBmTLSAuthEnabled(t *testing.T) {
+func TestIsPromMtlsAuthEnabled(t *testing.T) {
 	t.Run("IsDBmTLSAuthEnabled returns false if all mTLS env vars are not set", func(t *testing.T) {
-		got := IsDBmTLSAuthEnabled()
+		got := IsPromMtlsAuthEnabled()
 		if got == true {
 			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, false)
 		}
 
-		t.Setenv("DB_MTLS_AUTH_CA_FILE", "some/client.ca")
-		got = IsDBmTLSAuthEnabled()
+		t.Setenv("PROM_MTLS_AUTH_CA_FILE", "some/client.ca")
+		got = IsPromMtlsAuthEnabled()
 		if got == true {
 			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, false)
 		}
 
-		t.Setenv("DB_MTLS_AUTH_CRT_FILE", "some/client.crt")
-		got = IsDBmTLSAuthEnabled()
+		t.Setenv("PROM_MTLS_AUTH_CRT_FILE", "some/client.crt")
+		got = IsPromMtlsAuthEnabled()
 		if got == true {
 			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, false)
 		}
 
-		t.Setenv("DB_MTLS_AUTH_KEY_FILE", "some/client.key")
-		got = IsDBmTLSAuthEnabled()
+		t.Setenv("PROM_MTLS_AUTH_KEY_FILE", "some/client.key")
+		got = IsPromMtlsAuthEnabled()
 		if got == false {
 			t.Errorf("IsDBmTLSAuthEnabled() = %v, want %v", got, true)
 		}

--- a/modules/prometheus-source/pkg/prom/config.go
+++ b/modules/prometheus-source/pkg/prom/config.go
@@ -1,8 +1,10 @@
 package prom
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"os"
 	"time"
 
 	coreenv "github.com/opencost/opencost/core/pkg/env"
@@ -78,6 +80,7 @@ func NewOpenCostPrometheusConfigFromEnv() (*OpenCostPrometheusConfig, error) {
 	// We will use the service account token and service-ca.crt to authenticate with the Prometheus server via kube-rbac-proxy.
 	// We need to ensure that the service account has the necessary permissions to access the Prometheus server by binding it to the appropriate role.
 	var tlsCaCert *x509.CertPool
+	var tlsClientCertificates []tls.Certificate
 	if env.IsKubeRbacProxyEnabled() {
 		restConfig, err := restclient.InClusterConfig()
 		if err != nil {
@@ -87,6 +90,27 @@ func NewOpenCostPrometheusConfigFromEnv() (*OpenCostPrometheusConfig, error) {
 		tlsCaCert, err = certutil.NewPool(ServiceCA)
 		if err != nil {
 			log.Errorf("%s was set to true but failed to load service-ca.crt: %s", env.KubeRbacProxyEnabledEnvVar, err)
+		}
+	} else if env.IsDBmTLSAuthEnabled() {
+		tlsCaCert = x509.NewCertPool()
+		// The /etc/ssl/cert.pem location is correct for Alpine Linux, the container base used here
+		systemCa, err := os.ReadFile("/etc/ssl/cert.pem")
+		if err != nil {
+			log.Errorf("mTLS options were set but failed to load system CAs: %s", err)
+		} else {
+			tlsCaCert.AppendCertsFromPEM(systemCa)
+		}
+		mTlsCa, err := os.ReadFile(env.GetDBmTLSAuthCAFile())
+		if err != nil {
+			log.Errorf("mTLS options were set but failed to load DB_MTLS_AUTH_CA_FILE: %s", err)
+		} else {
+			tlsCaCert.AppendCertsFromPEM(mTlsCa)
+		}
+		mTlsKeyPair, err := tls.LoadX509KeyPair(env.GetDBmTLSAuthCrtFile(), env.GetDBmTLSAuthKeyFile())
+		if err != nil {
+			log.Errorf("mTLS options were set but failed to load DB_MTLS_AUTH_CRT_FILE or DB_MTLS_AUTH_KEY_FILE: %s", err)
+		} else {
+			tlsClientCertificates = []tls.Certificate{mTlsKeyPair}
 		}
 	}
 
@@ -104,6 +128,7 @@ func NewOpenCostPrometheusConfigFromEnv() (*OpenCostPrometheusConfig, error) {
 		TLSHandshakeTimeout:   tlsHandshakeTimeout,
 		TLSInsecureSkipVerify: env.IsInsecureSkipVerify(),
 		RootCAs:               tlsCaCert,
+		ClientCertificates:    tlsClientCertificates,
 		RateLimitRetryOpts:    rateLimitRetryOpts,
 		Auth:                  auth,
 		QueryConcurrency:      queryConcurrency,

--- a/modules/prometheus-source/pkg/prom/config.go
+++ b/modules/prometheus-source/pkg/prom/config.go
@@ -102,13 +102,13 @@ func NewOpenCostPrometheusConfigFromEnv() (*OpenCostPrometheusConfig, error) {
 		}
 		mTlsCa, err := os.ReadFile(env.GetPromMtlsAuthCAFile())
 		if err != nil {
-			log.Errorf("mTLS options were set but failed to load DB_MTLS_AUTH_CA_FILE: %s", err)
+			log.Errorf("mTLS options were set but failed to load PROM_MTLS_AUTH_CA_FILE: %s", err)
 		} else {
 			tlsCaCert.AppendCertsFromPEM(mTlsCa)
 		}
 		mTlsKeyPair, err := tls.LoadX509KeyPair(env.GetPromMtlsAuthCrtFile(), env.GetPromMtlsAuthKeyFile())
 		if err != nil {
-			log.Errorf("mTLS options were set but failed to load DB_MTLS_AUTH_CRT_FILE or DB_MTLS_AUTH_KEY_FILE: %s", err)
+			log.Errorf("mTLS options were set but failed to load PROM_MTLS_AUTH_CRT_FILE or PROM_MTLS_AUTH_KEY_FILE: %s", err)
 		} else {
 			tlsClientCertificates = []tls.Certificate{mTlsKeyPair}
 		}

--- a/modules/prometheus-source/pkg/prom/config.go
+++ b/modules/prometheus-source/pkg/prom/config.go
@@ -91,7 +91,7 @@ func NewOpenCostPrometheusConfigFromEnv() (*OpenCostPrometheusConfig, error) {
 		if err != nil {
 			log.Errorf("%s was set to true but failed to load service-ca.crt: %s", env.KubeRbacProxyEnabledEnvVar, err)
 		}
-	} else if env.IsDBmTLSAuthEnabled() {
+	} else if env.IsPromMtlsAuthEnabled() {
 		tlsCaCert = x509.NewCertPool()
 		// The /etc/ssl/cert.pem location is correct for Alpine Linux, the container base used here
 		systemCa, err := os.ReadFile("/etc/ssl/cert.pem")
@@ -100,13 +100,13 @@ func NewOpenCostPrometheusConfigFromEnv() (*OpenCostPrometheusConfig, error) {
 		} else {
 			tlsCaCert.AppendCertsFromPEM(systemCa)
 		}
-		mTlsCa, err := os.ReadFile(env.GetDBmTLSAuthCAFile())
+		mTlsCa, err := os.ReadFile(env.GetPromMtlsAuthCAFile())
 		if err != nil {
 			log.Errorf("mTLS options were set but failed to load DB_MTLS_AUTH_CA_FILE: %s", err)
 		} else {
 			tlsCaCert.AppendCertsFromPEM(mTlsCa)
 		}
-		mTlsKeyPair, err := tls.LoadX509KeyPair(env.GetDBmTLSAuthCrtFile(), env.GetDBmTLSAuthKeyFile())
+		mTlsKeyPair, err := tls.LoadX509KeyPair(env.GetPromMtlsAuthCrtFile(), env.GetPromMtlsAuthKeyFile())
 		if err != nil {
 			log.Errorf("mTLS options were set but failed to load DB_MTLS_AUTH_CRT_FILE or DB_MTLS_AUTH_KEY_FILE: %s", err)
 		} else {

--- a/modules/prometheus-source/pkg/prom/prom.go
+++ b/modules/prometheus-source/pkg/prom/prom.go
@@ -379,6 +379,7 @@ type PrometheusClientConfig struct {
 	QueryLogFile          string
 	HeaderXScopeOrgId     string
 	RootCAs               *x509.CertPool
+	ClientCertificates    []tls.Certificate
 }
 
 // NewPrometheusClient creates a new rate limited client which limits by outbound concurrent requests.
@@ -395,6 +396,7 @@ func NewPrometheusClient(address string, config *PrometheusClientConfig) (promet
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: config.TLSInsecureSkipVerify,
 			RootCAs:            config.RootCAs,
+			Certificates:       config.ClientCertificates,
 			MinVersion:         tls.VersionTLS12,
 		},
 	})


### PR DESCRIPTION
## What does this PR change?

Adds three new environment variables describing file locations for the ca certificate, client certificate, and client key, respectively. When used together, they instruct the prometheus client to connect using mTLS.

* `DB_MTLS_AUTH_CA_FILE`
* `DB_MTLS_AUTH_CRT_FILE`
* `DB_MTLS_AUTH_KEY_FILE`

## Does this PR relate to any other PRs?
* No

## How will this PR impact users?
* This is an opt-in feature and should not impact existing users. The three environment variables will need to be specified together and their respective files mounted for the feature to be enabled.

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?
* Build and deployed to a private kubernetes cluster using Prometheus Mimir with mTLS as the prometheus endpoint.

## Does this PR require changes to documentation?
* Yes, to the helm chart documentation describing how to enable the feature.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* TBD