### PR TITLE
try writing commit statuses

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set Quality Gate status (pending)
         if: always()
-        uses: guibranco/github-status-action-v2@latest
+        uses: guibranco/github-status-action-v2@v1.1.14
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           state: 'pending'
@@ -117,7 +117,7 @@ jobs:
       - name: Set Quality Gate status (failed - PR)
         id: fail-quality-gate-pr
         if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status != 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM != ''
-        uses: guibranco/github-status-action-v2@latest
+        uses: guibranco/github-status-action-v2@v1.1.14
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           state: 'failure'
@@ -128,7 +128,7 @@ jobs:
       - name: Set Quality Gate status (failed - develop)
         id: fail-quality-gate-develop
         if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status != 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM == ''
-        uses: guibranco/github-status-action-v2@latest
+        uses: guibranco/github-status-action-v2@v1.1.14
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           state: 'failure'
@@ -139,7 +139,7 @@ jobs:
       - name: Set Quality Gate status (passed - PR)
         id: pass-quality-gate-pr
         if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM != ''
-        uses: guibranco/github-status-action-v2@latest
+        uses: guibranco/github-status-action-v2@v1.1.14
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           state: 'success'
@@ -150,7 +150,7 @@ jobs:
       - name: Set Quality Gate status (passed - develop)
         id: pass-quality-gate-develop
         if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM == ''
-        uses: guibranco/github-status-action-v2@latest
+        uses: guibranco/github-status-action-v2@v1.1.14
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           state: 'success'

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -12,17 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
-      checks: write
+      statuses: write
       contents: read
       actions: read
     steps:
-      - uses: LouisBrunner/checks-action@v2.0.0
+      - name: Set Quality Gate status (pending)
         if: always()
+        uses: guibranco/github-status-action-v2@latest
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Quality Gate
-          status: in_progress
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          state: 'pending'
+          context: 'Quality Gate'
+          description: 'Quality Gate check in progress...'
           sha: ${{ github.event.workflow_run.head_sha }}
+          target_url: 'https://sonarcloud.io/dashboard?id=opencost_opencost'
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
@@ -111,25 +114,47 @@ jobs:
         env:
              SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
              SONAR_HOST_URL: "https://sonarcloud.io"
-      - uses: LouisBrunner/checks-action@v2.0.0
-        id: fail-quality-gate
-        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status != 'PASSED'
+      - name: Set Quality Gate status (failed - PR)
+        id: fail-quality-gate-pr
+        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status != 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM != ''
+        uses: guibranco/github-status-action-v2@latest
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Quality Gate
-          status: completed
-          conclusion: failure
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          state: 'failure'
+          context: 'Quality Gate'
+          description: 'Quality Gate failed. Check the SonarCloud Dashboard for PR #${{ steps.set-vars.outputs.SONAR_PR_NUM }}'
           sha: ${{ github.event.workflow_run.head_sha }}
-          output: |
-            {"summary":"Failed - see https://sonarcloud.io/summary/new_code?id=opencost_opencostl&pullRequest=${{ steps.set-vars.outputs.SONAR_PR_NUM }}","text_description":"Quality Gate failed. Check the [SonarCloud Dashboard](https://sonarcloud.io/dashboard?id=opencost_opencost&pullRequest=${{ steps.set-vars.outputs.SONAR_PR_NUM }}) for more details."}
-      - uses: LouisBrunner/checks-action@v2.0.0
-        id: pass-quality-gate
-        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'PASSED'
+          target_url: 'https://sonarcloud.io/dashboard?id=opencost_opencost&pullRequest=${{ steps.set-vars.outputs.SONAR_PR_NUM }}'
+      - name: Set Quality Gate status (failed - develop)
+        id: fail-quality-gate-develop
+        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status != 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM == ''
+        uses: guibranco/github-status-action-v2@latest
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Quality Gate
-          status: completed
-          conclusion: success
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          state: 'failure'
+          context: 'Quality Gate'
+          description: 'Quality Gate failed. Check the SonarCloud Dashboard for more details.'
           sha: ${{ github.event.workflow_run.head_sha }}
-          output: |
-            {"summary":"Passed","text_description":"Quality Gate passed. Check the [SonarCloud Dashboard](https://sonarcloud.io/dashboard?id=opencost_opencost&pullRequest=${{ steps.set-vars.outputs.SONAR_PR_NUM }}) for more details."} 
+          target_url: 'https://sonarcloud.io/dashboard?id=opencost_opencost'
+      - name: Set Quality Gate status (passed - PR)
+        id: pass-quality-gate-pr
+        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM != ''
+        uses: guibranco/github-status-action-v2@latest
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          state: 'success'
+          context: 'Quality Gate'
+          description: 'Quality Gate passed. Check the SonarCloud Dashboard for PR #${{ steps.set-vars.outputs.SONAR_PR_NUM }}'
+          sha: ${{ github.event.workflow_run.head_sha }}
+          target_url: 'https://sonarcloud.io/dashboard?id=opencost_opencost&pullRequest=${{ steps.set-vars.outputs.SONAR_PR_NUM }}'
+      - name: Set Quality Gate status (passed - develop)
+        id: pass-quality-gate-develop
+        if: steps.sonarqube-quality-gate-check.outputs.quality-gate-status == 'PASSED' && steps.set-vars.outputs.SONAR_PR_NUM == ''
+        uses: guibranco/github-status-action-v2@latest
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          state: 'success'
+          context: 'Quality Gate'
+          description: 'Quality Gate passed. Check the SonarCloud Dashboard for more details.'
+          sha: ${{ github.event.workflow_run.head_sha }}
+          target_url: 'https://sonarcloud.io/dashboard?id=opencost_opencost' 


### PR DESCRIPTION
## Description
switches to providing commit status updates as the checks approach wasn't really working 

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace GitHub Checks with commit status updates in the Sonar workflow, posting pending/failure/success statuses (PR and develop) with links to SonarCloud.
> 
> - **CI/GitHub Actions**:
>   - **Sonar workflow** (`.github/workflows/sonar.yaml`):
>     - Use `guibranco/github-status-action-v2` to set commit statuses for Quality Gate: pending at start, then failure/success for both PR and develop, with SonarCloud target URLs and context.
>     - Add `permissions.statuses: write`; remove `LouisBrunner/checks-action` steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ab32b5aca9b3aebdd7a74e44cddda6c54894c17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->