### PR TITLE
fix(mcp): Add nil checks to prevent panic in cloud cost transformation

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -868,6 +868,13 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 	// Process each cloud cost set in the range
 	for i, ccSet := range ccsr.CloudCostSets {
 		if ccSet == nil {
+			log.Warnf("transformCloudCostSetRange: skipping nil CloudCostSet at index %d", i)
+			continue
+		}
+
+		// Check for nil Window or nil Start/End pointers before dereferencing
+		if ccSet.Window.Start() == nil || ccSet.Window.End() == nil {
+			log.Warnf("transformCloudCostSetRange: skipping CloudCostSet at index %d with invalid window (nil start or end)", i)
 			continue
 		}
 
@@ -885,6 +892,13 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 		// Convert each cloud cost item
 		for _, item := range ccSet.CloudCosts {
 			if item == nil {
+				log.Warnf("transformCloudCostSetRange: skipping nil CloudCost item in set %s", setName)
+				continue
+			}
+
+			// Check for nil Window or nil Start/End pointers on the item
+			if item.Window.Start() == nil || item.Window.End() == nil {
+				log.Warnf("transformCloudCostSetRange: skipping CloudCost item with invalid window (nil start or end) in set %s", setName)
 				continue
 			}
 
@@ -947,6 +961,9 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 	var avgKubernetesPercent float64
 	var numerator, denominator float64
 	for _, ccSet := range ccsr.CloudCostSets {
+		if ccSet == nil {
+			continue
+		}
 		for _, item := range ccSet.CloudCosts {
 			if item == nil {
 				continue

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -964,8 +964,16 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 		if ccSet == nil {
 			continue
 		}
+		// Skip sets with invalid windows (consistent with first loop)
+		if ccSet.Window.Start() == nil || ccSet.Window.End() == nil {
+			continue
+		}
 		for _, item := range ccSet.CloudCosts {
 			if item == nil {
+				continue
+			}
+			// Skip items with invalid windows (consistent with first loop)
+			if item.Window.Start() == nil || item.Window.End() == nil {
 				continue
 			}
 			cost := item.NetCost.Cost

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -874,7 +874,7 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 
 		// Check for nil Window or nil Start/End pointers before dereferencing
 		if ccSet.Window.Start() == nil || ccSet.Window.End() == nil {
-			log.Warnf("transformCloudCostSetRange: skipping CloudCostSet at index %d with invalid window (nil start or end)", i)
+			log.Warnf("transformCloudCostSetRange: skipping CloudCostSet at index %d with invalid window (start=%v, end=%v)", i, ccSet.Window.Start(), ccSet.Window.End())
 			continue
 		}
 
@@ -898,7 +898,7 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 
 			// Check for nil Window or nil Start/End pointers on the item
 			if item.Window.Start() == nil || item.Window.End() == nil {
-				log.Warnf("transformCloudCostSetRange: skipping CloudCost item with invalid window (nil start or end) in set %s", setName)
+				log.Warnf("transformCloudCostSetRange: skipping CloudCost item with invalid window (start=%v, end=%v) in set %s", item.Window.Start(), item.Window.End(), setName)
 				continue
 			}
 
@@ -962,18 +962,22 @@ func transformCloudCostSetRange(ccsr *opencost.CloudCostSetRange) *CloudCostResp
 	var numerator, denominator float64
 	for _, ccSet := range ccsr.CloudCostSets {
 		if ccSet == nil {
+			log.Warnf("transformCloudCostSetRange: skipping nil CloudCostSet in Kubernetes percent calculation")
 			continue
 		}
 		// Skip sets with invalid windows (consistent with first loop)
 		if ccSet.Window.Start() == nil || ccSet.Window.End() == nil {
+			log.Warnf("transformCloudCostSetRange: skipping CloudCostSet with invalid window (start=%v, end=%v) in Kubernetes percent calculation", ccSet.Window.Start(), ccSet.Window.End())
 			continue
 		}
 		for _, item := range ccSet.CloudCosts {
 			if item == nil {
+				log.Warnf("transformCloudCostSetRange: skipping nil CloudCost item in Kubernetes percent calculation")
 				continue
 			}
 			// Skip items with invalid windows (consistent with first loop)
 			if item.Window.Start() == nil || item.Window.End() == nil {
+				log.Warnf("transformCloudCostSetRange: skipping CloudCost item with invalid window (start=%v, end=%v) in Kubernetes percent calculation", item.Window.Start(), item.Window.End())
 				continue
 			}
 			cost := item.NetCost.Cost


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Adds comprehensive nil pointer checks in the `transformCloudCostSetRange` function to prevent panic crashes when cloud providers return malformed window data. The function now safely handles nil `Window.Start()` and `Window.End()` pointers for both **CloudCostSet** and individual **CloudCost** items, logging warnings and skipping invalid data instead of crashing the MCP server.

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
Fixes #3502

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
No breaking changes. This is a defensive fix that improves MCP server stability:

**Before**: MCP server would panic and crash when receiving malformed cloud cost data with nil window timestamps
**After**: Server logs warnings and gracefully skips invalid data, continuing to process valid cloud costs
Fully backward compatible - valid data processing unchanged


## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
Unit Tests:

Added `TestTransformCloudCostSetRange_NilPointerHandling `covering 6 critical scenarios:

- Nil CloudCostSetRange
- Nil CloudCostSet in slice
- Nil [Window.Start()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [Window.End()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on CloudCostSet
- Nil [Window.Start()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [Window.End()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on CloudCost items
- Mixed valid/invalid data to ensure graceful handling

All MCP package tests pass: go test ./pkg/mcp 

Integration Tests:
The integration test failures in the original PR #3503 are pre-existing infrastructure issues unrelated to this fix, as this change only affects the MCP package's nil pointer handling logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents panics in `transformCloudCostSetRange` by skipping/logging nil or invalid windows for sets/items and adds targeted unit tests.
> 
> - **MCP Backend**:
>   - **Cloud cost transform**: In `transformCloudCostSetRange`, skip and log when encountering:
>     - `nil` `CloudCostSet`
>     - `CloudCostSet.Window` with `nil` `Start` or `End`
>     - `nil` `CloudCost` items or items with `nil` `Window.Start`/`End`
>   - **Stability**: Add `nil` guard in Kubernetes percent averaging loop.
> - **Tests**:
>   - Add `TestTransformCloudCostSetRange_NilPointerHandling` covering `nil` range, `nil` set, `nil` window bounds, invalid item windows, and mixed valid/invalid items.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61af74736fe3ddae7830389b160aac63bc5801d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->