### PR TITLE
Cloud Integration Status Refresh

### DIFF
--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/core/pkg/util/timeutil"
 	"github.com/opencost/opencost/pkg/cloud"
 )
 
@@ -68,6 +69,22 @@ type AthenaIntegration struct {
 
 // Query Athena for CUR data and build a new CloudCostSetRange containing the info
 func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.CloudCostSetRange, error) {
+	return ai.getCloudCost(start, end, 0)
+}
+
+func (ai *AthenaIntegration) RefreshStatus() cloud.ConnectionStatus {
+	end := time.Now().UTC().Truncate(timeutil.Day)
+	start := end.Add(-7 * timeutil.Day)
+
+	_, err := ai.getCloudCost(start, end, 1)
+	if err != nil {
+		ai.ConnectionStatus = cloud.FailedConnection
+	}
+
+	return ai.ConnectionStatus
+}
+
+func (ai *AthenaIntegration) getCloudCost(start, end time.Time, limit int) (*opencost.CloudCostSetRange, error) {
 	log.Infof("AthenaIntegration[%s]: GetCloudCost: %s", ai.Key(), opencost.NewWindow(&start, &end).String())
 	// Query for all column names
 	allColumns, err := ai.GetColumns()
@@ -161,6 +178,9 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.Cloud
 		WHERE %s
 		GROUP BY %s
 	`
+	if limit > 0 {
+		queryStr = fmt.Sprintf("%s LIMIT %d", queryStr, limit)
+	}
 	aqi.Query = fmt.Sprintf(queryStr, columnStr, ai.Table, whereClause, groupByStr)
 
 	ccsr, err := opencost.NewCloudCostSetRange(start, end, opencost.AccumulateOptionDay, ai.Key())
@@ -328,7 +348,7 @@ func (ai *AthenaIntegration) GetPartitionWhere(start, end time.Time) string {
 	month := time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, time.UTC)
 	endMonth := time.Date(end.Year(), end.Month(), 1, 0, 0, 0, 0, time.UTC)
 	var disjuncts []string
-	
+
 	// For CUR 2.0, check if billing_period partitions actually exist
 	useBillingPeriodPartitions := false
 	if ai.CURVersion != "1.0" {
@@ -337,7 +357,7 @@ func (ai *AthenaIntegration) GetPartitionWhere(start, end time.Time) string {
 			useBillingPeriodPartitions = true
 		}
 	}
-	
+
 	for !month.After(endMonth) {
 		if ai.CURVersion == "1.0" {
 			// CUR 1.0 uses year and month columns for partitioning

--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -76,6 +76,8 @@ func (ai *AthenaIntegration) RefreshStatus() cloud.ConnectionStatus {
 	end := time.Now().UTC().Truncate(timeutil.Day)
 	start := end.Add(-7 * timeutil.Day)
 
+	// getCloudCost already sets ConnectionStatus in the event there is no error, so we don't need to handle the positive
+	// case here
 	_, err := ai.getCloudCost(start, end, 1)
 	if err != nil {
 		ai.ConnectionStatus = cloud.FailedConnection

--- a/pkg/cloud/aws/athenaquerier.go
+++ b/pkg/cloud/aws/athenaquerier.go
@@ -69,7 +69,7 @@ func (aq *AthenaQuerier) HasBillingPeriodPartitions() (bool, error) {
 	// Use SHOW PARTITIONS to check if billing_period partitions exist
 	query := fmt.Sprintf("SHOW PARTITIONS \"%s\"", aq.Table)
 	hasBillingPeriodPartition := false
-	
+
 	athenaErr := aq.Query(context.TODO(), query, GetAthenaQueryFunc(func(row types.Row) {
 		if len(row.Data) > 0 && row.Data[0].VarCharValue != nil {
 			partitionValue := *row.Data[0].VarCharValue

--- a/pkg/cloud/aws/s3selectintegration.go
+++ b/pkg/cloud/aws/s3selectintegration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/pkg/cloud"
 )
 
 const S3SelectDateLayout = "2006-01-02T15:04:05Z"
@@ -372,4 +373,21 @@ func hasK8sLabel(labels opencost.CloudCostLabels) bool {
 		return true
 	}
 	return false
+}
+
+func (s3si *S3SelectIntegration) RefreshStatus() cloud.ConnectionStatus {
+	client, err := s3si.GetS3Client()
+	if err != nil {
+		s3si.ConnectionStatus = cloud.FailedConnection
+	}
+	objs, err := s3si.ListObjects(client)
+	if err != nil {
+		s3si.ConnectionStatus = cloud.FailedConnection
+	} else if len(objs.Contents) == 0 {
+		s3si.ConnectionStatus = cloud.MissingData
+	} else {
+		s3si.ConnectionStatus = cloud.SuccessfulConnection
+	}
+
+	return s3si.ConnectionStatus
 }

--- a/pkg/cloud/gcp/bigqueryintegration.go
+++ b/pkg/cloud/gcp/bigqueryintegration.go
@@ -47,6 +47,8 @@ func (bqi *BigQueryIntegration) RefreshStatus() cloud.ConnectionStatus {
 	end := time.Now().UTC().Truncate(timeutil.Day)
 	start := end.Add(-7 * timeutil.Day)
 
+	// the call to Query within getCloudCost already sets ConnectionStatus in the event there is no error, so we don't
+	// need to handle the positive case here
 	_, err := bqi.getCloudCost(start, end, 1)
 	if err != nil {
 		bqi.ConnectionStatus = cloud.FailedConnection

--- a/pkg/cloud/gcp/bigqueryintegration.go
+++ b/pkg/cloud/gcp/bigqueryintegration.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/core/pkg/util/timeutil"
+	"github.com/opencost/opencost/pkg/cloud"
 	"google.golang.org/api/iterator"
 )
 
@@ -38,6 +40,22 @@ const BiqQueryWherePartitionFmt = `DATE(_PARTITIONTIME) >= "%s" AND DATE(_PARTIT
 const BiqQueryWhereDateFmt = `usage_start_time >= "%s" AND usage_start_time < "%s"`
 
 func (bqi *BigQueryIntegration) GetCloudCost(start time.Time, end time.Time) (*opencost.CloudCostSetRange, error) {
+	return bqi.getCloudCost(start, end, 0)
+}
+
+func (bqi *BigQueryIntegration) RefreshStatus() cloud.ConnectionStatus {
+	end := time.Now().UTC().Truncate(timeutil.Day)
+	start := end.Add(-7 * timeutil.Day)
+
+	_, err := bqi.getCloudCost(start, end, 1)
+	if err != nil {
+		bqi.ConnectionStatus = cloud.FailedConnection
+	}
+
+	return bqi.ConnectionStatus
+}
+
+func (bqi *BigQueryIntegration) getCloudCost(start time.Time, end time.Time, limit int) (*opencost.CloudCostSetRange, error) {
 	cudRates, err := bqi.GetFlexibleCUDRates(start, end)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving CUD rates: %w", err)
@@ -87,6 +105,9 @@ func (bqi *BigQueryIntegration) GetCloudCost(start time.Time, end time.Time) (*o
 		WHERE %s
 		GROUP BY %s
 	`
+	if limit > 0 {
+		queryStr = fmt.Sprintf("%s LIMIT %d", queryStr, limit)
+	}
 
 	querystr := fmt.Sprintf(queryStr, columnStr, table, whereClause, groupByStr)
 

--- a/pkg/cloud/oracle/usageapiintegration.go
+++ b/pkg/cloud/oracle/usageapiintegration.go
@@ -158,6 +158,11 @@ func (uai *UsageApiIntegration) GetStatus() cloud.ConnectionStatus {
 	return uai.ConnectionStatus
 }
 
+func (uai *UsageApiIntegration) RefreshStatus() cloud.ConnectionStatus {
+	// this function is not implemented for the oracle provider
+	return uai.ConnectionStatus
+}
+
 func SelectOCICategory(service string) string {
 	if service == "Compute" {
 		return opencost.ComputeCategory

--- a/pkg/cloud/oracle/usageapiintegration.go
+++ b/pkg/cloud/oracle/usageapiintegration.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/pkg/cloud"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -159,7 +160,7 @@ func (uai *UsageApiIntegration) GetStatus() cloud.ConnectionStatus {
 }
 
 func (uai *UsageApiIntegration) RefreshStatus() cloud.ConnectionStatus {
-	// this function is not implemented for the oracle provider
+	log.Warn("status refresh is not supported for the Oracle provider")
 	return uai.ConnectionStatus
 }
 

--- a/pkg/cloudcost/ingestionmanager.go
+++ b/pkg/cloudcost/ingestionmanager.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
-	"github.com/opencost/opencost/core/pkg/util/timeutil"
 	"github.com/opencost/opencost/pkg/cloud"
 	"github.com/opencost/opencost/pkg/cloud/config"
 )
@@ -213,24 +212,11 @@ func (im *IngestionManager) createIngestor(config cloud.KeyedConfig) error {
 		return fmt.Errorf("IngestionManager: createIngestor: %w", err)
 	}
 
-	populateConnectionStatus(ing)
+	ing.RefreshStatus()
 
 	ing.Start(false)
 
 	im.ingestors[config.Key()] = ing
 
 	return nil
-}
-
-// populateConnectionStatus attempts to pull the past 7 days worth of data for a given key's ingestor, which will cause
-// the ingestor to populate the ingestor's connection status
-func populateConnectionStatus(ing *ingestor) {
-	// Calculate a window for the past 7 days
-	end := time.Now().UTC()
-	end = end.Truncate(timeutil.Day)
-	start := end.Add(-7 * timeutil.Day)
-	end = start.Add(timeutil.Day)
-
-	// Attempt to ingest data from the specified cloud integration from the past 7 days
-	ing.BuildWindow(start, end)
 }

--- a/pkg/cloudcost/ingestionmanager.go
+++ b/pkg/cloudcost/ingestionmanager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/core/pkg/util/timeutil"
 	"github.com/opencost/opencost/pkg/cloud"
 	"github.com/opencost/opencost/pkg/cloud/config"
 )
@@ -212,9 +213,24 @@ func (im *IngestionManager) createIngestor(config cloud.KeyedConfig) error {
 		return fmt.Errorf("IngestionManager: createIngestor: %w", err)
 	}
 
+	populateConnectionStatus(ing)
+
 	ing.Start(false)
 
 	im.ingestors[config.Key()] = ing
 
 	return nil
+}
+
+// populateConnectionStatus attempts to pull the past 7 days worth of data for a given key's ingestor, which will cause
+// the ingestor to populate the ingestor's connection status
+func populateConnectionStatus(ing *ingestor) {
+	// Calculate a window for the past 7 days
+	end := time.Now().UTC()
+	end = end.Truncate(timeutil.Day)
+	start := end.Add(-7 * timeutil.Day)
+	end = start.Add(timeutil.Day)
+
+	// Attempt to ingest data from the specified cloud integration from the past 7 days
+	ing.BuildWindow(start, end)
 }

--- a/pkg/cloudcost/ingestor.go
+++ b/pkg/cloudcost/ingestor.go
@@ -340,3 +340,7 @@ func (ing *ingestor) expandCoverage(window opencost.Window) {
 
 	ing.coverage = coverage
 }
+
+func (ing *ingestor) RefreshStatus() cloud.ConnectionStatus {
+	return ing.integration.RefreshStatus()
+}

--- a/pkg/cloudcost/integration.go
+++ b/pkg/cloudcost/integration.go
@@ -16,6 +16,7 @@ import (
 type CloudCostIntegration interface {
 	GetCloudCost(time.Time, time.Time) (*opencost.CloudCostSetRange, error)
 	GetStatus() cloud.ConnectionStatus
+	RefreshStatus() cloud.ConnectionStatus
 }
 
 // GetIntegrationFromConfig coverts any valid KeyedConfig into the appropriate BillingIntegration if possible


### PR DESCRIPTION
## Description
* The intent behind this change is to add "status refresh" functionality to cloud integrations. Currently, when a cloud integration is created, the "check if credentials are valid, and if data exists" logic occurs asynchronously. Additionally, the "does data exist?" check requires that data be pulled down from the provider.
* This PR adds `RefreshStatus()` to each cloud provider, which synchronously performs an "are the credentials valid, and does data exist?" check, without pulling down any data. It does this by attempting to list a very small subset of data from the provider, which will either fail due to bad credentials, or will succeed with "missing data" or "connection successful".
* This functionality allows downstream apps to quickly determine whether their cloud integration credentials are valid.

## Related Issues
N/A.

## User Impact
Users will have fast-feedback regarding the connection status of their cloud configs.

## Testing
Updated `kubecost-cost-model` to call `RefreshStatus()` via `/cloud/config/test`, and validated that requests for AWS, Azure, and GCP cloud integrations pass and fail as expected.
Also validated that existing cloud integration functionality continues to function as before.