### PR TITLE
Support resource quotas in filter ops pkg

### DIFF
--- a/core/pkg/filter/ops/ops.go
+++ b/core/pkg/filter/ops/ops.go
@@ -6,6 +6,7 @@ package ops
 
 import (
 	"fmt"
+	"github.com/opencost/opencost/core/pkg/filter/resourcequota"
 	"reflect"
 	"strings"
 
@@ -27,10 +28,11 @@ type keyFieldType interface {
 // This is somewhat of a fancy solution, but allows us to "register" DefaultFieldByName funcs
 // funcs by Field type.
 var defaultFieldByType = map[string]any{
-	typeutil.TypeOf[allocation.AllocationField](): allocation.DefaultFieldByName,
-	typeutil.TypeOf[asset.AssetField]():           asset.DefaultFieldByName,
-	typeutil.TypeOf[cloudcost.CloudCostField]():   cloudcost.DefaultFieldByName,
-	typeutil.TypeOf[k8sobject.K8sObjectField]():   k8sobject.DefaultFieldByName,
+	typeutil.TypeOf[allocation.AllocationField]():       allocation.DefaultFieldByName,
+	typeutil.TypeOf[asset.AssetField]():                 asset.DefaultFieldByName,
+	typeutil.TypeOf[cloudcost.CloudCostField]():         cloudcost.DefaultFieldByName,
+	typeutil.TypeOf[k8sobject.K8sObjectField]():         k8sobject.DefaultFieldByName,
+	typeutil.TypeOf[resourcequota.ResourceQuotaField](): resourcequota.DefaultFieldByName,
 	// typeutil.TypeOf[containerstats.ContainerStatsField](): containerstats.DefaultFieldByName,
 }
 


### PR DESCRIPTION
## Description
Add support for resource quota filter fields in filter ops package.

## Related Issues
N/A

## User Impact
Users can use the filter `ops` package to manipulate filters targeting resource quotas.

## Testing
N/A
