### PR TITLE
Do not backtrack start time - append end only.

### DIFF
--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -2518,8 +2518,7 @@ func calculateStartAndEnd(result []*util.Vector, resolution time.Duration, windo
 	// of the pod by giving "one resolution" worth of duration, half on each
 	// side of the given timestamp.
 	if s.Equal(e) {
-		s = s.Add(-1 * resolution / time.Duration(2))
-		e = e.Add(resolution / time.Duration(2))
+		e = e.Add(resolution)
 	}
 	if s.Before(*window.Start()) {
 		s = *window.Start()


### PR DESCRIPTION
## Description
* We were introducing a start modification whenever start and end times were reported in the metrics. This allowed us to calculate container costs based on a sub-time versus zeroing out the costs for container that lived on that node. 
* This change shifts the time along the end, rather than backing into the previous 1/2 resolution. 
* Start/End are still constrained on the encapsulating window.
