### PR TITLE
fix issue with sonar refs

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -98,8 +98,8 @@ jobs:
           args: >
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
             -Dsonar.pullrequest.key=${{ steps.set-vars.outputs.SONAR_PR_NUM }}
-            -Dsonar.pullrequest.branch="${{ steps.set-vars.outputs.SONAR_HEAD }}"
-            -Dsonar.pullrequest.base="${{ steps.set-vars.outputs.SONAR_BASE }}"
+            -Dsonar.pullrequest.branch=${{ steps.set-vars.outputs.SONAR_HEAD }}
+            -Dsonar.pullrequest.base=${{ steps.set-vars.outputs.SONAR_BASE }}
             -Dsonar.projectKey=opencost_opencost
             -Dsonar.organization=opencost
       - name: SonarQube Quality Gate check

--- a/pkg/cmd/costmodel/config.go
+++ b/pkg/cmd/costmodel/config.go
@@ -32,4 +32,5 @@ func (c *Config) log() {
 	log.Infof("Cloud Costs enabled: %t", c.CloudCostEnabled)
 	log.Infof("Custom Costs enabled: %t", c.CustomCostEnabled)
 	log.Infof("MCP Server enabled: %t", c.MCPServerEnabled)
+	log.Infof("Custom Costs enabled: %t", c.CustomCostEnabled)
 }

--- a/pkg/cmd/costmodel/config.go
+++ b/pkg/cmd/costmodel/config.go
@@ -22,6 +22,7 @@ func DefaultConfig() *Config {
 		CarbonEstimatesEnabled: env.IsCarbonEstimatesEnabled(),
 		CloudCostEnabled:       env.IsCloudCostEnabled(),
 		MCPServerEnabled:       env.IsMCPServerEnabled(),
+		CustomCostEnabled:      env.IsCustomCostEnabled(),
 	}
 }
 

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -72,7 +72,7 @@ func Execute(conf *Config) error {
 	}
 
 	var customCostPipelineService *customcost.PipelineService
-	if conf.CloudCostEnabled {
+	if conf.CustomCostEnabled {
 		customCostPipelineService = costmodel.InitializeCustomCost(router)
 	}
 


### PR DESCRIPTION
## Description
fixes sonar ref issue

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unquotes SonarCloud PR branch/base args and initializes custom cost pipeline only when `CustomCostEnabled` is set, adding its default config and log.
> 
> - **CI**:
>   - Adjust SonarCloud scan args in `.github/workflows/sonar.yaml` to use unquoted PR refs for `sonar.pullrequest.branch` and `sonar.pullrequest.base`.
> - **Cost Model**:
>   - `pkg/cmd/costmodel/config.go`:
>     - Add `CustomCostEnabled` to `DefaultConfig()`.
>     - Add logging for `Custom Costs enabled`.
>   - `pkg/cmd/costmodel/costmodel.go`:
>     - Initialize custom cost pipeline only when `CustomCostEnabled` is true (instead of `CloudCostEnabled`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56ed5202e50356e5adf98b0969a2de39f9f7cb33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->