### PR TITLE
Enhance diagnostic logging in NodePricing

### DIFF
--- a/pkg/cloud/alibaba/provider.go
+++ b/pkg/cloud/alibaba/provider.go
@@ -510,17 +510,16 @@ func (alibaba *Alibaba) NodePricing(key models.Key) (*models.Node, models.Pricin
 
 	pricing, ok := alibaba.Pricing[keyFeature]
 	if !ok {
-		keys := make([]string, 0, len(alibaba.Pricing))
-		for k := range alibaba.Pricing {
-			keys = append(keys, k)
-		}
+		log.DedupedInfof(10, "Alibaba NodePricing: key %q not found in pricing data, attempting fallback lookup without disk info", keyFeature)
 		kf := key.(*AlibabaNodeKey)
 		// Try to look up pricing with no disk attached
-		pricing, ok = alibaba.Pricing[kf.FeaturesWithOtherDisk("")]
+		fallbackKey := kf.FeaturesWithOtherDisk("")
+		pricing, ok = alibaba.Pricing[fallbackKey]
 		if !ok {
-			log.Errorf("Node pricing information not found for node with feature: %s . Existing keys are: %+v", keyFeature, keys)
+			log.DedupedInfof(10, "Alibaba NodePricing: unknown instance type, key %q (fallback key %q) not found in %d available pricing keys", keyFeature, fallbackKey, len(alibaba.Pricing))
 			return nil, meta, fmt.Errorf("Node pricing information not found for node with feature: %s letting it use default values", keyFeature)
 		}
+		log.DedupedInfof(10, "Alibaba NodePricing: found pricing using fallback key %q for original key %q", fallbackKey, keyFeature)
 	}
 
 	log.Debugf("returning the node price for the node with feature: %s", keyFeature)

--- a/pkg/cloud/alibaba/provider_test.go
+++ b/pkg/cloud/alibaba/provider_test.go
@@ -1140,6 +1140,40 @@ func TestNodePricing_Error(t *testing.T) {
 	}
 }
 
