### PR TITLE
Cleanup code which sanitized hardcoded value "AKIXXX"

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -518,12 +518,6 @@ func (aws *AWS) UpdateConfig(r io.Reader, updateType string) (*models.CustomPric
 				return err
 			}
 
-			// If the sample nil service key name is set, zero it out so that it is not
-			// misinterpreted as a real service key.
-			if asfi.ServiceKeyName == "AKIXXX" {
-				asfi.ServiceKeyName = ""
-			}
-
 			c.ServiceKeyName = asfi.ServiceKeyName
 			if asfi.ServiceKeySecret != "" {
 				c.ServiceKeySecret = asfi.ServiceKeySecret
@@ -540,12 +534,6 @@ func (aws *AWS) UpdateConfig(r io.Reader, updateType string) (*models.CustomPric
 			err := json.NewDecoder(r).Decode(&aai)
 			if err != nil {
 				return err
-			}
-
-			// If the sample nil service key name is set, zero it out so that it is not
-			// misinterpreted as a real service key.
-			if aai.ServiceKeyName == "AKIXXX" {
-				aai.ServiceKeyName = ""
 			}
 
 			c.AthenaBucketName = aai.AthenaBucketName
@@ -1590,12 +1578,6 @@ func (aws *AWS) loadAWSAuthSecret(force bool) (*AWSAccessKey, error) {
 	err = json.Unmarshal(result, &ak)
 	if err != nil {
 		return nil, err
-	}
-
-	// If the sample nil service key name is set, zero it out so that it is not
-	// misinterpreted as a real service key.
-	if ak.AccessKeyID == "AKIXXX" {
-		ak.AccessKeyID = ""
 	}
 
 	awsSecret = &ak

--- a/pkg/cloud/config/watcher.go
+++ b/pkg/cloud/config/watcher.go
@@ -207,12 +207,6 @@ func (cfw *ConfigFileWatcher) GetConfigs() []cloud.KeyedConfig {
 			aai.AccountID = customPricing.ProjectID
 		}
 
-		// If the sample nil service key name is set, zero it out so that it is not
-		// misinterpreted as a real service key.
-		if aai.ServiceKeyName == "AKIXXX" {
-			aai.ServiceKeyName = ""
-		}
-
 		kc := aws.ConvertAwsAthenaInfoToConfig(aai)
 		configs = append(configs, kc)
 		return configs

--- a/pkg/cloud/provider/provider.go
+++ b/pkg/cloud/provider/provider.go
@@ -123,13 +123,6 @@ func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.
 		cp.accountID = providerConfig.customPricing.ClusterAccountID
 	}
 
-	providerConfig.Update(func(cp *models.CustomPricing) error {
-		if cp.ServiceKeyName == "AKIXXX" {
-			cp.ServiceKeyName = ""
-		}
-		return nil
-	})
-
 	switch cp.provider {
 	case opencost.CSVProvider:
 		log.Infof("Using CSV Provider with CSV at %s", env.GetCSVPath())

--- a/pkg/cloud/provider/providerconfig.go
+++ b/pkg/cloud/provider/providerconfig.go
@@ -73,12 +73,6 @@ func (pc *ProviderConfig) onConfigFileUpdated(changeType config.ChangeType, data
 		if pc.customPricing.SpotGPU == "" {
 			pc.customPricing.SpotGPU = DefaultPricing().SpotGPU // Migration for users without this value set by default.
 		}
-
-		// If the sample nil service key name is set, zero it out so that it is not
-		// misinterpreted as a real service key.
-		if pc.customPricing.ServiceKeyName == "AKIXXX" {
-			pc.customPricing.ServiceKeyName = ""
-		}
 	}
 }
 
@@ -145,12 +139,6 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*models.CustomPrici
 	pc.customPricing = &customPricing
 	if pc.customPricing.SpotGPU == "" {
 		pc.customPricing.SpotGPU = DefaultPricing().SpotGPU // Migration for users without this value set by default.
-	}
-
-	// If the sample nil service key name is set, zero it out so that it is not
-	// misinterpreted as a real service key.
-	if pc.customPricing.ServiceKeyName == "AKIXXX" {
-		pc.customPricing.ServiceKeyName = ""
 	}
 
 	return pc.customPricing, nil

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -163,13 +163,7 @@ func IsEmitDeprecatedMetrics() bool {
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents
 // the AWS access key for authentication
 func GetAWSAccessKeyID() string {
-	awsAccessKeyID := env.Get(AWSAccessKeyIDEnvVar, "")
-	// If the sample nil service key name is set, zero it out so that it is not
-	// misinterpreted as a real service key.
-	if awsAccessKeyID == "AKIXXX" {
-		awsAccessKeyID = ""
-	}
-	return awsAccessKeyID
+	return env.Get(AWSAccessKeyIDEnvVar, "")
 }
 
 // GetAWSAccessKeySecret returns the environment variable value for AWSAccessKeySecretEnvVar which represents


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
As titled. "AKIXXX" once existed in the `aws.json` https://github.com/opencost/opencost/blob/v1.102.0/configs/aws.json#L15, but is now an empty string https://github.com/opencost/opencost/blob/v1.119.0/configs/aws.json#L15. No longer need this hardcoded sanitize code.

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
N/A

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
No tests. The CI unit tests and integration tests will be sufficient?
