### PR TITLE
Add Athena cloud-integration Error Logging

### DIFF
--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -74,7 +74,7 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.Cloud
 
 func (ai *AthenaIntegration) RefreshStatus() cloud.ConnectionStatus {
 	end := time.Now().UTC().Truncate(timeutil.Day)
-	start := end.Add(-2 * timeutil.Day) // lookback 48 hours
+	start := end.Add(-3 * timeutil.Day) // lookback 72 hours
 
 	// getCloudCost already sets ConnectionStatus in the event there is no error, so we don't need to handle the positive
 	// case here

--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -74,7 +74,7 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.Cloud
 
 func (ai *AthenaIntegration) RefreshStatus() cloud.ConnectionStatus {
 	end := time.Now().UTC().Truncate(timeutil.Day)
-	start := end.Add(-1 * timeutil.Day)
+	start := end.Add(-2 * timeutil.Day) // lookback 48 hours
 
 	// getCloudCost already sets ConnectionStatus in the event there is no error, so we don't need to handle the positive
 	// case here

--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -74,12 +74,13 @@ func (ai *AthenaIntegration) GetCloudCost(start, end time.Time) (*opencost.Cloud
 
 func (ai *AthenaIntegration) RefreshStatus() cloud.ConnectionStatus {
 	end := time.Now().UTC().Truncate(timeutil.Day)
-	start := end.Add(-7 * timeutil.Day)
+	start := end.Add(-1 * timeutil.Day)
 
 	// getCloudCost already sets ConnectionStatus in the event there is no error, so we don't need to handle the positive
 	// case here
 	_, err := ai.getCloudCost(start, end, 1)
 	if err != nil {
+		log.Errorf("AthenaIntegration: RefreshStatus: error while refreshing status: %s", err.Error())
 		ai.ConnectionStatus = cloud.FailedConnection
 	}
 


### PR DESCRIPTION
## Description
In  `RefreshStatus()`, the error message returned from `getCloudCost` is never logged. A user sees a failed cloud-integration status, but has no direct indication as to why the status has Failed. 

Additionally, the original query performed an Athena query for 7 days' worth of cost data, limiting the result to 1. A small tweak was added to look back 72 hours (3 days)

## Related Issues
N/A

## User Impact
Improved error logging
Reduced Athena TCO

## Testing
Minor refactor; current unit tests pass