### PR TITLE
fix(mcp): Propagate request context to cloud cost queries

### DIFF
--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -188,7 +188,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 			Query: queryRequest,
 		}
 
-		mcpResp, err := mcpServer.ProcessMCPRequest(mcpReq)
+		mcpResp, err := mcpServer.ProcessMCPRequest(ctx, mcpReq)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process allocation request: %w", err)
 		}
@@ -207,7 +207,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 			Query: queryRequest,
 		}
 
-		mcpResp, err := mcpServer.ProcessMCPRequest(mcpReq)
+		mcpResp, err := mcpServer.ProcessMCPRequest(ctx, mcpReq)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process asset request: %w", err)
 		}
@@ -235,7 +235,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 			Query: queryRequest,
 		}
 
-		mcpResp, err := mcpServer.ProcessMCPRequest(mcpReq)
+		mcpResp, err := mcpServer.ProcessMCPRequest(ctx, mcpReq)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process cloud cost request: %w", err)
 		}
@@ -258,7 +258,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 			Query: queryRequest,
 		}
 
-		mcpResp, err := mcpServer.ProcessMCPRequest(mcpReq)
+		mcpResp, err := mcpServer.ProcessMCPRequest(ctx, mcpReq)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process efficiency request: %w", err)
 		}

--- a/pkg/env/opencost.go
+++ b/pkg/env/opencost.go
@@ -15,7 +15,8 @@ const (
 )
 
 const (
-	UTCOffsetEnvVar = "UTC_OFFSET"
+	UTCOffsetEnvVar              = "UTC_OFFSET"
+	MCPQueryTimeoutSecondsEnvVar = "MCP_QUERY_TIMEOUT_SECONDS"
 )
 
 func GetOpencostAPIPort() int {
@@ -41,4 +42,11 @@ func GetParsedUTCOffset() time.Duration {
 		return time.Duration(0)
 	}
 	return offset
+}
+
+// GetMCPQueryTimeout returns the configured timeout for MCP query operations.
+// Default is 60 seconds, but can be configured via MCP_QUERY_TIMEOUT_SECONDS environment variable.
+func GetMCPQueryTimeout() time.Duration {
+	seconds := env.GetInt(MCPQueryTimeoutSecondsEnvVar, 60)
+	return time.Duration(seconds) * time.Second
 }

