### PR TITLE
fix(plugins): Return error when plugin config directory is unreadable

### DIFF
--- a/pkg/customcost/pipelineservice.go
+++ b/pkg/customcost/pipelineservice.go
@@ -37,6 +37,7 @@ func getRegisteredPlugins(configDir string, execDir string) (map[string]*plugin.
 	configFiles, err := os.ReadDir(configDir)
 	if err != nil {
 		log.Errorf("error reading files in directory %s: %v", configDir, err)
+		return nil, fmt.Errorf("failed to read plugin config directory: %w", err)
 	}
 
 	// list of plugins that we must run are the strings before _


### PR DESCRIPTION

## Description
<!-- Provide a clear and concise description of what this PR changes. -->
**File Modified**: [pkg/customcost/pipelineservice.go:40](vscode-webview://0abag3551p7b60gs44u1517f71skh67d2mkt98iumguk9b79a65k/pkg/customcost/pipelineservice.go#L40) 

**Change:**
Added a return statement to properly handle the error when os.ReadDir(configDir) fails
The function now returns the error instead of silently continuing with an empty plugin list
**Before:**
```
configFiles, err := os.ReadDir(configDir)
if err != nil {
    log.Errorf("error reading files in directory %s: %v", configDir, err)
    // Missing return - continues with empty slice
}
```
**After:**
```
configFiles, err := os.ReadDir(configDir)
if err != nil {
    log.Errorf("error reading files in directory %s: %v", configDir, err)
    return nil, fmt.Errorf("failed to read plugin config directory: %w", err)
}
```

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
**Closes:** #3489

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
No Breaking Change.

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
- Confirmed the code compiles successfully
- Verified the error propagation chain: `getRegisteredPlugins` → `NewPipelineService` → returns error to caller
