### PR TITLE
Add support for GCP C4 and C4A compute instances

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -734,6 +734,14 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 					instanceType = "n4standard"
 				}
 
+				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "C4 INSTANCE") {
+					instanceType = "c4standard"
+				}
+
+				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "C4A ARM INSTANCE") {
+					instanceType = "c4astandard"
+				}
+
 				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "A2 INSTANCE") {
 					instanceType = "a2"
 				}
@@ -1499,6 +1507,10 @@ func parseGCPInstanceTypeLabel(it string) string {
 			instanceType = "n2standard"
 		} else if instanceType == "n4highmem" || instanceType == "n4highcpu" {
 			instanceType = "n4standard" // N4 variants are priced the same per vCPU and RAM
+		} else if instanceType == "c4highmem" || instanceType == "c4highcpu" {
+			instanceType = "c4standard" // C4 variants are priced the same per vCPU and RAM
+		} else if instanceType == "c4ahighmem" || instanceType == "c4ahighcpu" {
+			instanceType = "c4astandard" // C4A variants are priced the same per vCPU and RAM
 		} else if instanceType == "e2highmem" || instanceType == "e2highcpu" {
 			instanceType = "e2standard"
 		} else if instanceType == "n2dhighmem" || instanceType == "n2dhighcpu" {
@@ -1640,7 +1652,7 @@ func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible b
 	}
 	discount := defaultDiscount
 	switch class {
-	case "e2", "f1", "g1", "n4":
+	case "e2", "f1", "g1", "n4", "c4", "c4a":
 		discount = 0.0
 	case "n2", "n2d":
 		discount = 0.2

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -56,6 +56,30 @@ func TestParseGCPInstanceTypeLabel(t *testing.T) {
 			input:    "n4-highmem-16",
 			expected: "n4standard",
 		},
+		{
+			input:    "c4-standard-8",
+			expected: "c4standard",
+		},
+		{
+			input:    "c4-highcpu-16",
+			expected: "c4standard",
+		},
+		{
+			input:    "c4-highmem-32",
+			expected: "c4standard",
+		},
+		{
+			input:    "c4a-standard-16",
+			expected: "c4astandard",
+		},
+		{
+			input:    "c4a-highcpu-8",
+			expected: "c4astandard",
+		},
+		{
+			input:    "c4a-highmem-32",
+			expected: "c4astandard",
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
## I'm creating this so I get an image I can run in our dev cluster to validate. **don't merge**

## Description

Added support for GCP C4 (Intel) and C4A (ARM/Axion) compute instances in the pricing API.

- C4 instance type detection in `parsePage` (matches `C4 INSTANCE` in GCP Billing API product descriptions)
- C4A instance type detection (matches `C4A ARM INSTANCE`)
- C4/C4A instance type label parsing — all variants map to `c4standard`/`c4astandard`
- C4/C4A added to 0% sustained use discount (same as N4, E2)

## Related Issues

Relates to #3109

## User Impact

No breaking changes. Resolves missing pricing data for C4/C4A nodes (e.g. `"no pricing data found for europe-west1,c4astandard,ondemand"`).

## Testing

- Unit tests added for `parseGCPInstanceTypeLabel` covering `c4-standard-8`, `c4-highcpu-16`, `c4-highmem-32`, `c4a-standard-16`, `c4a-highcpu-8`, `c4a-highmem-32`.
- Verified SKU description strings against live GCP Billing API via `gcloud`.
- All existing tests pass.