### PR TITLE
Suppress spot feed warnings when spot data feed not configured

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1403,7 +1403,9 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 			UsageType:    PreemptibleType,
 		}, meta, nil
 	} else if aws.isPreemptible(key) { // Preemptible but we don't have any data in the pricing report.
-		log.DedupedWarningf(5, "Node %s marked preemptible but we have no data in spot feed", k.ID())
+		if aws.SpotRefreshEnabled() {
+			log.DedupedWarningf(5, "Node %s marked preemptible but we have no data in spot feed", k.ID())
+		}
 		if publicPricingFound {
 			// return public price if found
 			return &models.Node{
@@ -1419,7 +1421,9 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 			}, meta, nil
 		} else {
 			// return defaults if public pricing not found
-			log.DedupedWarningf(5, "Could not find Node %s's public pricing info, using default configured spot prices instead", k.ID())
+			if aws.SpotRefreshEnabled() {
+				log.DedupedWarningf(5, "Could not find Node %s's public pricing info, using default configured spot prices instead", k.ID())
+			}
 			return &models.Node{
 				VCPU:         terms.VCpu,
 				VCPUCost:     aws.BaseSpotCPUPrice,


### PR DESCRIPTION
## Description
Suppresses AWS spot feed warning logs on default installations where spot data feed is not configured.

**Problem:** Default installations log warnings for every preemptible node:
```
WRN Node i-05d3ee5813b30da02 marked preemptible but we have no data in spot feed
```

**Solution:** Only log warnings when `SpotRefreshEnabled()` returns true.

## Related Issues
N/A

## User Impact
- Default installations: No spot feed warnings
- Configured spot feed: Warnings still appear when expected

## Testing
- All existing tests pass (11 test cases)