### PR TITLE
feat: Apply configured discounts to Prometheus node cost metrics 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.3-alpine3.21 AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine3.21 AS build-env
 
 WORKDIR /app
 

--- a/pkg/cloud/aws/athenaconfiguration.go
+++ b/pkg/cloud/aws/athenaconfiguration.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/util/json"
 	"github.com/opencost/opencost/pkg/cloud"
@@ -219,6 +220,10 @@ func (ac *AthenaConfiguration) UnmarshalJSON(b []byte) error {
 // ConvertAwsAthenaInfoToConfig takes a legacy config and generates a Config based on the presence of properties to match
 // legacy behavior
 func ConvertAwsAthenaInfoToConfig(aai AwsAthenaInfo) cloud.KeyedConfig {
+	// Debug: Log incoming AwsAthenaInfo
+	log.Debugf("ConvertAwsAthenaInfoToConfig: AccountID=%s, AthenaBucketName=%s, AthenaRegion=%s, AthenaDatabase=%s, AthenaTable=%s",
+		aai.AccountID, aai.AthenaBucketName, aai.AthenaRegion, aai.AthenaDatabase, aai.AthenaTable)
+
 	if aai.IsEmpty() {
 		return nil
 	}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -509,6 +509,10 @@ func (aws *AWS) GetAWSAthenaInfo() (*AwsAthenaInfo, error) {
 		return nil, fmt.Errorf("could not retrieve AwsAthenaInfo %s", err)
 	}
 
+	// Debug: Log the AthenaProjectID from config
+	log.Debugf("GetAWSAthenaInfo: config.AthenaProjectID=%s, AthenaBucketName=%s, AthenaRegion=%s, AthenaDatabase=%s, AthenaTable=%s",
+		config.AthenaProjectID, config.AthenaBucketName, config.AthenaRegion, config.AthenaDatabase, config.AthenaTable)
+
 	aak, err := aws.GetAWSAccessKey()
 	if err != nil {
 		return nil, err
@@ -2084,6 +2088,8 @@ func (aws *AWS) QueryAthenaPaginated(ctx context.Context, query string, fn func(
 	}
 	if awsAthenaInfo.AthenaDatabase == "" || awsAthenaInfo.AthenaTable == "" || awsAthenaInfo.AthenaRegion == "" ||
 		awsAthenaInfo.AthenaBucketName == "" || awsAthenaInfo.AccountID == "" {
+		log.Debugf("AthenaDatabase: %s, AthenaTable: %s, AthenaRegion: %s, AthenaBucketName: %s, AccountID: %s",
+			awsAthenaInfo.AthenaDatabase, awsAthenaInfo.AthenaTable, awsAthenaInfo.AthenaRegion, awsAthenaInfo.AthenaBucketName, awsAthenaInfo.AccountID)
 		return fmt.Errorf("QueryAthenaPaginated: athena configuration incomplete")
 	}
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1409,6 +1409,9 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 		}
 	} else if sp, ok := aws.savingsPlanPricing(k.ID()); ok {
 		strCost := fmt.Sprintf("%f", sp.EffectiveCost)
+		// Debug: Log when using Savings Plan pricing for a node
+		log.Debugf("createNode: Using SavingsPlan pricing for node=%s, EffectiveCost=%s (OnDemand would be: %s)",
+			k.ID(), strCost, cost)
 		return &models.Node{
 			Cost:         strCost,
 			VCPU:         terms.VCpu,
@@ -2154,16 +2157,21 @@ type SavingsPlanData struct {
 }
 
 func (aws *AWS) GetSavingsPlanDataFromAthena() error {
+	log.Debugf("GetSavingsPlanDataFromAthena: Starting Savings Plan data fetch from Athena")
 	cfg, err := aws.GetConfig()
 	if err != nil {
 		aws.RIPricingError = err
+		log.Errorf("GetSavingsPlanDataFromAthena: Failed to get config: %s", err.Error())
 		return err
 	}
 	if cfg.AthenaBucketName == "" {
 		err = ErrNoAthenaBucket
 		aws.RIPricingError = err
+		log.Debugf("GetSavingsPlanDataFromAthena: No AthenaBucketName configured")
 		return err
 	}
+	log.Debugf("GetSavingsPlanDataFromAthena: AthenaBucketName=%s, AthenaDatabase=%s, AthenaTable=%s",
+		cfg.AthenaBucketName, cfg.AthenaDatabase, cfg.AthenaTable)
 	if aws.SavingsPlanDataByInstanceID == nil {
 		aws.SavingsPlanDataByInstanceID = make(map[string]*SavingsPlanData)
 	}

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -180,6 +180,8 @@ type CustomPricing struct {
 	CurrencyCode                 string `json:"currencyCode"`
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`
+	SpotDiscount                 string `json:"spotDiscount,omitempty"`
+	SpotNegotiatedDiscount       string `json:"spotNegotiatedDiscount,omitempty"`
 	ClusterName                  string `json:"clusterName"`
 	ClusterAccountID             string `json:"clusterAccount,omitempty"`
 	DefaultLBPrice               string `json:"defaultLBPrice"`

--- a/pkg/cloud/provider/providerconfig.go
+++ b/pkg/cloud/provider/providerconfig.go
@@ -69,6 +69,10 @@ func (pc *ProviderConfig) onConfigFileUpdated(changeType config.ChangeType, data
 			customPricing = DefaultPricing()
 		}
 
+		// Debug: Log AthenaProjectID when config is updated
+		log.Debugf("onConfigFileUpdated: AthenaProjectID=%s, ProjectID=%s, AthenaBucketName=%s",
+			customPricing.AthenaProjectID, customPricing.ProjectID, customPricing.AthenaBucketName)
+
 		pc.customPricing = customPricing
 		if pc.customPricing.SpotGPU == "" {
 			pc.customPricing.SpotGPU = DefaultPricing().SpotGPU // Migration for users without this value set by default.
@@ -135,6 +139,10 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*models.CustomPrici
 		log.Infof("Could not decode Custom Pricing file at path %s", pc.configFile.Path())
 		return DefaultPricing(), err
 	}
+
+	// Debug: Log parsed AthenaProjectID
+	log.Debugf("loadConfig: Parsed AthenaProjectID=%s, AthenaBucketName=%s",
+		customPricing.AthenaProjectID, customPricing.AthenaBucketName)
 
 	pc.customPricing = &customPricing
 	if pc.customPricing.SpotGPU == "" {

--- a/pkg/cloud/provider/providerconfig.go
+++ b/pkg/cloud/provider/providerconfig.go
@@ -140,9 +140,11 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*models.CustomPrici
 		return DefaultPricing(), err
 	}
 
-	// Debug: Log parsed AthenaProjectID
-	log.Debugf("loadConfig: Parsed AthenaProjectID=%s, AthenaBucketName=%s",
-		customPricing.AthenaProjectID, customPricing.AthenaBucketName)
+	// Debug: Log parsed config values including discounts
+	log.Debugf("loadConfig: Parsed config - AthenaProjectID=%s, AthenaBucketName=%s, AthenaRegion=%s, AthenaDatabase=%s, AthenaTable=%s",
+		customPricing.AthenaProjectID, customPricing.AthenaBucketName, customPricing.AthenaRegion, customPricing.AthenaDatabase, customPricing.AthenaTable)
+	log.Debugf("loadConfig: Discount=%s, NegotiatedDiscount=%s, CPU=%s, RAM=%s, GPU=%s, SpotCPU=%s, SpotRAM=%s, SpotGPU=%s",
+		customPricing.Discount, customPricing.NegotiatedDiscount, customPricing.CPU, customPricing.RAM, customPricing.GPU, customPricing.SpotCPU, customPricing.SpotRAM, customPricing.SpotGPU)
 
 	pc.customPricing = &customPricing
 	if pc.customPricing.SpotGPU == "" {

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/core/pkg/util"
 	"github.com/opencost/opencost/pkg/cloud/provider"
+	pkgenv "github.com/opencost/opencost/pkg/env"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -1863,33 +1864,53 @@ func applyNodeDiscount(nodeMap map[nodeKey]*nodePricing, cm *CostModel) {
 		return
 	}
 
-	// Debug: Log discount config values
-	log.Debugf("applyNodeDiscount: Config Discount=%s, NegotiatedDiscount=%s, SpotDiscount=%s, SpotNegotiatedDiscount=%s",
-		c.Discount, c.NegotiatedDiscount, c.SpotDiscount, c.SpotNegotiatedDiscount)
+	// Priority: Environment variable > Config file
+	discountStr := pkgenv.GetDiscount()
+	if discountStr == "" {
+		discountStr = c.Discount
+	}
+	negDiscountStr := pkgenv.GetNegotiatedDiscount()
+	if negDiscountStr == "" {
+		negDiscountStr = c.NegotiatedDiscount
+	}
+	spotDiscountStr := pkgenv.GetSpotDiscount()
+	if spotDiscountStr == "" {
+		spotDiscountStr = c.SpotDiscount
+	}
+	spotNegDiscountStr := pkgenv.GetSpotNegotiatedDiscount()
+	if spotNegDiscountStr == "" {
+		spotNegDiscountStr = c.SpotNegotiatedDiscount
+	}
+
+	log.Debugf("applyNodeDiscount: discount=%s (env=%s, config=%s), negotiatedDiscount=%s (env=%s, config=%s), spotDiscount=%s (env=%s, config=%s), spotNegotiatedDiscount=%s (env=%s, config=%s)",
+		discountStr, pkgenv.GetDiscount(), c.Discount,
+		negDiscountStr, pkgenv.GetNegotiatedDiscount(), c.NegotiatedDiscount,
+		spotDiscountStr, pkgenv.GetSpotDiscount(), c.SpotDiscount,
+		spotNegDiscountStr, pkgenv.GetSpotNegotiatedDiscount(), c.SpotNegotiatedDiscount)
 
 	// Parse on-demand discounts
-	discount, err := ParsePercentString(c.Discount)
+	discount, err := ParsePercentString(discountStr)
 	if err != nil {
-		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse discount: %s", err)
+		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse discount '%s': %s", discountStr, err)
 		return
 	}
 
-	negotiatedDiscount, err := ParsePercentString(c.NegotiatedDiscount)
+	negotiatedDiscount, err := ParsePercentString(negDiscountStr)
 	if err != nil {
-		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse negotiatedDiscount: %s", err)
+		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse negotiatedDiscount '%s': %s", negDiscountStr, err)
 		return
 	}
 
 	// Parse spot-specific discounts (fallback to 0 if not configured)
-	spotDiscount, err := ParsePercentString(c.SpotDiscount)
+	spotDiscount, err := ParsePercentString(spotDiscountStr)
 	if err != nil {
-		log.Warnf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse spotDiscount: %s", err)
+		log.Warnf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse spotDiscount '%s': %s", spotDiscountStr, err)
 		spotDiscount = 0
 	}
 
-	spotNegotiatedDiscount, err := ParsePercentString(c.SpotNegotiatedDiscount)
+	spotNegotiatedDiscount, err := ParsePercentString(spotNegDiscountStr)
 	if err != nil {
-		log.Warnf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse spotNegotiatedDiscount: %s", err)
+		log.Warnf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse spotNegotiatedDiscount '%s': %s", spotNegDiscountStr, err)
 		spotNegotiatedDiscount = 0
 	}
 

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -1863,6 +1863,9 @@ func applyNodeDiscount(nodeMap map[nodeKey]*nodePricing, cm *CostModel) {
 		return
 	}
 
+	// Debug: Log discount config values
+	log.Debugf("applyNodeDiscount: Config Discount=%s, NegotiatedDiscount=%s", c.Discount, c.NegotiatedDiscount)
+
 	discount, err := ParsePercentString(c.Discount)
 	if err != nil {
 		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: %s", err)
@@ -1875,11 +1878,20 @@ func applyNodeDiscount(nodeMap map[nodeKey]*nodePricing, cm *CostModel) {
 		return
 	}
 
+	// Debug: Log parsed discount values
+	log.Debugf("applyNodeDiscount: Parsed discount=%.4f (%.2f%%), negotiatedDiscount=%.4f (%.2f%%)",
+		discount, discount*100, negotiatedDiscount, negotiatedDiscount*100)
+
 	for _, node := range nodeMap {
 		// TODO GKE Reserved Instances into account
 		node.Discount = cm.Provider.CombinedDiscountForNode(node.NodeType, node.Preemptible, discount, negotiatedDiscount)
+		originalCPUCost := node.CostPerCPUHr
+		originalRAMCost := node.CostPerRAMGiBHr
 		node.CostPerCPUHr *= (1.0 - node.Discount)
 		node.CostPerRAMGiBHr *= (1.0 - node.Discount)
+		// Debug: Log discount application per node
+		log.Debugf("applyNodeDiscount: Node=%s, NodeType=%s, Preemptible=%t, CombinedDiscount=%.4f (%.2f%%), CostPerCPUHr: %.6f -> %.6f, CostPerRAMGiBHr: %.6f -> %.6f",
+			node.Name, node.NodeType, node.Preemptible, node.Discount, node.Discount*100, originalCPUCost, node.CostPerCPUHr, originalRAMCost, node.CostPerRAMGiBHr)
 	}
 }
 

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -1864,27 +1864,52 @@ func applyNodeDiscount(nodeMap map[nodeKey]*nodePricing, cm *CostModel) {
 	}
 
 	// Debug: Log discount config values
-	log.Debugf("applyNodeDiscount: Config Discount=%s, NegotiatedDiscount=%s", c.Discount, c.NegotiatedDiscount)
+	log.Debugf("applyNodeDiscount: Config Discount=%s, NegotiatedDiscount=%s, SpotDiscount=%s, SpotNegotiatedDiscount=%s",
+		c.Discount, c.NegotiatedDiscount, c.SpotDiscount, c.SpotNegotiatedDiscount)
 
+	// Parse on-demand discounts
 	discount, err := ParsePercentString(c.Discount)
 	if err != nil {
-		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: %s", err)
+		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse discount: %s", err)
 		return
 	}
 
 	negotiatedDiscount, err := ParsePercentString(c.NegotiatedDiscount)
 	if err != nil {
-		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: %s", err)
+		log.Errorf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse negotiatedDiscount: %s", err)
 		return
 	}
 
+	// Parse spot-specific discounts (fallback to 0 if not configured)
+	spotDiscount, err := ParsePercentString(c.SpotDiscount)
+	if err != nil {
+		log.Warnf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse spotDiscount: %s", err)
+		spotDiscount = 0
+	}
+
+	spotNegotiatedDiscount, err := ParsePercentString(c.SpotNegotiatedDiscount)
+	if err != nil {
+		log.Warnf("CostModel.ComputeAllocation: applyNodeDiscount: failed to parse spotNegotiatedDiscount: %s", err)
+		spotNegotiatedDiscount = 0
+	}
+
 	// Debug: Log parsed discount values
-	log.Debugf("applyNodeDiscount: Parsed discount=%.4f (%.2f%%), negotiatedDiscount=%.4f (%.2f%%)",
-		discount, discount*100, negotiatedDiscount, negotiatedDiscount*100)
+	log.Debugf("applyNodeDiscount: Parsed discount=%.4f (%.2f%%), negotiatedDiscount=%.4f (%.2f%%), spotDiscount=%.4f (%.2f%%), spotNegotiatedDiscount=%.4f (%.2f%%)",
+		discount, discount*100, negotiatedDiscount, negotiatedDiscount*100, spotDiscount, spotDiscount*100, spotNegotiatedDiscount, spotNegotiatedDiscount*100)
 
 	for _, node := range nodeMap {
+		// Use spot-specific discounts for preemptible/spot nodes
+		var effectiveDiscount, effectiveNegotiatedDiscount float64
+		if node.Preemptible {
+			effectiveDiscount = spotDiscount
+			effectiveNegotiatedDiscount = spotNegotiatedDiscount
+		} else {
+			effectiveDiscount = discount
+			effectiveNegotiatedDiscount = negotiatedDiscount
+		}
+
 		// TODO GKE Reserved Instances into account
-		node.Discount = cm.Provider.CombinedDiscountForNode(node.NodeType, node.Preemptible, discount, negotiatedDiscount)
+		node.Discount = cm.Provider.CombinedDiscountForNode(node.NodeType, node.Preemptible, effectiveDiscount, effectiveNegotiatedDiscount)
 		originalCPUCost := node.CostPerCPUHr
 		originalRAMCost := node.CostPerRAMGiBHr
 		node.CostPerCPUHr *= (1.0 - node.Discount)

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1299,7 +1299,7 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 	// OnDemand discount (applies to non-spot nodes)
 	onDemandDiscount := 1.0
 	if cfg.Discount != "" {
-		discountParsed, err := strconv.ParseFloat(cfg.Discount, 64)
+		discountParsed, err := ParsePercentString(cfg.Discount)
 		if err != nil {
 			log.Warnf("GetNodeCost: Failed to parse discount '%s': %v", cfg.Discount, err)
 		} else {
@@ -1308,7 +1308,7 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 		}
 	}
 	if cfg.NegotiatedDiscount != "" {
-		negDiscountParsed, err := strconv.ParseFloat(cfg.NegotiatedDiscount, 64)
+		negDiscountParsed, err := ParsePercentString(cfg.NegotiatedDiscount)
 		if err != nil {
 			log.Warnf("GetNodeCost: Failed to parse negotiatedDiscount '%s': %v", cfg.NegotiatedDiscount, err)
 		} else {
@@ -1320,7 +1320,7 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 	// Spot discount (applies to spot nodes)
 	spotDiscount := 1.0
 	if cfg.SpotDiscount != "" {
-		spotDiscountParsed, err := strconv.ParseFloat(cfg.SpotDiscount, 64)
+		spotDiscountParsed, err := ParsePercentString(cfg.SpotDiscount)
 		if err != nil {
 			log.Warnf("GetNodeCost: Failed to parse spotDiscount '%s': %v", cfg.SpotDiscount, err)
 		} else {
@@ -1329,7 +1329,7 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 		}
 	}
 	if cfg.SpotNegotiatedDiscount != "" {
-		spotNegDiscountParsed, err := strconv.ParseFloat(cfg.SpotNegotiatedDiscount, 64)
+		spotNegDiscountParsed, err := ParsePercentString(cfg.SpotNegotiatedDiscount)
 		if err != nil {
 			log.Warnf("GetNodeCost: Failed to parse spotNegotiatedDiscount '%s': %v", cfg.SpotNegotiatedDiscount, err)
 		} else {
@@ -1359,7 +1359,9 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 		// Apply discount to VCPUCost
 		if node.VCPUCost != "" {
 			vcpuCost, err := strconv.ParseFloat(node.VCPUCost, 64)
-			if err == nil {
+			if err != nil {
+				log.Warnf("GetNodeCost: node=%s failed to parse VCPUCost '%s': %v", name, node.VCPUCost, err)
+			} else {
 				originalVCPU := vcpuCost
 				vcpuCost = vcpuCost * discount
 				node.VCPUCost = fmt.Sprintf("%f", vcpuCost)
@@ -1369,7 +1371,9 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 		// Apply discount to RAMCost
 		if node.RAMCost != "" {
 			ramCost, err := strconv.ParseFloat(node.RAMCost, 64)
-			if err == nil {
+			if err != nil {
+				log.Warnf("GetNodeCost: node=%s failed to parse RAMCost '%s': %v", name, node.RAMCost, err)
+			} else {
 				originalRAM := ramCost
 				ramCost = ramCost * discount
 				node.RAMCost = fmt.Sprintf("%f", ramCost)
@@ -1379,7 +1383,9 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 		// Apply discount to GPUCost
 		if node.GPUCost != "" {
 			gpuCost, err := strconv.ParseFloat(node.GPUCost, 64)
-			if err == nil {
+			if err != nil {
+				log.Warnf("GetNodeCost: node=%s failed to parse GPUCost '%s': %v", name, node.GPUCost, err)
+			} else {
 				originalGPU := gpuCost
 				gpuCost = gpuCost * discount
 				node.GPUCost = fmt.Sprintf("%f", gpuCost)
@@ -1389,7 +1395,9 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 		// Apply discount to total Cost
 		if node.Cost != "" {
 			totalCost, err := strconv.ParseFloat(node.Cost, 64)
-			if err == nil {
+			if err != nil {
+				log.Warnf("GetNodeCost: node=%s failed to parse Cost '%s': %v", name, node.Cost, err)
+			} else {
 				originalCost := totalCost
 				totalCost = totalCost * discount
 				node.Cost = fmt.Sprintf("%f", totalCost)

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -927,6 +927,10 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 			}
 		}
 
+		// Debug: Log node pricing details including source and usage type
+		log.Debugf("GetNodeCost: node=%s, providerID=%s, Cost=%s, VCPUCost=%s, RAMCost=%s, UsageType=%s, PricingType=%s",
+			name, n.SpecProviderID, cnode.Cost, cnode.VCPUCost, cnode.RAMCost, cnode.UsageType, cnode.PricingType)
+
 		pmd.PricingTypeCounts[cnode.PricingType]++
 
 		// newCnode builds upon cnode but populates/overrides certain fields.
@@ -1289,6 +1293,110 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 	}
 	cm.pricingMetadata = pmd
 	cp.ApplyReservedInstancePricing(nodes)
+
+	// Apply discount to node costs for metrics
+	// This ensures Prometheus metrics reflect the configured discount
+	// OnDemand discount (applies to non-spot nodes)
+	onDemandDiscount := 1.0
+	if cfg.Discount != "" {
+		discountParsed, err := strconv.ParseFloat(cfg.Discount, 64)
+		if err != nil {
+			log.Warnf("GetNodeCost: Failed to parse discount '%s': %v", cfg.Discount, err)
+		} else {
+			onDemandDiscount = onDemandDiscount * (1.0 - discountParsed)
+			log.Debugf("GetNodeCost: Parsed onDemand discount=%f, multiplier=%f", discountParsed, onDemandDiscount)
+		}
+	}
+	if cfg.NegotiatedDiscount != "" {
+		negDiscountParsed, err := strconv.ParseFloat(cfg.NegotiatedDiscount, 64)
+		if err != nil {
+			log.Warnf("GetNodeCost: Failed to parse negotiatedDiscount '%s': %v", cfg.NegotiatedDiscount, err)
+		} else {
+			onDemandDiscount = onDemandDiscount * (1.0 - negDiscountParsed)
+			log.Debugf("GetNodeCost: Parsed negotiatedDiscount=%f, combined onDemand multiplier=%f", negDiscountParsed, onDemandDiscount)
+		}
+	}
+
+	// Spot discount (applies to spot nodes)
+	spotDiscount := 1.0
+	if cfg.SpotDiscount != "" {
+		spotDiscountParsed, err := strconv.ParseFloat(cfg.SpotDiscount, 64)
+		if err != nil {
+			log.Warnf("GetNodeCost: Failed to parse spotDiscount '%s': %v", cfg.SpotDiscount, err)
+		} else {
+			spotDiscount = spotDiscount * (1.0 - spotDiscountParsed)
+			log.Debugf("GetNodeCost: Parsed spotDiscount=%f, multiplier=%f", spotDiscountParsed, spotDiscount)
+		}
+	}
+	if cfg.SpotNegotiatedDiscount != "" {
+		spotNegDiscountParsed, err := strconv.ParseFloat(cfg.SpotNegotiatedDiscount, 64)
+		if err != nil {
+			log.Warnf("GetNodeCost: Failed to parse spotNegotiatedDiscount '%s': %v", cfg.SpotNegotiatedDiscount, err)
+		} else {
+			spotDiscount = spotDiscount * (1.0 - spotNegDiscountParsed)
+			log.Debugf("GetNodeCost: Parsed spotNegotiatedDiscount=%f, combined spot multiplier=%f", spotNegDiscountParsed, spotDiscount)
+		}
+	}
+
+	log.Infof("GetNodeCost: OnDemand discount multiplier=%f, Spot discount multiplier=%f", onDemandDiscount, spotDiscount)
+
+	for name, node := range nodes {
+		// Determine which discount to apply based on whether node is spot
+		discount := onDemandDiscount
+		nodeType := "ondemand"
+		if node.IsSpot() {
+			discount = spotDiscount
+			nodeType = "spot"
+		}
+
+		if discount == 1.0 {
+			log.Debugf("GetNodeCost: node=%s type=%s no discount to apply", name, nodeType)
+			continue
+		}
+
+		log.Debugf("GetNodeCost: node=%s type=%s applying discount multiplier %f", name, nodeType, discount)
+
+		// Apply discount to VCPUCost
+		if node.VCPUCost != "" {
+			vcpuCost, err := strconv.ParseFloat(node.VCPUCost, 64)
+			if err == nil {
+				originalVCPU := vcpuCost
+				vcpuCost = vcpuCost * discount
+				node.VCPUCost = fmt.Sprintf("%f", vcpuCost)
+				log.Debugf("GetNodeCost: node=%s VCPUCost %f -> %f", name, originalVCPU, vcpuCost)
+			}
+		}
+		// Apply discount to RAMCost
+		if node.RAMCost != "" {
+			ramCost, err := strconv.ParseFloat(node.RAMCost, 64)
+			if err == nil {
+				originalRAM := ramCost
+				ramCost = ramCost * discount
+				node.RAMCost = fmt.Sprintf("%f", ramCost)
+				log.Debugf("GetNodeCost: node=%s RAMCost %f -> %f", name, originalRAM, ramCost)
+			}
+		}
+		// Apply discount to GPUCost
+		if node.GPUCost != "" {
+			gpuCost, err := strconv.ParseFloat(node.GPUCost, 64)
+			if err == nil {
+				originalGPU := gpuCost
+				gpuCost = gpuCost * discount
+				node.GPUCost = fmt.Sprintf("%f", gpuCost)
+				log.Debugf("GetNodeCost: node=%s GPUCost %f -> %f", name, originalGPU, gpuCost)
+			}
+		}
+		// Apply discount to total Cost
+		if node.Cost != "" {
+			totalCost, err := strconv.ParseFloat(node.Cost, 64)
+			if err == nil {
+				originalCost := totalCost
+				totalCost = totalCost * discount
+				node.Cost = fmt.Sprintf("%f", totalCost)
+				log.Debugf("GetNodeCost: node=%s Cost %f -> %f", name, originalCost, totalCost)
+			}
+		}
+	}
 
 	return nodes, nil
 }

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/util"
 	"github.com/opencost/opencost/core/pkg/util/promutil"
 	costAnalyzerCloud "github.com/opencost/opencost/pkg/cloud/models"
+	pkgenv "github.com/opencost/opencost/pkg/env"
 	km "github.com/opencost/opencost/pkg/kubemodel"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1296,45 +1297,63 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 
 	// Apply discount to node costs for metrics
 	// This ensures Prometheus metrics reflect the configured discount
+	// Priority: Environment variable > Config file
+
 	// OnDemand discount (applies to non-spot nodes)
 	onDemandDiscount := 1.0
-	if cfg.Discount != "" {
-		discountParsed, err := ParsePercentString(cfg.Discount)
+	discountStr := pkgenv.GetDiscount()
+	if discountStr == "" {
+		discountStr = cfg.Discount
+	}
+	if discountStr != "" {
+		discountParsed, err := ParsePercentString(discountStr)
 		if err != nil {
-			log.Warnf("GetNodeCost: Failed to parse discount '%s': %v", cfg.Discount, err)
+			log.Warnf("GetNodeCost: Failed to parse discount '%s': %v", discountStr, err)
 		} else {
 			onDemandDiscount = onDemandDiscount * (1.0 - discountParsed)
-			log.Debugf("GetNodeCost: Parsed onDemand discount=%f, multiplier=%f", discountParsed, onDemandDiscount)
+			log.Debugf("GetNodeCost: Parsed onDemand discount=%f, multiplier=%f (env=%s, config=%s)", discountParsed, onDemandDiscount, pkgenv.GetDiscount(), cfg.Discount)
 		}
 	}
-	if cfg.NegotiatedDiscount != "" {
-		negDiscountParsed, err := ParsePercentString(cfg.NegotiatedDiscount)
+	negDiscountStr := pkgenv.GetNegotiatedDiscount()
+	if negDiscountStr == "" {
+		negDiscountStr = cfg.NegotiatedDiscount
+	}
+	if negDiscountStr != "" {
+		negDiscountParsed, err := ParsePercentString(negDiscountStr)
 		if err != nil {
-			log.Warnf("GetNodeCost: Failed to parse negotiatedDiscount '%s': %v", cfg.NegotiatedDiscount, err)
+			log.Warnf("GetNodeCost: Failed to parse negotiatedDiscount '%s': %v", negDiscountStr, err)
 		} else {
 			onDemandDiscount = onDemandDiscount * (1.0 - negDiscountParsed)
-			log.Debugf("GetNodeCost: Parsed negotiatedDiscount=%f, combined onDemand multiplier=%f", negDiscountParsed, onDemandDiscount)
+			log.Debugf("GetNodeCost: Parsed negotiatedDiscount=%f, combined onDemand multiplier=%f (env=%s, config=%s)", negDiscountParsed, onDemandDiscount, pkgenv.GetNegotiatedDiscount(), cfg.NegotiatedDiscount)
 		}
 	}
 
 	// Spot discount (applies to spot nodes)
 	spotDiscount := 1.0
-	if cfg.SpotDiscount != "" {
-		spotDiscountParsed, err := ParsePercentString(cfg.SpotDiscount)
+	spotDiscountStr := pkgenv.GetSpotDiscount()
+	if spotDiscountStr == "" {
+		spotDiscountStr = cfg.SpotDiscount
+	}
+	if spotDiscountStr != "" {
+		spotDiscountParsed, err := ParsePercentString(spotDiscountStr)
 		if err != nil {
-			log.Warnf("GetNodeCost: Failed to parse spotDiscount '%s': %v", cfg.SpotDiscount, err)
+			log.Warnf("GetNodeCost: Failed to parse spotDiscount '%s': %v", spotDiscountStr, err)
 		} else {
 			spotDiscount = spotDiscount * (1.0 - spotDiscountParsed)
-			log.Debugf("GetNodeCost: Parsed spotDiscount=%f, multiplier=%f", spotDiscountParsed, spotDiscount)
+			log.Debugf("GetNodeCost: Parsed spotDiscount=%f, multiplier=%f (env=%s, config=%s)", spotDiscountParsed, spotDiscount, pkgenv.GetSpotDiscount(), cfg.SpotDiscount)
 		}
 	}
-	if cfg.SpotNegotiatedDiscount != "" {
-		spotNegDiscountParsed, err := ParsePercentString(cfg.SpotNegotiatedDiscount)
+	spotNegDiscountStr := pkgenv.GetSpotNegotiatedDiscount()
+	if spotNegDiscountStr == "" {
+		spotNegDiscountStr = cfg.SpotNegotiatedDiscount
+	}
+	if spotNegDiscountStr != "" {
+		spotNegDiscountParsed, err := ParsePercentString(spotNegDiscountStr)
 		if err != nil {
-			log.Warnf("GetNodeCost: Failed to parse spotNegotiatedDiscount '%s': %v", cfg.SpotNegotiatedDiscount, err)
+			log.Warnf("GetNodeCost: Failed to parse spotNegotiatedDiscount '%s': %v", spotNegDiscountStr, err)
 		} else {
 			spotDiscount = spotDiscount * (1.0 - spotNegDiscountParsed)
-			log.Debugf("GetNodeCost: Parsed spotNegotiatedDiscount=%f, combined spot multiplier=%f", spotNegDiscountParsed, spotDiscount)
+			log.Debugf("GetNodeCost: Parsed spotNegotiatedDiscount=%f, combined spot multiplier=%f (env=%s, config=%s)", spotNegDiscountParsed, spotDiscount, pkgenv.GetSpotNegotiatedDiscount(), cfg.SpotNegotiatedDiscount)
 		}
 	}
 

--- a/pkg/costmodel/discount_test.go
+++ b/pkg/costmodel/discount_test.go
@@ -1,7 +1,10 @@
 package costmodel
 
 import (
+	"os"
 	"testing"
+
+	pkgenv "github.com/opencost/opencost/pkg/env"
 )
 
 func TestParsePercentString(t *testing.T) {
@@ -214,6 +217,88 @@ func TestCostDiscountApplication(t *testing.T) {
 			diff := result - tt.expectedCost
 			if diff < -0.0001 || diff > 0.0001 {
 				t.Errorf("Cost after discount = %f, want %f", result, tt.expectedCost)
+			}
+		})
+	}
+}
+
+func TestEnvVarPriorityOverConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		envVar         string
+		envValue       string
+		configValue    string
+		getEnvFunc     func() string
+		expectedResult string
+	}{
+		{
+			name:           "DISCOUNT env var overrides config",
+			envVar:         pkgenv.DiscountEnvVar,
+			envValue:       "50",
+			configValue:    "30",
+			getEnvFunc:     pkgenv.GetDiscount,
+			expectedResult: "50",
+		},
+		{
+			name:           "NEGOTIATED_DISCOUNT env var overrides config",
+			envVar:         pkgenv.NegotiatedDiscountEnvVar,
+			envValue:       "20",
+			configValue:    "10",
+			getEnvFunc:     pkgenv.GetNegotiatedDiscount,
+			expectedResult: "20",
+		},
+		{
+			name:           "SPOT_DISCOUNT env var overrides config",
+			envVar:         pkgenv.SpotDiscountEnvVar,
+			envValue:       "15",
+			configValue:    "5",
+			getEnvFunc:     pkgenv.GetSpotDiscount,
+			expectedResult: "15",
+		},
+		{
+			name:           "SPOT_NEGOTIATED_DISCOUNT env var overrides config",
+			envVar:         pkgenv.SpotNegotiatedDiscountEnvVar,
+			envValue:       "25",
+			configValue:    "10",
+			getEnvFunc:     pkgenv.GetSpotNegotiatedDiscount,
+			expectedResult: "25",
+		},
+		{
+			name:           "empty env var falls back to config",
+			envVar:         pkgenv.DiscountEnvVar,
+			envValue:       "",
+			configValue:    "30",
+			getEnvFunc:     pkgenv.GetDiscount,
+			expectedResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set env var
+			if tt.envValue != "" {
+				os.Setenv(tt.envVar, tt.envValue)
+				defer os.Unsetenv(tt.envVar)
+			} else {
+				os.Unsetenv(tt.envVar)
+			}
+
+			envResult := tt.getEnvFunc()
+			if envResult != tt.expectedResult {
+				t.Errorf("GetEnvFunc() = %q, want %q", envResult, tt.expectedResult)
+			}
+
+			// Test the priority logic: env > config
+			finalValue := envResult
+			if finalValue == "" {
+				finalValue = tt.configValue
+			}
+
+			if tt.envValue != "" && finalValue != tt.envValue {
+				t.Errorf("Priority logic: got %q, want env value %q", finalValue, tt.envValue)
+			}
+			if tt.envValue == "" && finalValue != tt.configValue {
+				t.Errorf("Fallback logic: got %q, want config value %q", finalValue, tt.configValue)
 			}
 		})
 	}

--- a/pkg/costmodel/discount_test.go
+++ b/pkg/costmodel/discount_test.go
@@ -1,0 +1,220 @@
+package costmodel
+
+import (
+	"testing"
+)
+
+func TestParsePercentString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected float64
+		wantErr  bool
+	}{
+		{
+			name:     "empty string returns 0",
+			input:    "",
+			expected: 0.0,
+			wantErr:  false,
+		},
+		{
+			name:     "decimal format 0.10 returns 0.001",
+			input:    "0.10",
+			expected: 0.001, // ParsePercentString multiplies by 0.01
+			wantErr:  false,
+		},
+		{
+			name:     "percentage format 10% returns 0.10",
+			input:    "10%",
+			expected: 0.10,
+			wantErr:  false,
+		},
+		{
+			name:     "percentage format 60% returns 0.60",
+			input:    "60%",
+			expected: 0.60,
+			wantErr:  false,
+		},
+		{
+			name:     "whole number 10 returns 0.10",
+			input:    "10",
+			expected: 0.10,
+			wantErr:  false,
+		},
+		{
+			name:     "whole number 60 returns 0.60",
+			input:    "60",
+			expected: 0.60,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid string returns error",
+			input:    "invalid",
+			expected: 0.0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParsePercentString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePercentString(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && result != tt.expected {
+				t.Errorf("ParsePercentString(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDiscountMultiplierCalculation(t *testing.T) {
+	tests := []struct {
+		name               string
+		discount           float64
+		negotiatedDiscount float64
+		expectedMultiplier float64
+	}{
+		{
+			name:               "no discount",
+			discount:           0.0,
+			negotiatedDiscount: 0.0,
+			expectedMultiplier: 1.0,
+		},
+		{
+			name:               "60% discount only",
+			discount:           0.60,
+			negotiatedDiscount: 0.0,
+			expectedMultiplier: 0.40, // 1 - 0.60
+		},
+		{
+			name:               "10% negotiated discount only",
+			discount:           0.0,
+			negotiatedDiscount: 0.10,
+			expectedMultiplier: 0.90, // 1 - 0.10
+		},
+		{
+			name:               "40% discount + 20% negotiated = 48% of original",
+			discount:           0.40,
+			negotiatedDiscount: 0.20,
+			expectedMultiplier: 0.48, // (1-0.4) * (1-0.2) = 0.6 * 0.8 = 0.48
+		},
+		{
+			name:               "50% discount + 50% negotiated = 25% of original",
+			discount:           0.50,
+			negotiatedDiscount: 0.50,
+			expectedMultiplier: 0.25, // (1-0.5) * (1-0.5) = 0.5 * 0.5 = 0.25
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Calculate multiplier the same way as in GetNodeCost
+			multiplier := 1.0
+			multiplier = multiplier * (1.0 - tt.discount)
+			multiplier = multiplier * (1.0 - tt.negotiatedDiscount)
+
+			// Allow small floating point differences
+			diff := multiplier - tt.expectedMultiplier
+			if diff < -0.0001 || diff > 0.0001 {
+				t.Errorf("Multiplier for discount=%f, negotiatedDiscount=%f = %f, want %f",
+					tt.discount, tt.negotiatedDiscount, multiplier, tt.expectedMultiplier)
+			}
+		})
+	}
+}
+
+func TestSpotVsOnDemandDiscountSelection(t *testing.T) {
+	tests := []struct {
+		name                    string
+		isSpot                  bool
+		onDemandDiscount        float64
+		spotDiscount            float64
+		expectedDiscountApplied float64
+	}{
+		{
+			name:                    "on-demand node uses on-demand discount",
+			isSpot:                  false,
+			onDemandDiscount:        0.60,
+			spotDiscount:            0.10,
+			expectedDiscountApplied: 0.60,
+		},
+		{
+			name:                    "spot node uses spot discount",
+			isSpot:                  true,
+			onDemandDiscount:        0.60,
+			spotDiscount:            0.10,
+			expectedDiscountApplied: 0.10,
+		},
+		{
+			name:                    "spot node with no spot discount",
+			isSpot:                  true,
+			onDemandDiscount:        0.60,
+			spotDiscount:            0.0,
+			expectedDiscountApplied: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the logic in GetNodeCost
+			var selectedDiscount float64
+			if tt.isSpot {
+				selectedDiscount = tt.spotDiscount
+			} else {
+				selectedDiscount = tt.onDemandDiscount
+			}
+
+			if selectedDiscount != tt.expectedDiscountApplied {
+				t.Errorf("For isSpot=%v, selected discount = %f, want %f",
+					tt.isSpot, selectedDiscount, tt.expectedDiscountApplied)
+			}
+		})
+	}
+}
+
+func TestCostDiscountApplication(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalCost float64
+		discountMult float64 // The multiplier (e.g., 0.4 for 60% discount)
+		expectedCost float64
+	}{
+		{
+			name:         "no discount",
+			originalCost: 100.0,
+			discountMult: 1.0,
+			expectedCost: 100.0,
+		},
+		{
+			name:         "60% discount",
+			originalCost: 100.0,
+			discountMult: 0.4, // 1 - 0.6
+			expectedCost: 40.0,
+		},
+		{
+			name:         "10% discount",
+			originalCost: 100.0,
+			discountMult: 0.9, // 1 - 0.1
+			expectedCost: 90.0,
+		},
+		{
+			name:         "combined 40% + 20% discount",
+			originalCost: 100.0,
+			discountMult: 0.48, // (1-0.4) * (1-0.2)
+			expectedCost: 48.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.originalCost * tt.discountMult
+
+			diff := result - tt.expectedCost
+			if diff < -0.0001 || diff > 0.0001 {
+				t.Errorf("Cost after discount = %f, want %f", result, tt.expectedCost)
+			}
+		})
+	}
+}

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -543,6 +543,10 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 
 				totalCost := cpu*cpuCost + ramCost*(ram/1024/1024/1024) + gpu*gpuCost
 
+				// Debug: Log when setting node cost metrics
+				log.Debugf("MetricsEmitter: Setting metrics for node=%s, type=%s, region=%s, providerID=%s, isSpot=%t, cpuCost=%.6f, ramCost=%.6f, gpuCost=%.6f, totalCost=%.6f, usageType=%s",
+					nodeName, nodeType, nodeRegion, node.ProviderID, node.IsSpot(), cpuCost, ramCost, gpuCost, totalCost, node.UsageType)
+
 				labelKey := getKeyFromLabelStrings(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID, node.ArchType, nodeUID)
 
 				avgCosts, ok := nodeCostAverages[labelKey]

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -96,7 +96,34 @@ const (
 
 	// Metrics Emitter
 	MetricsEmitterQueryWindowEnvVar = "METRICS_EMITTER_QUERY_WINDOW"
+
+	// Discount configuration
+	DiscountEnvVar               = "DISCOUNT"
+	NegotiatedDiscountEnvVar     = "NEGOTIATED_DISCOUNT"
+	SpotDiscountEnvVar           = "SPOT_DISCOUNT"
+	SpotNegotiatedDiscountEnvVar = "SPOT_NEGOTIATED_DISCOUNT"
 )
+
+// GetDiscount returns the discount from DISCOUNT env variable, or empty string if not set.
+// Value should be a percentage string like "60" for 60%, "0.60", or "60%".
+func GetDiscount() string {
+	return env.Get(DiscountEnvVar, "")
+}
+
+// GetNegotiatedDiscount returns the negotiated discount from NEGOTIATED_DISCOUNT env variable.
+func GetNegotiatedDiscount() string {
+	return env.Get(NegotiatedDiscountEnvVar, "")
+}
+
+// GetSpotDiscount returns the spot discount from SPOT_DISCOUNT env variable.
+func GetSpotDiscount() string {
+	return env.Get(SpotDiscountEnvVar, "")
+}
+
+// GetSpotNegotiatedDiscount returns the spot negotiated discount from SPOT_NEGOTIATED_DISCOUNT env variable.
+func GetSpotNegotiatedDiscount() string {
+	return env.Get(SpotNegotiatedDiscountEnvVar, "")
+}
 
 func GetGCPAuthSecretFilePath() string {
 	return env.GetPathFromConfig(GCPAuthSecretFile)


### PR DESCRIPTION
## Description
Apply configured discounts to Prometheus node cost metrics. Previously discounts only affected allocation calculations, not the exported metrics (node_total_hourly_cost, node_cpu_hourly_cost, etc.). Also adds separate spotDiscount and spotNegotiatedDiscount config options for different discounts on spot vs ondemand nodes.

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact

- Non-breaking: Existing behavior unchanged if no discount configured
- New config options: spotDiscount, spotNegotiatedDiscount in CustomPricing
- Metrics now reflect configured discounts, matching allocation API behavior

## Testing
Verified discount multiplier applied correctly via debug logs

```
2026-01-29T07:21:43.821860748Z DBG GetNodeCost: node=ip-100-xx-xx-xx.ec2.internal type=ondemand applying discount multiplier 0.960000
 2026-01-29T07:21:43.82194443Z DBG GetNodeCost: node=ip-100-xx-xx-xx.ec2.internal type=spot applying discount multiplier 0.980000

```
 
Tested spot vs ondemand node detection 
