### PR TITLE
checkout branch into context of upstream for new code determination purposes

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,10 +32,13 @@ jobs:
           repository: opencost/opencost
           fetch-depth: 0
       - name: Fetch PR branch from fork
+        env:
+          HEAD_REPO_FULL_NAME: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          git remote add fork https://github.com/${{ github.event.workflow_run.head_repository.full_name }}.git
-          git fetch fork ${{ github.event.workflow_run.head_branch }}:${{ github.event.workflow_run.head_branch }}
-          git checkout ${{ github.event.workflow_run.head_branch }}
+          git remote add fork "https://github.com/$HEAD_REPO_FULL_NAME.git"
+          git fetch fork "$HEAD_BRANCH:$HEAD_BRANCH"
+          git checkout "$HEAD_BRANCH"
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -33,16 +33,24 @@ jobs:
           ref: develop
           fetch-depth: 0
       - name: Fetch PR branch from fork
-        if: github.event.workflow_run.head_branch != 'develop'
+        if: github.event.workflow_run.head_branch != 'develop' || github.event.workflow_run.head_repository.full_name != 'opencost/opencost'
         env:
           HEAD_REPO_FULL_NAME: ${{ github.event.workflow_run.head_repository.full_name }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           git remote add fork "https://github.com/$HEAD_REPO_FULL_NAME.git"
-          git fetch fork "$HEAD_BRANCH:$HEAD_BRANCH"
-          git checkout "$HEAD_BRANCH"
+          if [ "$HEAD_BRANCH" = "develop" ]; then
+            # For fork's develop branch, fetch and checkout by SHA to avoid refspec conflict
+            git fetch fork "$HEAD_BRANCH"
+            git checkout "$HEAD_SHA"
+          else
+            # For feature branches, fetch and checkout normally
+            git fetch fork "$HEAD_BRANCH:$HEAD_BRANCH"
+            git checkout "$HEAD_BRANCH"
+          fi
       - name: Checkout develop branch at specific SHA
-        if: github.event.workflow_run.head_branch == 'develop'
+        if: github.event.workflow_run.head_branch == 'develop' && github.event.workflow_run.head_repository.full_name == 'opencost/opencost'
         run: |
           git checkout ${{ github.event.workflow_run.head_sha }}
       - name: Download coverage artifacts

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -30,12 +30,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: opencost/opencost
+          ref: develop
           fetch-depth: 0
       - name: Fetch PR branch from fork
+        if: github.event.workflow_run.head_branch != 'develop'
         run: |
           git remote add fork https://github.com/${{ github.event.workflow_run.head_repository.full_name }}.git
           git fetch fork ${{ github.event.workflow_run.head_branch }}:${{ github.event.workflow_run.head_branch }}
           git checkout ${{ github.event.workflow_run.head_branch }}
+      - name: Checkout develop branch at specific SHA
+        if: github.event.workflow_run.head_branch == 'develop'
+        run: |
+          git checkout ${{ github.event.workflow_run.head_sha }}
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -26,11 +26,16 @@ jobs:
           description: 'Quality Gate check in progress...'
           sha: ${{ github.event.workflow_run.head_sha }}
           target_url: 'https://sonarcloud.io/dashboard?id=opencost_opencost'
-      - uses: actions/checkout@v4
+      - name: Checkout upstream repository
+        uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          repository: opencost/opencost
           fetch-depth: 0
+      - name: Fetch PR branch from fork
+        run: |
+          git remote add fork https://github.com/${{ github.event.workflow_run.head_repository.full_name }}.git
+          git fetch fork ${{ github.event.workflow_run.head_branch }}:${{ github.event.workflow_run.head_branch }}
+          git checkout ${{ github.event.workflow_run.head_branch }}
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Description
We want to ensure sonar has the right frame of reference for determining what is new code in a PR. the way the workflow was written, if the fork's develop was behind opencost's develop branch, but the PR branch was synced, it would seem like there were a huge number of new lines of code. 

This PR updates the workflow to always check out opencost/opencost, but checkout the branch into that correct parent context

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Sonar workflow to always checkout upstream develop and conditionally fetch/checkout the PR branch (with SHA handling for develop) to ensure correct analysis context.
> 
> - **CI — Sonar workflow (`.github/workflows/sonar.yaml`)**:
>   - **Checkout logic**:
>     - Always checkout `opencost/opencost@develop` with `fetch-depth: 0`.
>     - Conditionally fetch and checkout PR branch from fork; for fork's `develop`, fetch and checkout by specific SHA.
>     - For upstream `develop` runs, checkout the exact workflow SHA.
>   - Keeps coverage artifact download and Quality Gate status steps unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aeb701a0623a1afe825a44a6d8d9d878af18c76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->