+func TestNodePricing_FallbackSuccess(t *testing.T) {
+	// Test the case where the primary key (with disk info) is not found,
+	// but the fallback key (without disk info) is found
+	fallbackKey := "r::i::os"
+	a := &Alibaba{
+		Pricing: map[string]*AlibabaPricing{
+			fallbackKey: {
+				Node: &models.Node{
+					Cost: "0.05",
+					VCPU: "2",
+				},
+			},
+		},
+	}
+	// Key with disk info that won't match, but fallback without disk will match
+	dummyKey := &AlibabaNodeKey{
+		ProviderID:         "foo",
+		RegionID:           "r",
+		InstanceType:       "i",
+		OSType:             "os",
+		SystemDiskCategory: "cloud_ssd", // This makes the primary key different
+	}
+	node, _, err := a.NodePricing(dummyKey)
+	if err != nil {
+		t.Fatalf("NodePricing should succeed with fallback key, got error: %v", err)
+	}
+	if node == nil {
+		t.Fatalf("NodePricing should return node")
+	}
+	if node.Cost != "0.05" {
+		t.Fatalf("Expected cost 0.05, got %s", node.Cost)
+	}
+}
+
 func TestGpuPricing(t *testing.T) {
 	a := &Alibaba{}
 	v, err := a.GpuPricing(nil)

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1539,10 +1539,12 @@ func (aws *AWS) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 	if ok {
 		return aws.createNode(terms, usageType, k)
 	} else if _, ok := aws.ValidPricingKeys[key]; ok {
+		log.DedupedInfof(10, "AWS NodePricing: key %q is valid but pricing data not loaded, attempting download", key)
 		aws.DownloadPricingDataLock.RUnlock()
 		err := aws.DownloadPricingData()
 		aws.DownloadPricingDataLock.RLock()
 		if err != nil {
+			log.DedupedInfof(10, "AWS NodePricing: failed to download pricing data for key %q: %v", key, err)
 			return &models.Node{
 				Cost:             aws.BaseCPUPrice,
 				BaseCPUPrice:     aws.BaseCPUPrice,
@@ -1554,6 +1556,7 @@ func (aws *AWS) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 		}
 		terms, termsOk := aws.Pricing[key]
 		if !termsOk {
+			log.DedupedInfof(10, "AWS NodePricing: pricing data still not found for key %q after successful download", key)
 			return &models.Node{
 				Cost:             aws.BaseCPUPrice,
 				BaseCPUPrice:     aws.BaseCPUPrice,
@@ -1568,8 +1571,7 @@ func (aws *AWS) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 		// Since Fargate pricing is listed at AmazonECS and is different from AmazonEC2, we handle it separately here
 		return aws.createFargateNode(awsKey, usageType)
 	} else { // Fall back to base pricing if we can't find the key. Base pricing is handled at the costmodel level.
-		// we seem to have an issue where this error gets thrown during app start.
-		// somehow the ValidPricingKeys map is being accessed before all the pricing data has been downloaded
+		log.DedupedInfof(10, "AWS NodePricing: unknown instance type, key %q not found in valid pricing keys", key)
 		return nil, meta, fmt.Errorf("Invalid Pricing Key \"%s\"", key)
 	}
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -797,3 +797,65 @@ func TestAWS_getFargatePod(t *testing.T) {
 		})
 	}
 }
+
+func TestNodePricing_Success(t *testing.T) {
+	aws := &AWS{
+		Pricing: map[string]*AWSProductTerms{
+			"us-east-1,m5.large,linux": {
+				OnDemand: &AWSOfferTerm{
+					PriceDimensions: map[string]*AWSRateCode{
+						"test": {
+							PricePerUnit: AWSCurrencyCode{USD: "0.096"},
+						},
+					},
+				},
+			},
+		},
+		ValidPricingKeys: map[string]bool{"us-east-1,m5.large,linux": true},
+		BaseCPUPrice:     "0.01",
+		BaseRAMPrice:     "0.001",
+		BaseGPUPrice:     "0.1",
+	}
+
+	key := &awsKey{
+		Labels: map[string]string{
+			v1.LabelTopologyRegion:     "us-east-1",
+			v1.LabelInstanceTypeStable: "m5.large",
+			v1.LabelOSStable:           "linux",
+		},
+	}
+
+	node, _, err := aws.NodePricing(key)
+	if err != nil {
+		t.Fatalf("NodePricing should succeed, got error: %v", err)
+	}
+	if node == nil {
+		t.Fatalf("NodePricing should return node")
+	}
+}
+
+func TestNodePricing_InvalidKey(t *testing.T) {
+	aws := &AWS{
+		Pricing:          map[string]*AWSProductTerms{},
+		ValidPricingKeys: map[string]bool{},
+		BaseCPUPrice:     "0.01",
+		BaseRAMPrice:     "0.001",
+		BaseGPUPrice:     "0.1",
+	}
+
+	key := &awsKey{
+		Labels: map[string]string{
+			v1.LabelTopologyRegion:     "unknown-region",
+			v1.LabelInstanceTypeStable: "unknown.type",
+			v1.LabelOSStable:           "linux",
+		},
+	}
+
+	node, _, err := aws.NodePricing(key)
+	if err == nil {
+		t.Fatalf("NodePricing should return error for invalid key")
+	}
+	if node != nil {
+		t.Fatalf("NodePricing should return nil node for invalid key")
+	}
+}

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1154,14 +1154,14 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 			}
 			return n.Node, meta, nil
 		} else {
-			log.Debugf("Could not find pricing for node %s from key %s", azKey, azKey.Features())
+			log.DedupedInfof(10, "Azure NodePricing: key %q not found in cache, attempting retail API lookup", featureString)
 		}
 	}
 
 	cost, err := getRetailPrice(region, instance, config.CurrencyCode, isSpot)
 
 	if err != nil {
-		log.DedupedWarningf(5, "failed to retrieve retail pricing: %s", err)
+		log.DedupedInfof(10, "Azure NodePricing: retail API lookup failed for key %q (region=%s, instance=%s): %v", featureString, region, instance, err)
 	} else {
 		gpu := ""
 		if azKey.isValidGPUNode() {
@@ -1187,7 +1187,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 		return node, meta, nil
 	}
 
-	log.DedupedWarningf(5, "No pricing data found for node %s from key %s", azKey, azKey.Features())
+	log.DedupedInfof(10, "Azure NodePricing: no pricing data found for key %q, using default base pricing", featureString)
 
 	c, err := az.GetConfig()
 	if err != nil {

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -447,7 +447,7 @@ func (do *DOKS) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 	// Try fetching catalog; fallback is okay
 	_, err := do.fetchPricingData()
 	if err != nil {
-		log.Warnf("Failed to fetch catalog: %v. Will try estimation or fallback.", err)
+		log.DedupedInfof(10, "DigitalOcean NodePricing: failed to fetch pricing catalog for key %q: %v", key.Features(), err)
 	}
 
 	arch := parseArch(key.Features())
@@ -456,7 +456,7 @@ func (do *DOKS) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 	// Try parsing vCPU/RAM from labels
 	vcpu, ram, err := parseResources(key.Features())
 	if err != nil || vcpu == 0 || ram == 0 {
-		log.Infof("Failed to extract CPU/RAM from features. Trying slug: %s", slug)
+		log.DedupedInfof(10, "DigitalOcean NodePricing: could not extract CPU/RAM from features for key %q, trying slug %q", key.Features(), slug)
 
 		var ok bool
 		// Try getting from slug (e.g., "s-2vcpu-4gb")
@@ -465,9 +465,9 @@ func (do *DOKS) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 			// Fallback: RAM = 2x CPU if CPU is known, cases like c-2
 			if vcpu > 0 {
 				ram = vcpu * 2
-				log.Warnf("Only CPU found. Assuming RAM = 2 * CPU → %dGiB", ram)
+				log.DedupedInfof(10, "DigitalOcean NodePricing: only CPU found for slug %q, assuming RAM = 2 * CPU → %dGiB", slug, ram)
 			} else {
-				log.Warnf("Could not extract vCPU/RAM from features or slug. Returning fallback.")
+				log.DedupedInfof(10, "DigitalOcean NodePricing: unknown instance type, could not extract vCPU/RAM from key %q or slug %q, using fallback pricing", key.Features(), slug)
 				return fallbackNode(slug)
 			}
 		}
@@ -496,7 +496,7 @@ func (do *DOKS) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 		}
 	}
 
