### PR TITLE
fix: Improve maintainer check for Dependabot

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -32,7 +32,7 @@ jobs:
             env:
               TEAMS: ${{ join(steps.teamAffiliation.outputs.teams, ',') }}
               ACTOR: ${{ github.actor }}
-              IS_MAINTAINER: ${{ contains(join(steps.teamAffiliation.outputs.teams, ','), 'OpenCost Maintainers') || github.actor == 'dependabot[bot]' }}
+              IS_MAINTAINER: ${{ contains(join(steps.teamAffiliation.outputs.teams, ','), 'OpenCost Maintainers') || (github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == 'opencost/opencost') }}
             run: |
                 echo "Actor: $ACTOR"
                 echo "teams: $TEAMS"

--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -37,7 +37,7 @@ jobs:
           env:
             TEAMS: ${{ join(steps.teamAffiliation.outputs.teams, ',') }}
             ACTOR: ${{ github.actor }}
-            IS_MAINTAINER: ${{ contains(join(steps.teamAffiliation.outputs.teams, ','), 'OpenCost Maintainers') || github.actor == 'dependabot[bot]' }}
+            IS_MAINTAINER: ${{ contains(join(steps.teamAffiliation.outputs.teams, ','), 'OpenCost Maintainers') || (github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == 'opencost/opencost') }}
           run: |
               echo "Actor: $ACTOR"
               echo "Is maintainer: $IS_MAINTAINER"


### PR DESCRIPTION
## Description

This prevents a permission bypass that would be possible by using dependabot in a fork.

## Related Issues

## User Impact

## Testing

---

@ameijer
