### PR TITLE
fix(env): make MCP server opt-in by defaulting MCP_SERVER_ENABLED to false

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ just validate-protobuf
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MCP_SERVER_ENABLED` | `true` | Enable MCP server |
+| `MCP_SERVER_ENABLED` | `false` | Enable MCP server |
 | `MCP_HTTP_PORT` | `8081` | MCP server HTTP port |
 
 ### Cloud Providers

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ Note: The standalone Kubernetes manifest files have been removed. Please use Hel
 
 ## MCP Server
 
-The OpenCost MCP (Model Context Protocol) server provides AI agents with access to cost allocation and asset data through a standardized interface. The MCP server is **enabled by default** in all OpenCost deployments, runs on port 8081, and is **built into the Helm chart** for easy production deployment. Users have full control to disable it or configure custom ports and settings.
+The OpenCost MCP (Model Context Protocol) server provides AI agents with access to cost allocation and asset data through a standardized interface. The MCP server is **disabled by default** (opt-in) in all OpenCost deployments, runs on port 8081, and is **built into the Helm chart** for easy production deployment. Users have full control to enable it or configure custom ports and settings.
 
 ### Features
 
-- **Enabled by Default**: MCP server starts automatically with OpenCost
-- **Full User Control**: Easy to disable or configure port and settings
+- **Opt-in by Default**: MCP server is disabled by default to minimize the attack surface and must be explicitly enabled
+- **Full User Control**: Easy to enable or configure port and settings
 - **Allocation Queries**: Retrieve cost allocation data with filtering and aggregation
 - **Asset Queries**: Access detailed asset information including nodes, disks, load balancers, and more
 - **Cloud Cost Queries**: Query cloud cost data with provider, service, and region filtering
 - **HTTP Transport**: Uses HTTP for reliable communication with MCP clients
-- **Zero Configuration**: Works out of the box with default OpenCost deployment
+- **Simple Configuration**: Easy to enable using standard environment variables
 - **Helm Integration**: Built into the official Helm chart for production deployments
 
 ### Quick Start
@@ -105,19 +105,19 @@ opencost:
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
 helm repo update
 
-# Deploy OpenCost with MCP server (enabled by default)
-helm install opencost opencost/opencost
+# Deploy OpenCost with MCP server enabled (opt-in)
+helm install opencost opencost/opencost --set opencost.mcp.enabled=true
 
 # Access MCP server via port forwarding (example)
 kubectl port-forward svc/opencost 8081:8081
 ```
 
