### PR TITLE
Fix JSON Casing

### DIFF
--- a/pkg/cloudcost/status.go
+++ b/pkg/cloudcost/status.go
@@ -15,7 +15,7 @@ type Status struct {
 	Valid            bool               `json:"valid"`
 	LastRun          time.Time          `json:"lastRun"`
 	NextRun          time.Time          `json:"nextRun"`
-	RefreshRate      string             `json:"RefreshRate"`
+	RefreshRate      string             `json:"refreshRate"`
 	Created          time.Time          `json:"created"`
 	Runs             int                `json:"runs"`
 	Coverage         string             `json:"coverage"`


### PR DESCRIPTION
## What does this PR change?
* Updates the JSON casing on the Cloud Cost `Status` type, which will allow the refresh rate to show up in the Kubecost UI.

## Does this PR relate to any other PRs?
* N/A.

## How will this PR impact users?
* Kubecost users will now see their integration's refresh rate in the Kubecost UI.

## Does this PR address any GitHub or Zendesk issues?
* N/A.

## How was this PR tested?
* N/A.

## Does this PR require changes to documentation?
* Nope.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A.