-	log.Warnf("No matching product found for slug %s (vCPU: %d, RAM: %d), falling back", slug, vcpu, ram)
+	log.DedupedInfof(10, "DigitalOcean NodePricing: no matching product found in catalog for slug %q (vCPU: %d, RAM: %d), using fallback pricing", slug, vcpu, ram)
 	return fallbackNode(slug)
 }
 

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -759,9 +759,8 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 
 				gpuType := NormalizeGPULabel(product.Description)
 				if gpuType != "" {
-				    log.Debugf("GCP Billing API: normalized GPU type: %q", gpuType)
+					log.Debugf("GCP Billing API: normalized GPU type: %q", gpuType)
 				}
-
 
 				candidateKeys := []string{}
 				if gcp.ValidPricingKeys == nil {
@@ -1565,11 +1564,12 @@ func (gcp *GCP) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 
 		return n.Node, meta, nil
 	} else if ok := gcp.isValidPricingKey(key); ok {
+		log.DedupedInfof(10, "GCP NodePricing: key %q is valid but pricing data not loaded, attempting download", key.Features())
 		meta.Warnings = append(meta.Warnings, fmt.Sprintf("No pricing found, but key is valid: %s", key.Features()))
 
 		err := gcp.DownloadPricingData()
 		if err != nil {
-			log.Warnf("no pricing data found for %s", key.Features())
+			log.DedupedInfof(10, "GCP NodePricing: failed to download pricing data for key %q: %v", key.Features(), err)
 
 			meta.Warnings = append(meta.Warnings, "Failed to download pricing data")
 
@@ -1586,13 +1586,14 @@ func (gcp *GCP) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 			return n.Node, meta, nil
 		}
 
-		log.Warnf("no pricing data found for %s", key.Features())
+		log.DedupedInfof(10, "GCP NodePricing: pricing data still not found for key %q after successful download", key.Features())
 
 		meta.Warnings = append(meta.Warnings, "Failed to find pricing after downloading data, but key is valid")
 
 		return nil, meta, fmt.Errorf("failed to find pricing data: %s", key.Features())
 	}
 
