### PR TITLE
Add configuration toggle to disable AWS spot data feed

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -855,8 +855,13 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 
 // SpotRefreshEnabled determines whether the required configs to run the spot feed query have been set up
 func (aws *AWS) SpotRefreshEnabled() bool {
-	// Fallback if AWS or config is not initialized
-	if aws == nil || aws.Config == nil {
+	// Guard against nil receiver
+	if aws == nil {
+		return false
+	}
+
+	// Fallback if config is not initialized
+	if aws.Config == nil {
 		return len(aws.SpotDataBucket) != 0 ||
 			len(aws.SpotDataRegion) != 0 ||
 			len(aws.ProjectID) != 0

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -856,9 +856,12 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 // SpotRefreshEnabled determines whether the required configs to run the spot feed query have been set up
 func (aws *AWS) SpotRefreshEnabled() bool {
 	// Check if spot data feed is explicitly disabled via config
-	c, err := aws.Config.GetCustomPricingData()
-	if err == nil && c.SpotDataFeedEnabled == "false" {
-		return false
+	// Guard against nil Config to prevent panic
+	if aws.Config != nil {
+		c, err := aws.Config.GetCustomPricingData()
+		if err == nil && c.SpotDataFeedEnabled == "false" {
+			return false
+		}
 	}
 	// Need a valid value for at least one of these fields to consider spot pricing as enabled
 	return len(aws.SpotDataBucket) != 0 || len(aws.SpotDataRegion) != 0 || len(aws.ProjectID) != 0

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -855,16 +855,23 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 
 // SpotRefreshEnabled determines whether the required configs to run the spot feed query have been set up
 func (aws *AWS) SpotRefreshEnabled() bool {
-	// Check if spot data feed is explicitly disabled via config
-	// Guard against nil Config to prevent panic
-	if aws.Config != nil {
-		c, err := aws.Config.GetCustomPricingData()
-		if err == nil && c.SpotDataFeedEnabled == "false" {
-			return false
-		}
+	// Fallback if AWS or config is not initialized
+	if aws == nil || aws.Config == nil {
+		return len(aws.SpotDataBucket) != 0 ||
+			len(aws.SpotDataRegion) != 0 ||
+			len(aws.ProjectID) != 0
 	}
-	// Need a valid value for at least one of these fields to consider spot pricing as enabled
-	return len(aws.SpotDataBucket) != 0 || len(aws.SpotDataRegion) != 0 || len(aws.ProjectID) != 0
+
+	// Check if spot data feed is explicitly disabled via config
+	c, err := aws.Config.GetCustomPricingData()
+	if err == nil && c.SpotDataFeedEnabled == "false" {
+		return false
+	}
+
+	// Default behavior
+	return len(aws.SpotDataBucket) != 0 ||
+		len(aws.SpotDataRegion) != 0 ||
+		len(aws.ProjectID) != 0
 }
 
 // DownloadPricingData fetches data from the AWS Pricing API

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -855,6 +855,11 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 
 // SpotRefreshEnabled determines whether the required configs to run the spot feed query have been set up
 func (aws *AWS) SpotRefreshEnabled() bool {
+	// Check if spot data feed is explicitly disabled via config
+	c, err := aws.Config.GetCustomPricingData()
+	if err == nil && c.SpotDataFeedEnabled == "false" {
+		return false
+	}
 	// Need a valid value for at least one of these fields to consider spot pricing as enabled
 	return len(aws.SpotDataBucket) != 0 || len(aws.SpotDataRegion) != 0 || len(aws.ProjectID) != 0
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/pkg/cloud/models"
+	"github.com/opencost/opencost/pkg/config"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -837,6 +838,126 @@ func TestAWS_getFargatePod(t *testing.T) {
 				if gotPod.Name != tt.wantPod.Name || gotPod.Spec.NodeName != tt.wantPod.Spec.NodeName {
 					t.Errorf("AWS.getFargatePod() gotPod = %v, want %v", gotPod, tt.wantPod)
 				}
+			}
+		})
+	}
+}
+
+// fakeProviderConfig implements models.ProviderConfig for testing
+type fakeProviderConfig struct {
+	customPricing *models.CustomPricing
+}
+
+func (f *fakeProviderConfig) GetCustomPricingData() (*models.CustomPricing, error) {
+	if f.customPricing != nil {
+		return f.customPricing, nil
+	}
+	return &models.CustomPricing{}, nil
+}
+
+func (f *fakeProviderConfig) Update(func(*models.CustomPricing) error) (*models.CustomPricing, error) {
+	return f.customPricing, nil
+}
+
+func (f *fakeProviderConfig) UpdateFromMap(map[string]string) (*models.CustomPricing, error) {
+	return f.customPricing, nil
+}
+
+func (f *fakeProviderConfig) ConfigFileManager() *config.ConfigFileManager {
+	return nil
+}
+
+func TestAWS_SpotRefreshEnabled(t *testing.T) {
+	tests := []struct {
+		name                string
+		spotDataBucket      string
+		spotDataRegion      string
+		projectID           string
+		spotDataFeedEnabled string
+		want                bool
+	}{
+		{
+			name:                "disabled via config - with bucket",
+			spotDataBucket:      "my-bucket",
+			spotDataRegion:      "us-east-1",
+			projectID:           "123456789",
+			spotDataFeedEnabled: "false",
+			want:                false,
+		},
+		{
+			name:                "disabled via config - with projectID only",
+			projectID:           "123456789",
+			spotDataFeedEnabled: "false",
+			want:                false,
+		},
+		{
+			name:                "enabled by default - with bucket",
+			spotDataBucket:      "my-bucket",
+			spotDataRegion:      "us-east-1",
+			projectID:           "123456789",
+			spotDataFeedEnabled: "",
+			want:                true,
+		},
+		{
+			name:                "enabled explicitly - with bucket",
+			spotDataBucket:      "my-bucket",
+			spotDataRegion:      "us-east-1",
+			projectID:           "123456789",
+			spotDataFeedEnabled: "true",
+			want:                true,
+		},
+		{
+			name:                "no spot config - disabled",
+			spotDataBucket:      "",
+			spotDataRegion:      "",
+			projectID:           "",
+			spotDataFeedEnabled: "",
+			want:                false,
+		},
+		{
+			name:                "no spot config - but explicitly enabled",
+			spotDataBucket:      "",
+			spotDataRegion:      "",
+			projectID:           "",
+			spotDataFeedEnabled: "true",
+			want:                false,
+		},
+		{
+			name:                "only projectID set - enabled by default",
+			projectID:           "123456789",
+			spotDataFeedEnabled: "",
+			want:                true,
+		},
+		{
+			name:                "only bucket set - enabled by default",
+			spotDataBucket:      "my-bucket",
+			spotDataFeedEnabled: "",
+			want:                true,
+		},
+		{
+			name:                "only region set - enabled by default",
+			spotDataRegion:      "us-east-1",
+			spotDataFeedEnabled: "",
+			want:                true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aws := &AWS{
+				SpotDataBucket: tt.spotDataBucket,
+				SpotDataRegion: tt.spotDataRegion,
+				ProjectID:      tt.projectID,
+				Config: &fakeProviderConfig{
+					customPricing: &models.CustomPricing{
+						SpotDataFeedEnabled: tt.spotDataFeedEnabled,
+					},
+				},
+			}
+
+			got := aws.SpotRefreshEnabled()
+			if got != tt.want {
+				t.Errorf("AWS.SpotRefreshEnabled() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -961,4 +961,35 @@ func TestAWS_SpotRefreshEnabled(t *testing.T) {
 			}
 		})
 	}
+
+	// Test nil Config scenario to ensure no panic
+	t.Run("nil config - falls back to field check", func(t *testing.T) {
+		aws := &AWS{
+			SpotDataBucket: "my-bucket",
+			SpotDataRegion: "us-east-1",
+			ProjectID:      "123456789",
+			Config:         nil, // nil Config should not cause panic
+		}
+
+		got := aws.SpotRefreshEnabled()
+		want := true // Should fall back to field-based check
+		if got != want {
+			t.Errorf("AWS.SpotRefreshEnabled() with nil Config = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("nil config - no spot fields", func(t *testing.T) {
+		aws := &AWS{
+			SpotDataBucket: "",
+			SpotDataRegion: "",
+			ProjectID:      "",
+			Config:         nil, // nil Config should not cause panic
+		}
+
+		got := aws.SpotRefreshEnabled()
+		want := false // No fields set, should return false
+		if got != want {
+			t.Errorf("AWS.SpotRefreshEnabled() with nil Config and no fields = %v, want %v", got, want)
+		}
+	})
 }

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -154,6 +154,7 @@ type CustomPricing struct {
 	AwsSpotDataRegion            string `json:"awsSpotDataRegion,omitempty"`
 	AwsSpotDataBucket            string `json:"awsSpotDataBucket,omitempty"`
 	AwsSpotDataPrefix            string `json:"awsSpotDataPrefix,omitempty"`
+	SpotDataFeedEnabled          string `json:"spotDataFeedEnabled,omitempty"`
 	ProjectID                    string `json:"projectID,omitempty"`
 	AthenaProjectID              string `json:"athenaProjectID,omitempty"`
 	AthenaBucketName             string `json:"athenaBucketName"`


### PR DESCRIPTION
Add configuration toggle to disable AWS spot data feed

Fixes #3050

## Summary
This PR adds a `spotDataFeedEnabled` configuration option to allow disabling AWS spot pricing data fetching when spot instances are not in use.

Currently, OpenCost attempts to fetch spot pricing data from S3 at regular intervals whenever spot-related configuration (`SpotDataBucket`, `SpotDataRegion`, or `ProjectID`) is present. This happens even in clusters that do not use spot instances, leading to unnecessary API calls and permission-related errors.

## Changes
- Added `SpotDataFeedEnabled` field to the `CustomPricing` model
- Updated `SpotRefreshEnabled()` to respect the new toggle
- Added tests to cover different scenarios and ensure correct behavior

## Behavior
- **Default**: Existing behavior is preserved — spot data fetching continues when spot configuration is present
- **Disabled**: Setting `spotDataFeedEnabled: "false"` disables spot data fetching entirely

## Testing
- All existing tests pass
- Added test cases to validate the new toggle behavior

## Notes
Helm chart support for this configuration can be added in a follow-up PR if needed.