### PR TITLE
update cloud cost integration functionality and handlers

### DIFF
--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -201,12 +201,12 @@ func (c *Controller) CreateConfig(conf cloud.KeyedConfig) error {
 
 	_, ok := statuses.Get(key, source)
 	if ok {
-		return fmt.Errorf("config with key %s from source %s already exist", key, source.String())
+		return fmt.Errorf("config with key %s from source %s already exists", key, source.String())
 	}
 
 	configType, err := ConfigTypeFromConfig(conf)
 	if err != nil {
-		return fmt.Errorf("config did not have recoginzed config: %w", err)
+		return fmt.Errorf("provided config did not have recoginzed config type: %w", err)
 	}
 
 	statuses.Insert(&Status{
@@ -233,6 +233,50 @@ func (c *Controller) CreateConfig(conf cloud.KeyedConfig) error {
 	}
 
 	c.broadcastAddConfig(conf)
+	err = c.storage.save(statuses)
+	if err != nil {
+		return fmt.Errorf("failed to save statues: %w", err)
+	}
+	return nil
+}
+
+// UpdateConfig updates an existing config in status with a source of ConfigControllerSource
+// It fails if the provided config does not already exist and if the config to be updated was not created by the config controller
+func (c *Controller) UpdateConfig(conf cloud.KeyedConfig) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	err := conf.Validate()
+	if err != nil {
+		return fmt.Errorf("provided configuration was invalid: %w", err)
+	}
+
+	statuses, err := c.storage.load()
+	if err != nil {
+		return fmt.Errorf("failed to load statuses")
+	}
+	source := ConfigControllerSource
+	key := conf.Key()
+
+	_, ok := statuses.Get(key, source)
+	if !ok {
+		return fmt.Errorf("unable to find existing config with key %s and source %s", key, source.String())
+	}
+
+	configType, err := ConfigTypeFromConfig(conf)
+	if err != nil {
+		return fmt.Errorf("config did not have recoginzed config: %w", err)
+	}
+
+	statuses.Insert(&Status{
+		Key:        key,
+		Source:     source,
+		Valid:      true,
+		Active:     true,
+		ConfigType: configType,
+		Config:     conf,
+	})
+
 	err = c.storage.save(statuses)
 	if err != nil {
 		return fmt.Errorf("failed to save statues: %w", err)

--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -259,6 +259,7 @@ func (c *Controller) UpdateConfig(conf cloud.KeyedConfig) error {
 	key := conf.Key()
 
 	_, ok := statuses.Get(key, source)
+	// we fail here if we're attempting to update any config that isn't created by the config controller
 	if !ok {
 		return fmt.Errorf("unable to find existing config with key %s and source %s", key, source.String())
 	}
@@ -277,6 +278,26 @@ func (c *Controller) UpdateConfig(conf cloud.KeyedConfig) error {
 		Config:     conf,
 	})
 
+	// check for configurations with the same configuration key and source that are already active.
+	for _, confStat := range statuses.List() {
+		if confStat.Key != key {
+			continue
+		}
+
+		// disable previous configuration in favor of the updated one
+		// note that this will not disable configs with the same key that are not created by config controller
+		if confStat.Source == ConfigControllerSource && confStat.Active {
+			confStat.Active = false
+			c.broadcastRemoveConfig(key)
+		}
+
+		if confStat.Source != ConfigControllerSource && confStat.Active {
+			log.Debugf("Detected active config with key %s that was not created by the config controller", key)
+		}
+
+	}
+
+	c.broadcastAddConfig(conf)
 	err = c.storage.save(statuses)
 	if err != nil {
 		return fmt.Errorf("failed to save statues: %w", err)

--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -194,7 +194,7 @@ func (c *Controller) CreateConfig(conf cloud.KeyedConfig) error {
 
 	statuses, err := c.storage.load()
 	if err != nil {
-		return fmt.Errorf("failed to load statuses")
+		return fmt.Errorf("failed to load statuses: %w")
 	}
 	source := ConfigControllerSource
 	key := conf.Key()
@@ -224,8 +224,8 @@ func (c *Controller) CreateConfig(conf cloud.KeyedConfig) error {
 			continue
 		}
 
-		// if active disable
-		if confStat.Active == true {
+		// if active, disable and remove from observers
+		if confStat.Active {
 			confStat.Active = false
 			c.broadcastRemoveConfig(key)
 		}
@@ -253,7 +253,7 @@ func (c *Controller) UpdateConfig(conf cloud.KeyedConfig) error {
 
 	statuses, err := c.storage.load()
 	if err != nil {
-		return fmt.Errorf("failed to load statuses")
+		return fmt.Errorf("failed to load statuses: %w", err)
 	}
 	source := ConfigControllerSource
 	key := conf.Key()
@@ -269,22 +269,14 @@ func (c *Controller) UpdateConfig(conf cloud.KeyedConfig) error {
 		return fmt.Errorf("config did not have recoginzed config: %w", err)
 	}
 
-	statuses.Insert(&Status{
-		Key:        key,
-		Source:     source,
-		Valid:      true,
-		Active:     true,
-		ConfigType: configType,
-		Config:     conf,
-	})
-
-	// check for configurations with the same configuration key and source that are already active.
+	// check for configurations with the same configuration key that are already active
+	// and disable them before inserting the updated config
 	for _, confStat := range statuses.List() {
 		if confStat.Key != key {
 			continue
 		}
 
-		// disable previous configuration in favor of the updated one
+		// disable previous active configurations
 		// note that this will not disable configs with the same key that are not created by config controller
 		if confStat.Source == ConfigControllerSource && confStat.Active {
 			confStat.Active = false
@@ -294,8 +286,16 @@ func (c *Controller) UpdateConfig(conf cloud.KeyedConfig) error {
 		if confStat.Source != ConfigControllerSource && confStat.Active {
 			log.Debugf("Detected active config with key %s that was not created by the config controller", key)
 		}
-
 	}
+
+	statuses.Insert(&Status{
+		Key:        key,
+		Source:     source,
+		Valid:      true,
+		Active:     true,
+		ConfigType: configType,
+		Config:     conf,
+	})
 
 	c.broadcastAddConfig(conf)
 	err = c.storage.save(statuses)

--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -194,7 +194,7 @@ func (c *Controller) CreateConfig(conf cloud.KeyedConfig) error {
 
 	statuses, err := c.storage.load()
 	if err != nil {
-		return fmt.Errorf("failed to load statuses: %w")
+		return fmt.Errorf("failed to load statuses: %w", err)
 	}
 	source := ConfigControllerSource
 	key := conf.Key()

--- a/pkg/cloud/config/controller_handlers.go
+++ b/pkg/cloud/config/controller_handlers.go
@@ -99,6 +99,10 @@ func (c *Controller) GetUpdateConfigHandler() func(w http.ResponseWriter, r *htt
 		w.Header().Set("Content-Type", "application/json")
 
 		configType := r.URL.Query().Get("type")
+		if configType == "" {
+			http.Error(w, "'type' parameter is required", http.StatusBadRequest)
+			return
+		}
 
 		config, err := ParseConfig(configType, r.Body)
 		if err != nil {

--- a/pkg/cloud/config/controller_handlers.go
+++ b/pkg/cloud/config/controller_handlers.go
@@ -86,6 +86,36 @@ func (c *Controller) GetAddConfigHandler() func(w http.ResponseWriter, r *http.R
 	}
 }
 
+// GetUpdateConfigHandler creates a handler from a http request which updates an existing integration via the integrationController
+func (c *Controller) GetUpdateConfigHandler() func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// perform basic checks to ensure that the pipeline can be accessed
+	fn := c.cloudCostChecks()
+	if fn != nil {
+		return fn
+	}
+
+	// Return valid handler func
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		w.Header().Set("Content-Type", "application/json")
+
+		configType := r.URL.Query().Get("type")
+
+		config, err := ParseConfig(configType, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		err = c.UpdateConfig(config)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		protocol.WriteData(w, fmt.Sprintf("Successfully updated integration with key %s", config.Key()))
+	}
+}
+
 func ParseConfig(configType string, body io.Reader) (cloud.KeyedConfig, error) {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(body)

--- a/pkg/cloud/config/statuses.go
+++ b/pkg/cloud/config/statuses.go
@@ -33,7 +33,7 @@ func ConfigTypeFromConfig(config cloud.KeyedConfig) (string, error) {
 	case *oracle.UsageApiConfiguration:
 		return UsageApiConfigType, nil
 	}
-	return "", fmt.Errorf("failed to config type for config with key: %s, type %T", config.Key(), config)
+	return "", fmt.Errorf("failed to determine config type for config with key: %s, type %T", config.Key(), config)
 }
 
 type Statuses map[ConfigSource]map[string]*Status


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Introduces the ability to update and edit cloud integrations created via endpoint. Does not impact cloud integrations created via helm or secret.

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
Closes https://apptio.atlassian.net/browse/KCM-3471, related to https://github.com/kubecost/kubecost-cost-model/pull/4116

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
No user impact

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
Unit tested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds edit/update capability for controller-managed cloud integration configs.
> 
> - New `UpdateConfig` on `Controller` validates, requires existing controller-owned config, updates status, and persists
> - New HTTP handler `GetUpdateConfigHandler` parses type/body and calls `UpdateConfig`
> - Comprehensive unit tests for update scenarios and interactions with other sources
> - Minor error/typo fixes in messages (e.g., "already exists", clearer config type errors)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2541544b1fad128ffeedf2375c131a8a6e4d9963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->