+	log.DedupedInfof(10, "GCP NodePricing: unknown instance type, key %q not found in valid pricing keys", key.Features())
 	meta.Warnings = append(meta.Warnings, fmt.Sprintf("No pricing found, and key is not valid: %s", key.Features()))
 
 	return nil, meta, fmt.Errorf("no pricing data found for %s", key.Features())

--- a/pkg/cloud/oracle/provider.go
+++ b/pkg/cloud/oracle/provider.go
@@ -56,12 +56,14 @@ func (o *Oracle) ClusterInfo() (map[string]string, error) {
 
 func (o *Oracle) NodePricing(key models.Key) (*models.Node, models.PricingMetadata, error) {
 	if err := o.ensurePricingData(); err != nil {
+		log.DedupedInfof(10, "Oracle NodePricing: failed to ensure pricing data for key %q: %v", key.Features(), err)
 		return nil, models.PricingMetadata{}, err
 	}
 	o.DownloadPricingDataLock.RLock()
 	defer o.DownloadPricingDataLock.RUnlock()
 	node, metadata, err := o.RateCardStore.ForKey(key, o.DefaultPricing)
 	if err != nil {
+		log.DedupedInfof(10, "Oracle NodePricing: rate card lookup failed for key %q: %v", key.Features(), err)
 		return node, metadata, err
 	}
 	// Check if the node is preemptible based on the label

--- a/pkg/cloud/oracle/ratecard.go
+++ b/pkg/cloud/oracle/ratecard.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/pkg/cloud/models"
 )
 
@@ -128,8 +129,10 @@ func (rcs *RateCardStore) ForKey(key models.Key, defaultPricing DefaultPricing) 
 	var node *models.Node
 	// Use the default pricing if the instance product is unknown
 	if product.isEmpty() {
+		log.DedupedInfof(10, "Oracle NodePricing: unknown instance type %q, using default pricing", features[0])
 		totalCost, err := defaultPricing.TotalInstanceCost()
 		if err != nil {
+			log.DedupedInfof(10, "Oracle NodePricing: failed to parse default pricing for key %q: %v", key.Features(), err)
 			return nil, models.PricingMetadata{}, fmt.Errorf("failed to parse default Oracle pricing: %w", err)
 		}
 		vcpuCost := defaultPricing.OCPU

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -261,21 +261,22 @@ func (otc *OTC) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 	key := k.Features()
 	meta := models.PricingMetadata{}
 
-	log.Info("looking for pricing data of node with key features " + key)
+	log.Debugf("OTC NodePricing: looking for pricing data with key %q", key)
 	pricing, ok := otc.Pricing[key]
 	if ok {
 		// The pricing key was found in the pricing list of the otc provider.
 		// Now create a pricing node from that data and return it.
-		log.Info("pricing data found")
+		log.Debugf("OTC NodePricing: pricing data found for key %q", key)
 		return otc.createNode(pricing, k)
 	} else if _, ok := otc.ValidPricingKeys[key]; ok {
 		// The pricing key is actually valid, but somehow it could not be found.
 		// Try re-downloading the pricing data to check for changes.
-		log.Info("key is valid, but no associated pricing data could be found; trying to re-download pricing data")
+		log.DedupedInfof(10, "OTC NodePricing: key %q is valid but pricing data not loaded, attempting download", key)
 		otc.DownloadPricingDataLock.RUnlock()
 		err := otc.DownloadPricingData()
 		otc.DownloadPricingDataLock.RLock()
 		if err != nil {
+			log.DedupedInfof(10, "OTC NodePricing: failed to download pricing data for key %q: %v", key, err)
 			return &models.Node{
 				Cost:             otc.BaseCPUPrice,
 				BaseCPUPrice:     otc.BaseCPUPrice,
@@ -287,6 +288,7 @@ func (otc *OTC) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 		pricing, ok = otc.Pricing[key]
 		if !ok {
 			// The given key does not exist in OTC or locally, return a default pricing node.
+			log.DedupedInfof(10, "OTC NodePricing: pricing data still not found for key %q after successful download", key)
 			return &models.Node{
 				Cost:             otc.BaseCPUPrice,
 				BaseCPUPrice:     otc.BaseCPUPrice,
@@ -296,11 +298,11 @@ func (otc *OTC) NodePricing(k models.Key) (*models.Node, models.PricingMetadata,
 			}, meta, fmt.Errorf("unable to find any Pricing data for \"%s\"", key)
 		}
 		// The local pricing date was just outdated.
-		log.Info("pricing data found after re-download")
+		log.Debugf("OTC NodePricing: pricing data found for key %q after re-download", key)
 		return otc.createNode(pricing, k)
 	} else {
 		// The given key is not valid, fall back to base pricing (handled by the costmodel)?
-		log.Info("given key \"" + key + "\" is invalid; falling back to default pricing")
+		log.DedupedInfof(10, "OTC NodePricing: unknown instance type, key %q not found in valid pricing keys", key)
 		return nil, meta, fmt.Errorf("invalid Pricing Key \"%s\"", key)
 	}
 }

--- a/pkg/cloud/otc/provider_test.go
+++ b/pkg/cloud/otc/provider_test.go
@@ -1,0 +1,108 @@
+package otc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockKey implements models.Key for testing
+type mockKey struct {
+	features string
+}
+
+func (m *mockKey) Features() string { return m.features }
+func (m *mockKey) GPUType() string  { return "" }
+func (m *mockKey) GPUCount() int    { return 0 }
+func (m *mockKey) ID() string       { return "" }
+
+func TestNodePricing_Success(t *testing.T) {
+	pricing := map[string]*OTCPricing{
+		"eu-de,s2.large.4,Open Linux": {
+			NodeAttributes: &OTCNodeAttributes{
+				Type:  "s2.large.4",
+				OS:    "Open Linux",
+				Price: "0.05",
+				RAM:   "8",
+				VCPU:  "2",
+			},
+		},
+	}
+
+	otc := &OTC{
+		Pricing:          pricing,
+		ValidPricingKeys: map[string]bool{"eu-de,s2.large.4,Open Linux": true},
+		BaseCPUPrice:     "0.01",
+		BaseRAMPrice:     "0.001",
+		BaseGPUPrice:     "0.1",
+	}
+	key := &mockKey{features: "eu-de,s2.large.4,Open Linux"}
+
+	node, meta, err := otc.NodePricing(key)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, node)
+	assert.NotNil(t, meta)
+	assert.Equal(t, "0.05", node.Cost)
+	assert.Equal(t, "2", node.VCPU)
+	assert.Equal(t, "8", node.RAM)
+}
+
+func TestNodePricing_InvalidKey(t *testing.T) {
+	otc := &OTC{
+		Pricing:          map[string]*OTCPricing{},
+		ValidPricingKeys: map[string]bool{},
+		BaseCPUPrice:     "0.01",
+		BaseRAMPrice:     "0.001",
+		BaseGPUPrice:     "0.1",
+	}
+	key := &mockKey{features: "unknown-region,unknown-type,unknown-os"}
+
+	node, _, err := otc.NodePricing(key)
+
+	assert.Error(t, err)
+	assert.Nil(t, node)
+	assert.Contains(t, err.Error(), "invalid Pricing Key")
+}
+
+func TestNodePricing_ValidKeyButNotLoaded(t *testing.T) {
+	// This tests the case where the key is valid but pricing data is not loaded
+	// In a real scenario, DownloadPricingData would be called, but we can't easily mock that
+	// So we test the error path where download fails
+
+	otc := &OTC{
+		Pricing:          map[string]*OTCPricing{},
+		ValidPricingKeys: map[string]bool{"eu-de,s2.large.4,Open Linux": true},
+		BaseCPUPrice:     "0.01",
+		BaseRAMPrice:     "0.001",
+		BaseGPUPrice:     "0.1",
+	}
+	key := &mockKey{features: "eu-de,s2.large.4,Open Linux"}
+
+	// This will trigger the download path which will fail since we're not in a real environment
+	// but it exercises the logging code path
+	node, _, err := otc.NodePricing(key)
+
+	// The function returns a node with base pricing on error
+	assert.Error(t, err)
+	if node != nil {
+		// If we got a node back, it should have base pricing
+		assert.Equal(t, "0.01", node.BaseCPUPrice)
+	}
+}
+
+func TestNodePricing_EmptyPricing(t *testing.T) {
+	otc := &OTC{
+		Pricing:          map[string]*OTCPricing{},
+		ValidPricingKeys: map[string]bool{},
+		BaseCPUPrice:     "0.01",
+		BaseRAMPrice:     "0.001",
+		BaseGPUPrice:     "0.1",
+	}
+	key := &mockKey{features: "eu-de,s2.large.4,Open Linux"}
+
+	node, _, err := otc.NodePricing(key)
+
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}

--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -141,8 +141,14 @@ func (c *Scaleway) NodePricing(key models.Key) (*models.Node, models.PricingMeta
 
 	// There is only the zone and the instance ID in the providerID, hence we must use the features
 	split := strings.Split(key.Features(), ",")
-	if pricing, ok := c.Pricing[split[0]]; ok {
-		if info, ok := pricing.NodesInfos[split[1]]; ok {
+	zone := split[0]
+	instanceType := ""
+	if len(split) > 1 {
+		instanceType = split[1]
+	}
+
+	if pricing, ok := c.Pricing[zone]; ok {
+		if info, ok := pricing.NodesInfos[instanceType]; ok {
 			return &models.Node{
 				Cost:        fmt.Sprintf("%f", info.HourlyPrice),
 				PricingType: models.DefaultPrices,
@@ -151,13 +157,14 @@ func (c *Scaleway) NodePricing(key models.Key) (*models.Node, models.PricingMeta
 				// This is tricky, as instances can have local volumes or not
 				Storage:      fmt.Sprintf("%d", info.PerVolumeConstraint.LSSD.MinSize),
 				GPU:          fmt.Sprintf("%d", *info.Gpu),
-				InstanceType: split[1],
-				Region:       split[0],
+				InstanceType: instanceType,
+				Region:       zone,
 				GPUName:      key.GPUType(),
 			}, meta, nil
-
 		}
-
+		log.DedupedInfof(10, "Scaleway NodePricing: unknown instance type %q in zone %q, %d instance types available for zone", instanceType, zone, len(pricing.NodesInfos))
+	} else {
+		log.DedupedInfof(10, "Scaleway NodePricing: unknown zone %q for key %q, %d zones available in pricing data", zone, key.Features(), len(c.Pricing))
 	}
 	return nil, meta, fmt.Errorf("Unable to find node pricing matching thes features `%s`", key.Features())
 }

--- a/pkg/cloud/scaleway/provider_test.go
+++ b/pkg/cloud/scaleway/provider_test.go
@@ -1,0 +1,124 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockKey implements models.Key for testing
+type mockKey struct {
+	features string
+	gpuType  string
+}
+
+func (m *mockKey) Features() string { return m.features }
+func (m *mockKey) GPUType() string  { return m.gpuType }
+func (m *mockKey) ID() string       { return "" }
+
+func TestNodePricing_Success(t *testing.T) {
+	gpuCount := uint64(0)
+	pricing := map[string]*ScalewayPricing{
+		"fr-par-1": {
+			NodesInfos: map[string]*instance.ServerType{
+				"DEV1-S": {
+					HourlyPrice: 0.01,
+					Ncpus:       2,
+					RAM:         2147483648,
+					Gpu:         &gpuCount,
+					PerVolumeConstraint: &instance.ServerTypeVolumeConstraintsByType{
+						LSSD: &instance.ServerTypeVolumeConstraintSizes{
+							MinSize: 20000000000,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := &Scaleway{Pricing: pricing}
+	key := &mockKey{features: "fr-par-1,DEV1-S"}
+
+	node, meta, err := c.NodePricing(key)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, node)
+	assert.NotNil(t, meta)
+	assert.Equal(t, "DEV1-S", node.InstanceType)
+	assert.Equal(t, "fr-par-1", node.Region)
+}
+
+func TestNodePricing_UnknownInstanceType(t *testing.T) {
+	gpuCount := uint64(0)
+	pricing := map[string]*ScalewayPricing{
+		"fr-par-1": {
+			NodesInfos: map[string]*instance.ServerType{
+				"DEV1-S": {
+					HourlyPrice: 0.01,
+					Ncpus:       2,
+					RAM:         2147483648,
+					Gpu:         &gpuCount,
+					PerVolumeConstraint: &instance.ServerTypeVolumeConstraintsByType{
+						LSSD: &instance.ServerTypeVolumeConstraintSizes{
+							MinSize: 20000000000,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := &Scaleway{Pricing: pricing}
+	key := &mockKey{features: "fr-par-1,UNKNOWN-TYPE"}
+
+	node, _, err := c.NodePricing(key)
+
+	assert.Error(t, err)
+	assert.Nil(t, node)
+	assert.Contains(t, err.Error(), "Unable to find node pricing")
+}
+
+func TestNodePricing_UnknownZone(t *testing.T) {
+	pricing := map[string]*ScalewayPricing{
+		"fr-par-1": {
+			NodesInfos: map[string]*instance.ServerType{},
+		},
+	}
+
+	c := &Scaleway{Pricing: pricing}
+	key := &mockKey{features: "unknown-zone,DEV1-S"}
+
+	node, _, err := c.NodePricing(key)
+
+	assert.Error(t, err)
+	assert.Nil(t, node)
+	assert.Contains(t, err.Error(), "Unable to find node pricing")
+}
+
+func TestNodePricing_EmptyPricing(t *testing.T) {
+	c := &Scaleway{Pricing: map[string]*ScalewayPricing{}}
+	key := &mockKey{features: "fr-par-1,DEV1-S"}
+
+	node, _, err := c.NodePricing(key)
+
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}
+
+func TestNodePricing_SingleElementFeatures(t *testing.T) {
+	pricing := map[string]*ScalewayPricing{
+		"fr-par-1": {
+			NodesInfos: map[string]*instance.ServerType{},
+		},
+	}
+
+	c := &Scaleway{Pricing: pricing}
+	key := &mockKey{features: "fr-par-1"}
+
+	node, _, err := c.NodePricing(key)
+
+	// Should fail because instance type is empty
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}


### PR DESCRIPTION
Add deduped INFO-level logging to help diagnose pricing lookup failures across all cloud providers. When pricing lookup fails, logs now include:
- The constructed pricing key
- The specific reason for failure (unknown instance type vs data not loaded vs API issue)

Changes applied to: AWS, GCP, Azure, Alibaba, Oracle, DigitalOcean, Scaleway, and OTC providers.

Uses DedupedInfof with limit 10 to prevent log spam while still providing useful diagnostic information.

Fixes #3549 (Part 2)

## Description
<!-- Provide a clear and concise description of what this PR changes. -->

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
