### PR TITLE
Fix listing directories in root path(empty string path)

### DIFF
--- a/core/pkg/storage/gcsstorage.go
+++ b/core/pkg/storage/gcsstorage.go
@@ -264,11 +264,6 @@ func (gs *GCSStorage) ListDirectories(path string) ([]*StorageInfo, error) {
 			return nil, errors.Wrap(err, "list gcs objects")
 		}
 
-		// ignore the root path directory
-		if attrs.Name == path {
-			continue
-		}
-
 		// We filter directories using DirDelim, so a nameless entry is a dir
 		// See gcs.ObjectAttrs Prefix property
 		if attrs.Name == "" {

--- a/core/pkg/storage/gcsstorage.go
+++ b/core/pkg/storage/gcsstorage.go
@@ -239,7 +239,7 @@ func (gs *GCSStorage) List(path string) ([]*StorageInfo, error) {
 func (gs *GCSStorage) ListDirectories(path string) ([]*StorageInfo, error) {
 	path = trimLeading(path)
 
-	log.Debugf("GCSStorage::List(%s)", path)
+	log.Debugf("GCSStorage::ListDirectories(%s)", path)
 	ctx := context.Background()
 
 	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
@@ -261,12 +261,12 @@ func (gs *GCSStorage) ListDirectories(path string) ([]*StorageInfo, error) {
 			break
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "list gcs objects")
+			return nil, errors.Wrap(err, "list gcs prefixes")
 		}
 
-		// We filter directories using DirDelim, so a nameless entry is a dir
+		// We filter directories using DirDelim, so a non empty prefix entry is a prefix(directory)
 		// See gcs.ObjectAttrs Prefix property
-		if attrs.Name == "" {
+		if attrs.Prefix != "" {
 			stats = append(stats, &StorageInfo{
 				Name:    attrs.Prefix,
 				Size:    attrs.Size,

--- a/core/pkg/storage/s3storage.go
+++ b/core/pkg/storage/s3storage.go
@@ -419,7 +419,7 @@ func (s3 *S3Storage) List(path string) ([]*StorageInfo, error) {
 func (s3 *S3Storage) ListDirectories(path string) ([]*StorageInfo, error) {
 	path = trimLeading(path)
 
-	log.Tracef("S3Storage::List(%s)", path)
+	log.Tracef("S3Storage::ListDirectories(%s)", path)
 	ctx := context.Background()
 
 	if path != "" {

--- a/core/pkg/storage/test.go
+++ b/core/pkg/storage/test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/opencost/opencost/core/pkg/util/json"
@@ -166,6 +167,13 @@ func TestStorageListDirectories(t *testing.T, store Storage) {
 		expected  []string
 		expectErr bool
 	}{
+		"root dir dir": {
+			path: "",
+			expected: []string{
+				strings.Split(testpath, "/")[0] + "/",
+			},
+			expectErr: false,
+		},
 		"base dir dir": {
 			path: path.Join(testpath, testName),
 			expected: []string{


### PR DESCRIPTION
## Description
Fix listing directories in root path(empty string path).
Right now when we list directories in GCS for root path (`path=""`) it gives an empty result due to the if statement filtering out all root path prefixes(directories) as `attrs.Name` is an empty string for all prfixes(directories) in gcs and we were checking `if attrs.Name==""` when `path=""`

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
Tested locally by running the aggregator with a GCP bucket.
Ran the added tests with a gcp bucket in config path and they pass