### PR TITLE
add community maintainers to list, along with expectations

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,85 @@
+# The OpenCost Community Team
+
+The wider OpenCost community identified work that falls into the categories of contributor experience, advocacy and communications, community management as integral to its success. This document outlines the responsibilities of the Community Maintainers, and links to OpenCost community resources. 
+
+## Current Team Roster
+
+See https://github.com/opencost/opencost/blob/develop/MAINTAINERS.md#community-maintainers
+
+## Responsibilities
+
+As opposed to defining a big overarching burden of responsibilities the team would have a hard time to actually realise, we want to slowly and carefully add tasks as we build out the team.
+
+- **Project communications** 
+- Monthly blog post
+- Social media
+- Mailing list
+- Slack
+- **Events and Advocacy**
+
+### Events and Advocacy
+
+It is important to us to create a space for our community to meet, engage, collaborate and learn from each other. Over the past months, we have participated in CloudNativeCon / KubeCon and at various meetups.
+
+If you want to join the planning effort, please come and talk to us!
+
+Also, if you would like to speak about OpenCost, do reach out - we are happy to help you find a speaking slot soon. The more the world hears about this, the better!
+
+### Communications
+
+We as a project want to make it a priority to inform our community and the wider world of developments well.
+It's what helps new contributors get up to speed, enables collaboration, integrations and more.
+
+The Community team helps with communication channels, including:
+
+- [Our blog](https://opencost.io/blog)
+- Slack (likely more to follow)
+  - [#opencost](https://cloud-native.slack.com/archives/opencost)
+- Social media
+- [CNCF Blog](https://www.cncf.io/blog/)
+- [Youtube](https://www.youtube.com/@CNCFOpenCost)
+
+#### How to use this
+
+##### As a maintainer or contributor
+
+Add news-worthy items to our community meeting notes, so that our community maintainers can broadcast them appropriately! 
+
+##### As a Community Maintainer
+
+1. Check the community meeting notes and see if there are items that still need doing.
+1. We would like to get monthly updates out to our community, so writing up content, getting quotes from relevant people, etc
+
+## How to join
+
+Talk to us in [`#opencost`](https://cloud-native.slack.com/archives/opencost) on [Slack](https://slack.cncf.io) and let us know if you're interested in contributing.
+We would love to have you part of the team.
+
+### Access to things
+
+In case you need access to a particular OpenCost resource to fulfil your role as team member, please [file an issue on this repository](https://github.com/opencost/opencost/issues/new) and tag some of the folks in the previous section.
+
+Below we list resources that are not tied to GitHub permissions. You can assume that the core OpenCost maintainers have access, community maintainers and sometimes CNCF staff as backup.
+
+For people listed below we made exceptions:
+
+#### Calendar
+
+TODO
+
+#### LinkedIn Group
+
+TODO
+
+#### Twitter account
+
+TODO
+
+#### YouTube channels
+
+<https://youtube.com/@CNCFOpenCost>
+
+
+### Credit
+
+Credit to the Flux project for their structure and contents of this file, and expectations of community maintainers - https://github.com/fluxcd/community/blob/main/COMMUNITY.md

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # OpenCost Committers and Maintainers
 
-Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/opencost-maintainers). [OpenCost Committers](https://github.com/orgs/opencost/teams/opencost-committers) are granted Triage permissions for the OpenCost repositories. The [GOVERNANCE.md](https://github.com/opencost/opencost/blob/develop/GOVERNANCE.md) describes the process for becoming a committer and maintainer of the project.
+Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/opencost-maintainers) and [OpenCost Community Maintainers](https://github.com/orgs/opencost/teams/opencost-community-maintainers). [OpenCost Committers](https://github.com/orgs/opencost/teams/opencost-committers) are granted Triage permissions for the OpenCost repositories. The [GOVERNANCE.md](https://github.com/opencost/opencost/blob/develop/GOVERNANCE.md) describes the process for becoming a committer and maintainer of the project.
 
 ## Maintainers
 
@@ -13,6 +13,12 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 | Niko Kovacevic | @nikovacevic | IBM | <Nicholas.Kovacevic@ibm.com> |
 | Sean Holcomb | @Sean-Holcomb | IBM | <sean.holcomb@ibm.com> |
 | Warwick Peatey | @peatey | IBM | <warwick.peatey@ibm.com> |
+
+## Community Maintainers
+
+| Maintainer | GitHub ID | Affiliation | Email |
+| --------------- | --------- | ----------- | ----------- |
+| Rajith Attapattu| @rajith77 | Randoli | <rajith@randoli.ca> |
 
 ## Opencost Emeritus Committers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,13 @@ Official list of [OpenCost Maintainers](https://github.com/orgs/opencost/teams/o
 | --------------- | --------- | ----------- | ----------- |
 | Rajith Attapattu| @rajith77 | Randoli | <rajith@randoli.ca> |
 
+## Sub Project Maintainers
+
+### opencost-integration-tests
+| Maintainer | GitHub ID | Affiliation | Email |
+| --------------- | --------- | ----------- | ----------- |
+| Manas Sivakumar | @Manas23601 |  | <manas23601@gmail.com> |
+
 ## Opencost Emeritus Committers
 
 We would like to acknowledge previous committers and their huge contributions to our collective success:


### PR DESCRIPTION
## Description
Updates maintainers, publish draft of community maintainers standards 

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces community governance docs and updates maintainer rosters.
> 
> - Adds `COMMUNITY.md` outlining Community Maintainers’ responsibilities, communication channels, joining process, and resource access
> - Updates `MAINTAINERS.md` to reference Community Maintainers, adds a new "Community Maintainers" section (includes Rajith Attapattu), and a "Sub Project Maintainers" section for `opencost-integration-tests` (adds Manas Sivakumar)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1af31ece18d5f6128141a00b4a5e461c7aef2a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->