### PR TITLE
don't use provider config, thereby reading from cloud-integration.json

### DIFF
--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/opencost/opencost/core/pkg/util/apiutil"
-	"github.com/opencost/opencost/pkg/cloud/models"
-	"github.com/opencost/opencost/pkg/cloud/provider"
 	"github.com/opencost/opencost/pkg/cloudcost"
 	"github.com/opencost/opencost/pkg/customcost"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -44,7 +42,7 @@ func Execute(conf *Config) error {
 
 	router := httprouter.New()
 	var a *costmodel.Accesses
-	var cp models.Provider
+
 	if conf.KubernetesEnabled {
 		a = costmodel.Initialize(router)
 		err := StartExportWorker(context.Background(), a.Model)
@@ -60,17 +58,12 @@ func Execute(conf *Config) error {
 			router.GET("/assets/carbon", a.ComputeAssetsCarbonHandler)
 		}
 
-		// set cloud provider for cloud cost
-		cp = a.CloudProvider
 	}
 
 	var cloudCostPipelineService *cloudcost.PipelineService
 	if conf.CloudCostEnabled {
-		var providerConfig models.ProviderConfig
-		if cp != nil {
-			providerConfig = provider.ExtractConfigFromProviders(cp)
-		}
-		cloudCostPipelineService = costmodel.InitializeCloudCost(router, providerConfig)
+
+		cloudCostPipelineService = costmodel.InitializeCloudCost(router)
 	}
 
 	var customCostPipelineService *customcost.PipelineService

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -607,9 +607,9 @@ func GetDefaultCollectorStorage() storage.Storage {
 }
 
 // InitializeCloudCost Initializes Cloud Cost pipeline and querier and registers endpoints
-func InitializeCloudCost(router *httprouter.Router, providerConfig models.ProviderConfig) *cloudcost.PipelineService {
+func InitializeCloudCost(router *httprouter.Router) *cloudcost.PipelineService {
 	log.Debugf("Cloud Cost config path: %s", env.GetCloudCostConfigPath())
-	cloudConfigController := cloudconfig.NewMemoryController(providerConfig)
+	cloudConfigController := cloudconfig.NewMemoryController(nil)
 
 	repo := cloudcost.NewMemoryRepository()
 	cloudCostPipelineService := cloudcost.NewPipelineService(repo, cloudConfigController, cloudcost.DefaultIngestorConfiguration())


### PR DESCRIPTION
## Release Notes
This update moves all cloud provider integration configuration to the new cloud-integrations.json system. Anyone using the old cloud provider credentials mechanism will need to upgrade to the new multi cloud configuration mechanism. 

## Description
fixes an issue where we were not reading from cloud-integration.json for cloud costs 

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
