### PR TITLE
Sth/kcm 5437

### DIFF
--- a/core/pkg/model/kubemodel/kubemodel_test.go
+++ b/core/pkg/model/kubemodel/kubemodel_test.go
@@ -166,50 +166,35 @@ func TestKubeModel(t *testing.T) {
 
 			kms := NewKubeModelSet(start, end)
 
-			err = kms.RegisterResourceQuota("", "test", "")
+			err = kms.RegisterResourceQuota(&ResourceQuota{UID: "", Name: "test"})
 			require.NotNil(t, err)
 			require.Len(t, kms.GetErrors(), 1)
-			require.Equal(t, "UID is nil for ResourceQuota 'test'", kms.GetErrors()[0].Message)
+			require.Equal(t, "UID is missing for ResourceQuota with name 'test'", kms.GetErrors()[0].Message)
 			require.Len(t, kms.ResourceQuotas, 0)
 		})
 
-		t.Run("register resource quota on KMS w/o namespace", func(t *testing.T) {
+		t.Run("register resource quota with empty NamespaceUID", func(t *testing.T) {
 			var err error
 
 			kms := NewKubeModelSet(start, end)
 
-			testUID := "uid"
-			testName := "name"
-
-			err = kms.RegisterResourceQuota(testUID, testName, "unregistered-namespace")
-			require.Nil(t, err)
-			require.Len(t, kms.GetWarnings(), 1)
-			require.Equal(t, "RegisterResourceQuota(uid, name, unregistered-namespace): missing namespace", kms.GetWarnings()[0].Message)
-
-			testRQ := &ResourceQuota{
-				UID:          "uid",
-				NamespaceUID: "",
-				Name:         "name",
-				Spec:         &ResourceQuotaSpec{Hard: &ResourceQuotaSpecHard{}},
-				Status:       &ResourceQuotaStatus{Used: &ResourceQuotaStatusUsed{}},
-			}
-
-			require.NotNil(t, kms.ResourceQuotas[testUID])
-			require.Equal(t, testRQ, kms.ResourceQuotas[testUID])
-			require.Equal(t, 1, kms.Metadata.ObjectCount)
+			err = kms.RegisterResourceQuota(&ResourceQuota{UID: "uid", Name: "name", NamespaceUID: ""})
+			require.NotNil(t, err)
+			require.Len(t, kms.GetErrors(), 1)
+			require.Equal(t, "Namespace is missing for ResourceQuota 'uid'", kms.GetErrors()[0].Message)
+			require.Len(t, kms.ResourceQuotas, 0)
 		})
 
 		t.Run("register resource quota on KMS w/ namespace", func(t *testing.T) {
 			kms := NewKubeModelSet(start, end)
-			kms.RegisterCluster("cluster-uid")
-			kms.RegisterNamespace("namespace-uid", "namespace")
+			kms.RegisterCluster(&Cluster{UID: "cluster-uid"})
+			kms.RegisterNamespace(&Namespace{UID: "namespace-uid", Name: "namespace"})
 			// At this point we have a KMS with a cluster and namespace registered
 
 			testUID := "uid"
 			testName := "name"
-			testNamespace := "namespace" // Register RQ in namespace that was already registered
 
-			kms.RegisterResourceQuota(testUID, testName, testNamespace)
+			kms.RegisterResourceQuota(&ResourceQuota{UID: testUID, Name: testName, NamespaceUID: "namespace-uid"})
 
 			testRQ := &ResourceQuota{
 				UID:          "uid",
@@ -225,7 +210,7 @@ func TestKubeModel(t *testing.T) {
 			require.Equal(t, 2, kms.Metadata.ObjectCount) // 1 namespace and 1 RQ
 
 			// Register same RQ again, expect no-op on second try
-			kms.RegisterResourceQuota(testUID, testName, testNamespace)
+			kms.RegisterResourceQuota(&ResourceQuota{UID: testUID, Name: testName, NamespaceUID: "namespace-uid"})
 			require.Len(t, kms.GetErrors(), 0)
 			require.NotNil(t, kms.ResourceQuotas[testUID])
 			require.Equal(t, testRQ, kms.ResourceQuotas[testUID])
@@ -234,12 +219,12 @@ func TestKubeModel(t *testing.T) {
 
 		t.Run("register multiple RQs in multiple namespaces", func(t *testing.T) {
 			kms := NewKubeModelSet(start, end)
-			kms.RegisterCluster("cluster-uid")
-			kms.RegisterNamespace("namespace-1-uid", "namespace-1")
-			kms.RegisterNamespace("namespace-2-uid", "namespace-2")
+			kms.RegisterCluster(&Cluster{UID: "cluster-uid"})
+			kms.RegisterNamespace(&Namespace{UID: "namespace-1-uid", Name: "namespace-1"})
+			kms.RegisterNamespace(&Namespace{UID: "namespace-2-uid", Name: "namespace-2"})
 
-			kms.RegisterResourceQuota("uid-1", "name-1", "namespace-1")
-			kms.RegisterResourceQuota("uid-2", "name-2", "namespace-2")
+			kms.RegisterResourceQuota(&ResourceQuota{UID: "uid-1", Name: "name-1", NamespaceUID: "namespace-1-uid"})
+			kms.RegisterResourceQuota(&ResourceQuota{UID: "uid-2", Name: "name-2", NamespaceUID: "namespace-2-uid"})
 
 			require.Len(t, kms.GetErrors(), 0)
 			require.NotNil(t, kms.ResourceQuotas)
@@ -264,24 +249,13 @@ func TestKubeModel(t *testing.T) {
 			require.Equal(t, testRQ2, kms.ResourceQuotas["uid-2"])
 			require.Equal(t, 4, kms.Metadata.ObjectCount) // 2 namespaces and 2 RQs
 
-			// Register a third RQ with an invalid namespace
-			kms.RegisterResourceQuota("uid-3", "name-3", "namespace-3")
-
-			require.Len(t, kms.GetWarnings(), 1)
-			require.Equal(t, "RegisterResourceQuota(uid-3, name-3, namespace-3): missing namespace", kms.GetWarnings()[0].Message)
-
-			testRQ3 := &ResourceQuota{
-				UID:          "uid-3",
-				NamespaceUID: "",
-				Name:         "name-3",
-				Spec:         &ResourceQuotaSpec{Hard: &ResourceQuotaSpecHard{}},
-				Status:       &ResourceQuotaStatus{Used: &ResourceQuotaStatusUsed{}},
-			}
-
-			require.Len(t, kms.ResourceQuotas, 3)
-			require.NotNil(t, kms.ResourceQuotas["uid-3"])
-			require.Equal(t, testRQ3, kms.ResourceQuotas["uid-3"])
-			require.Equal(t, 5, kms.Metadata.ObjectCount) // 2 namespaces and 3 RQs
+			// Register a third RQ with empty NamespaceUID — expect error, not registered
+			err := kms.RegisterResourceQuota(&ResourceQuota{UID: "uid-3", Name: "name-3", NamespaceUID: ""})
+			require.NotNil(t, err)
+			require.Len(t, kms.GetErrors(), 1)
+			require.Equal(t, "Namespace is missing for ResourceQuota 'uid-3'", kms.GetErrors()[0].Message)
+			require.Len(t, kms.ResourceQuotas, 2)          // still 2
+			require.Equal(t, 4, kms.Metadata.ObjectCount)  // unchanged
 		})
 	})
 }

--- a/core/pkg/model/kubemodel/node.go
+++ b/core/pkg/model/kubemodel/node.go
@@ -52,6 +52,7 @@ func (kms *KubeModelSet) RegisterNode(node *Node) error {
 		kms.Window.End.Before(node.End) {
 		err := fmt.Errorf(
 			"Node '%s' has a start or end time (%s-%s) outside of the window %s-%s",
+			node.UID,
 			node.Start.Format(time.RFC3339),
 			node.End.Format(time.RFC3339),
 			kms.Window.Start.Format(time.RFC3339),

--- a/core/pkg/model/kubemodel/pod.go
+++ b/core/pkg/model/kubemodel/pod.go
@@ -46,6 +46,7 @@ func (kms *KubeModelSet) RegisterPod(pod *Pod) error {
 		kms.Window.End.Before(pod.End) {
 		err := fmt.Errorf(
 			"Pod '%s' has a start or end time (%s-%s) outside of the window %s-%s",
+			pod.UID,
 			pod.Start.Format(time.RFC3339),
 			pod.End.Format(time.RFC3339),
 			kms.Window.Start.Format(time.RFC3339),

--- a/core/pkg/model/pricingmodel/node.go
+++ b/core/pkg/model/pricingmodel/node.go
@@ -10,7 +10,7 @@ const (
 	NodePricingTypeTotal   NodePricingType = "Total"
 	NodePricingTypeCPUCore NodePricingType = "CPUCore"
 	NodePricingTypeRamGB   NodePricingType = "RamGB"
-	NodePricingTypeGPU     NodePricingType = "GPU"
+	NodePricingTypeDevice  NodePricingType = "Device"
 )
 
 // @bingen:generate:NodeKey

--- a/core/pkg/model/pricingmodel/node.go
+++ b/core/pkg/model/pricingmodel/node.go
@@ -4,6 +4,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/model/shared"
 )
 
+// @bingen:generate:NodePricingType
 type NodePricingType string
 
 const (
@@ -15,13 +16,13 @@ const (
 
 // @bingen:generate:NodeKey
 type NodeKey struct {
-	Provider    shared.Provider
-	Region      string
-	NodeType    string
-	UsageType   shared.UsageType
-	Family      string
-	Accelerator string
-	Type        NodePricingType
+	Provider   shared.Provider
+	Region     string
+	NodeType   string
+	UsageType  shared.UsageType
+	Family     string
+	DeviceType string
+	Type       NodePricingType
 }
 
 // @bingen:generate:NodePricing

--- a/core/pkg/model/pricingmodel/node.go
+++ b/core/pkg/model/pricingmodel/node.go
@@ -16,13 +16,13 @@ const (
 
 // @bingen:generate:NodeKey
 type NodeKey struct {
-	Provider   shared.Provider
-	Region     string
-	NodeType   string
-	UsageType  shared.UsageType
-	Family     string
-	DeviceType string
-	Type       NodePricingType
+	Provider    shared.Provider
+	PricingType NodePricingType
+	UsageType   shared.UsageType
+	Region      string
+	NodeType    string
+	Family      string
+	DeviceType  string
 }
 
 // @bingen:generate:NodePricing

--- a/core/pkg/model/pricingmodel/node.go
+++ b/core/pkg/model/pricingmodel/node.go
@@ -4,15 +4,27 @@ import (
 	"github.com/opencost/opencost/core/pkg/model/shared"
 )
 
+type NodePricingType string
+
+const (
+	NodePricingTypeTotal   NodePricingType = "Total"
+	NodePricingTypeCPUCore NodePricingType = "CPUCore"
+	NodePricingTypeRamGB   NodePricingType = "RamGB"
+	NodePricingTypeGPU     NodePricingType = "GPU"
+)
+
 // @bingen:generate:NodeKey
 type NodeKey struct {
-	Provider  shared.Provider
-	Region    string
-	NodeType  string
-	UsageType shared.UsageType
+	Provider    shared.Provider
+	Region      string
+	NodeType    string
+	UsageType   shared.UsageType
+	Family      string
+	Accelerator string
+	Type        NodePricingType
 }
 
 // @bingen:generate:NodePricing
 type NodePricing struct {
-	TotalHourlyRate float64
+	HourlyRate float64
 }

--- a/core/pkg/model/pricingmodel/node_test.go
+++ b/core/pkg/model/pricingmodel/node_test.go
@@ -20,7 +20,7 @@ func TestNodeKeyRoundtrip(t *testing.T) {
 				UsageType:  shared.UsageTypeOnDemand,
 				Family:     "n2",
 				DeviceType: "nvidia-tesla-t4",
-				Type:       NodePricingTypeDevice,
+				PricingType:       NodePricingTypeDevice,
 			},
 		},
 		{
@@ -31,7 +31,7 @@ func TestNodeKeyRoundtrip(t *testing.T) {
 				NodeType:  "m5.xlarge",
 				UsageType: shared.UsageTypeOnDemand,
 				Family:    "m5",
-				Type:      NodePricingTypeCPUCore,
+				PricingType:      NodePricingTypeCPUCore,
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestNodeKeyRoundtrip(t *testing.T) {
 				Region:    "eastus",
 				NodeType:  "Standard_D4s_v3",
 				UsageType: shared.UsageTypeSpot,
-				Type:      NodePricingTypeTotal,
+				PricingType:      NodePricingTypeTotal,
 			},
 		},
 		{
@@ -51,7 +51,7 @@ func TestNodeKeyRoundtrip(t *testing.T) {
 				Region:    "europe-west1",
 				Family:    "n1",
 				UsageType: shared.UsageTypeOnDemand,
-				Type:      NodePricingTypeRamGB,
+				PricingType:      NodePricingTypeRamGB,
 			},
 		},
 		{

--- a/core/pkg/model/pricingmodel/node_test.go
+++ b/core/pkg/model/pricingmodel/node_test.go
@@ -1,0 +1,101 @@
+package pricingmodel
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/model/shared"
+)
+
+func TestNodeKeyRoundtrip(t *testing.T) {
+	cases := []struct {
+		name string
+		key  NodeKey
+	}{
+		{
+			name: "full GPU key",
+			key: NodeKey{
+				Provider:   shared.ProviderGCP,
+				Region:     "us-central1",
+				NodeType:   "n2-standard-4",
+				UsageType:  shared.UsageTypeOnDemand,
+				Family:     "n2",
+				DeviceType: "nvidia-tesla-t4",
+				Type:       NodePricingTypeDevice,
+			},
+		},
+		{
+			name: "on-demand CPU key",
+			key: NodeKey{
+				Provider:  shared.ProviderAWS,
+				Region:    "us-east-1",
+				NodeType:  "m5.xlarge",
+				UsageType: shared.UsageTypeOnDemand,
+				Family:    "m5",
+				Type:      NodePricingTypeCPUCore,
+			},
+		},
+		{
+			name: "spot total key",
+			key: NodeKey{
+				Provider:  shared.ProviderAzure,
+				Region:    "eastus",
+				NodeType:  "Standard_D4s_v3",
+				UsageType: shared.UsageTypeSpot,
+				Type:      NodePricingTypeTotal,
+			},
+		},
+		{
+			name: "RAM key",
+			key: NodeKey{
+				Provider:  shared.ProviderGCP,
+				Region:    "europe-west1",
+				Family:    "n1",
+				UsageType: shared.UsageTypeOnDemand,
+				Type:      NodePricingTypeRamGB,
+			},
+		},
+		{
+			name: "empty key",
+			key:  NodeKey{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.key.MarshalBinary()
+			if err != nil {
+				t.Fatalf("MarshalBinary() error: %v", err)
+			}
+
+			var got NodeKey
+			if err := got.UnmarshalBinary(data); err != nil {
+				t.Fatalf("UnmarshalBinary() error: %v", err)
+			}
+
+			if got != tc.key {
+				t.Errorf("roundtrip mismatch:\n  got  %+v\n  want %+v", got, tc.key)
+			}
+		})
+	}
+}
+
+func TestNodePricingRoundtrip(t *testing.T) {
+	cases := []float64{0, 0.048, 0.192, 1.5, 2.0, 99.99}
+
+	for _, rate := range cases {
+		np := NodePricing{HourlyRate: rate}
+		data, err := np.MarshalBinary()
+		if err != nil {
+			t.Fatalf("MarshalBinary(%v) error: %v", rate, err)
+		}
+
+		var got NodePricing
+		if err := got.UnmarshalBinary(data); err != nil {
+			t.Fatalf("UnmarshalBinary(%v) error: %v", rate, err)
+		}
+
+		if got.HourlyRate != np.HourlyRate {
+			t.Errorf("HourlyRate roundtrip: got %v, want %v", got.HourlyRate, np.HourlyRate)
+		}
+	}
+}

--- a/core/pkg/model/pricingmodel/pricingmodel.go
+++ b/core/pkg/model/pricingmodel/pricingmodel.go
@@ -4,17 +4,23 @@ import (
 	"time"
 )
 
+// @bingen:generate:PricingSourceType
+type PricingSourceType string
+
 // @bingen:generate:PricingModelSet
 type PricingModelSet struct {
 	TimeStamp   time.Time
-	Source      string
+	SourceType  PricingSourceType
+	SourceKey   string
 	NodePricing map[NodeKey]NodePricing
 }
 
-func NewPricingModelSet(timeStamp time.Time, source string) *PricingModelSet {
+// NewPricingModelSet creates a PricingModelSet with SourceKey initialized to sourceType.
+func NewPricingModelSet(timeStamp time.Time, sourceType PricingSourceType, sourceKey string) *PricingModelSet {
 	return &PricingModelSet{
 		TimeStamp:   timeStamp,
-		Source:      source,
+		SourceType:  sourceType,
+		SourceKey:   sourceKey,
 		NodePricing: make(map[NodeKey]NodePricing),
 	}
 }

--- a/core/pkg/model/pricingmodel/pricingmodel_codecs.go
+++ b/core/pkg/model/pricingmodel/pricingmodel_codecs.go
@@ -13,9 +13,9 @@ package pricingmodel
 
 import (
 	"fmt"
+	"github.com/opencost/opencost/core/pkg/model/shared"
 	util "github.com/opencost/opencost/core/pkg/util"
 	"reflect"
-	"github.com/opencost/opencost/core/pkg/model/shared"
 	"strings"
 	"sync"
 	"time"
@@ -309,10 +309,10 @@ func (target *NodeKey) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	}
 	// --- [begin][write][alias](NodePricingType) ---
 	if ctx.IsStringTable() {
-		g := ctx.Table.AddOrGet(string(target.Type))
+		g := ctx.Table.AddOrGet(string(target.PricingType))
 		buff.WriteInt(g) // write table index
 	} else {
-		buff.WriteString(string(target.Type)) // write string
+		buff.WriteString(string(target.PricingType)) // write string
 	}
 	// --- [end][write][alias](NodePricingType) ---
 
@@ -447,7 +447,7 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 	w := x
 	u = w
 
-	target.Type = NodePricingType(u)
+	target.PricingType = NodePricingType(u)
 	// --- [end][read][alias](NodePricingType) ---
 
 	return nil

--- a/core/pkg/model/pricingmodel/pricingmodel_codecs.go
+++ b/core/pkg/model/pricingmodel/pricingmodel_codecs.go
@@ -13,12 +13,13 @@ package pricingmodel
 
 import (
 	"fmt"
-	"github.com/opencost/opencost/core/pkg/model/shared"
-	util "github.com/opencost/opencost/core/pkg/util"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/opencost/opencost/core/pkg/model/shared"
+	"github.com/opencost/opencost/core/pkg/util"
 )
 
 const (
@@ -607,10 +608,10 @@ func (target *PricingModelSet) MarshalBinaryWithContext(ctx *EncodingContext) (e
 	// --- [end][write][reference](time.Time) ---
 
 	if ctx.IsStringTable() {
-		b := ctx.Table.AddOrGet(target.Source)
+		b := ctx.Table.AddOrGet(string(target.SourceType))
 		buff.WriteInt(b) // write table index
 	} else {
-		buff.WriteString(target.Source) // write string
+		buff.WriteString(string(target.SourceType)) // write string
 	}
 	if target.NodePricing == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
@@ -639,6 +640,12 @@ func (target *PricingModelSet) MarshalBinaryWithContext(ctx *EncodingContext) (e
 		}
 		// --- [end][write][map](map[NodeKey]NodePricing) ---
 
+	}
+	if ctx.IsStringTable() {
+		i := ctx.Table.AddOrGet(target.SourceKey)
+		buff.WriteInt(i) // write table index
+	} else {
+		buff.WriteString(target.SourceKey) // write string
 	}
 	return nil
 }
@@ -716,7 +723,7 @@ func (target *PricingModelSet) UnmarshalBinaryWithContext(ctx *DecodingContext) 
 		e = buff.ReadString() // read string
 	}
 	d := e
-	target.Source = d
+	target.SourceType = PricingSourceType(d)
 
 	if buff.ReadUInt8() == uint8(0) {
 		target.NodePricing = nil
@@ -751,5 +758,13 @@ func (target *PricingModelSet) UnmarshalBinaryWithContext(ctx *DecodingContext) 
 		// --- [end][read][map](map[NodeKey]NodePricing) ---
 
 	}
+	var m string
+	if ctx.IsStringTable() {
+		n := buff.ReadInt() // read string index
+		m = ctx.Table[n]
+	} else {
+		m = buff.ReadString() // read string
+	}
+	target.SourceKey = m
 	return nil
 }

--- a/core/pkg/model/pricingmodel/pricingmodel_codecs.go
+++ b/core/pkg/model/pricingmodel/pricingmodel_codecs.go
@@ -289,6 +289,24 @@ func (target *NodeKey) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	} else {
 		buff.WriteString(string(target.UsageType)) // write string
 	}
+	if ctx.IsStringTable() {
+		e := ctx.Table.AddOrGet(target.Family)
+		buff.WriteInt(e) // write table index
+	} else {
+		buff.WriteString(target.Family) // write string
+	}
+	if ctx.IsStringTable() {
+		f := ctx.Table.AddOrGet(target.Accelerator)
+		buff.WriteInt(f) // write table index
+	} else {
+		buff.WriteString(target.Accelerator) // write string
+	}
+	if ctx.IsStringTable() {
+		g := ctx.Table.AddOrGet(string(target.Type))
+		buff.WriteInt(g) // write table index
+	} else {
+		buff.WriteString(string(target.Type)) // write string
+	}
 
 	return nil
 }
@@ -383,6 +401,33 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 	}
 	target.UsageType = shared.UsageType(m)
 
+	var p string
+	if ctx.IsStringTable() {
+		q := buff.ReadInt() // read string index
+		p = ctx.Table[q]
+	} else {
+		p = buff.ReadString() // read string
+	}
+	target.Family = p
+
+	var s string
+	if ctx.IsStringTable() {
+		t := buff.ReadInt() // read string index
+		s = ctx.Table[t]
+	} else {
+		s = buff.ReadString() // read string
+	}
+	target.Accelerator = s
+
+	var u string
+	if ctx.IsStringTable() {
+		w := buff.ReadInt() // read string index
+		u = ctx.Table[w]
+	} else {
+		u = buff.ReadString() // read string
+	}
+	target.Type = NodePricingType(u)
+
 	return nil
 }
 
@@ -426,7 +471,7 @@ func (target *NodePricing) MarshalBinaryWithContext(ctx *EncodingContext) (err e
 	buff := ctx.Buffer
 	buff.WriteUInt8(DefaultCodecVersion) // version
 
-	buff.WriteFloat64(target.TotalHourlyRate) // write float64
+	buff.WriteFloat64(target.HourlyRate) // write float64
 	return nil
 }
 
@@ -485,7 +530,7 @@ func (target *NodePricing) UnmarshalBinaryWithContext(ctx *DecodingContext) (err
 	}
 
 	a := buff.ReadFloat64() // read float64
-	target.TotalHourlyRate = a
+	target.HourlyRate = a
 
 	return nil
 }

--- a/core/pkg/model/pricingmodel/pricingmodel_codecs.go
+++ b/core/pkg/model/pricingmodel/pricingmodel_codecs.go
@@ -265,12 +265,15 @@ func (target *NodeKey) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	buff := ctx.Buffer
 	buff.WriteUInt8(DefaultCodecVersion) // version
 
+	// --- [begin][write][alias](shared.Provider) ---
 	if ctx.IsStringTable() {
 		a := ctx.Table.AddOrGet(string(target.Provider))
 		buff.WriteInt(a) // write table index
 	} else {
 		buff.WriteString(string(target.Provider)) // write string
 	}
+	// --- [end][write][alias](shared.Provider) ---
+
 	if ctx.IsStringTable() {
 		b := ctx.Table.AddOrGet(target.Region)
 		buff.WriteInt(b) // write table index
@@ -283,12 +286,15 @@ func (target *NodeKey) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 	} else {
 		buff.WriteString(target.NodeType) // write string
 	}
+	// --- [begin][write][alias](shared.UsageType) ---
 	if ctx.IsStringTable() {
 		d := ctx.Table.AddOrGet(string(target.UsageType))
 		buff.WriteInt(d) // write table index
 	} else {
 		buff.WriteString(string(target.UsageType)) // write string
 	}
+	// --- [end][write][alias](shared.UsageType) ---
+
 	if ctx.IsStringTable() {
 		e := ctx.Table.AddOrGet(target.Family)
 		buff.WriteInt(e) // write table index
@@ -296,17 +302,19 @@ func (target *NodeKey) MarshalBinaryWithContext(ctx *EncodingContext) (err error
 		buff.WriteString(target.Family) // write string
 	}
 	if ctx.IsStringTable() {
-		f := ctx.Table.AddOrGet(target.Accelerator)
+		f := ctx.Table.AddOrGet(target.DeviceType)
 		buff.WriteInt(f) // write table index
 	} else {
-		buff.WriteString(target.Accelerator) // write string
+		buff.WriteString(target.DeviceType) // write string
 	}
+	// --- [begin][write][alias](NodePricingType) ---
 	if ctx.IsStringTable() {
 		g := ctx.Table.AddOrGet(string(target.Type))
 		buff.WriteInt(g) // write table index
 	} else {
 		buff.WriteString(string(target.Type)) // write string
 	}
+	// --- [end][write][alias](NodePricingType) ---
 
 	return nil
 }
@@ -365,14 +373,16 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 		return fmt.Errorf("Invalid Version Unmarshaling NodeKey. Expected %d or less, got %d", DefaultCodecVersion, version)
 	}
 
-	var b string
+	// --- [begin][read][alias](shared.Provider) ---
+	var a string
 	if ctx.IsStringTable() {
-		c := buff.ReadInt() // read string index
-		b = ctx.Table[c]
+		b := buff.ReadInt() // read string index
+		a = ctx.Table[b]
 	} else {
-		b = buff.ReadString() // read string
+		a = buff.ReadString() // read string
 	}
-	target.Provider = shared.Provider(b)
+	target.Provider = shared.Provider(a)
+	// --- [end][read][alias](shared.Provider) ---
 
 	var e string
 	if ctx.IsStringTable() {
@@ -381,7 +391,8 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 	} else {
 		e = buff.ReadString() // read string
 	}
-	target.Region = e
+	d := e
+	target.Region = d
 
 	var h string
 	if ctx.IsStringTable() {
@@ -390,16 +401,19 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 	} else {
 		h = buff.ReadString() // read string
 	}
-	target.NodeType = h
+	g := h
+	target.NodeType = g
 
-	var m string
+	// --- [begin][read][alias](shared.UsageType) ---
+	var l string
 	if ctx.IsStringTable() {
-		n := buff.ReadInt() // read string index
-		m = ctx.Table[n]
+		m := buff.ReadInt() // read string index
+		l = ctx.Table[m]
 	} else {
-		m = buff.ReadString() // read string
+		l = buff.ReadString() // read string
 	}
-	target.UsageType = shared.UsageType(m)
+	target.UsageType = shared.UsageType(l)
+	// --- [end][read][alias](shared.UsageType) ---
 
 	var p string
 	if ctx.IsStringTable() {
@@ -408,7 +422,8 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 	} else {
 		p = buff.ReadString() // read string
 	}
-	target.Family = p
+	o := p
+	target.Family = o
 
 	var s string
 	if ctx.IsStringTable() {
@@ -417,16 +432,23 @@ func (target *NodeKey) UnmarshalBinaryWithContext(ctx *DecodingContext) (err err
 	} else {
 		s = buff.ReadString() // read string
 	}
-	target.Accelerator = s
+	r := s
+	target.DeviceType = r
 
+	// --- [begin][read][alias](NodePricingType) ---
 	var u string
+	var x string
 	if ctx.IsStringTable() {
-		w := buff.ReadInt() // read string index
-		u = ctx.Table[w]
+		y := buff.ReadInt() // read string index
+		x = ctx.Table[y]
 	} else {
-		u = buff.ReadString() // read string
+		x = buff.ReadString() // read string
 	}
+	w := x
+	u = w
+
 	target.Type = NodePricingType(u)
+	// --- [end][read][alias](NodePricingType) ---
 
 	return nil
 }

--- a/core/pkg/model/pricingmodel/pricingsource.go
+++ b/core/pkg/model/pricingmodel/pricingsource.go
@@ -1,6 +1,13 @@
 package pricingmodel
 
 type PricingSource interface {
+	// PricingSourceType returns the instance type of the PricingSource, each implementation of this interface should
+	// provide a unique type that all instances should return
+	PricingSourceType() PricingSourceType
+	// PricingSourceKey returns the unique key of the PricingSource instance. In PricingSource implementation that may
+	// have multiple instances running side by side this key (derived from some configuration will) will Identify each
+	// instance. In PricingSource implementations where there will only be a single instance (ex Provider List Pricing)
+	// The PricingSourceKey should match the PricingSourceType
 	PricingSourceKey() string
 	GetPricing() (*PricingModelSet, error)
 }

--- a/core/pkg/model/shared/provider.go
+++ b/core/pkg/model/shared/provider.go
@@ -5,15 +5,6 @@ import "strings"
 // @bingen:generate:Provider
 type Provider string
 
-func (p Provider) MarshalBinary() ([]byte, error) {
-	return []byte(p), nil
-}
-
-func (p *Provider) UnmarshalBinary(data []byte) error {
-	*p = Provider(data)
-	return nil
-}
-
 const (
 	ProviderEmpty        Provider = ""
 	ProviderAWS          Provider = "AWS"

--- a/core/pkg/nodestats/nodes_test.go
+++ b/core/pkg/nodestats/nodes_test.go
@@ -125,6 +125,9 @@ func (tcc *NodesOnlyClusterCache) GetAllStorageClasses() []*clustercache.Storage
 // GetAllJobs returns all the cached jobs
 func (tcc *NodesOnlyClusterCache) GetAllJobs() []*clustercache.Job { return nil }
 
+// GetAllJobs returns all the cached cronjobs
+func (tcc *NodesOnlyClusterCache) GetAllCronJobs() []*clustercache.CronJob { return nil }
+
 // GetAllPodDisruptionBudgets returns all cached pod disruption budgets
 func (tcc *NodesOnlyClusterCache) GetAllPodDisruptionBudgets() []*clustercache.PodDisruptionBudget {
 	return nil

--- a/pkg/cloud/aws/pricelistapi.go
+++ b/pkg/cloud/aws/pricelistapi.go
@@ -213,3 +213,15 @@ type PriceListEC2PricePerUnit struct {
 	USD string `json:"USD,omitempty"`
 	CNY string `json:"CNY,omitempty"`
 }
+
+// ForCurrency returns the price string for the given currency code, falling
+// back to USD if the code is unrecognized or the field is empty.
+func (p PriceListEC2PricePerUnit) ForCurrency(code string) string {
+	switch strings.ToUpper(code) {
+	case "CNY":
+		if p.CNY != "" {
+			return p.CNY
+		}
+	}
+	return p.USD
+}

--- a/pkg/cloud/aws/pricelistapi_test.go
+++ b/pkg/cloud/aws/pricelistapi_test.go
@@ -1,0 +1,58 @@
+package aws
+
+import "testing"
+
+func TestForCurrency(t *testing.T) {
+	cases := []struct {
+		name string
+		unit PriceListEC2PricePerUnit
+		code string
+		want string
+	}{
+		{
+			name: "USD explicit",
+			unit: PriceListEC2PricePerUnit{USD: "0.096", CNY: "0.62"},
+			code: "USD",
+			want: "0.096",
+		},
+		{
+			name: "USD default when code is empty",
+			unit: PriceListEC2PricePerUnit{USD: "0.096"},
+			code: "",
+			want: "0.096",
+		},
+		{
+			name: "USD default for unrecognized code",
+			unit: PriceListEC2PricePerUnit{USD: "0.096"},
+			code: "EUR",
+			want: "0.096",
+		},
+		{
+			name: "CNY uppercase",
+			unit: PriceListEC2PricePerUnit{USD: "0.096", CNY: "0.62"},
+			code: "CNY",
+			want: "0.62",
+		},
+		{
+			name: "CNY lowercase",
+			unit: PriceListEC2PricePerUnit{USD: "0.096", CNY: "0.62"},
+			code: "cny",
+			want: "0.62",
+		},
+		{
+			name: "CNY empty falls back to USD",
+			unit: PriceListEC2PricePerUnit{USD: "0.096", CNY: ""},
+			code: "CNY",
+			want: "0.096",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.unit.ForCurrency(tc.code)
+			if got != tc.want {
+				t.Errorf("ForCurrency(%q) = %q, want %q", tc.code, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cloud/aws/pricinglistpricingsource.go
+++ b/pkg/cloud/aws/pricinglistpricingsource.go
@@ -19,7 +19,17 @@ const pricingCacheDir = "pricingsource/aws"
 const pricingCacheFile = "cached_ec2_pricingmodelset"
 const PricingListPricingSourceKey = "aws_pricing_list_api"
 
-type PricingListPricingSource struct{}
+type PricingListPricingSourceConfig struct {
+	CurrencyCode string
+}
+
+type PricingListPricingSource struct {
+	config PricingListPricingSourceConfig
+}
+
+func NewPricingListPricingSource(cfg PricingListPricingSourceConfig) *PricingListPricingSource {
+	return &PricingListPricingSource{config: cfg}
+}
 
 func (p *PricingListPricingSource) cacheFilePath() (string, error) {
 	dir := env.GetPathFromConfig(pricingCacheDir)
@@ -121,14 +131,12 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 		if !ok {
 			return
 		}
-		isCN := false
 		hourlyRateCode := HourlyRateCode
 		if _, ok = OnDemandRateCodes[term.OfferTermCode]; !ok {
 			if _, okCN := OnDemandRateCodesCn[term.OfferTermCode]; !okCN {
 				// Skip if term is not OnDemand
 				return
 			}
-			isCN = true
 			hourlyRateCode = HourlyRateCodeCn
 		}
 		priceDimensionKey := strings.Join([]string{term.Sku, term.OfferTermCode, hourlyRateCode}, ".")
@@ -138,10 +146,7 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 			return
 		}
 
-		priceStr := pricingDimension.PricePerUnit.USD
-		if isCN {
-			priceStr = pricingDimension.PricePerUnit.CNY
-		}
+		priceStr := pricingDimension.PricePerUnit.ForCurrency(p.config.CurrencyCode)
 		price, err := strconv.ParseFloat(priceStr, 64)
 		if err != nil {
 			log.Errorf("failed to parse str to float '%s': %s", priceStr, err.Error())

--- a/pkg/cloud/aws/pricinglistpricingsource.go
+++ b/pkg/cloud/aws/pricinglistpricingsource.go
@@ -17,7 +17,8 @@ import (
 const pricingCacheTTL = 24 * time.Hour
 const pricingCacheDir = "pricingsource/aws"
 const pricingCacheFile = "cached_ec2_pricingmodelset"
-const PricingListPricingSourceKey = "aws_pricing_list_api"
+
+const PricingListPricingSourceType pricingmodel.PricingSourceType = "aws_pricing_list_api"
 
 type PricingListPricingSourceConfig struct {
 	CurrencyCode string
@@ -79,8 +80,13 @@ func (p *PricingListPricingSource) saveToCache(pms *pricingmodel.PricingModelSet
 	}
 }
 
+func (p *PricingListPricingSource) PricingSourceType() pricingmodel.PricingSourceType {
+	return PricingListPricingSourceType
+}
+
+// PricingSourceKey returns the PricingSourceType because it is meant to run single instance.
 func (p *PricingListPricingSource) PricingSourceKey() string {
-	return PricingListPricingSourceKey
+	return string(PricingListPricingSourceType)
 }
 
 func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, error) {
@@ -93,7 +99,7 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 	start := time.Now()
 
 	now := time.Now().UTC()
-	pms := pricingmodel.NewPricingModelSet(now, PricingListPricingSourceKey)
+	pms := pricingmodel.NewPricingModelSet(now, p.PricingSourceType(), p.PricingSourceKey())
 	skuToNodeKey := make(map[string]pricingmodel.NodeKey)
 
 	var productCount, termCount int

--- a/pkg/cloud/aws/pricinglistpricingsource.go
+++ b/pkg/cloud/aws/pricinglistpricingsource.go
@@ -129,11 +129,11 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 		}
 
 		skuToNodeKey[product.Sku] = pricingmodel.NodeKey{
-			Provider:  shared.ProviderAWS,
-			Region:    attr.RegionCode,
-			NodeType:  attr.InstanceType,
-			UsageType: shared.UsageTypeOnDemand,
-			Type:      pricingmodel.NodePricingTypeTotal,
+			Provider:    shared.ProviderAWS,
+			Region:      attr.RegionCode,
+			NodeType:    attr.InstanceType,
+			UsageType:   shared.UsageTypeOnDemand,
+			PricingType: pricingmodel.NodePricingTypeTotal,
 		}
 	}
 

--- a/pkg/cloud/aws/pricinglistpricingsource.go
+++ b/pkg/cloud/aws/pricinglistpricingsource.go
@@ -85,14 +85,26 @@ func (p *PricingListPricingSource) PricingSourceKey() string {
 
 func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, error) {
 	if cached, ok := p.loadFromCache(); ok {
+		log.Infof("PricingListPricingSource: loaded %d pricing entries from cache", len(cached.NodePricing))
 		return cached, nil
 	}
+
+	log.Infof("PricingListPricingSource: starting AWS EC2 pricing list download (large file, this may take a while)")
+	start := time.Now()
+
 	now := time.Now().UTC()
 	pms := pricingmodel.NewPricingModelSet(now, PricingListPricingSourceKey)
 	skuToNodeKey := make(map[string]pricingmodel.NodeKey)
 
+	var productCount, termCount int
+	const logInterval = 50000
+
 	// When parsing product we create keys based off of product attributes and link those to a SKU.
 	handleProduct := func(product *PriceListEC2Product) {
+		productCount++
+		if productCount%logInterval == 0 {
+			log.Infof("PricingListPricingSource: processed %d products...", productCount)
+		}
 		attr := product.Attributes
 		if attr.LocationType != "AWS Region" {
 			return
@@ -127,6 +139,10 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 
 	// Terms are used to define pricing and have the sku to look up the appropriate key.
 	handleTerm := func(term *PriceListEC2Term) {
+		termCount++
+		if termCount%logInterval == 0 {
+			log.Infof("PricingListPricingSource: processed %d terms, %d pricing entries so far...", termCount, len(pms.NodePricing))
+		}
 		nodeKey, ok := skuToNodeKey[term.Sku]
 		if !ok {
 			return
@@ -161,6 +177,9 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to query list pricing data %w", err)
 	}
+
+	log.Infof("PricingListPricingSource: completed in %s — %d products, %d terms, %d pricing entries",
+		time.Since(start).Round(time.Second), productCount, termCount, len(pms.NodePricing))
 
 	p.saveToCache(pms)
 

--- a/pkg/cloud/aws/pricinglistpricingsource.go
+++ b/pkg/cloud/aws/pricinglistpricingsource.go
@@ -111,6 +111,7 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 			Region:    attr.RegionCode,
 			NodeType:  attr.InstanceType,
 			UsageType: shared.UsageTypeOnDemand,
+			Type:      pricingmodel.NodePricingTypeTotal,
 		}
 	}
 
@@ -147,7 +148,7 @@ func (p *PricingListPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 			return
 		}
 		pms.NodePricing[nodeKey] = pricingmodel.NodePricing{
-			TotalHourlyRate: price,
+			HourlyRate: price,
 		}
 	}
 

--- a/pkg/cloud/azure/retailpricingsource.go
+++ b/pkg/cloud/azure/retailpricingsource.go
@@ -25,6 +25,8 @@ type AzureRetailPricingSourceConfig struct {
 	CurrencyCode string
 }
 
+var azureRetailHTTPClient = &http.Client{Timeout: 60 * time.Second}
+
 // AzureRetailPricingSource implements pricingmodel.PricingSource using the
 // Azure Retail Prices API (no authentication required).
 type AzureRetailPricingSource struct {
@@ -47,7 +49,7 @@ func (a *AzureRetailPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 	pageCount := 0
 
 	for url != "" {
-		resp, err := http.Get(url)
+		resp, err := azureRetailHTTPClient.Get(url)
 		if err != nil {
 			return nil, fmt.Errorf("AzureRetailPricingSource: GET %s: %w", url, err)
 		}

--- a/pkg/cloud/azure/retailpricingsource.go
+++ b/pkg/cloud/azure/retailpricingsource.go
@@ -100,11 +100,11 @@ func (a *AzureRetailPricingSource) parsePage(body io.Reader, pms *pricingmodel.P
 		}
 
 		key := pricingmodel.NodeKey{
-			Provider:  shared.ProviderAzure,
-			Region:    item.ArmRegionName,
-			NodeType:  item.ArmSkuName,
-			UsageType: usageTypeFromSku(item.SkuName),
-			Type:      pricingmodel.NodePricingTypeTotal,
+			Provider:    shared.ProviderAzure,
+			Region:      item.ArmRegionName,
+			NodeType:    item.ArmSkuName,
+			UsageType:   usageTypeFromSku(item.SkuName),
+			PricingType: pricingmodel.NodePricingTypeTotal,
 		}
 
 		pms.NodePricing[key] = pricingmodel.NodePricing{

--- a/pkg/cloud/azure/retailpricingsource.go
+++ b/pkg/cloud/azure/retailpricingsource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -51,6 +52,12 @@ func (a *AzureRetailPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 			return nil, fmt.Errorf("AzureRetailPricingSource: GET %s: %w", url, err)
 		}
 
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("AzureRetailPricingSource: unexpected status %d on page %d: %s", resp.StatusCode, pageCount, string(body))
+		}
+
 		next, err := a.parsePage(resp.Body, pms)
 		resp.Body.Close()
 		if err != nil {
@@ -67,11 +74,12 @@ func (a *AzureRetailPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 }
 
 func (a *AzureRetailPricingSource) buildInitialURL() string {
-	url := fmt.Sprintf("%s?$filter=%s", azureRetailPricingBaseURL, azureRetailVMFilter)
+	params := url.Values{}
+	params.Set("$filter", azureRetailVMFilter)
 	if a.config.CurrencyCode != "" {
-		url += fmt.Sprintf("&currencyCode='%s'", a.config.CurrencyCode)
+		params.Set("currencyCode", a.config.CurrencyCode)
 	}
-	return url
+	return azureRetailPricingBaseURL + "?" + params.Encode()
 }
 
 func (a *AzureRetailPricingSource) parsePage(body io.Reader, pms *pricingmodel.PricingModelSet) (nextURL string, err error) {

--- a/pkg/cloud/azure/retailpricingsource.go
+++ b/pkg/cloud/azure/retailpricingsource.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	azureRetailPricingBaseURL   = "https://prices.azure.com/api/retail/prices"
-	azureRetailVMFilter         = "serviceName eq 'Virtual Machines' and priceType eq 'Consumption'"
-	AzureRetailPricingSourceKey = "azure_retail_pricing_api"
+	azureRetailPricingBaseURL = "https://prices.azure.com/api/retail/prices"
+	azureRetailVMFilter       = "serviceName eq 'Virtual Machines' and priceType eq 'Consumption'"
 )
+
+const AzureRetailPricingSourceType pricingmodel.PricingSourceType = "azure_retail_pricing_api"
 
 // AzureRetailPricingSourceConfig holds configuration for AzureRetailPricingSource.
 type AzureRetailPricingSourceConfig struct {
@@ -37,13 +38,18 @@ func NewAzureRetailPricingSource(cfg AzureRetailPricingSourceConfig) *AzureRetai
 	return &AzureRetailPricingSource{config: cfg}
 }
 
+func (a *AzureRetailPricingSource) PricingSourceType() pricingmodel.PricingSourceType {
+	return AzureRetailPricingSourceType
+}
+
+// PricingSourceKey returns the PricingSourceType because it is meant to run single instance.
 func (a *AzureRetailPricingSource) PricingSourceKey() string {
-	return AzureRetailPricingSourceKey
+	return string(AzureRetailPricingSourceType)
 }
 
 func (a *AzureRetailPricingSource) GetPricing() (*pricingmodel.PricingModelSet, error) {
 	now := time.Now().UTC()
-	pms := pricingmodel.NewPricingModelSet(now, AzureRetailPricingSourceKey)
+	pms := pricingmodel.NewPricingModelSet(now, a.PricingSourceType(), a.PricingSourceKey())
 
 	url := a.buildInitialURL()
 	pageCount := 0

--- a/pkg/cloud/azure/retailpricingsource.go
+++ b/pkg/cloud/azure/retailpricingsource.go
@@ -95,10 +95,11 @@ func (a *AzureRetailPricingSource) parsePage(body io.Reader, pms *pricingmodel.P
 			Region:    item.ArmRegionName,
 			NodeType:  item.ArmSkuName,
 			UsageType: usageTypeFromSku(item.SkuName),
+			Type:      pricingmodel.NodePricingTypeTotal,
 		}
 
 		pms.NodePricing[key] = pricingmodel.NodePricing{
-			TotalHourlyRate: float64(item.RetailPrice),
+			HourlyRate: float64(item.RetailPrice),
 		}
 	}
 

--- a/pkg/cloud/azure/retailpricingsource.go
+++ b/pkg/cloud/azure/retailpricingsource.go
@@ -74,12 +74,11 @@ func (a *AzureRetailPricingSource) GetPricing() (*pricingmodel.PricingModelSet, 
 }
 
 func (a *AzureRetailPricingSource) buildInitialURL() string {
-	params := url.Values{}
-	params.Set("$filter", azureRetailVMFilter)
+	u := azureRetailPricingBaseURL + "?$filter=" + url.QueryEscape(azureRetailVMFilter)
 	if a.config.CurrencyCode != "" {
-		params.Set("currencyCode", a.config.CurrencyCode)
+		u += "&currencyCode=" + url.QueryEscape(a.config.CurrencyCode)
 	}
-	return azureRetailPricingBaseURL + "?" + params.Encode()
+	return u
 }
 
 func (a *AzureRetailPricingSource) parsePage(body io.Reader, pms *pricingmodel.PricingModelSet) (nextURL string, err error) {

--- a/pkg/cloud/azure/retailpricingsource_test.go
+++ b/pkg/cloud/azure/retailpricingsource_test.go
@@ -165,11 +165,11 @@ func TestAzureRetailPricingSource_ParsePage(t *testing.T) {
 	}
 
 	onDemandKey := pricingmodel.NodeKey{
-		Provider:  shared.ProviderAzure,
-		Region:    "eastus",
-		NodeType:  "Standard_D4s_v3",
-		UsageType: shared.UsageTypeOnDemand,
-		Type:      pricingmodel.NodePricingTypeTotal,
+		Provider:    shared.ProviderAzure,
+		Region:      "eastus",
+		NodeType:    "Standard_D4s_v3",
+		UsageType:   shared.UsageTypeOnDemand,
+		PricingType: pricingmodel.NodePricingTypeTotal,
 	}
 	if entry, ok := pms.NodePricing[onDemandKey]; !ok {
 		t.Error("missing OnDemand entry")
@@ -178,11 +178,11 @@ func TestAzureRetailPricingSource_ParsePage(t *testing.T) {
 	}
 
 	spotKey := pricingmodel.NodeKey{
-		Provider:  shared.ProviderAzure,
-		Region:    "eastus",
-		NodeType:  "Standard_D4s_v3",
-		UsageType: shared.UsageTypeSpot,
-		Type:      pricingmodel.NodePricingTypeTotal,
+		Provider:    shared.ProviderAzure,
+		Region:      "eastus",
+		NodeType:    "Standard_D4s_v3",
+		UsageType:   shared.UsageTypeSpot,
+		PricingType: pricingmodel.NodePricingTypeTotal,
 	}
 	if _, ok := pms.NodePricing[spotKey]; !ok {
 		t.Error("missing Spot entry")

--- a/pkg/cloud/azure/retailpricingsource_test.go
+++ b/pkg/cloud/azure/retailpricingsource_test.go
@@ -153,7 +153,7 @@ func TestAzureRetailPricingSource_ParsePage(t *testing.T) {
 	body, _ := json.Marshal(page)
 
 	src := NewAzureRetailPricingSource(AzureRetailPricingSourceConfig{})
-	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), AzureRetailPricingSourceKey)
+	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), src.PricingSourceType(), src.PricingSourceKey())
 
 	_, err := src.parsePage(strings.NewReader(string(body)), pms)
 	if err != nil {

--- a/pkg/cloud/azure/retailpricingsource_test.go
+++ b/pkg/cloud/azure/retailpricingsource_test.go
@@ -1,0 +1,190 @@
+package azure
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/model/pricingmodel"
+	"github.com/opencost/opencost/core/pkg/model/shared"
+)
+
+func TestAzureRetailPricingSource_BuildInitialURL(t *testing.T) {
+	cases := []struct {
+		name         string
+		currencyCode string
+	}{
+		{"no currency", ""},
+		{"USD", "USD"},
+		{"EUR", "EUR"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := NewAzureRetailPricingSource(AzureRetailPricingSourceConfig{CurrencyCode: tc.currencyCode})
+			u := src.buildInitialURL()
+
+			if strings.Contains(u, " ") {
+				t.Errorf("URL contains unencoded space: %s", u)
+			}
+			if strings.Contains(u, "'") {
+				t.Errorf("URL contains unencoded single quote: %s", u)
+			}
+			if !strings.Contains(u, "$filter=") {
+				t.Errorf("URL missing $filter param: %s", u)
+			}
+			if tc.currencyCode != "" {
+				if !strings.Contains(u, "currencyCode="+tc.currencyCode) {
+					t.Errorf("URL missing or malformed currencyCode param: %s", u)
+				}
+				// ensure no single quotes wrapped around the currency value
+				if strings.Contains(u, "'"+tc.currencyCode+"'") {
+					t.Errorf("currency code is wrapped in single quotes: %s", u)
+				}
+			}
+		})
+	}
+}
+
+func TestAzureRetailPricingSource_IncludeItem(t *testing.T) {
+	src := NewAzureRetailPricingSource(AzureRetailPricingSourceConfig{})
+
+	cases := []struct {
+		name string
+		item AzureRetailPricingAttributes
+		want bool
+	}{
+		{
+			name: "valid linux VM",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "Virtual Machines D Series"},
+			want: true,
+		},
+		{
+			name: "spot SKU is included",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3 Spot", ProductName: "Virtual Machines D Series"},
+			want: true,
+		},
+		{
+			name: "missing ArmSkuName",
+			item: AzureRetailPricingAttributes{ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "Virtual Machines D Series"},
+			want: false,
+		},
+		{
+			name: "missing ArmRegionName",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", SkuName: "D4s v3", ProductName: "Virtual Machines D Series"},
+			want: false,
+		},
+		{
+			name: "Windows product excluded",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "Windows Virtual Machines"},
+			want: false,
+		},
+		{
+			name: "low priority excluded",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3 Low Priority", ProductName: "Virtual Machines D Series"},
+			want: false,
+		},
+		{
+			name: "cloud services excluded",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "Cloud Services General"},
+			want: false,
+		},
+		{
+			name: "cloudservices excluded",
+			item: AzureRetailPricingAttributes{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "CloudServices General"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := src.includeItem(tc.item)
+			if got != tc.want {
+				t.Errorf("includeItem() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUsageTypeFromSku(t *testing.T) {
+	cases := []struct {
+		skuName string
+		want    shared.UsageType
+	}{
+		{"D4s v3", shared.UsageTypeOnDemand},
+		{"D4s v3 Spot", shared.UsageTypeSpot},
+		{"D4s v3 spot", shared.UsageTypeSpot},
+		{"D4s V3 SPOT", shared.UsageTypeSpot},
+		{"E8s v5 Spot Extra", shared.UsageTypeSpot},
+		{"", shared.UsageTypeOnDemand},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.skuName, func(t *testing.T) {
+			got := usageTypeFromSku(tc.skuName)
+			if got != tc.want {
+				t.Errorf("usageTypeFromSku(%q) = %q, want %q", tc.skuName, got, tc.want)
+			}
+		})
+	}
+}
+
+func absf(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func TestAzureRetailPricingSource_ParsePage(t *testing.T) {
+	items := []AzureRetailPricingAttributes{
+		// included: standard on-demand VM
+		{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "Virtual Machines D Series", RetailPrice: 0.192},
+		// included: spot VM
+		{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3 Spot", ProductName: "Virtual Machines D Series", RetailPrice: 0.05},
+		// excluded: Windows
+		{ArmSkuName: "Standard_D4s_v3", ArmRegionName: "eastus", SkuName: "D4s v3", ProductName: "Windows Virtual Machines", RetailPrice: 0.3},
+		// excluded: missing region
+		{ArmSkuName: "Standard_D4s_v3", SkuName: "D4s v3", ProductName: "Virtual Machines D Series", RetailPrice: 0.192},
+	}
+
+	page := AzureRetailPricing{Items: items}
+	body, _ := json.Marshal(page)
+
+	src := NewAzureRetailPricingSource(AzureRetailPricingSourceConfig{})
+	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), AzureRetailPricingSourceKey)
+
+	_, err := src.parsePage(strings.NewReader(string(body)), pms)
+	if err != nil {
+		t.Fatalf("parsePage error: %v", err)
+	}
+
+	if len(pms.NodePricing) != 2 {
+		t.Errorf("expected 2 pricing entries, got %d", len(pms.NodePricing))
+	}
+
+	onDemandKey := pricingmodel.NodeKey{
+		Provider:  shared.ProviderAzure,
+		Region:    "eastus",
+		NodeType:  "Standard_D4s_v3",
+		UsageType: shared.UsageTypeOnDemand,
+		Type:      pricingmodel.NodePricingTypeTotal,
+	}
+	if entry, ok := pms.NodePricing[onDemandKey]; !ok {
+		t.Error("missing OnDemand entry")
+	} else if absf(entry.HourlyRate-0.192) > 1e-5 {
+		t.Errorf("OnDemand HourlyRate = %v, want ~0.192", entry.HourlyRate)
+	}
+
+	spotKey := pricingmodel.NodeKey{
+		Provider:  shared.ProviderAzure,
+		Region:    "eastus",
+		NodeType:  "Standard_D4s_v3",
+		UsageType: shared.UsageTypeSpot,
+		Type:      pricingmodel.NodePricingTypeTotal,
+	}
+	if _, ok := pms.NodePricing[spotKey]; !ok {
+		t.Error("missing Spot entry")
+	}
+}

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -36,11 +36,18 @@ type GCPBillingPricingSourceConfig struct {
 // hourly rates keyed by family and region, which consumers combine with
 // machine specs to compute total instance costs.
 type GCPBillingPricingSource struct {
-	config GCPBillingPricingSourceConfig
+	apiKey       string
+	currencyCode string
 }
 
-func NewGCPBillingPricingSource(cfg GCPBillingPricingSourceConfig) *GCPBillingPricingSource {
-	return &GCPBillingPricingSource{config: cfg}
+func NewGCPBillingPricingSource(cfg GCPBillingPricingSourceConfig) (*GCPBillingPricingSource, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("cannot initialize GCPBillingPriceSource with empty API Key")
+	}
+	return &GCPBillingPricingSource{
+		apiKey:       cfg.APIKey,
+		currencyCode: cfg.CurrencyCode,
+	}, nil
 }
 
 func (g *GCPBillingPricingSource) PricingSourceKey() string {
@@ -48,6 +55,9 @@ func (g *GCPBillingPricingSource) PricingSourceKey() string {
 }
 
 func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, error) {
+	if g.apiKey == "" {
+		return nil, fmt.Errorf("GCPBillingPricingSource: api key is nil")
+	}
 	now := time.Now().UTC()
 	pms := pricingmodel.NewPricingModelSet(now, GCPBillingPricingSourceKey)
 
@@ -86,9 +96,9 @@ func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, e
 }
 
 func (g *GCPBillingPricingSource) buildURL(pageToken string) string {
-	url := fmt.Sprintf("%s?key=%s", gcpBillingBaseURL, g.config.APIKey)
-	if g.config.CurrencyCode != "" {
-		url += "&currencyCode=" + g.config.CurrencyCode
+	url := fmt.Sprintf("%s?key=%s", gcpBillingBaseURL, g.apiKey)
+	if g.currencyCode != "" {
+		url += "&currencyCode=" + g.currencyCode
 	}
 	if pageToken != "" {
 		url += "&pageToken=" + pageToken
@@ -149,11 +159,11 @@ func (g *GCPBillingPricingSource) processGPUSKU(sku *GCPPricing, usageType share
 	}
 	for _, region := range sku.ServiceRegions {
 		key := pricingmodel.NodeKey{
-			Provider:    shared.ProviderGCP,
-			Region:      region,
-			UsageType:   usageType,
-			Accelerator: accelerator,
-			Type:        pricingmodel.NodePricingTypeDevice,
+			Provider:   shared.ProviderGCP,
+			Region:     region,
+			UsageType:  usageType,
+			DeviceType: accelerator,
+			Type:       pricingmodel.NodePricingTypeDevice,
 		}
 		pms.NodePricing[key] = pricingmodel.NodePricing{HourlyRate: hourlyRate}
 	}

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -161,11 +161,11 @@ func (g *GCPBillingPricingSource) processGPUSKU(sku *GCPPricing, usageType share
 	}
 	for _, region := range sku.ServiceRegions {
 		key := pricingmodel.NodeKey{
-			Provider:   shared.ProviderGCP,
-			Region:     region,
-			UsageType:  usageType,
-			DeviceType: accelerator,
-			Type:       pricingmodel.NodePricingTypeDevice,
+			Provider:    shared.ProviderGCP,
+			Region:      region,
+			UsageType:   usageType,
+			DeviceType:  accelerator,
+			PricingType: pricingmodel.NodePricingTypeDevice,
 		}
 		pms.NodePricing[key] = pricingmodel.NodePricing{HourlyRate: hourlyRate}
 	}
@@ -191,11 +191,11 @@ func (g *GCPBillingPricingSource) processComputeSKU(sku *GCPPricing, usageType s
 
 	for _, region := range sku.ServiceRegions {
 		key := pricingmodel.NodeKey{
-			Provider:  shared.ProviderGCP,
-			Region:    region,
-			Family:    family,
-			UsageType: usageType,
-			Type:      pricingType,
+			Provider:    shared.ProviderGCP,
+			Region:      region,
+			Family:      family,
+			UsageType:   usageType,
+			PricingType: pricingType,
 		}
 		pms.NodePricing[key] = pricingmodel.NodePricing{HourlyRate: hourlyRate}
 	}

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -60,6 +60,12 @@ func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, e
 			return nil, fmt.Errorf("GCPBillingPricingSource: GET: %w", err)
 		}
 
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("GCPBillingPricingSource: unexpected status %d on page %d: %s", resp.StatusCode, pageCount, string(body))
+		}
+
 		nextToken, err := g.parsePage(resp.Body, pms)
 		resp.Body.Close()
 		if err != nil {

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -31,6 +31,8 @@ type GCPBillingPricingSourceConfig struct {
 	CurrencyCode string
 }
 
+var gcpBillingHTTPClient = &http.Client{Timeout: 60 * time.Second}
+
 // GCPBillingPricingSource implements pricingmodel.PricingSource using the
 // GCP Cloud Billing Catalog API. It emits per-vCPU, per-GB RAM, and per-GPU
 // hourly rates keyed by family and region, which consumers combine with
@@ -65,7 +67,7 @@ func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, e
 	pageCount := 0
 
 	for url != "" {
-		resp, err := http.Get(url)
+		resp, err := gcpBillingHTTPClient.Get(url)
 		if err != nil {
 			return nil, fmt.Errorf("GCPBillingPricingSource: GET: %w", err)
 		}

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -153,7 +153,7 @@ func (g *GCPBillingPricingSource) processGPUSKU(sku *GCPPricing, usageType share
 			Region:      region,
 			UsageType:   usageType,
 			Accelerator: accelerator,
-			Type:        pricingmodel.NodePricingTypeGPU,
+			Type:        pricingmodel.NodePricingTypeDevice,
 		}
 		pms.NodePricing[key] = pricingmodel.NodePricing{HourlyRate: hourlyRate}
 	}

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -18,11 +18,15 @@ import (
 const (
 	gcpBillingComputeServiceID = "6F81-5844-456A"
 	gcpBillingBaseURL          = "https://cloudbilling.googleapis.com/v1/services/" + gcpBillingComputeServiceID + "/skus"
-	GCPBillingPricingSourceKey = "gcp_billing_catalog_api"
-	gcpResourceFamilyCompute   = "Compute"
-	gcpResourceGroupGPU        = "GPU"
-	gcpUsageTypeOnDemand       = "OnDemand"
-	gcpUsageTypePreemptible    = "Preemptible"
+)
+
+const GCPBillingPricingSourceType pricingmodel.PricingSourceType = "gcp_billing_catalog_api"
+
+const (
+	gcpResourceFamilyCompute = "Compute"
+	gcpResourceGroupGPU      = "GPU"
+	gcpUsageTypeOnDemand     = "OnDemand"
+	gcpUsageTypePreemptible  = "Preemptible"
 )
 
 // GCPBillingPricingSourceConfig holds configuration for GCPBillingPricingSource.
@@ -52,8 +56,13 @@ func NewGCPBillingPricingSource(cfg GCPBillingPricingSourceConfig) (*GCPBillingP
 	}, nil
 }
 
+func (g *GCPBillingPricingSource) PricingSourceType() pricingmodel.PricingSourceType {
+	return GCPBillingPricingSourceType
+}
+
+// PricingSourceKey returns the PricingSourceType because it is meant to run single instance.
 func (g *GCPBillingPricingSource) PricingSourceKey() string {
-	return GCPBillingPricingSourceKey
+	return string(GCPBillingPricingSourceType)
 }
 
 func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, error) {
@@ -61,7 +70,7 @@ func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, e
 		return nil, fmt.Errorf("GCPBillingPricingSource: api key is nil")
 	}
 	now := time.Now().UTC()
-	pms := pricingmodel.NewPricingModelSet(now, GCPBillingPricingSourceKey)
+	pms := pricingmodel.NewPricingModelSet(now, g.PricingSourceType(), g.PricingSourceKey())
 
 	url := g.buildURL("")
 	pageCount := 0

--- a/pkg/cloud/gcp/billingpricingsource.go
+++ b/pkg/cloud/gcp/billingpricingsource.go
@@ -1,0 +1,222 @@
+package gcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/log"
+	"github.com/opencost/opencost/core/pkg/model/pricingmodel"
+	"github.com/opencost/opencost/core/pkg/model/shared"
+)
+
+const (
+	gcpBillingComputeServiceID = "6F81-5844-456A"
+	gcpBillingBaseURL          = "https://cloudbilling.googleapis.com/v1/services/" + gcpBillingComputeServiceID + "/skus"
+	GCPBillingPricingSourceKey = "gcp_billing_catalog_api"
+	gcpResourceFamilyCompute   = "Compute"
+	gcpResourceGroupGPU        = "GPU"
+	gcpUsageTypeOnDemand       = "OnDemand"
+	gcpUsageTypePreemptible    = "Preemptible"
+)
+
+// GCPBillingPricingSourceConfig holds configuration for GCPBillingPricingSource.
+type GCPBillingPricingSourceConfig struct {
+	APIKey       string
+	CurrencyCode string
+}
+
+// GCPBillingPricingSource implements pricingmodel.PricingSource using the
+// GCP Cloud Billing Catalog API. It emits per-vCPU, per-GB RAM, and per-GPU
+// hourly rates keyed by family and region, which consumers combine with
+// machine specs to compute total instance costs.
+type GCPBillingPricingSource struct {
+	config GCPBillingPricingSourceConfig
+}
+
+func NewGCPBillingPricingSource(cfg GCPBillingPricingSourceConfig) *GCPBillingPricingSource {
+	return &GCPBillingPricingSource{config: cfg}
+}
+
+func (g *GCPBillingPricingSource) PricingSourceKey() string {
+	return GCPBillingPricingSourceKey
+}
+
+func (g *GCPBillingPricingSource) GetPricing() (*pricingmodel.PricingModelSet, error) {
+	now := time.Now().UTC()
+	pms := pricingmodel.NewPricingModelSet(now, GCPBillingPricingSourceKey)
+
+	url := g.buildURL("")
+	pageCount := 0
+
+	for url != "" {
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("GCPBillingPricingSource: GET: %w", err)
+		}
+
+		nextToken, err := g.parsePage(resp.Body, pms)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("GCPBillingPricingSource: parsing page %d: %w", pageCount, err)
+		}
+
+		pageCount++
+		log.Debugf("GCPBillingPricingSource: fetched page %d", pageCount)
+
+		if nextToken == "" {
+			break
+		}
+		url = g.buildURL(nextToken)
+	}
+
+	log.Infof("GCPBillingPricingSource: loaded %d pricing entries across %d pages", len(pms.NodePricing), pageCount)
+	return pms, nil
+}
+
+func (g *GCPBillingPricingSource) buildURL(pageToken string) string {
+	url := fmt.Sprintf("%s?key=%s", gcpBillingBaseURL, g.config.APIKey)
+	if g.config.CurrencyCode != "" {
+		url += "&currencyCode=" + g.config.CurrencyCode
+	}
+	if pageToken != "" {
+		url += "&pageToken=" + pageToken
+	}
+	return url
+}
+
+type gcpBillingPage struct {
+	SKUs          []*GCPPricing `json:"skus"`
+	NextPageToken string        `json:"nextPageToken"`
+}
+
+func (g *GCPBillingPricingSource) parsePage(body io.Reader, pms *pricingmodel.PricingModelSet) (string, error) {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return "", fmt.Errorf("reading response body: %w", err)
+	}
+
+	var page gcpBillingPage
+	if err := json.Unmarshal(data, &page); err != nil {
+		return "", fmt.Errorf("unmarshalling response: %w", err)
+	}
+
+	for _, sku := range page.SKUs {
+		g.processSKU(sku, pms)
+	}
+
+	return page.NextPageToken, nil
+}
+
+func (g *GCPBillingPricingSource) processSKU(sku *GCPPricing, pms *pricingmodel.PricingModelSet) {
+	if sku.Category == nil || sku.Category.ResourceFamily != gcpResourceFamilyCompute {
+		return
+	}
+
+	usageType := gcpUsageType(sku.Category.UsageType)
+	if usageType == shared.UsageTypeEmpty {
+		return // skip commitments and unrecognized usage types
+	}
+
+	hourlyRate, ok := gcpExtractHourlyRate(sku)
+	if !ok || hourlyRate == 0 {
+		return
+	}
+
+	if strings.EqualFold(sku.Category.ResourceGroup, gcpResourceGroupGPU) {
+		g.processGPUSKU(sku, usageType, hourlyRate, pms)
+		return
+	}
+
+	g.processComputeSKU(sku, usageType, hourlyRate, pms)
+}
+
+func (g *GCPBillingPricingSource) processGPUSKU(sku *GCPPricing, usageType shared.UsageType, hourlyRate float64, pms *pricingmodel.PricingModelSet) {
+	accelerator := NormalizeGPULabel(sku.Description)
+	if accelerator == "" {
+		return
+	}
+	for _, region := range sku.ServiceRegions {
+		key := pricingmodel.NodeKey{
+			Provider:    shared.ProviderGCP,
+			Region:      region,
+			UsageType:   usageType,
+			Accelerator: accelerator,
+			Type:        pricingmodel.NodePricingTypeGPU,
+		}
+		pms.NodePricing[key] = pricingmodel.NodePricing{HourlyRate: hourlyRate}
+	}
+}
+
+func (g *GCPBillingPricingSource) processComputeSKU(sku *GCPPricing, usageType shared.UsageType, hourlyRate float64, pms *pricingmodel.PricingModelSet) {
+	// Skip legacy ambiguous resource groups — family cannot be determined without
+	// parsing the description, which is unreliable across SKU generations.
+	rg := strings.ToLower(sku.Category.ResourceGroup)
+	if rg == "ram" || rg == "cpu" {
+		return
+	}
+
+	family := gcpNormalizeFamily(sku.Category.ResourceGroup)
+	if family == "" {
+		return
+	}
+
+	pricingType := pricingmodel.NodePricingTypeCPUCore
+	if strings.Contains(strings.ToUpper(sku.Description), "RAM") {
+		pricingType = pricingmodel.NodePricingTypeRamGB
+	}
+
+	for _, region := range sku.ServiceRegions {
+		key := pricingmodel.NodeKey{
+			Provider:  shared.ProviderGCP,
+			Region:    region,
+			Family:    family,
+			UsageType: usageType,
+			Type:      pricingType,
+		}
+		pms.NodePricing[key] = pricingmodel.NodePricing{HourlyRate: hourlyRate}
+	}
+}
+
+// gcpNormalizeFamily maps a GCP Billing API ResourceGroup (e.g. "N1Standard",
+// "N2DStandard", "E2", "A2") to a lowercase family identifier (e.g. "n1",
+// "n2d", "e2", "a2") by lowercasing and stripping the "standard" suffix.
+func gcpNormalizeFamily(resourceGroup string) string {
+	return strings.TrimSuffix(strings.ToLower(resourceGroup), "standard")
+}
+
+// gcpUsageType maps GCP billing usage type strings to shared.UsageType.
+// Returns UsageTypeEmpty for commitment SKUs, which should be skipped.
+func gcpUsageType(gcpType string) shared.UsageType {
+	switch gcpType {
+	case gcpUsageTypeOnDemand:
+		return shared.UsageTypeOnDemand
+	case gcpUsageTypePreemptible:
+		return shared.UsageTypeSpot
+	default:
+		return shared.UsageTypeEmpty
+	}
+}
+
+// gcpExtractHourlyRate extracts the hourly rate from a SKU's pricing info.
+// Per the GCP Billing Catalog API docs, the price is units + nanos*10^-9.
+func gcpExtractHourlyRate(sku *GCPPricing) (float64, bool) {
+	if len(sku.PricingInfo) == 0 {
+		return 0, false
+	}
+	rates := sku.PricingInfo[0].PricingExpression.TieredRates
+	if len(rates) == 0 {
+		return 0, false
+	}
+	last := rates[len(rates)-1]
+	units, err := strconv.Atoi(last.UnitPrice.Units)
+	if err != nil {
+		units = 0
+	}
+	return (last.UnitPrice.Nanos * math.Pow10(-9)) + float64(units), true
+}

--- a/pkg/cloud/gcp/billingpricingsource_test.go
+++ b/pkg/cloud/gcp/billingpricingsource_test.go
@@ -177,7 +177,7 @@ func TestGCPBillingPricingSource_ParsePage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGCPBillingPricingSource error: %v", err)
 	}
-	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), GCPBillingPricingSourceKey)
+	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), src.PricingSourceType(), src.PricingSourceKey())
 
 	nextToken, err := src.parsePage(strings.NewReader(string(body)), pms)
 	if err != nil {
@@ -245,7 +245,7 @@ func TestGCPBillingPricingSource_ParsePage_Preemptible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGCPBillingPricingSource error: %v", err)
 	}
-	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), GCPBillingPricingSourceKey)
+	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), src.PricingSourceType(), src.PricingSourceKey())
 
 	if _, err := src.parsePage(strings.NewReader(string(body)), pms); err != nil {
 		t.Fatalf("parsePage error: %v", err)

--- a/pkg/cloud/gcp/billingpricingsource_test.go
+++ b/pkg/cloud/gcp/billingpricingsource_test.go
@@ -1,0 +1,297 @@
+package gcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/model/pricingmodel"
+	"github.com/opencost/opencost/core/pkg/model/shared"
+)
+
+func TestGCPNormalizeFamily(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"N1Standard", "n1"},
+		{"N2Standard", "n2"},
+		{"N2DStandard", "n2d"},
+		{"E2", "e2"},
+		{"A2", "a2"},
+		{"A3", "a3"},
+		{"G2", "g2"},
+		{"C2Standard", "c2"},
+		{"C2DStandard", "c2d"},
+		{"C3Standard", "c3"},
+		{"C3DStandard", "c3d"},
+		{"M1", "m1"},
+		{"M2", "m2"},
+		{"M3", "m3"},
+		{"T2DStandard", "t2d"},
+		{"T2AStandard", "t2a"},
+		{"N4Standard", "n4"},
+		{"H3Standard", "h3"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := gcpNormalizeFamily(tc.in)
+			if got != tc.want {
+				t.Errorf("gcpNormalizeFamily(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGCPUsageType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want shared.UsageType
+	}{
+		{"OnDemand", shared.UsageTypeOnDemand},
+		{"Preemptible", shared.UsageTypeSpot},
+		{"Commit1Yr", shared.UsageTypeEmpty},
+		{"Commit3Yr", shared.UsageTypeEmpty},
+		{"", shared.UsageTypeEmpty},
+		{"unknown", shared.UsageTypeEmpty},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := gcpUsageType(tc.in)
+			if got != tc.want {
+				t.Errorf("gcpUsageType(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGCPExtractHourlyRate(t *testing.T) {
+	cases := []struct {
+		name   string
+		sku    *GCPPricing
+		want   float64
+		wantOK bool
+	}{
+		{
+			name:   "nanos only",
+			sku:    skuWithRate("0", 48000000),
+			want:   0.048,
+			wantOK: true,
+		},
+		{
+			name:   "units and nanos",
+			sku:    skuWithRate("1", 500000000),
+			want:   1.5,
+			wantOK: true,
+		},
+		{
+			name:   "whole units no nanos",
+			sku:    skuWithRate("2", 0),
+			want:   2.0,
+			wantOK: true,
+		},
+		{
+			name:   "no pricing info",
+			sku:    &GCPPricing{PricingInfo: []*PricingInfo{}},
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "no tiered rates",
+			sku:    skuWithRates([]*TieredRates{}),
+			want:   0,
+			wantOK: false,
+		},
+		{
+			name:   "nil pricing info",
+			sku:    &GCPPricing{},
+			want:   0,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := gcpExtractHourlyRate(tc.sku)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && abs(got-tc.want) > 1e-9 {
+				t.Errorf("rate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGCPBillingPricingSource_ParsePage(t *testing.T) {
+	page := gcpBillingPage{
+		NextPageToken: "token-xyz",
+		SKUs: []*GCPPricing{
+			// N1 CPU OnDemand — us-central1
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Compute", ResourceGroup: "N1Standard", UsageType: "OnDemand"},
+				ServiceRegions: []string{"us-central1"},
+				Description:    "N1 Predefined Instance Core running in Americas",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 31611000)},
+			},
+			// N1 RAM OnDemand — us-central1
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Compute", ResourceGroup: "N1Standard", UsageType: "OnDemand"},
+				ServiceRegions: []string{"us-central1"},
+				Description:    "N1 Predefined Instance RAM running in Americas",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 4237000)},
+			},
+			// T4 GPU OnDemand — us-central1
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Compute", ResourceGroup: "GPU", UsageType: "OnDemand"},
+				ServiceRegions: []string{"us-central1"},
+				Description:    "NVIDIA Tesla T4 running in Americas",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 400000000)},
+			},
+			// N1 CPU Commit1Yr — should be skipped
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Compute", ResourceGroup: "N1Standard", UsageType: "Commit1Yr"},
+				ServiceRegions: []string{"us-central1"},
+				Description:    "Commitment v1: N1 in Americas for 1 year",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 20000000)},
+			},
+			// Non-Compute resourceFamily — should be skipped
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Storage", ResourceGroup: "SSD", UsageType: "OnDemand"},
+				ServiceRegions: []string{"us-central1"},
+				Description:    "SSD backed Local Storage",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 17000000)},
+			},
+			// GPU SKU with zero rate — should be skipped (reserved)
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Compute", ResourceGroup: "GPU", UsageType: "OnDemand"},
+				ServiceRegions: []string{"us-central1"},
+				Description:    "NVIDIA Tesla V100 running in Americas",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 0)},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(page)
+	src, err := NewGCPBillingPricingSource(GCPBillingPricingSourceConfig{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewGCPBillingPricingSource error: %v", err)
+	}
+	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), GCPBillingPricingSourceKey)
+
+	nextToken, err := src.parsePage(strings.NewReader(string(body)), pms)
+	if err != nil {
+		t.Fatalf("parsePage error: %v", err)
+	}
+
+	if nextToken != "token-xyz" {
+		t.Errorf("nextToken = %q, want %q", nextToken, "token-xyz")
+	}
+
+	if len(pms.NodePricing) != 3 {
+		t.Errorf("expected 3 pricing entries (CPU, RAM, GPU), got %d", len(pms.NodePricing))
+	}
+
+	cpuKey := pricingmodel.NodeKey{
+		Provider:  shared.ProviderGCP,
+		Region:    "us-central1",
+		Family:    "n1",
+		UsageType: shared.UsageTypeOnDemand,
+		Type:      pricingmodel.NodePricingTypeCPUCore,
+	}
+	if _, ok := pms.NodePricing[cpuKey]; !ok {
+		t.Error("missing CPU entry for n1/us-central1")
+	}
+
+	ramKey := pricingmodel.NodeKey{
+		Provider:  shared.ProviderGCP,
+		Region:    "us-central1",
+		Family:    "n1",
+		UsageType: shared.UsageTypeOnDemand,
+		Type:      pricingmodel.NodePricingTypeRamGB,
+	}
+	if _, ok := pms.NodePricing[ramKey]; !ok {
+		t.Error("missing RAM entry for n1/us-central1")
+	}
+
+	gpuKey := pricingmodel.NodeKey{
+		Provider:   shared.ProviderGCP,
+		Region:     "us-central1",
+		UsageType:  shared.UsageTypeOnDemand,
+		DeviceType: "nvidia-tesla-t4",
+		Type:       pricingmodel.NodePricingTypeDevice,
+	}
+	if entry, ok := pms.NodePricing[gpuKey]; !ok {
+		t.Error("missing GPU entry for T4/us-central1")
+	} else if abs(entry.HourlyRate-0.4) > 1e-9 {
+		t.Errorf("GPU HourlyRate = %v, want 0.4", entry.HourlyRate)
+	}
+}
+
+func TestGCPBillingPricingSource_ParsePage_Preemptible(t *testing.T) {
+	page := gcpBillingPage{
+		SKUs: []*GCPPricing{
+			{
+				Category:       &GCPResourceInfo{ResourceFamily: "Compute", ResourceGroup: "N1Standard", UsageType: "Preemptible"},
+				ServiceRegions: []string{"us-east1"},
+				Description:    "Preemptible N1 Predefined Instance Core",
+				PricingInfo:    []*PricingInfo{pricingInfo("0", 6655000)},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(page)
+	src, err := NewGCPBillingPricingSource(GCPBillingPricingSourceConfig{APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("NewGCPBillingPricingSource error: %v", err)
+	}
+	pms := pricingmodel.NewPricingModelSet(time.Now().UTC(), GCPBillingPricingSourceKey)
+
+	if _, err := src.parsePage(strings.NewReader(string(body)), pms); err != nil {
+		t.Fatalf("parsePage error: %v", err)
+	}
+
+	key := pricingmodel.NodeKey{
+		Provider:  shared.ProviderGCP,
+		Region:    "us-east1",
+		Family:    "n1",
+		UsageType: shared.UsageTypeSpot,
+		Type:      pricingmodel.NodePricingTypeCPUCore,
+	}
+	if _, ok := pms.NodePricing[key]; !ok {
+		t.Error("missing Preemptible CPU entry")
+	}
+}
+
+// --- helpers ---
+
+func skuWithRate(units string, nanos float64) *GCPPricing {
+	return skuWithRates([]*TieredRates{
+		{UnitPrice: &UnitPriceInfo{Units: units, Nanos: nanos}},
+	})
+}
+
+func skuWithRates(rates []*TieredRates) *GCPPricing {
+	return &GCPPricing{
+		PricingInfo: []*PricingInfo{
+			{PricingExpression: &PricingExpression{TieredRates: rates}},
+		},
+	}
+}
+
+func pricingInfo(units string, nanos float64) *PricingInfo {
+	return &PricingInfo{
+		PricingExpression: &PricingExpression{
+			TieredRates: []*TieredRates{
+				{UnitPrice: &UnitPriceInfo{Units: units, Nanos: nanos}},
+			},
+		},
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/pkg/cloud/gcp/billingpricingsource_test.go
+++ b/pkg/cloud/gcp/billingpricingsource_test.go
@@ -193,33 +193,33 @@ func TestGCPBillingPricingSource_ParsePage(t *testing.T) {
 	}
 
 	cpuKey := pricingmodel.NodeKey{
-		Provider:  shared.ProviderGCP,
-		Region:    "us-central1",
-		Family:    "n1",
-		UsageType: shared.UsageTypeOnDemand,
-		Type:      pricingmodel.NodePricingTypeCPUCore,
+		Provider:    shared.ProviderGCP,
+		Region:      "us-central1",
+		Family:      "n1",
+		UsageType:   shared.UsageTypeOnDemand,
+		PricingType: pricingmodel.NodePricingTypeCPUCore,
 	}
 	if _, ok := pms.NodePricing[cpuKey]; !ok {
 		t.Error("missing CPU entry for n1/us-central1")
 	}
 
 	ramKey := pricingmodel.NodeKey{
-		Provider:  shared.ProviderGCP,
-		Region:    "us-central1",
-		Family:    "n1",
-		UsageType: shared.UsageTypeOnDemand,
-		Type:      pricingmodel.NodePricingTypeRamGB,
+		Provider:    shared.ProviderGCP,
+		Region:      "us-central1",
+		Family:      "n1",
+		UsageType:   shared.UsageTypeOnDemand,
+		PricingType: pricingmodel.NodePricingTypeRamGB,
 	}
 	if _, ok := pms.NodePricing[ramKey]; !ok {
 		t.Error("missing RAM entry for n1/us-central1")
 	}
 
 	gpuKey := pricingmodel.NodeKey{
-		Provider:   shared.ProviderGCP,
-		Region:     "us-central1",
-		UsageType:  shared.UsageTypeOnDemand,
-		DeviceType: "nvidia-tesla-t4",
-		Type:       pricingmodel.NodePricingTypeDevice,
+		Provider:    shared.ProviderGCP,
+		Region:      "us-central1",
+		UsageType:   shared.UsageTypeOnDemand,
+		DeviceType:  "nvidia-tesla-t4",
+		PricingType: pricingmodel.NodePricingTypeDevice,
 	}
 	if entry, ok := pms.NodePricing[gpuKey]; !ok {
 		t.Error("missing GPU entry for T4/us-central1")
@@ -252,11 +252,11 @@ func TestGCPBillingPricingSource_ParsePage_Preemptible(t *testing.T) {
 	}
 
 	key := pricingmodel.NodeKey{
-		Provider:  shared.ProviderGCP,
-		Region:    "us-east1",
-		Family:    "n1",
-		UsageType: shared.UsageTypeSpot,
-		Type:      pricingmodel.NodePricingTypeCPUCore,
+		Provider:    shared.ProviderGCP,
+		Region:      "us-east1",
+		Family:      "n1",
+		UsageType:   shared.UsageTypeSpot,
+		PricingType: pricingmodel.NodePricingTypeCPUCore,
 	}
 	if _, ok := pms.NodePricing[key]; !ok {
 		t.Error("missing Preemptible CPU entry")

--- a/pkg/pricingmodel/config.go
+++ b/pkg/pricingmodel/config.go
@@ -4,14 +4,16 @@ import (
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/util/timeutil"
+	"github.com/opencost/opencost/pkg/env"
 )
 
 // PipelineConfig holds configuration for the pricing model pipeline.
-// If nil is passed to NewPipeline, DefaultPipelineConfig is used.
 type PipelineConfig struct {
 	AppName           string
+	CurrencyCode      string
 	AWSRunnerConfig   AWSRunnerConfig
 	AzureRunnerConfig AzureRunnerConfig
+	GCPRunnerConfig   GCPRunnerConfig
 }
 
 type AWSRunnerConfig struct {
@@ -22,12 +24,18 @@ type AWSRunnerConfig struct {
 type AzureRunnerConfig struct {
 	Enabled         bool
 	RefreshInterval time.Duration
-	CurrencyCode    string
+}
+
+type GCPRunnerConfig struct {
+	Enabled         bool
+	RefreshInterval time.Duration
+	APIKey          string
 }
 
 func DefaultPipelineConfig(appName string) PipelineConfig {
 	return PipelineConfig{
-		AppName: appName,
+		AppName:      appName,
+		CurrencyCode: "USD",
 		AWSRunnerConfig: AWSRunnerConfig{
 			Enabled:         true,
 			RefreshInterval: timeutil.Day,
@@ -35,6 +43,11 @@ func DefaultPipelineConfig(appName string) PipelineConfig {
 		AzureRunnerConfig: AzureRunnerConfig{
 			Enabled:         true,
 			RefreshInterval: timeutil.Day,
+		},
+		GCPRunnerConfig: GCPRunnerConfig{
+			Enabled:         true,
+			RefreshInterval: timeutil.Day,
+			APIKey:          env.GetCloudProviderAPIKey(),
 		},
 	}
 }

--- a/pkg/pricingmodel/pipeline.go
+++ b/pkg/pricingmodel/pipeline.go
@@ -76,20 +76,22 @@ func NewPipeline(store corestorage.Storage, cfg PipelineConfig) (*Pipeline, erro
 	}
 
 	if cfg.GCPRunnerConfig.Enabled {
-		if cfg.GCPRunnerConfig.APIKey == "" {
-			log.Warnf("GCP Billing Catelog Pricing Source is enabled but no api key was provided")
-		}
-		src := gcp.NewGCPBillingPricingSource(gcp.GCPBillingPricingSourceConfig{
+
+		src, err := gcp.NewGCPBillingPricingSource(gcp.GCPBillingPricingSourceConfig{
 			APIKey:       cfg.GCPRunnerConfig.APIKey,
 			CurrencyCode: cfg.CurrencyCode,
 		})
-		rc := runnerConfig{
-			interval: cfg.GCPRunnerConfig.RefreshInterval,
+		if err != nil {
+			log.Error(err.Error())
+		} else {
+			rc := runnerConfig{
+				interval: cfg.GCPRunnerConfig.RefreshInterval,
+			}
+			if t, ok := lastUpdates[src.PricingSourceKey()]; ok {
+				rc.lastRun = &t
+			}
+			p.addSource(src, rc)
 		}
-		if t, ok := lastUpdates[src.PricingSourceKey()]; ok {
-			rc.lastRun = &t
-		}
-		p.addSource(src, rc)
 	}
 
 	return p, nil

--- a/pkg/pricingmodel/pipeline.go
+++ b/pkg/pricingmodel/pipeline.go
@@ -10,6 +10,7 @@ import (
 	corestorage "github.com/opencost/opencost/core/pkg/storage"
 	"github.com/opencost/opencost/pkg/cloud/aws"
 	"github.com/opencost/opencost/pkg/cloud/azure"
+	"github.com/opencost/opencost/pkg/cloud/gcp"
 )
 
 // Pipeline manages a set of runners, one per PricingSource, exporting pricing
@@ -49,7 +50,9 @@ func NewPipeline(store corestorage.Storage, cfg PipelineConfig) (*Pipeline, erro
 	}
 
 	if cfg.AWSRunnerConfig.Enabled {
-		src := &aws.PricingListPricingSource{}
+		src := aws.NewPricingListPricingSource(aws.PricingListPricingSourceConfig{
+			CurrencyCode: cfg.CurrencyCode,
+		})
 		rc := runnerConfig{
 			interval: cfg.AWSRunnerConfig.RefreshInterval,
 		}
@@ -61,10 +64,27 @@ func NewPipeline(store corestorage.Storage, cfg PipelineConfig) (*Pipeline, erro
 
 	if cfg.AzureRunnerConfig.Enabled {
 		src := azure.NewAzureRetailPricingSource(azure.AzureRetailPricingSourceConfig{
-			CurrencyCode: cfg.AzureRunnerConfig.CurrencyCode,
+			CurrencyCode: cfg.CurrencyCode,
 		})
 		rc := runnerConfig{
 			interval: cfg.AzureRunnerConfig.RefreshInterval,
+		}
+		if t, ok := lastUpdates[src.PricingSourceKey()]; ok {
+			rc.lastRun = &t
+		}
+		p.addSource(src, rc)
+	}
+
+	if cfg.GCPRunnerConfig.Enabled {
+		if cfg.GCPRunnerConfig.APIKey == "" {
+			log.Warnf("GCP Billing Catelog Pricing Source is enabled but no api key was provided")
+		}
+		src := gcp.NewGCPBillingPricingSource(gcp.GCPBillingPricingSourceConfig{
+			APIKey:       cfg.GCPRunnerConfig.APIKey,
+			CurrencyCode: cfg.CurrencyCode,
+		})
+		rc := runnerConfig{
+			interval: cfg.GCPRunnerConfig.RefreshInterval,
 		}
 		if t, ok := lastUpdates[src.PricingSourceKey()]; ok {
 			rc.lastRun = &t

--- a/pkg/pricingmodel/runner.go
+++ b/pkg/pricingmodel/runner.go
@@ -123,15 +123,15 @@ func (r *runner) export() {
 		return
 	}
 
-	err = r.store.Write(r.source.PricingSourceKey(), pms)
+	err = r.store.Write(pms)
 	if err != nil {
-		log.Errorf("PricingModel[%s]: runner: failed to write pricing model set to storage: %v", pms.Source, err)
+		log.Errorf("PricingModel[%s]: runner: failed to write pricing model set to storage: %v", r.source.PricingSourceKey(), err)
 		r.statusLock.Lock()
 		r.status.LastError = err.Error()
 		r.statusLock.Unlock()
 		return
 	}
-	
+
 	r.statusLock.Lock()
 	r.status.LastRun = time.Now().UTC()
 	r.status.Runs++

--- a/pkg/pricingmodel/storage.go
+++ b/pkg/pricingmodel/storage.go
@@ -33,8 +33,8 @@ func newStorageWriter(store storage.Storage, appName string) (*storageWriter, er
 	}, nil
 }
 
-func (sw *storageWriter) Write(sourceKey string, pms *pricingmodel.PricingModelSet) error {
-	fullPath := sw.pathing.ToFullPath("", sourceKey, sw.encoder.FileExt())
+func (sw *storageWriter) Write(pms *pricingmodel.PricingModelSet) error {
+	fullPath := sw.pathing.ToFullPath("", pms.SourceKey, sw.encoder.FileExt())
 	data, err := sw.encoder.Encode(pms)
 	if err != nil {
 		return fmt.Errorf("failed to encode data: %w", err)
@@ -43,7 +43,7 @@ func (sw *storageWriter) Write(sourceKey string, pms *pricingmodel.PricingModelS
 	if err != nil {
 		return fmt.Errorf("failed to write to storage: %w", err)
 	}
-	log.Infof("PricingModel[%s]: exported pricing model set (%d bytes)", sourceKey, len(data))
+	log.Infof("PricingModel[%s]: exported pricing model set (%d bytes)", pms.SourceKey, len(data))
 	return nil
 }
 


### PR DESCRIPTION
## Description
  Extends the NodeKey/NodePricing pricing model schema and implements a GCP Cloud Billing Catalog pricing source alongside the existing AWS and Azure sources.  
                                                                                                                                                                  
  Schema changes (core/pkg/model/pricingmodel):                                                                                                                   
  - Added Family string, Accelerator string, and Type NodePricingType fields to NodeKey to support component-based pricing (per-vCPU, per-GB RAM, per-device) used
   by GCP                                                                                                                                                         
  - Renamed TotalHourlyRate → HourlyRate on NodePricing to reflect that entries may represent a component rate rather than a total instance rate                
  - Added NodePricingType string alias with constants: Total, CPUCore, RamGB, Device                                                                              
  - Regenerated bingen codecs; manually fixed cross-package import path issue in generated file                                                                   
                                                                                               
  GCP pricing source (pkg/cloud/gcp/billingpricingsource.go):                                                                                                     
  - Fetches paginated SKUs from the GCP Cloud Billing Catalog API (cloudbilling.googleapis.com)                                                                   
  - Emits per-vCPU and per-GB RAM entries keyed by family + region, and per-device entries keyed by accelerator label + region                                    
  - Reuses existing GCPPricing/NormalizeGPULabel types from the GCP provider package                                                                              
  - Skips commitment SKUs and zero-price reserved device SKUs                                                                                                     
                                                                                                                                                                  
  Pipeline config:                                                                                                                                                
  - Added GCPRunnerConfig (disabled by default; requires APIKey)                                                                                                  
  - Moved CurrencyCode to top-level PipelineConfig; all three sources share a single currency setting                                                             
  - AWS source now uses PriceListEC2PricePerUnit.ForCurrency() to select the configured currency, defaulting to USD                                               
                                                                                                                                                                  
  Bug fixes:                                                                                                                                                      
  - Fixed Azure Retail Pricing source sending unencoded $filter query parameter, causing 400 responses from Azure Front Door                                      
  - Added HTTP status code checks to Azure and GCP sources with body logging on error   

## Related Issues


## User Impact
The NodeKey and NodePricing types are updated. Consumers reading PricingModelSet data from storage will need to handle the renamed HourlyRate field and the new 
  Type/Family/Accelerator fields on NodeKey. The bingen wire format for NodeKey has changed (three additional string fields appended); existing cached files will
  fail to deserialize and should be deleted.                                                                                                                      
                                                                                                                                                                
  This is a breaking change to the NodeKey/NodePricing schema relative to feature/kubemodel.     

## Testing
  - Built and ran the AWS and Azure pricing sources end-to-end; confirmed pricing entries are populated correctly                                                 
  - Confirmed Azure 400 fix resolves the URL encoding issue
  - GCP source builds and follows the same pattern as Azure; requires a valid Billing API key for live testing  