-The MCP server is **enabled by default** in the Helm chart. For custom configuration:
+The MCP server is **disabled by default** in the Helm chart. For custom configuration:
 
 ```bash
-# Deploy with MCP server disabled
+# Deploy with MCP server enabled
 helm install opencost opencost/opencost \
-  --set opencost.mcp.enabled=false
+  --set opencost.mcp.enabled=true
 
 # Deploy with custom MCP port
 helm install opencost opencost/opencost \
@@ -132,8 +132,8 @@ helm install opencost opencost/opencost \
 
 | Configuration | Command | Description |
 |---------------|---------|-------------|
-| **Default** | `helm install opencost opencost/opencost` | MCP enabled on port 8081 |
-| **Disable** | `--set opencost.mcp.enabled=false` | Completely disable MCP server |
+| **Default** | `helm install opencost opencost/opencost` | MCP disabled by default |
+| **Enable** | `--set opencost.mcp.enabled=true` | Enable MCP server on port 8081 |
 | **Custom Port** | `--set opencost.mcp.port=9091` | Use different port |
 | **Debug Mode** | `--set opencost.mcp.extraEnv.MCP_LOG_LEVEL=debug` | Enable debug logging |
 

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -90,7 +90,7 @@ func Execute(conf *Config) error {
 	} else if conf.MCPServerEnabled {
 		log.Warnf("MCP Server is enabled but Kubernetes is not available. MCP server requires Kubernetes to function.")
 	} else {
-		if _, exists := os.LookupEnv(env.MCPServerEnabledEnvVar); !exists {
+		if value, exists := os.LookupEnv(env.MCPServerEnabledEnvVar); !exists || value == "" {
 			log.Infof("MCP server is now disabled by default. If you wish to use the MCP server, please set the %s environment variable to true.", env.MCPServerEnabledEnvVar)
 		}
 	}

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -89,6 +89,10 @@ func Execute(conf *Config) error {
 		}
 	} else if conf.MCPServerEnabled {
 		log.Warnf("MCP Server is enabled but Kubernetes is not available. MCP server requires Kubernetes to function.")
+	} else {
+		if _, exists := os.LookupEnv(env.MCPServerEnabledEnvVar); !exists {
+			log.Infof("MCP server is now disabled by default. If you wish to use the MCP server, please set the %s environment variable to true.", env.MCPServerEnabledEnvVar)
+		}
 	}
 
 	apiutil.ApplyContainerDiagnosticEndpoints(router)

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -443,7 +443,7 @@ func GetOVHMonthlyNodepools() []string {
 // IsMCPServerEnabled returns the environment variable value for MCPServerEnabledEnvVar which represents
 // whether or not the MCP server is enabled.
 func IsMCPServerEnabled() bool {
-	return env.GetBool(MCPServerEnabledEnvVar, true)
+	return env.GetBool(MCPServerEnabledEnvVar, false)
 }
 
 // GetMCPHTTPPort returns the environment variable value for MCPHTTPPortEnvVar which represents

--- a/pkg/env/costmodel_test.go
+++ b/pkg/env/costmodel_test.go
@@ -79,3 +79,17 @@ func TestGetKubernetesEnabled(t *testing.T) {
 	}
 
 }
+
+func TestIsMCPServerEnabled_DefaultFalse(t *testing.T) {
+	t.Setenv("MCP_SERVER_ENABLED", "")
+	if got := IsMCPServerEnabled(); got {
+		t.Fatalf("expected false when env var unset, got %v", got)
+	}
+}
+
+func TestIsMCPServerEnabled_True(t *testing.T) {
+	t.Setenv("MCP_SERVER_ENABLED", "true")
+	if got := IsMCPServerEnabled(); !got {
+		t.Fatalf("expected true when env var set to true, got %v", got)
+	}
+}

--- a/pkg/env/costmodel_test.go
+++ b/pkg/env/costmodel_test.go
@@ -81,9 +81,17 @@ func TestGetKubernetesEnabled(t *testing.T) {
 }
 
 func TestIsMCPServerEnabled_DefaultFalse(t *testing.T) {
-	t.Setenv("MCP_SERVER_ENABLED", "")
+	old, hadOld := os.LookupEnv("MCP_SERVER_ENABLED")
+	os.Unsetenv("MCP_SERVER_ENABLED")
+	t.Cleanup(func() {
+		if hadOld {
+			os.Setenv("MCP_SERVER_ENABLED", old)
+		} else {
+			os.Unsetenv("MCP_SERVER_ENABLED")
+		}
+	})
 	if got := IsMCPServerEnabled(); got {
-		t.Fatalf("expected false when env var unset, got %v", got)
+		t.Fatalf("expected false when MCP_SERVER_ENABLED is unset, got %v", got)
 	}
 }
 


### PR DESCRIPTION
This pull request changes the default behavior of the MCP (Model Context Protocol) server in OpenCost from enabled to disabled by default, making it opt-in for users. Documentation, configuration, and code logic have all been updated to reflect this new default. The most important changes are:

**Default Behavior Change:**

* The MCP server is now disabled by default (`MCP_SERVER_ENABLED` is `false` by default), requiring explicit user action to enable it. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L147-R147) [[2]](diffhunk://#diff-65773d9e4e9f58cc389e5ec2c391a39d56c37d85ea1de6e26057ff9b95b3cda3L446-R446)

**Documentation Updates:**

* Updated `README.md` to clarify that the MCP server is opt-in (disabled by default), revised quick start instructions, and changed Helm chart usage examples to show how to enable the MCP server. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L108-R120) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R136)

**User Feedback and Logging:**

* Added a log message to inform users that the MCP server is now disabled by default and how to enable it via the environment variable.

**Testing:**

* Added tests to verify that `IsMCPServerEnabled` returns `false` when the environment variable is unset and `true` when explicitly set.

Follows principle of least privilege: port 8081 should not be exposed without explicit user intent. Users upgrading will see an informational log message guiding them to set MCP_SERVER_ENABLED=true if needed. Updates README.md and CLAUDE.md to reflect opt-in behaviour.

Closes #3715

