### PR TITLE
fix: Azure provider status code check in getRetailPrice()

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -307,7 +307,7 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 		return "", fmt.Errorf("failed to fetch retail price with URL \"%s\": %v", pricingURL, err)
 	}
 
-	if resp.StatusCode < 200 && resp.StatusCode > 299 {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return "", fmt.Errorf("retail price responded with error status code %d", resp.StatusCode)
 	}
 

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -306,6 +306,7 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch retail price with URL \"%s\": %v", pricingURL, err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return "", fmt.Errorf("retail price responded with error status code %d", resp.StatusCode)


### PR DESCRIPTION
## Description
The condition at line 310 in `pkg/cloud/azure/provider.go` uses 
`&&` instead of `||`:

`if resp.StatusCode < 200 && resp.StatusCode > 299 {`

No integer can be simultaneously less than 200 AND greater than 
299, so this condition is always false. Non-2xx responses from 
the Azure retail pricing API are silently treated as successful.

## Fix
Changed `&&` to `||` so non-2xx responses are correctly caught.

## Testing
The fix is a one character logical operator change with no 
side effects.

Fixes #3701