### PR TITLE
Move failed RI lookup log to warn

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -936,7 +936,7 @@ func (aws *AWS) DownloadPricingData() error {
 			if errors.Is(err, ErrNoAthenaBucket) {
 				log.Debugf("No \"athenaBucketName\" configured, ReservedInstanceData watcher will not run")
 			} else {
-				log.Errorf("Failed to lookup reserved instance data: %s", err.Error())
+				log.Warnf("Failed to lookup reserved instance data: %s", err.Error())
 			}
 		} else { // If we make one successful run, check on new reservation data every hour
 			go func() {

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -759,9 +759,8 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 
 				gpuType := NormalizeGPULabel(product.Description)
 				if gpuType != "" {
-				    log.Debugf("GCP Billing API: normalized GPU type: %q", gpuType)
+					log.Debugf("GCP Billing API: normalized GPU type: %q", gpuType)
 				}
-
 
 				candidateKeys := []string{}
 				if gcp.ValidPricingKeys == nil {
@@ -1089,7 +1088,7 @@ func (gcp *GCP) DownloadPricingData() error {
 
 	reserved, err := gcp.getReservedInstances()
 	if err != nil {
-		log.Errorf("Failed to lookup reserved instance data: %s", err.Error())
+		log.Warnf("Failed to lookup reserved instance data: %s", err.Error())
 	} else {
 		gcp.ReservedInstances = reserved
 


### PR DESCRIPTION
## Description
Small log cleanup to move RI lookup failure to `warn` instead of `error`.

## Related Issues
N/A

## User Impact
More accurate depiction of RI lookup failure as not an explicit error in some cases (no RIs, no Athena bucket).

## Testing
