### PR TITLE
Remove Misleading Provider Log

### DIFF
--- a/pkg/cloud/provider/providerconfig.go
+++ b/pkg/cloud/provider/providerconfig.go
@@ -88,7 +88,6 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*models.CustomPrici
 
 	// File Doesn't Exist
 	if !exists {
-		log.Infof("Could not find Custom Pricing file at path '%s'", pc.configFile.Path())
 		pc.customPricing = DefaultPricing()
 		// If config file is not present use the contents from mount models/ as pricing data
 		// in closed source rather than from from  DefaultPricing as first source of truth.


### PR DESCRIPTION
## Description
Removes a misleading `Could not find Custom Pricing file at path '...'` log that would appear when using custom pricing. This log would appear even when custom pricing was working properly.

## Related Issues
N/A.

## User Impact
Users will no longer see this misleading log that lead them to think that their custom pricing wasn't working properly.

## Testing
N/A.
