### PR TITLE
Remove unused configs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,12 @@
-## What does this PR change?
-* 
+## Description
+<!-- Provide a clear and concise description of what this PR changes. -->
 
-## Does this PR relate to any other PRs?
-* 
+## Related Issues
+<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
 
-## How will this PR impact users?
-* 
+## User Impact
+<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
 
-## Does this PR address any GitHub or Zendesk issues?
-* Closes ...
-
-## How was this PR tested?
-* 
-
-## Does this PR require changes to documentation?
-* 
-
-## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
-* 
+## Testing
+<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
+<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

--- a/core/pkg/opencost/query.go
+++ b/core/pkg/opencost/query.go
@@ -40,7 +40,6 @@ type AllocationQueryOptions struct {
 	SharedHourlyCosts       map[string]float64
 	ShareIdle               string
 	ShareSplit              string
-	ShareTenancyCosts       bool
 	SplitIdle               bool
 	Step                    time.Duration
 }

--- a/pkg/cloud/alibaba/provider.go
+++ b/pkg/cloud/alibaba/provider.go
@@ -605,9 +605,6 @@ func (alibaba *Alibaba) GetConfig() (*models.CustomPricing, error) {
 	if c.NegotiatedDiscount == "" {
 		c.NegotiatedDiscount = "0%"
 	}
-	if c.ShareTenancyCosts == "" {
-		c.ShareTenancyCosts = models.DefaultShareTenancyCost
-	}
 
 	return c, nil
 }

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -449,9 +449,6 @@ func (aws *AWS) GetConfig() (*models.CustomPricing, error) {
 	if c.NegotiatedDiscount == "" {
 		c.NegotiatedDiscount = "0%"
 	}
-	if c.ShareTenancyCosts == "" {
-		c.ShareTenancyCosts = models.DefaultShareTenancyCost
-	}
 
 	return c, nil
 }

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1596,9 +1596,6 @@ func (az *Azure) GetConfig() (*models.CustomPricing, error) {
 	if c.AzureOfferDurableID == "" {
 		c.AzureOfferDurableID = "MS-AZR-0003p"
 	}
-	if c.ShareTenancyCosts == "" {
-		c.ShareTenancyCosts = models.DefaultShareTenancyCost
-	}
 	if c.SpotLabel == "" {
 		c.SpotLabel = defaultSpotLabel
 	}

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -151,9 +151,6 @@ func (gcp *GCP) GetConfig() (*models.CustomPricing, error) {
 	if c.CurrencyCode == "" {
 		c.CurrencyCode = "USD"
 	}
-	if c.ShareTenancyCosts == "" {
-		c.ShareTenancyCosts = models.DefaultShareTenancyCost
-	}
 	return c, nil
 }
 

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -406,7 +406,6 @@ func TestGCP_GetConfig(t *testing.T) {
 	assert.Equal(t, "30%", config.Discount)
 	assert.Equal(t, "0%", config.NegotiatedDiscount)
 	assert.Equal(t, "USD", config.CurrencyCode)
-	assert.Equal(t, models.DefaultShareTenancyCost, config.ShareTenancyCosts)
 }
 
 func TestGCP_GetManagementPlatform(t *testing.T) {
@@ -1259,7 +1258,6 @@ func (m *mockConfig) GetCustomPricingData() (*models.CustomPricing, error) {
 		Discount:              "30%",
 		NegotiatedDiscount:    "0%",
 		CurrencyCode:          "USD",
-		ShareTenancyCosts:     models.DefaultShareTenancyCost,
 		ZoneNetworkEgress:     "0.12",
 		RegionNetworkEgress:   "0.08",
 		InternetNetworkEgress: "0.15",

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/opencost/opencost/core/pkg/clustercache"
-	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/pkg/config"
 )
 
@@ -166,7 +165,6 @@ type CustomPricing struct {
 	AthenaCURVersion             string `json:"athenaCURVersion,omitempty"` // "1.0" or "2.0", defaults to "2.0"
 	BillingDataDataset           string `json:"billingDataDataset,omitempty"`
 	CustomPricesEnabled          string `json:"customPricesEnabled"`
-	DefaultIdle                  string `json:"defaultIdle"`
 	AzureSubscriptionID          string `json:"azureSubscriptionID"`
 	AzureClientID                string `json:"azureClientID"`
 	AzureClientSecret            string `json:"azureClientSecret"`
@@ -183,38 +181,10 @@ type CustomPricing struct {
 	CurrencyCode                 string `json:"currencyCode"`
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`
-	SharedOverhead               string `json:"sharedOverhead"`
 	ClusterName                  string `json:"clusterName"`
 	ClusterAccountID             string `json:"clusterAccount,omitempty"`
-	SharedNamespaces             string `json:"sharedNamespaces"`
-	SharedLabelNames             string `json:"sharedLabelNames"`
-	SharedLabelValues            string `json:"sharedLabelValues"`
 	ShareTenancyCosts            string `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
-	ReadOnly                     string `json:"readOnly"`
-	EditorAccess                 string `json:"editorAccess"`
-	KubecostToken                string `json:"kubecostToken"`
-	GoogleAnalyticsTag           string `json:"googleAnalyticsTag"`
-	ExcludeProviderID            string `json:"excludeProviderID"`
 	DefaultLBPrice               string `json:"defaultLBPrice"`
-}
-
-// GetSharedOverheadCostPerMonth parses and returns a float64 representation
-// of the configured monthly shared overhead cost. If the string version cannot
-// be parsed into a float, an error is logged and 0.0 is returned.
-func (cp *CustomPricing) GetSharedOverheadCostPerMonth() float64 {
-	// Empty string should be interpreted as "no cost", i.e. 0.0
-	if cp.SharedOverhead == "" {
-		return 0.0
-	}
-
-	// Attempt to parse, but log and return 0.0 if that fails.
-	sharedCostPerMonth, err := strconv.ParseFloat(cp.SharedOverhead, 64)
-	if err != nil {
-		log.Errorf("SharedOverhead: failed to parse shared overhead \"%s\": %s", cp.SharedOverhead, err)
-		return 0.0
-	}
-
-	return sharedCostPerMonth
 }
 
 func sanitizeFloatString(number string, allowNaN bool) (string, error) {

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -20,7 +20,6 @@ var (
 const (
 	AuthSecretPath                 = "/var/secrets/service-key.json"
 	StorageConfigSecretPath        = "/var/azure-storage-config/azure-storage-config.json"
-	DefaultShareTenancyCost        = "true"
 	KarpenterCapacityTypeLabel     = "karpenter.sh/capacity-type"
 	KarpenterCapacitySpotTypeValue = "spot"
 )
@@ -183,7 +182,6 @@ type CustomPricing struct {
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`
 	ClusterName                  string `json:"clusterName"`
 	ClusterAccountID             string `json:"clusterAccount,omitempty"`
-	ShareTenancyCosts            string `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
 	DefaultLBPrice               string `json:"defaultLBPrice"`
 }
 

--- a/pkg/cloud/provider/cloud_test.go
+++ b/pkg/cloud/provider/cloud_test.go
@@ -233,7 +233,7 @@ func TestNodePriceFromCSVWithGPU(t *testing.T) {
 }
 
 func TestNodePriceFromCSVWithGPULabels(t *testing.T) {
-	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","clusterName":"","shareTenancyCosts":"true","defaultLBPrice":""}`
+	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","clusterName":"","defaultLBPrice":""}`
 
 	nameWant := "gke-standard-cluster-1-pool-1-91dc432d-cg69"
 	wantGPUCost := "0.75"
@@ -300,7 +300,7 @@ func TestNodePriceFromCSVWithGPULabels(t *testing.T) {
 }
 
 func TestRKE2NodePriceFromCSVWithGPULabels(t *testing.T) {
-	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","clusterName":"","shareTenancyCosts":"true","defaultLBPrice":""}`
+	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","clusterName":"","defaultLBPrice":""}`
 
 	nameWant := "gke-standard-cluster-1-pool-1-91dc432d-cg69"
 	wantGPUCost := "0.750000"
@@ -622,8 +622,7 @@ func TestNodePriceFromCSVWithBadConfig(t *testing.T) {
 		"currencyCode":"",
 		"discount":"",
 		"negotiatedDiscount":"",
-		"clusterName":"",
-		"shareTenancyCosts":"true"
+		"clusterName":""
 	}`
 
 	tempPath := t.TempDir()

--- a/pkg/cloud/provider/cloud_test.go
+++ b/pkg/cloud/provider/cloud_test.go
@@ -233,7 +233,7 @@ func TestNodePriceFromCSVWithGPU(t *testing.T) {
 }
 
 func TestNodePriceFromCSVWithGPULabels(t *testing.T) {
-	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","defaultIdle":"","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","sharedOverhead":"","clusterName":"","sharedNamespaces":"","sharedLabelNames":"","sharedLabelValues":"","shareTenancyCosts":"true","readOnly":"","editorAccess":"","kubecostToken":"","googleAnalyticsTag":"","excludeProviderID":"","defaultLBPrice":""}`
+	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","clusterName":"","shareTenancyCosts":"true","defaultLBPrice":""}`
 
 	nameWant := "gke-standard-cluster-1-pool-1-91dc432d-cg69"
 	wantGPUCost := "0.75"
@@ -300,7 +300,7 @@ func TestNodePriceFromCSVWithGPULabels(t *testing.T) {
 }
 
 func TestRKE2NodePriceFromCSVWithGPULabels(t *testing.T) {
-	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","defaultIdle":"","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","sharedOverhead":"","clusterName":"","sharedNamespaces":"","sharedLabelNames":"","sharedLabelValues":"","shareTenancyCosts":"true","readOnly":"","editorAccess":"","kubecostToken":"","googleAnalyticsTag":"","excludeProviderID":"","defaultLBPrice":""}`
+	const defaultConfigJson = `{"provider":"base","description":"Default prices based on GCP us-central1","CPU":"0.021811","spotCPU":"0.006543","RAM":"0.002923","spotRAM":"0.000877","GPU":"0.95","spotGPU":"0.308","storage":"0.00005479452","zoneNetworkEgress":"0.01","regionNetworkEgress":"0.01","internetNetworkEgress":"0.12","firstFiveForwardingRulesCost":"","additionalForwardingRuleCost":"","LBIngressDataCost":"","athenaBucketName":"","athenaRegion":"","athenaDatabase":"","athenaCatalog":"","athenaTable":"","athenaWorkgroup":"","masterPayerARN":"","customPricesEnabled":"false","azureSubscriptionID":"","azureClientID":"","azureClientSecret":"","azureTenantID":"","azureBillingRegion":"","azureBillingAccount":"","azureOfferDurableID":"","azureStorageSubscriptionID":"","azureStorageAccount":"","azureStorageAccessKey":"","azureStorageContainer":"","azureContainerPath":"","azureCloud":"","currencyCode":"","discount":"","negotiatedDiscount":"","clusterName":"","shareTenancyCosts":"true","defaultLBPrice":""}`
 
 	nameWant := "gke-standard-cluster-1-pool-1-91dc432d-cg69"
 	wantGPUCost := "0.750000"
@@ -607,7 +607,6 @@ func TestNodePriceFromCSVWithBadConfig(t *testing.T) {
 		"athenaWorkgroup":"",
 		"masterPayerARN":"",
 		"customPricesEnabled":"false",
-		"defaultIdle":"",
 		"azureSubscriptionID":"",
 		"azureClientID":"",
 		"azureClientSecret":"",
@@ -623,17 +622,8 @@ func TestNodePriceFromCSVWithBadConfig(t *testing.T) {
 		"currencyCode":"",
 		"discount":"",
 		"negotiatedDiscount":"",
-		"sharedOverhead":"",
 		"clusterName":"",
-		"sharedNamespaces":"",
-		"sharedLabelNames":"",
-		"sharedLabelValues":"",
-		"shareTenancyCosts":"true",
-		"readOnly":"",
-		"editorAccess":"",
-		"kubecostToken":"",
-		"googleAnalyticsTag":"",
-		"excludeProviderID":""
+		"shareTenancyCosts":"true"
 	}`
 
 	tempPath := t.TempDir()

--- a/pkg/cloud/provider/providerconfig.go
+++ b/pkg/cloud/provider/providerconfig.go
@@ -74,10 +74,6 @@ func (pc *ProviderConfig) onConfigFileUpdated(changeType config.ChangeType, data
 			pc.customPricing.SpotGPU = DefaultPricing().SpotGPU // Migration for users without this value set by default.
 		}
 
-		if pc.customPricing.ShareTenancyCosts == "" {
-			pc.customPricing.ShareTenancyCosts = models.DefaultShareTenancyCost
-		}
-
 		// If the sample nil service key name is set, zero it out so that it is not
 		// misinterpreted as a real service key.
 		if pc.customPricing.ServiceKeyName == "AKIXXX" {
@@ -149,10 +145,6 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*models.CustomPrici
 	pc.customPricing = &customPricing
 	if pc.customPricing.SpotGPU == "" {
 		pc.customPricing.SpotGPU = DefaultPricing().SpotGPU // Migration for users without this value set by default.
-	}
-
-	if pc.customPricing.ShareTenancyCosts == "" {
-		pc.customPricing.ShareTenancyCosts = models.DefaultShareTenancyCost
 	}
 
 	// If the sample nil service key name is set, zero it out so that it is not
@@ -268,7 +260,6 @@ func DefaultPricing() *models.CustomPricing {
 		RegionNetworkEgress:   "0.01",
 		InternetNetworkEgress: "0.12",
 		CustomPricesEnabled:   "false",
-		ShareTenancyCosts:     "true",
 	}
 }
 

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -20,9 +20,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/util/retry"
 	"github.com/opencost/opencost/core/pkg/util/timeutil"
 	"github.com/opencost/opencost/core/pkg/version"
-	"github.com/opencost/opencost/pkg/cloud/aws"
 	cloudconfig "github.com/opencost/opencost/pkg/cloud/config"
-	"github.com/opencost/opencost/pkg/cloud/gcp"
 	"github.com/opencost/opencost/pkg/cloud/provider"
 	"github.com/opencost/opencost/pkg/cloudcost"
 	"github.com/opencost/opencost/pkg/config"
@@ -39,7 +37,6 @@ import (
 	"github.com/opencost/opencost/core/pkg/util/json"
 	"github.com/opencost/opencost/modules/collector-source/pkg/collector"
 	"github.com/opencost/opencost/modules/prometheus-source/pkg/prom"
-	"github.com/opencost/opencost/pkg/cloud/azure"
 	"github.com/opencost/opencost/pkg/cloud/models"
 	clusterc "github.com/opencost/opencost/pkg/clustercache"
 	"github.com/opencost/opencost/pkg/env"
@@ -52,10 +49,6 @@ import (
 
 const (
 	RFC3339Milli         = "2006-01-02T15:04:05.000Z"
-	maxCacheMinutes1d    = 11
-	maxCacheMinutes2d    = 17
-	maxCacheMinutes7d    = 37
-	maxCacheMinutes30d   = 137
 	CustomPricingSetting = "CustomPricing"
 	DiscountSetting      = "Discount"
 )
@@ -208,61 +201,6 @@ func (a *Accesses) GetAllNodePricing(w http.ResponseWriter, r *http.Request, ps 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	data, err := a.CloudProvider.AllNodePricing()
-	WriteData(w, data, err)
-}
-
-func (a *Accesses) GetConfigs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	data, err := a.CloudProvider.GetConfig()
-	WriteData(w, data, err)
-}
-
-func (a *Accesses) UpdateSpotInfoConfigs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	data, err := a.CloudProvider.UpdateConfig(r.Body, aws.SpotInfoUpdateType)
-	WriteData(w, data, err)
-
-	err = a.CloudProvider.DownloadPricingData()
-	if err != nil {
-		log.Errorf("Error redownloading data on config update: %s", err.Error())
-	}
-}
-
-func (a *Accesses) UpdateAthenaInfoConfigs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	data, err := a.CloudProvider.UpdateConfig(r.Body, aws.AthenaInfoUpdateType)
-	WriteData(w, data, err)
-}
-
-func (a *Accesses) UpdateBigQueryInfoConfigs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	data, err := a.CloudProvider.UpdateConfig(r.Body, gcp.BigqueryUpdateType)
-	WriteData(w, data, err)
-}
-
-func (a *Accesses) UpdateAzureStorageConfigs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	data, err := a.CloudProvider.UpdateConfig(r.Body, azure.AzureStorageUpdateType)
-	if err != nil {
-		WriteData(w, nil, err)
-		return
-	}
-	WriteData(w, data, err)
-}
-
-func (a *Accesses) UpdateConfigByKey(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	data, err := a.CloudProvider.UpdateConfig(r.Body, "")
 	WriteData(w, data, err)
 }
 

--- a/pkg/costmodel/settings.go
+++ b/pkg/costmodel/settings.go
@@ -86,7 +86,7 @@ func (a *Accesses) customPricingHasChanged() bool {
 	// describe parameters by which we determine whether or not custom
 	// pricing settings have changed
 	encodeCustomPricing := func(cp *models.CustomPricing) string {
-		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s:%s:%s", cp.CustomPricesEnabled, cp.CPU, cp.SpotCPU,
+		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s:%s", cp.CustomPricesEnabled, cp.CPU, cp.SpotCPU,
 			cp.RAM, cp.SpotRAM, cp.GPU, cp.Storage, cp.CurrencyCode)
 	}
 

--- a/pkg/costmodel/settings.go
+++ b/pkg/costmodel/settings.go
@@ -87,7 +87,7 @@ func (a *Accesses) customPricingHasChanged() bool {
 	// pricing settings have changed
 	encodeCustomPricing := func(cp *models.CustomPricing) string {
 		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s:%s:%s", cp.CustomPricesEnabled, cp.CPU, cp.SpotCPU,
-			cp.RAM, cp.SpotRAM, cp.GPU, cp.Storage, cp.CurrencyCode, cp.SharedOverhead)
+			cp.RAM, cp.SpotRAM, cp.GPU, cp.Storage, cp.CurrencyCode)
 	}
 
 	// compare cached custom pricing parameters with current values


### PR DESCRIPTION
## What does this PR change?
* Deletes unused HTTP handlers to GET/UPDATE configs
* Updates PR template
* Removes configs from `CustomPricing` struct which are no longer used downstream. These configs were originally added to pass values through from a ConfigMap -> Backend -> Frontend. In retrospect the `CustomPricing` struct was probably not the right avenue to do so.
* Removes `ShareTenancyCost`. A default value for it was being set in multiple places, but was never used anywhere in OpenCost or downstream repos.

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* N/A

## How was this PR tested?

### 1. Default install

A default install of OpenCost via the Helm chart will not have Custom Pricing enabled. Therefore the impact of these changes is negligible on a default install.

```
$ helm upgrade -i opencost --repo https://opencost.github.io/opencost-helm-chart opencost
```

```log
INF Could not find Custom Pricing file at path '/var/configs/aws.json'
INF Could not write Custom Pricing file to path '/var/configs/aws.json'
INF No pricing-configs configmap found at install time, using existing configs: configmaps "pricing-configs" not found
```

### 2. No build/test errors

Confirmed that none of the removed configs/vars are used elsewhere in OpenCost. Therefore if configuring your own custom pricing JSON there should be no effect.

Example config ([docs ref](https://opencost.io/docs/configuration/on-prem/#custom-pricing-using-the-opencost-helm-chart)):

```yaml
opencost:
  customPricing:
    enabled: true
    costModel:
      description: Modified prices based on your internal pricing
      CPU: 1.25
      RAM: 0.50
      storage: 0.25
```

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A