--- a/pkg/env/opencost.go
+++ b/pkg/env/opencost.go
@@ -46,7 +46,11 @@ func GetParsedUTCOffset() time.Duration {
 
 // GetMCPQueryTimeout returns the configured timeout for MCP query operations.
 // Default is 60 seconds, but can be configured via MCP_QUERY_TIMEOUT_SECONDS environment variable.
+// Minimum timeout is 1 second to prevent immediate timeouts.
 func GetMCPQueryTimeout() time.Duration {
 	seconds := env.GetInt(MCPQueryTimeoutSecondsEnvVar, 60)
+	if seconds <= 0 {
+		seconds = 1
+	}
 	return time.Duration(seconds) * time.Second
 }

--- a/pkg/env/opencost_test.go
+++ b/pkg/env/opencost_test.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/opencost/opencost/core/pkg/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAPIPort(t *testing.T) {
@@ -44,4 +47,52 @@ func TestGetAPIPort(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetMCPQueryTimeout_Default(t *testing.T) {
+	// Ensure env var is not set
+	os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
+
+	timeout := GetMCPQueryTimeout()
+	assert.Equal(t, 60*time.Second, timeout, "Default timeout should be 60 seconds")
+}
+
+func TestGetMCPQueryTimeout_CustomValue(t *testing.T) {
+	// Set custom timeout
+	err := os.Setenv(MCPQueryTimeoutSecondsEnvVar, "120")
+	require.NoError(t, err)
+	defer os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
+
+	timeout := GetMCPQueryTimeout()
+	assert.Equal(t, 120*time.Second, timeout, "Custom timeout should be 120 seconds")
+}
+
+func TestGetMCPQueryTimeout_InvalidValue(t *testing.T) {
+	// Set invalid value (should fall back to default)
+	err := os.Setenv(MCPQueryTimeoutSecondsEnvVar, "invalid")
+	require.NoError(t, err)
+	defer os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
+
+	timeout := GetMCPQueryTimeout()
+	assert.Equal(t, 60*time.Second, timeout, "Invalid value should fall back to default 60 seconds")
+}
+
+func TestGetMCPQueryTimeout_ZeroValue(t *testing.T) {
+	// Set zero value
+	err := os.Setenv(MCPQueryTimeoutSecondsEnvVar, "0")
+	require.NoError(t, err)
+	defer os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
+
+	timeout := GetMCPQueryTimeout()
+	assert.Equal(t, 0*time.Second, timeout, "Zero value should be respected")
+}
+
+func TestGetMCPQueryTimeout_LargeValue(t *testing.T) {
+	// Set large timeout value
+	err := os.Setenv(MCPQueryTimeoutSecondsEnvVar, "3600")
+	require.NoError(t, err)
+	defer os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
+
+	timeout := GetMCPQueryTimeout()
+	assert.Equal(t, 3600*time.Second, timeout, "Large timeout should be accepted (1 hour)")
 }

--- a/pkg/env/opencost_test.go
+++ b/pkg/env/opencost_test.go
@@ -78,13 +78,23 @@ func TestGetMCPQueryTimeout_InvalidValue(t *testing.T) {
 }
 
 func TestGetMCPQueryTimeout_ZeroValue(t *testing.T) {
-	// Set zero value
+	// Set zero value - should fall back to minimum of 1 second
 	err := os.Setenv(MCPQueryTimeoutSecondsEnvVar, "0")
 	require.NoError(t, err)
 	defer os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
 
 	timeout := GetMCPQueryTimeout()
-	assert.Equal(t, 0*time.Second, timeout, "Zero value should be respected")
+	assert.Equal(t, 1*time.Second, timeout, "Zero value should use minimum of 1 second")
+}
+
+func TestGetMCPQueryTimeout_NegativeValue(t *testing.T) {
+	// Set negative value - should fall back to minimum of 1 second
+	err := os.Setenv(MCPQueryTimeoutSecondsEnvVar, "-10")
+	require.NoError(t, err)
+	defer os.Unsetenv(MCPQueryTimeoutSecondsEnvVar)
+
+	timeout := GetMCPQueryTimeout()
+	assert.Equal(t, 1*time.Second, timeout, "Negative value should use minimum of 1 second")
 }
 
 func TestGetMCPQueryTimeout_LargeValue(t *testing.T) {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -19,6 +19,7 @@ import (
 	models "github.com/opencost/opencost/pkg/cloud/models"
 	"github.com/opencost/opencost/pkg/cloudcost"
 	"github.com/opencost/opencost/pkg/costmodel"
+	"github.com/opencost/opencost/pkg/env"
 )
 
 // QueryType defines the type of query to be executed.
@@ -377,8 +378,8 @@ func NewMCPServer(costModel *costmodel.CostModel, provider models.Provider, clou
 }
 
 // ProcessMCPRequest processes an MCP request and returns an MCP response.
-
-func (s *MCPServer) ProcessMCPRequest(request *MCPRequest) (*MCPResponse, error) {
+// It accepts a context for proper timeout handling and cancellation.
+func (s *MCPServer) ProcessMCPRequest(ctx context.Context, request *MCPRequest) (*MCPResponse, error) {
 	// 1. Validate Request
 	if err := validate.Struct(request); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)
@@ -396,7 +397,7 @@ func (s *MCPServer) ProcessMCPRequest(request *MCPRequest) (*MCPResponse, error)
 	case AssetQueryType:
 		data, err = s.QueryAssets(request.Query)
 	case CloudCostQueryType:
-		data, err = s.QueryCloudCosts(request.Query)
+		data, err = s.QueryCloudCosts(ctx, request.Query)
 	case EfficiencyQueryType:
 		data, err = s.QueryEfficiency(request.Query)
 	default:
@@ -714,7 +715,7 @@ func transformAssetSet(assetSet *opencost.AssetSet) *AssetResponse {
 }
 
 // QueryCloudCosts translates an MCP query into a CloudCost repository query and transforms the result.
-func (s *MCPServer) QueryCloudCosts(query *OpenCostQueryRequest) (*CloudCostResponse, error) {
+func (s *MCPServer) QueryCloudCosts(ctx context.Context, query *OpenCostQueryRequest) (*CloudCostResponse, error) {
 	// 1. Check if cloud cost querier is available
 	if s.cloudQuerier == nil {
 		return nil, fmt.Errorf("cloud cost querier not configured - check cloud-integration.json file")
@@ -738,13 +739,18 @@ func (s *MCPServer) QueryCloudCosts(query *OpenCostQueryRequest) (*CloudCostResp
 		request = s.buildCloudCostQueryRequest(request, query.CloudCostParams)
 	}
 
-	// 5. Query the repository (this handles multiple cloud providers automatically)
-	ccsr, err := s.cloudQuerier.Query(context.TODO(), request)
+	// 5. Create a timeout context for the query with configured timeout
+	queryTimeout := env.GetMCPQueryTimeout()
+	queryCtx, cancel := context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
+
+	// 6. Query the repository (this handles multiple cloud providers automatically)
+	ccsr, err := s.cloudQuerier.Query(queryCtx, request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query cloud costs: %w", err)
 	}
 
-	// 6. Transform Response
+	// 7. Transform Response
 	return transformCloudCostSetRange(ccsr), nil
 }
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -715,6 +715,7 @@ func transformAssetSet(assetSet *opencost.AssetSet) *AssetResponse {
 }
 
 // QueryCloudCosts translates an MCP query into a CloudCost repository query and transforms the result.
+// The ctx parameter is used for timeout and cancellation handling of the cloud cost query.
 func (s *MCPServer) QueryCloudCosts(ctx context.Context, query *OpenCostQueryRequest) (*CloudCostResponse, error) {
 	// 1. Check if cloud cost querier is available
 	if s.cloudQuerier == nil {

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1463,27 +1463,45 @@ func TestTransformCloudCostSetRange_NilPointerHandling(t *testing.T) {
 	}
 }
 
+// contextAwareQuerier is a mock querier that checks for context cancellation
+type contextAwareQuerier struct {
+	contextWasCancelled bool
+}
+
+func (caq *contextAwareQuerier) Query(ctx context.Context, req cloudcost.QueryRequest) (*opencost.CloudCostSetRange, error) {
+	// Check if context is already cancelled
+	select {
+	case <-ctx.Done():
+		caq.contextWasCancelled = true
+		return nil, ctx.Err()
+	default:
+		// Return empty set range
+		ccsr, _ := opencost.NewCloudCostSetRange(time.Now().Add(-24*time.Hour), time.Now(), opencost.AccumulateOptionDay, "")
+		return ccsr, nil
+	}
+}
+
 func TestQueryCloudCosts_ContextCancellation(t *testing.T) {
 	// Create a context that is already cancelled
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	// Create a mock querier that would detect context cancellation
-	dq := &dummyQuerier{}
-	s := &MCPServer{cloudQuerier: dq}
+	// Create a context-aware mock querier
+	caq := &contextAwareQuerier{}
+	s := &MCPServer{cloudQuerier: caq}
 
 	req := &OpenCostQueryRequest{
 		QueryType: CloudCostQueryType,
 		Window:    "1d",
 	}
 
-	// This should fail or handle the cancelled context
-	// The actual behavior depends on the querier implementation
+	// Query should fail with context cancelled error
 	_, err := s.QueryCloudCosts(ctx, req)
-	// We expect that either the query fails due to cancelled context
-	// or it completes successfully (depending on querier implementation)
-	// This test ensures context is propagated correctly
-	_ = err // Context propagation is what matters here
+	
+	// Verify context cancellation was detected
+	assert.Error(t, err)
+	assert.True(t, caq.contextWasCancelled, "Context cancellation should be detected by querier")
+	assert.ErrorIs(t, err, context.Canceled, "Error should be context.Canceled")
 }
 
 func TestProcessMCPRequest_ContextPropagation(t *testing.T) {

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -608,7 +608,7 @@ func TestQueryCloudCosts_QuerierCapture(t *testing.T) {
 		},
 	}
 
-	_, err := s.QueryCloudCosts(req)
+	_, err := s.QueryCloudCosts(context.Background(), req)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"provider", "service"}, dq.last.AggregateBy)
@@ -633,7 +633,7 @@ func TestProcessMCPRequest_CloudCostDispatch(t *testing.T) {
 		},
 	}
 
-	resp, err := s.ProcessMCPRequest(req)
+	resp, err := s.ProcessMCPRequest(context.Background(), req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Data)
@@ -648,7 +648,7 @@ func TestProcessMCPRequest_UnsupportedType(t *testing.T) {
 			Window:    "1d",
 		},
 	}
-	_, err := s.ProcessMCPRequest(req)
+	_, err := s.ProcessMCPRequest(context.Background(), req)
 	require.Error(t, err)
 }
 
@@ -661,7 +661,7 @@ func TestProcessMCPRequest_ValidationError(t *testing.T) {
 			Window:    "",
 		},
 	}
-	_, err := s.ProcessMCPRequest(req)
+	_, err := s.ProcessMCPRequest(context.Background(), req)
 	require.Error(t, err)
 }
 
@@ -829,7 +829,7 @@ func TestQueryCloudCosts_NilCloudQuerier(t *testing.T) {
 		Window:    "24h",
 	}
 
-	_, err := s.QueryCloudCosts(req)
+	_, err := s.QueryCloudCosts(context.Background(), req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cloud cost querier not configured")
 }
@@ -842,7 +842,7 @@ func TestQueryCloudCosts_InvalidWindow(t *testing.T) {
 		Window:    "invalid-window",
 	}
 
-	_, err := s.QueryCloudCosts(req)
+	_, err := s.QueryCloudCosts(context.Background(), req)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse window")
 }
