### PR TITLE
Refactor logging to use structured logging for filter parsing errors

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/filter"
 	"github.com/opencost/opencost/core/pkg/filter/allocation"
 	cloudcostfilter "github.com/opencost/opencost/core/pkg/filter/cloudcost"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	models "github.com/opencost/opencost/pkg/cloud/models"
 	"github.com/opencost/opencost/pkg/cloudcost"
@@ -770,7 +771,7 @@ func (s *MCPServer) buildCloudCostQueryRequest(request cloudcost.QueryRequest, p
 		filter, err = parser.Parse(params.Filter)
 		if err != nil {
 			// Log error but continue without filter rather than failing the entire request
-			fmt.Printf("Warning: failed to parse filter string '%s': %v\n", params.Filter, err)
+			log.Warnf("failed to parse filter string '%s': %v", params.Filter, err)
 		}
 	} else {
 		// Build filter from individual parameters
@@ -840,7 +841,7 @@ func (s *MCPServer) buildFilterFromParams(params *CloudCostQuery) filter.Filter 
 	filter, err := parser.Parse(filterString)
 	if err != nil {
 		// Log error but return nil rather than failing
-		fmt.Printf("Warning: failed to parse combined filter '%s': %v\n", filterString, err)
+		log.Warnf("failed to parse combined filter '%s': %v", filterString, err)
 		return nil
 	}
 


### PR DESCRIPTION
## Description
This PR replaces `fmt.Printf` calls with structured logging in the MCP server implementation to ensure consistency with the rest of the OpenCost codebase.

**Changes made:**
- Added import for `github.com/opencost/opencost/core/pkg/log` package
- Replaced `fmt.Printf` with `log.Warnf` at line 773 (filter string parsing error)
- Replaced `fmt.Printf` with `log.Warnf` at line 843 (combined filter parsing error)

This ensures all logging uses the project's standard logging infrastructure with proper log levels, structured output format, and better observability.


## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
Fixes #3484

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
**No breaking changes.** This is an internal improvement to logging infrastructure.
- **Before**: Warning messages were printed to stdout using `fmt.Printf` without proper log levels
- **After**: Warning messages use structured logging with appropriate log levels and formatting

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
**Manual Testing:**
1. Verified the code compiles successfully with the new import
2. Confirmed all `fmt.Printf` calls have been replaced in `pkg/mcp/server.go`
3. Verified the logging API usage matches other parts of the codebase (checked similar patterns in `pkg/clustercache/`, `pkg/env/`, `pkg/util/watcher/`)

No functional changes were made to the filter parsing logic - only the logging mechanism was updated.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace fmt.Printf with log.Warnf for cloud cost filter parsing errors and add the log package import.
> 
> - **MCP Server (`pkg/mcp/server.go`)**:
>   - **Logging**: Replace `fmt.Printf` warnings with `log.Warnf` in `buildCloudCostQueryRequest` and `buildFilterFromParams` for filter parsing errors.
>   - **Imports**: Add `github.com/opencost/opencost/core/pkg/log`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d188cd1565222e7d64508b8fc10dea09847a1131. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->