### PR TITLE
Cdp/parser fix

### DIFF
--- a/core/pkg/filter/resourcequota/parser.go
+++ b/core/pkg/filter/resourcequota/parser.go
@@ -1,6 +1,9 @@
 package resourcequota
 
-import "github.com/opencost/opencost/core/pkg/filter/ast"
+import (
+	"github.com/opencost/opencost/core/pkg/filter/ast"
+	"github.com/opencost/opencost/core/pkg/filter/ops"
+)
 
 var resourceQuotaFilterFields []*ast.Field = []*ast.Field{
 	ast.NewField(FieldClusterID),
@@ -19,6 +22,7 @@ func init() {
 		ff := *f
 		fieldMap[ResourceQuotaField(ff.Name)] = &ff
 	}
+	ops.RegisterDefaultFieldLookup[ResourceQuotaField](DefaultFieldByName)
 }
 
 // DefaultFieldByName returns only default resource quota filter fields by name.

--- a/core/pkg/filter/resourcequota/parser_test.go
+++ b/core/pkg/filter/resourcequota/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/opencost/opencost/core/pkg/filter/ast"
+	"github.com/opencost/opencost/core/pkg/filter/ops"
 )
 
 func TestDefaultFieldByName(t *testing.T) {
@@ -40,4 +41,29 @@ func TestDefaultFieldByName(t *testing.T) {
 		t.Errorf("expected %s; received %s", "uid", astf.Name)
 	}
 
+}
+
+func TestOpsEqWithResourceQuotaField(t *testing.T) {
+	clusterFilter := ops.Eq(FieldClusterID, "test-cluster")
+
+	equalOp, ok := clusterFilter.(*ast.EqualOp)
+	if !ok {
+		t.Fatalf("expected *ast.EqualOp, got %T", clusterFilter)
+	}
+
+	if equalOp.Left.Field == nil {
+		t.Fatal("expected Field to be non-nil, got nil")
+	}
+
+	if equalOp.Left.Field.Name == "" {
+		t.Fatal("expected Field.Name to be non-empty, got empty string")
+	}
+
+	if equalOp.Left.Field.Name != "cluster" {
+		t.Errorf("expected Field.Name to be 'cluster', got '%s'", equalOp.Left.Field.Name)
+	}
+
+	if equalOp.Right != "test-cluster" {
+		t.Errorf("expected Right to be 'test-cluster', got '%s'", equalOp.Right)
+	}
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
During scale testing, I noticed the ingestor stopped and never restarted because the `StateApplyPricing` handler never transitioned the ingestion state to `StateComplete`. Ingestion is never reattempted on these stuck files because we are stuck in the `StateApplyPricing` state. This fix ensures `StateApplyPricing` transitions to `StateComplete`, allowing the orchestrator to create a new writer and restart the ingestor. 

```
2026-01-27T18:58:07.792963986Z WRN Savings: error computing resource quota sizing savings (CLUSTER): error getting node group recommendations: failed to build container query: failed to build container query: error building base query: failed to compile filter: 2 errors occurred:
        * Failed to compile EqualOp: failed to get column name for EqualOp: unsupported filter field: 
        * SqlOp scope must have > 0 operands to close


2026-01-27T18:58:08.049639413Z INF Ingestor[diagnostics]: Stopped
2026-01-27T18:58:08.049639543Z INF Ingestor[assets]: Stopped
2026-01-27T18:58:08.049643533Z INF Ingestor[networkinsights]: Stopped
2026-01-27T18:58:08.049675504Z INF Ingestor[]: Stopped
2026-01-27T18:58:08.049698104Z INF Ingestor[kubemodel]: Stopped
2026-01-27T18:58:08.049700144Z INF Ingestor[cloudcosts]: Stopped
2026-01-27T18:58:09.505459819Z WRN Savings: error computing resource quota sizing savings (CLUSTER): error getting node group recommendations: failed to build container query: failed to build container query: error building base query: failed to compile filter: 2 errors occurred:
        * Failed to compile EqualOp: failed to get column name for EqualOp: unsupported filter field: 
        * SqlOp scope must have > 0 operands to close


2026-01-27T18:58:11.276314493Z WRN Savings: error computing resource quota sizing savings (CLUSTER): error getting node group recommendations: failed to build container query: failed to build container query: error building base query: failed to compile filter: 2 errors occurred:
        * Failed to compile EqualOp: failed to get column name for EqualOp: unsupported filter field: 
        * SqlOp scope must have > 0 operands to close


2026-01-27T18:58:12.680176216Z INF Ingestor[allocations]: Stopped
```

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
This is a bug fix, described above. 

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
I deployed the changes and validated the ingestor restarted successfully. 