@@ -884,7 +884,7 @@ func TestProcessMCPRequest_ResponseMetadata(t *testing.T) {
 		},
 	}
 
-	resp, err := s.ProcessMCPRequest(req)
+	resp, err := s.ProcessMCPRequest(context.Background(), req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -1461,4 +1461,47 @@ func TestTransformCloudCostSetRange_NilPointerHandling(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQueryCloudCosts_ContextCancellation(t *testing.T) {
+	// Create a context that is already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Create a mock querier that would detect context cancellation
+	dq := &dummyQuerier{}
+	s := &MCPServer{cloudQuerier: dq}
+
+	req := &OpenCostQueryRequest{
+		QueryType: CloudCostQueryType,
+		Window:    "1d",
+	}
+
+	// This should fail or handle the cancelled context
+	// The actual behavior depends on the querier implementation
+	_, err := s.QueryCloudCosts(ctx, req)
+	// We expect that either the query fails due to cancelled context
+	// or it completes successfully (depending on querier implementation)
+	// This test ensures context is propagated correctly
+	_ = err // Context propagation is what matters here
+}
+
+func TestProcessMCPRequest_ContextPropagation(t *testing.T) {
+	// Test that context is properly propagated through ProcessMCPRequest
+	ctx := context.Background()
+	dq := &dummyQuerier{}
+	s := &MCPServer{cloudQuerier: dq}
+
+	req := &MCPRequest{
+		Query: &OpenCostQueryRequest{
+			QueryType: CloudCostQueryType,
+			Window:    "1d",
+		},
+	}
+
+	resp, err := s.ProcessMCPRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// Verify that the querier was called (context was propagated)
+	assert.NotNil(t, dq.last)
 }


### PR DESCRIPTION

## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Propagates request context to cloud cost queries in the MCP server to enable proper timeout handling and cancellation. Adds a configurable timeout (default 60 seconds) via the MCP_QUERY_TIMEOUT_SECONDS environment variable.

## Changes:

- Updated `ProcessMCPRequest` and `QueryCloudCosts `to accept and propagate context
- Replaced c`ontext.TODO()` with timeout context using `env.GetMCPQueryTimeout()`
- Added `GetMCPQueryTimeout()` configuration function in `opencost.go`

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
Fixes #3517 

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
Non-breaking change - adds configurable timeout support for cloud cost queries.

- Default behavior: 60-second timeout for cloud cost queries (configurable)
- Configuration: Set MCP_QUERY_TIMEOUT_SECONDS environment variable to customize
 **Benefits:**
- Queries can be cancelled if client disconnects
- Prevents indefinite hangs and resource waste
- Proper context propagation throughout the call chain


## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

- Added 5 new tests in [opencost_test.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for timeout configuration
- Added 2 new tests in [server_test.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for context propagation
- Updated 7 existing tests to pass context parameters
- All 79 MCP package tests pass
- All environment package tests pass
