### PR TITLE
Sth/kcm 5496 Prom Implementation

### DIFF
--- a/modules/collector-source/pkg/metric/collector.go
+++ b/modules/collector-source/pkg/metric/collector.go
@@ -100,7 +100,7 @@ const (
 	NetInternetServiceIngressGiBID             MetricCollectorID = "NetInternetServiceIngressGiB"
 	NetNatGatewayIngressGiBID                  MetricCollectorID = "NetNatGatewayIngressGiB"
 	NetReceiveBytesID                          MetricCollectorID = "NetReceiveBytes"
-	NamespaceInfoID                            MetricCollectorID = "NamespaceUptime"
+	NamespaceInfoID                            MetricCollectorID = "NamespaceInfo"
 	NamespaceUptimeID                          MetricCollectorID = "NamespaceUptime"
 	NamespaceLabelsID                          MetricCollectorID = "NamespaceLabels"
 	NamespaceAnnotationsID                     MetricCollectorID = "NamespaceAnnotations"

--- a/modules/prometheus-source/pkg/prom/metricsquerier.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier.go
@@ -92,7 +92,22 @@ func (pds *PrometheusMetricsQuerier) QueryPVUsedMax(start, end time.Time) *sourc
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPVCUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryPVCUptime"
+	const queryFmtPVCUptime = `avg(kube_persistentvolumeclaim_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryPVCUptime := fmt.Sprintf(queryFmtPVCUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryPVCUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryPVCUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPVCInfo(start, end time.Time) *source.Future[source.PVCInfoResult] {
@@ -258,13 +273,40 @@ func (pds *PrometheusMetricsQuerier) QueryLocalStorageActiveMinutes(start, end t
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNodeInfo(start, end time.Time) *source.Future[source.NodeInfoResult] {
-	//TODO implement
-	return nil
+	const queryName = "QueryNodeInfo"
+	const queryFmtNodeInfo = `avg(avg_over_time(node_info{%s}[%s])) by (%s, node, uid, provider_id, instance_type)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryNodeInfo := fmt.Sprintf(queryFmtNodeInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeInfo)
+
+	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
+	return source.NewFuture(source.DecodeNodeInfoResult, ctx.QueryAtTime(queryNodeInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNodeUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	//TODO implement
-	return nil
+	const queryName = "QueryNodeUptime"
+	const queryFmtNodeUptime = `avg(node_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryNodeUptime := fmt.Sprintf(queryFmtNodeUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryNodeUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresCapacity(start, end time.Time) *source.Future[source.NodeCPUCoresCapacityResult] {
@@ -452,11 +494,39 @@ func (pds *PrometheusMetricsQuerier) QueryNodeRAMUserPercent(start, end time.Tim
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNodeResourceCapacities(start, end time.Time) *source.Future[source.ResourceResult] {
-	return nil
+	const queryName = "QueryNodeResourceCapacities"
+	const queryFmtNodeResourceCapacities = `avg(avg_over_time(kube_node_status_capacity{%s}[%s])) by (%s, node, uid, resource, unit)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryNodeResourceCapacities := fmt.Sprintf(queryFmtNodeResourceCapacities, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeResourceCapacities)
+
+	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
+	return source.NewFuture(source.DecodeResourceResult, ctx.QueryAtTime(queryNodeResourceCapacities, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNodeResourcesAllocatable(start, end time.Time) *source.Future[source.ResourceResult] {
-	return nil
+	const queryName = "QueryNodeResourcesAllocatable"
+	const queryFmtNodeResourcesAllocatable = `avg(avg_over_time(kube_node_status_allocatable{%s}[%s])) by (%s, node, uid, resource, unit)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryNodeResourcesAllocatable := fmt.Sprintf(queryFmtNodeResourcesAllocatable, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeResourcesAllocatable)
+
+	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
+	return source.NewFuture(source.DecodeResourceResult, ctx.QueryAtTime(queryNodeResourcesAllocatable, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryLBPricePerHr(start, end time.Time) *source.Future[source.LBPricePerHrResult] {
@@ -497,7 +567,21 @@ func (pds *PrometheusMetricsQuerier) QueryLBActiveMinutes(start, end time.Time) 
 }
 
 func (pds *PrometheusMetricsQuerier) QueryClusterInfo(start, end time.Time) *source.Future[source.ClusterInfoResult] {
-	return nil
+	const queryName = "QueryClusterInfo"
+	const queryFmtClusterInfo = `avg(avg_over_time(kubecost_cluster_info{%s}[%s])) by (%s, uid, provider, account_id, provisioner_name, region)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryClusterInfo := fmt.Sprintf(queryFmtClusterInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryClusterInfo)
+
+	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
+	return source.NewFuture(source.DecodeClusterInfoResult, ctx.QueryAtTime(queryClusterInfo, end))
 }
 
 // Note: cluster_info is not currently emitted
@@ -599,19 +683,76 @@ func (pds *PrometheusMetricsQuerier) QueryPodsUID(start, end time.Time) *source.
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPodInfo(start, end time.Time) *source.Future[source.PodInfoResult] {
-	return nil
+	const queryName = "QueryPodInfo"
+	const queryFmtPodInfo = `avg(avg_over_time(pod_info{%s}[%s])) by (%s, pod, uid, namespace_uid, node_uid)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryPodInfo := fmt.Sprintf(queryFmtPodInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryPodInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodePodInfoResult, ctx.QueryAtTime(queryPodInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPodUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryPodUptime"
+	const queryFmtPodUptime = `avg(pod_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryPodUptime := fmt.Sprintf(queryFmtPodUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryPodUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryPodUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPodOwners(start, end time.Time) *source.Future[source.OwnerResult] {
-	return nil
+	const queryName = "QueryPodOwners"
+	const queryFmtPodOwners = `avg(avg_over_time(kube_pod_owner{%s}[%s])) by (%s, uid, owner_uid, owner_kind)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryPodOwners := fmt.Sprintf(queryFmtPodOwners, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryPodOwners)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeOwnerResult, ctx.QueryAtTime(queryPodOwners, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPodPVCVolumes(start, end time.Time) *source.Future[source.PodPVCVolumeResult] {
-	return nil
+	const queryName = "QueryPodPVCVolumes"
+	const queryFmtPodPVCVolumes = `avg(avg_over_time(pod_pvc_volume{%s}[%s])) by (%s, uid, persistentvolumeclaim_uid, pod_volume_name)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryPodPVCVolumes := fmt.Sprintf(queryFmtPodPVCVolumes, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryPodPVCVolumes)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodePodPVCVolumeResult, ctx.QueryAtTime(queryPodPVCVolumes, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPodNetworkEgressBytes(start, end time.Time) *source.Future[source.PodNetworkBytesResult] {
@@ -651,15 +792,58 @@ func (pds *PrometheusMetricsQuerier) QueryPodNetworkIngressBytes(start, end time
 }
 
 func (pds *PrometheusMetricsQuerier) QueryContainerUptime(start, end time.Time) *source.Future[source.ContainerUptimeResult] {
-	return nil
+	const queryName = "QueryContainerUptime"
+	const queryFmtContainerUptime = `avg(kube_pod_container_status_running{container!="", %s} != 0) by (container, uid, %s)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryContainerUptime := fmt.Sprintf(queryFmtContainerUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryContainerUptime)
+
+	ctx := pds.promContexts.NewNamedContext(AllocationContextName)
+	return source.NewFuture(source.DecodeContainerUptimeResult, ctx.QueryAtTime(queryContainerUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryContainerResourceRequests(start, end time.Time) *source.Future[source.ContainerResourceResult] {
-	return nil
+	const queryName = "QueryContainerResourceRequests"
+	const queryFmtContainerResourceRequests = `avg(avg_over_time(kube_pod_container_resource_requests{container!="", container!="POD", node!="", %s}[%s])) by (container, uid, resource, unit, %s)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryContainerResourceRequests := fmt.Sprintf(queryFmtContainerResourceRequests, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryContainerResourceRequests)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeContainerResourceResult, ctx.QueryAtTime(queryContainerResourceRequests, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryContainerResourceLimits(start, end time.Time) *source.Future[source.ContainerResourceResult] {
-	return nil
+	const queryName = "QueryContainerResourceLimits"
+	const queryFmtContainerResourceLimits = `avg(avg_over_time(kube_pod_container_resource_limits{container!="", container!="POD", node!="", %s}[%s])) by (container, uid, resource, unit, %s)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryContainerResourceLimits := fmt.Sprintf(queryFmtContainerResourceLimits, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryContainerResourceLimits)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeContainerResourceResult, ctx.QueryAtTime(queryContainerResourceLimits, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryRAMBytesAllocated(start, end time.Time) *source.Future[source.RAMBytesAllocatedResult] {
@@ -974,19 +1158,76 @@ func (pds *PrometheusMetricsQuerier) QueryIsGPUShared(start, end time.Time) *sou
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDCGMDeviceInfo(start, end time.Time) *source.Future[source.DCGMDeviceInfoResult] {
-	return nil
+	const queryName = "QueryDCGMDeviceInfo"
+	const queryFmtDCGMDeviceInfo = `avg(avg_over_time(DCGM_FI_DEV_DEC_UTIL{%s}[%s])) by (UUID, device, modelName, Hostname, %s)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDCGMDeviceInfo := fmt.Sprintf(queryFmtDCGMDeviceInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDCGMDeviceInfo)
+
+	ctx := pds.promContexts.NewNamedContext(ComputeCostDataContextName)
+	return source.NewFuture(source.DecodeDCGMDeviceInfoResult, ctx.QueryAtTime(queryDCGMDeviceInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDCGMDeviceUptime(start, end time.Time) *source.Future[source.DCGMDeviceUptimeResult] {
-	return nil
+	const queryName = "QueryDCGMDeviceUptime"
+	const queryFmtDCGMDeviceUptime = `avg(DCGM_FI_DEV_DEC_UTIL{%s}) by (UUID, %s)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDCGMDeviceUptime := fmt.Sprintf(queryFmtDCGMDeviceUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDCGMDeviceUptime)
+
+	ctx := pds.promContexts.NewNamedContext(ComputeCostDataContextName)
+	return source.NewFuture(source.DecodeDCGMDeviceUptimeResult, ctx.QueryAtTime(queryDCGMDeviceUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDCGMContainerUsageAvg(start, end time.Time) *source.Future[source.DCGMDeviceContainerUsageResult] {
-	return nil
+	const queryName = "QueryDCGMContainerUsageAvg"
+	const queryFmtDCGMContainerUsageAvg = `avg(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!="", %s}[%s])) by (UUID, pod_uid, container, %s)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDCGMContainerUsageAvg := fmt.Sprintf(queryFmtDCGMContainerUsageAvg, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDCGMContainerUsageAvg)
+
+	ctx := pds.promContexts.NewNamedContext(ComputeCostDataContextName)
+	return source.NewFuture(source.DecodeDCGMDeviceContainerUsageResult, ctx.QueryAtTime(queryDCGMContainerUsageAvg, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDCGMContainerUsageMax(start, end time.Time) *source.Future[source.DCGMDeviceContainerUsageResult] {
-	return nil
+	const queryName = "QueryDCGMContainerUsageMax"
+	const queryFmtDCGMContainerUsageMax = `max(max_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!="", %s}[%s])) by (UUID, pod_uid, container, %s)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDCGMContainerUsageMax := fmt.Sprintf(queryFmtDCGMContainerUsageMax, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDCGMContainerUsageMax)
+
+	ctx := pds.promContexts.NewNamedContext(ComputeCostDataContextName)
+	return source.NewFuture(source.DecodeDCGMDeviceContainerUsageResult, ctx.QueryAtTime(queryDCGMContainerUsageMax, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryGPUInfo(start, end time.Time) *source.Future[source.GPUInfoResult] {
@@ -1152,7 +1393,22 @@ func (pds *PrometheusMetricsQuerier) QueryPVInfo(start, end time.Time) *source.F
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPVUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryPVUptime"
+	const queryFmtPVUptime = `avg(kubecost_pv_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryPVUptime := fmt.Sprintf(queryFmtPVUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryPVUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryPVUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNetZoneGiB(start, end time.Time) *source.Future[source.NetZoneGiBResult] {
@@ -1474,7 +1730,21 @@ func (pds *PrometheusMetricsQuerier) QueryNetReceiveBytes(start, end time.Time) 
 }
 
 func (pds *PrometheusMetricsQuerier) QueryNamespaceInfo(start, end time.Time) *source.Future[source.NamespaceInfoResult] {
-	return nil
+	const queryName = "QueryNamespaceInfo"
+	const queryFmtNamespaceInfo = `avg(avg_over_time(namespace_info{%s}[%s])) by (%s, uid, namespace)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryNamespaceInfo := fmt.Sprintf(queryFmtNamespaceInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNamespaceInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeNamespaceInfoResult, ctx.QueryAtTime(queryNamespaceInfo, end))
 }
 
 // Note: namespace_info is not currently emitted
@@ -1571,11 +1841,40 @@ func (pds *PrometheusMetricsQuerier) QueryPodAnnotations(start, end time.Time) *
 }
 
 func (pds *PrometheusMetricsQuerier) QueryServiceInfo(start, end time.Time) *source.Future[source.ServiceInfoResult] {
-	return nil
+	const queryName = "QueryServiceInfo"
+	const queryFmtServiceInfo = `avg(avg_over_time(service_selector_labels{%s}[%s])) by (%s, uid, namespace_uid, service, service_type)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryServiceInfo := fmt.Sprintf(queryFmtServiceInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryServiceInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeServiceInfoResult, ctx.QueryAtTime(queryServiceInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryServiceUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryServiceUptime"
+	const queryFmtServiceUptime = `avg(service_selector_labels{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryServiceUptime := fmt.Sprintf(queryFmtServiceUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryServiceUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryServiceUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryServiceSelectorLabels(start, end time.Time) *source.Future[source.ServiceLabelsResult] {
@@ -1597,19 +1896,76 @@ func (pds *PrometheusMetricsQuerier) QueryServiceSelectorLabels(start, end time.
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDeploymentInfo(start, end time.Time) *source.Future[source.DeploymentInfoResult] {
-	return nil
+	const queryName = "QueryDeploymentInfo"
+	const queryFmtDeploymentInfo = `avg(avg_over_time(deployment_info{%s}[%s])) by (%s, uid, namespace_uid, deployment)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDeploymentInfo := fmt.Sprintf(queryFmtDeploymentInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDeploymentInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeDeploymentInfoResult, ctx.QueryAtTime(queryDeploymentInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDeploymentUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryDeploymentUptime"
+	const queryFmtDeploymentUptime = `avg(deployment_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDeploymentUptime := fmt.Sprintf(queryFmtDeploymentUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDeploymentUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryDeploymentUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDeploymentLabels(start, end time.Time) *source.Future[source.LabelsResult] {
-	return nil
+	const queryName = "QueryDeploymentLabels"
+	const queryFmtDeploymentLabels = `avg_over_time(deployment_labels{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDeploymentLabels := fmt.Sprintf(queryFmtDeploymentLabels, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDeploymentLabels)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeLabelsResult, ctx.QueryAtTime(queryDeploymentLabels, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDeploymentAnnotations(start, end time.Time) *source.Future[source.AnnotationsResult] {
-	return nil
+	const queryName = "QueryDeploymentAnnotations"
+	const queryFmtDeploymentAnnotations = `avg_over_time(deployment_annotations{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDeploymentAnnotations := fmt.Sprintf(queryFmtDeploymentAnnotations, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDeploymentAnnotations)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeAnnotationsResult, ctx.QueryAtTime(queryDeploymentAnnotations, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDeploymentMatchLabels(start, end time.Time) *source.Future[source.DeploymentLabelsResult] {
@@ -1631,19 +1987,76 @@ func (pds *PrometheusMetricsQuerier) QueryDeploymentMatchLabels(start, end time.
 }
 
 func (pds *PrometheusMetricsQuerier) QueryStatefulSetInfo(start, end time.Time) *source.Future[source.StatefulSetInfoResult] {
-	return nil
+	const queryName = "QueryStatefulSetInfo"
+	const queryFmtStatefulSetInfo = `avg(avg_over_time(statefulset_info{%s}[%s])) by (%s, uid, namespace_uid, statefulSet)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryStatefulSetInfo := fmt.Sprintf(queryFmtStatefulSetInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryStatefulSetInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeStatefulSetInfoResult, ctx.QueryAtTime(queryStatefulSetInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryStatefulSetUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryStatefulSetUptime"
+	const queryFmtStatefulSetUptime = `avg(statefulset_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryStatefulSetUptime := fmt.Sprintf(queryFmtStatefulSetUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryStatefulSetUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryStatefulSetUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryStatefulSetLabels(start, end time.Time) *source.Future[source.LabelsResult] {
-	return nil
+	const queryName = "QueryStatefulSetLabels"
+	const queryFmtStatefulSetLabels = `avg_over_time(statefulset_labels{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryStatefulSetLabels := fmt.Sprintf(queryFmtStatefulSetLabels, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryStatefulSetLabels)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeLabelsResult, ctx.QueryAtTime(queryStatefulSetLabels, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryStatefulSetAnnotations(start, end time.Time) *source.Future[source.AnnotationsResult] {
-	return nil
+	const queryName = "QueryStatefulSetAnnotations"
+	const queryFmtStatefulSetAnnotations = `avg_over_time(statefulset_annotations{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryStatefulSetAnnotations := fmt.Sprintf(queryFmtStatefulSetAnnotations, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryStatefulSetAnnotations)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeAnnotationsResult, ctx.QueryAtTime(queryStatefulSetAnnotations, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryStatefulSetMatchLabels(start, end time.Time) *source.Future[source.StatefulSetLabelsResult] {
@@ -1665,71 +2078,313 @@ func (pds *PrometheusMetricsQuerier) QueryStatefulSetMatchLabels(start, end time
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDaemonSetInfo(start, end time.Time) *source.Future[source.DaemonSetInfoResult] {
-	return nil
+	const queryName = "QueryDaemonSetInfo"
+	const queryFmtDaemonSetInfo = `avg(avg_over_time(daemonset_info{%s}[%s])) by (%s, uid, namespace_uid, daemonset)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDaemonSetInfo := fmt.Sprintf(queryFmtDaemonSetInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDaemonSetInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeDaemonSetInfoResult, ctx.QueryAtTime(queryDaemonSetInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDaemonSetUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryDaemonSetUptime"
+	const queryFmtDaemonSetUptime = `avg(daemonset_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDaemonSetUptime := fmt.Sprintf(queryFmtDaemonSetUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDaemonSetUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryDaemonSetUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDaemonSetLabels(start, end time.Time) *source.Future[source.LabelsResult] {
-	return nil
+	const queryName = "QueryDaemonSetLabels"
+	const queryFmtDaemonSetLabels = `avg_over_time(daemonset_labels{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDaemonSetLabels := fmt.Sprintf(queryFmtDaemonSetLabels, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDaemonSetLabels)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeLabelsResult, ctx.QueryAtTime(queryDaemonSetLabels, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryDaemonSetAnnotations(start, end time.Time) *source.Future[source.AnnotationsResult] {
-	return nil
+	const queryName = "QueryDaemonSetAnnotations"
+	const queryFmtDaemonSetAnnotations = `avg_over_time(daemonset_annotations{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryDaemonSetAnnotations := fmt.Sprintf(queryFmtDaemonSetAnnotations, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryDaemonSetAnnotations)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeAnnotationsResult, ctx.QueryAtTime(queryDaemonSetAnnotations, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryJobInfo(start, end time.Time) *source.Future[source.JobInfoResult] {
-	return nil
+	const queryName = "QueryJobInfo"
+	const queryFmtJobInfo = `avg(avg_over_time(job_info{%s}[%s])) by (%s, uid, namespace_uid, job)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryJobInfo := fmt.Sprintf(queryFmtJobInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryJobInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeJobInfoResult, ctx.QueryAtTime(queryJobInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryJobUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryJobUptime"
+	const queryFmtJobUptime = `avg(job_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryJobUptime := fmt.Sprintf(queryFmtJobUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryJobUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryJobUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryJobLabels(start, end time.Time) *source.Future[source.LabelsResult] {
-	return nil
+	const queryName = "QueryJobLabels"
+	const queryFmtJobLabels = `avg_over_time(job_labels{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryJobLabels := fmt.Sprintf(queryFmtJobLabels, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryJobLabels)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeLabelsResult, ctx.QueryAtTime(queryJobLabels, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryJobAnnotations(start, end time.Time) *source.Future[source.AnnotationsResult] {
-	return nil
+	const queryName = "QueryJobAnnotations"
+	const queryFmtJobAnnotations = `avg_over_time(job_annotations{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryJobAnnotations := fmt.Sprintf(queryFmtJobAnnotations, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryJobAnnotations)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeAnnotationsResult, ctx.QueryAtTime(queryJobAnnotations, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryCronJobInfo(start, end time.Time) *source.Future[source.CronJobInfoResult] {
-	return nil
+	const queryName = "QueryCronJobInfo"
+	const queryFmtCronJobInfo = `avg(avg_over_time(cronjob_info{%s}[%s])) by (%s, uid, namespace_uid, cronjob)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryCronJobInfo := fmt.Sprintf(queryFmtCronJobInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryCronJobInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeCronJobInfoResult, ctx.QueryAtTime(queryCronJobInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryCronJobUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryCronJobUptime"
+	const queryFmtCronJobUptime = `avg(cronjob_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryCronJobUptime := fmt.Sprintf(queryFmtCronJobUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryCronJobUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryCronJobUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryCronJobLabels(start, end time.Time) *source.Future[source.LabelsResult] {
-	return nil
+	const queryName = "QueryCronJobLabels"
+	const queryFmtCronJobLabels = `avg_over_time(cronjob_labels{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryCronJobLabels := fmt.Sprintf(queryFmtCronJobLabels, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryCronJobLabels)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeLabelsResult, ctx.QueryAtTime(queryCronJobLabels, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryCronJobAnnotations(start, end time.Time) *source.Future[source.AnnotationsResult] {
-	return nil
+	const queryName = "QueryCronJobAnnotations"
+	const queryFmtCronJobAnnotations = `avg_over_time(cronjob_annotations{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryCronJobAnnotations := fmt.Sprintf(queryFmtCronJobAnnotations, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryCronJobAnnotations)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeAnnotationsResult, ctx.QueryAtTime(queryCronJobAnnotations, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryReplicaSetInfo(start, end time.Time) *source.Future[source.ReplicaSetInfoResult] {
-	return nil
+	const queryName = "QueryReplicaSetInfo"
+	const queryFmtReplicaSetInfo = `avg(avg_over_time(replicaset_info{%s}[%s])) by (%s, uid, namespace_uid, replicaset)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryReplicaSetInfo := fmt.Sprintf(queryFmtReplicaSetInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryReplicaSetInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeReplicaSetInfoResult, ctx.QueryAtTime(queryReplicaSetInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryReplicaSetUptime(start, end time.Time) *source.Future[source.UptimeResult] {
-	return nil
+	const queryName = "QueryReplicaSetUptime"
+	const queryFmtReplicaSetUptime = `avg(replicaset_info{%s}) by (%s, uid)[%s:%dm]`
+
+	cfg := pds.promConfig
+	minsPerResolution := cfg.DataResolutionMinutes
+
+	durStr := pds.durationStringFor(start, end, minsPerResolution, false)
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryReplicaSetUptime := fmt.Sprintf(queryFmtReplicaSetUptime, cfg.ClusterFilter, cfg.ClusterLabel, durStr, minsPerResolution)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryReplicaSetUptime)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeUptimeResult, ctx.QueryAtTime(queryReplicaSetUptime, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryReplicaSetLabels(start, end time.Time) *source.Future[source.LabelsResult] {
-	return nil
+	const queryName = "QueryReplicaSetLabels"
+	const queryFmtReplicaSetLabels = `avg_over_time(replicaset_labels{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryReplicaSetLabels := fmt.Sprintf(queryFmtReplicaSetLabels, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryReplicaSetLabels)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeLabelsResult, ctx.QueryAtTime(queryReplicaSetLabels, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryReplicaSetAnnotations(start, end time.Time) *source.Future[source.AnnotationsResult] {
-	return nil
+	const queryName = "QueryReplicaSetAnnotations"
+	const queryFmtReplicaSetAnnotations = `avg_over_time(replicaset_annotations{%s}[%s])`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryReplicaSetAnnotations := fmt.Sprintf(queryFmtReplicaSetAnnotations, cfg.ClusterFilter, durStr)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryReplicaSetAnnotations)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeAnnotationsResult, ctx.QueryAtTime(queryReplicaSetAnnotations, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryReplicaSetOwners(start, end time.Time) *source.Future[source.OwnerResult] {
-	return nil
+	const queryName = "QueryReplicaSetOwners"
+	const queryFmtReplicaSetOwners = `avg(avg_over_time(kube_replicaset_owner{%s}[%s])) by (%s, uid, owner_uid, owner_kind)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryReplicaSetOwners := fmt.Sprintf(queryFmtReplicaSetOwners, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryReplicaSetOwners)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeOwnerResult, ctx.QueryAtTime(queryReplicaSetOwners, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryPodsWithDaemonSetOwner(start, end time.Time) *source.Future[source.PodsWithDaemonSetOwnerResult] {
@@ -1825,7 +2480,21 @@ func (pds *PrometheusMetricsQuerier) QueryReplicaSetsWithRollout(start, end time
 // Note: The ResourceQuota metrics are _not_ emitted at the moment. Leaving the query implementations here in case we add metric emission later on.
 
 func (pds *PrometheusMetricsQuerier) QueryResourceQuotaInfo(start, end time.Time) *source.Future[source.ResourceQuotaInfoResult] {
-	return nil
+	const queryName = "QueryResourceQuotaInfo"
+	const queryFmtResourceQuotaInfo = `avg(avg_over_time(resourcequota_info{%s}[%s])) by (%s, uid, namespace_uid, resourcequota)`
+
+	cfg := pds.promConfig
+
+	durStr := timeutil.DurationString(end.Sub(start))
+	if durStr == "" {
+		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
+	}
+
+	queryResourceQuotaInfo := fmt.Sprintf(queryFmtResourceQuotaInfo, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryResourceQuotaInfo)
+
+	ctx := pds.promContexts.NewNamedContext(KubeModelContextName)
+	return source.NewFuture(source.DecodeResourceQuotaInfoResult, ctx.QueryAtTime(queryResourceQuotaInfo, end))
 }
 
 func (pds *PrometheusMetricsQuerier) QueryResourceQuotaUptime(start, end time.Time) *source.Future[source.UptimeResult] {

--- a/modules/prometheus-source/pkg/prom/metricsquerier.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier.go
@@ -568,7 +568,7 @@ func (pds *PrometheusMetricsQuerier) QueryLBActiveMinutes(start, end time.Time) 
 
 func (pds *PrometheusMetricsQuerier) QueryClusterInfo(start, end time.Time) *source.Future[source.ClusterInfoResult] {
 	const queryName = "QueryClusterInfo"
-	const queryFmtClusterInfo = `avg(avg_over_time(kubecost_cluster_info{%s}[%s])) by (%s, uid, provider, account_id, provisioner_name, region)`
+	const queryFmtClusterInfo = `avg(avg_over_time(cluster_info{%s}[%s])) by (%s, uid, provider, account_id, provisioner_name, region)`
 
 	cfg := pds.promConfig
 
@@ -584,7 +584,6 @@ func (pds *PrometheusMetricsQuerier) QueryClusterInfo(start, end time.Time) *sou
 	return source.NewFuture(source.DecodeClusterInfoResult, ctx.QueryAtTime(queryClusterInfo, end))
 }
 
-// Note: cluster_info is not currently emitted
 func (pds *PrometheusMetricsQuerier) QueryClusterUptime(start, end time.Time) *source.Future[source.UptimeResult] {
 	const queryName = "QueryClusterUptime"
 	const queryFmtClusterUptime = `avg(cluster_info{%s}) by (%s, uid)[%s:%dm]`

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -359,7 +359,7 @@ func NewCostModelMetricsEmitter(clusterCache clustercache.ClusterCache, provider
 	// init will only actually execute once to register the custom gauges
 	initCostModelMetrics(clusterInfo, metricsConfig)
 
-	metrics.InitKubeMetrics(clusterCache, metricsConfig, &metrics.KubeMetricsOpts{
+	metrics.InitKubeMetrics(clusterInfo, clusterCache, metricsConfig, &metrics.KubeMetricsOpts{
 		EmitKubecostControllerMetrics: true,
 		EmitNamespaceAnnotations:      env.IsEmitNamespaceAnnotationsMetric(),
 		EmitPodAnnotations:            env.IsEmitPodAnnotationsMetric(),

--- a/pkg/metrics/kubemetrics.go
+++ b/pkg/metrics/kubemetrics.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/opencost/opencost/core/pkg/clusters"
 	"github.com/opencost/opencost/core/pkg/util/promutil"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -45,7 +46,12 @@ func DefaultKubeMetricsOpts() *KubeMetricsOpts {
 }
 
 // InitKubeMetrics initializes kubernetes metric emission using the provided options.
-func InitKubeMetrics(clusterCache clustercache.ClusterCache, metricsConfig *MetricsConfig, opts *KubeMetricsOpts) {
+func InitKubeMetrics(
+	clusterInfo clusters.ClusterInfoProvider,
+	clusterCache clustercache.ClusterCache,
+	metricsConfig *MetricsConfig,
+	opts *KubeMetricsOpts,
+) {
 	if opts == nil {
 		opts = DefaultKubeMetricsOpts()
 	}
@@ -64,6 +70,12 @@ func InitKubeMetrics(clusterCache clustercache.ClusterCache, metricsConfig *Metr
 				"kube_pod_status_phase",
 			)
 		}
+
+		prometheus.MustRegister(KubeModelCollector{
+			KubeClusterCache: clusterCache,
+			ClusterInfo:      clusterInfo,
+			metricsConfig:    *metricsConfig,
+		})
 
 		if opts.EmitKubecostControllerMetrics {
 			prometheus.MustRegister(KubecostServiceCollector{

--- a/pkg/metrics/kubemodel.go
+++ b/pkg/metrics/kubemodel.go
@@ -1,0 +1,546 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/opencost/opencost/core/pkg/clusters"
+	"github.com/opencost/opencost/core/pkg/log"
+	coreutil "github.com/opencost/opencost/core/pkg/util"
+	"github.com/opencost/opencost/core/pkg/util/promutil"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+//--------------------------------------------------------------------------
+//  KubeModelCollector
+//--------------------------------------------------------------------------
+
+// kubeModelMetricNames lists every metric name emitted by KubeModelCollector.
+// These are checked against the disabled-metrics map in Describe/Collect.
+var kubeModelMetricNames = []string{
+	"node_info",
+	"cluster_info",
+	"pod_info",
+	"pod_pvc_volume",
+	"namespace_info",
+	"deployment_info",
+	"deployment_labels",
+	"deployment_annotations",
+	"statefulset_info",
+	"statefulset_labels",
+	"statefulset_annotations",
+	"daemonset_info",
+	"daemonset_labels",
+	"daemonset_annotations",
+	"job_info",
+	"job_labels",
+	"job_annotations",
+	"cronjob_info",
+	"cronjob_labels",
+	"cronjob_annotations",
+	"replicaset_info",
+	"replicaset_labels",
+	"replicaset_annotations",
+	"resourcequota_info",
+}
+
+// KubeModelCollector emits a unified set of info/labels/annotations metrics for
+// all Kubernetes resource types. It mirrors the collector-source ClusterCacheScraper:
+// indexes are built once per Collect call and per-resource scrapes run concurrently.
+type KubeModelCollector struct {
+	KubeClusterCache clustercache.ClusterCache
+	ClusterInfo      clusters.ClusterInfoProvider
+	metricsConfig    MetricsConfig
+}
+
+// Describe sends a generic descriptor for each metric emitted by this collector.
+func (c KubeModelCollector) Describe(ch chan<- *prometheus.Desc) {
+	disabled := c.metricsConfig.GetDisabledMetricsMap()
+	for _, name := range kubeModelMetricNames {
+		if _, ok := disabled[name]; ok {
+			continue
+		}
+		ch <- prometheus.NewDesc(name, name, []string{}, nil)
+	}
+}
+
+// Collect fetches all cluster resources, builds cross-reference indexes, then
+// emits info/labels/annotations metrics concurrently per resource type.
+func (c KubeModelCollector) Collect(ch chan<- prometheus.Metric) {
+	disabled := c.metricsConfig.GetDisabledMetricsMap()
+
+	// Fetch all resources from the cache up front.
+	nodes := c.KubeClusterCache.GetAllNodes()
+	namespaces := c.KubeClusterCache.GetAllNamespaces()
+	pods := c.KubeClusterCache.GetAllPods()
+	pvcs := c.KubeClusterCache.GetAllPersistentVolumeClaims()
+	deployments := c.KubeClusterCache.GetAllDeployments()
+	statefulSets := c.KubeClusterCache.GetAllStatefulSets()
+	daemonSets := c.KubeClusterCache.GetAllDaemonSets()
+	jobs := c.KubeClusterCache.GetAllJobs()
+	cronJobs := c.KubeClusterCache.GetAllCronJobs()
+	replicaSets := c.KubeClusterCache.GetAllReplicaSets()
+	resourceQuotas := c.KubeClusterCache.GetAllResourceQuotas()
+
+	// Build cross-reference indexes.
+	nsIndex := make(map[string]types.UID, len(namespaces))
+	for _, ns := range namespaces {
+		nsIndex[ns.Name] = ns.UID
+	}
+	nodeIndex := make(map[string]types.UID, len(nodes))
+	for _, node := range nodes {
+		nodeIndex[node.Name] = node.UID
+	}
+	pvcIndex := make(map[string]types.UID, len(pvcs))
+	for _, pvc := range pvcs {
+		pvcIndex[pvcIndexKey(pvc.Namespace, pvc.Name)] = pvc.UID
+	}
+
+	// Collect concurrently using a channel.
+	type scrapeFn func() []kubeModelMetric
+	fns := []scrapeFn{
+		func() []kubeModelMetric { return c.scrapeClusterInfo(disabled) },
+		func() []kubeModelMetric { return c.scrapeNodes(nodes, disabled) },
+		func() []kubeModelMetric { return c.scrapeNamespaces(namespaces, disabled) },
+		func() []kubeModelMetric { return c.scrapePods(pods, nsIndex, nodeIndex, pvcIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeDeployments(deployments, nsIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeStatefulSets(statefulSets, nsIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeDaemonSets(daemonSets, nsIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeJobs(jobs, nsIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeCronJobs(cronJobs, nsIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeReplicaSets(replicaSets, nsIndex, disabled) },
+		func() []kubeModelMetric { return c.scrapeResourceQuotas(resourceQuotas, nsIndex, disabled) },
+	}
+
+	results := make(chan []kubeModelMetric, len(fns))
+	for _, fn := range fns {
+		fn := fn
+		go func() { results <- fn() }()
+	}
+	for range fns {
+		for _, m := range <-results {
+			ch <- m
+		}
+	}
+}
+
+// pvcIndexKey returns a map key for a PVC by namespace+name.
+func pvcIndexKey(namespace, name string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+//--------------------------------------------------------------------------
+//  kubeModelMetric — generic prometheus.Metric for kube-model emissions
+//--------------------------------------------------------------------------
+
+// kubeModelMetric implements prometheus.Metric for any kube-model info/labels metric.
+// All labels are stored in a map and emitted via Write; the gauge value defaults to 1.
+type kubeModelMetric struct {
+	name   string
+	help   string
+	labels map[string]string
+	value  float64
+}
+
+func newInfoMetric(name string, labels map[string]string) kubeModelMetric {
+	return kubeModelMetric{name: name, help: name, labels: labels, value: 1}
+}
+
+func newValueMetric(name string, labels map[string]string, value float64) kubeModelMetric {
+	return kubeModelMetric{name: name, help: name, labels: labels, value: value}
+}
+
+func (m kubeModelMetric) Desc() *prometheus.Desc {
+	return prometheus.NewDesc(m.name, m.help, promutil.LabelNamesFrom(m.labels), prometheus.Labels{})
+}
+
+func (m kubeModelMetric) Write(pb *dto.Metric) error {
+	pb.Gauge = &dto.Gauge{Value: &m.value}
+	pairs := make([]*dto.LabelPair, 0, len(m.labels))
+	for k, v := range m.labels {
+		pairs = append(pairs, &dto.LabelPair{
+			Name:  toStringPtr(k),
+			Value: toStringPtr(v),
+		})
+	}
+	pb.Label = pairs
+	return nil
+}
+
+//--------------------------------------------------------------------------
+//  Per-resource scrape helpers
+//--------------------------------------------------------------------------
+
+func (c KubeModelCollector) scrapeClusterInfo(disabled map[string]struct{}) []kubeModelMetric {
+	if _, ok := disabled["cluster_info"]; ok {
+		return nil
+	}
+	if c.ClusterInfo == nil {
+		return nil
+	}
+	info := c.ClusterInfo.GetClusterInfo()
+	labels := map[string]string{
+		"uid":              info[clusters.ClusterInfoIdKey],
+		"provider":         info[clusters.ClusterInfoProviderKey],
+		"account_id":       info[clusters.ClusterInfoAccountKey],
+		"provisioner_name": info[clusters.ClusterInfoProvisionerKey],
+		"region":           info[clusters.ClusterInfoRegionKey],
+	}
+	// GCP uses "project" instead of "account"
+	if labels["account_id"] == "" {
+		labels["account_id"] = info[clusters.ClusterInfoProjectKey]
+	}
+	return []kubeModelMetric{newInfoMetric("cluster_info", labels)}
+}
+
+func (c KubeModelCollector) scrapeNodes(nodes []*clustercache.Node, disabled map[string]struct{}) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "node_info")
+
+	for _, node := range nodes {
+		nodeInfo := map[string]string{
+			"node":        node.Name,
+			"uid":         string(node.UID),
+			"provider_id": node.SpecProviderID,
+		}
+		if instanceType, ok := coreutil.GetInstanceType(node.Labels); ok {
+			nodeInfo["instance_type"] = instanceType
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("node_info", nodeInfo))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeNamespaces(namespaces []*clustercache.Namespace, disabled map[string]struct{}) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "namespace_info")
+
+	for _, ns := range namespaces {
+		if emitInfo {
+			out = append(out, newInfoMetric("namespace_info", map[string]string{
+				"uid":       string(ns.UID),
+				"namespace": ns.Name,
+			}))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapePods(
+	pods []*clustercache.Pod,
+	nsIndex map[string]types.UID,
+	nodeIndex map[string]types.UID,
+	pvcIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "pod_info")
+	emitPVC := !isDisabled(disabled, "pod_pvc_volume")
+
+	for _, pod := range pods {
+		nsUID, ok := nsIndex[pod.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: pod namespace uid missing for namespace '%s'", pod.Namespace)
+		}
+		nodeUID, ok := nodeIndex[pod.Spec.NodeName]
+		if !ok && pod.Spec.NodeName != "" {
+			log.Debugf("KubeModelCollector: pod node uid missing for node '%s'", pod.Spec.NodeName)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("pod_info", map[string]string{
+				"uid":           string(pod.UID),
+				"pod":           pod.Name,
+				"namespace_uid": string(nsUID),
+				"node_uid":      string(nodeUID),
+			}))
+		}
+
+		if emitPVC {
+			for _, vol := range pod.Spec.Volumes {
+				if vol.PersistentVolumeClaim == nil {
+					continue
+				}
+				pvcUID := pvcIndex[pvcIndexKey(pod.Namespace, vol.PersistentVolumeClaim.ClaimName)]
+				out = append(out, newInfoMetric("pod_pvc_volume", map[string]string{
+					"uid":                      string(pod.UID),
+					"persistentvolumeclaim_uid": string(pvcUID),
+					"pod_volume_name":           vol.Name,
+				}))
+			}
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeDeployments(
+	deployments []*clustercache.Deployment,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "deployment_info")
+	emitLabels := !isDisabled(disabled, "deployment_labels")
+	emitAnno := !isDisabled(disabled, "deployment_annotations")
+
+	for _, d := range deployments {
+		nsUID, ok := nsIndex[d.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: deployment namespace uid missing for namespace '%s'", d.Namespace)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("deployment_info", map[string]string{
+				"uid":           string(d.UID),
+				"namespace_uid": string(nsUID),
+				"deployment":    d.Name,
+			}))
+		}
+		if emitLabels {
+			out = append(out, kubeLabelsMetric("deployment_labels", string(d.UID), d.Labels))
+		}
+		if emitAnno {
+			out = append(out, kubeAnnotationsMetric("deployment_annotations", string(d.UID), d.Annotations))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeStatefulSets(
+	sets []*clustercache.StatefulSet,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "statefulset_info")
+	emitLabels := !isDisabled(disabled, "statefulset_labels")
+	emitAnno := !isDisabled(disabled, "statefulset_annotations")
+
+	for _, s := range sets {
+		nsUID, ok := nsIndex[s.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: statefulset namespace uid missing for namespace '%s'", s.Namespace)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("statefulset_info", map[string]string{
+				"uid":           string(s.UID),
+				"namespace_uid": string(nsUID),
+				"statefulSet":   s.Name,
+			}))
+		}
+		if emitLabels {
+			out = append(out, kubeLabelsMetric("statefulset_labels", string(s.UID), s.Labels))
+		}
+		if emitAnno {
+			out = append(out, kubeAnnotationsMetric("statefulset_annotations", string(s.UID), s.Annotations))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeDaemonSets(
+	sets []*clustercache.DaemonSet,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "daemonset_info")
+	emitLabels := !isDisabled(disabled, "daemonset_labels")
+	emitAnno := !isDisabled(disabled, "daemonset_annotations")
+
+	for _, ds := range sets {
+		nsUID, ok := nsIndex[ds.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: daemonset namespace uid missing for namespace '%s'", ds.Namespace)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("daemonset_info", map[string]string{
+				"uid":           string(ds.UID),
+				"namespace_uid": string(nsUID),
+				"daemonset":     ds.Name,
+			}))
+		}
+		if emitLabels {
+			out = append(out, kubeLabelsMetric("daemonset_labels", string(ds.UID), ds.Labels))
+		}
+		if emitAnno {
+			out = append(out, kubeAnnotationsMetric("daemonset_annotations", string(ds.UID), ds.Annotations))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeJobs(
+	jobs []*clustercache.Job,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "job_info")
+	emitLabels := !isDisabled(disabled, "job_labels")
+	emitAnno := !isDisabled(disabled, "job_annotations")
+
+	for _, j := range jobs {
+		nsUID, ok := nsIndex[j.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: job namespace uid missing for namespace '%s'", j.Namespace)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("job_info", map[string]string{
+				"uid":           string(j.UID),
+				"namespace_uid": string(nsUID),
+				"job":           j.Name,
+			}))
+		}
+		if emitLabels {
+			out = append(out, kubeLabelsMetric("job_labels", string(j.UID), j.Labels))
+		}
+		if emitAnno {
+			out = append(out, kubeAnnotationsMetric("job_annotations", string(j.UID), j.Annotations))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeCronJobs(
+	cronJobs []*clustercache.CronJob,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "cronjob_info")
+	emitLabels := !isDisabled(disabled, "cronjob_labels")
+	emitAnno := !isDisabled(disabled, "cronjob_annotations")
+
+	for _, cj := range cronJobs {
+		nsUID, ok := nsIndex[cj.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: cronjob namespace uid missing for namespace '%s'", cj.Namespace)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("cronjob_info", map[string]string{
+				"uid":           string(cj.UID),
+				"namespace_uid": string(nsUID),
+				"cronjob":       cj.Name,
+			}))
+		}
+		if emitLabels {
+			out = append(out, kubeLabelsMetric("cronjob_labels", string(cj.UID), cj.Labels))
+		}
+		if emitAnno {
+			out = append(out, kubeAnnotationsMetric("cronjob_annotations", string(cj.UID), cj.Annotations))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeReplicaSets(
+	sets []*clustercache.ReplicaSet,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	var out []kubeModelMetric
+	emitInfo := !isDisabled(disabled, "replicaset_info")
+	emitLabels := !isDisabled(disabled, "replicaset_labels")
+	emitAnno := !isDisabled(disabled, "replicaset_annotations")
+
+	for _, rs := range sets {
+		nsUID, ok := nsIndex[rs.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: replicaset namespace uid missing for namespace '%s'", rs.Namespace)
+		}
+
+		if emitInfo {
+			out = append(out, newInfoMetric("replicaset_info", map[string]string{
+				"uid":           string(rs.UID),
+				"namespace_uid": string(nsUID),
+				"replicaset":    rs.Name,
+			}))
+		}
+		if emitLabels {
+			out = append(out, kubeLabelsMetric("replicaset_labels", string(rs.UID), rs.Labels))
+		}
+		if emitAnno {
+			out = append(out, kubeAnnotationsMetric("replicaset_annotations", string(rs.UID), rs.Annotations))
+		}
+	}
+	return out
+}
+
+func (c KubeModelCollector) scrapeResourceQuotas(
+	quotas []*clustercache.ResourceQuota,
+	nsIndex map[string]types.UID,
+	disabled map[string]struct{},
+) []kubeModelMetric {
+	if isDisabled(disabled, "resourcequota_info") {
+		return nil
+	}
+	var out []kubeModelMetric
+	for _, rq := range quotas {
+		nsUID, ok := nsIndex[rq.Namespace]
+		if !ok {
+			log.Debugf("KubeModelCollector: resourcequota namespace uid missing for namespace '%s'", rq.Namespace)
+		}
+		out = append(out, newInfoMetric("resourcequota_info", map[string]string{
+			"uid":           string(rq.UID),
+			"namespace_uid": string(nsUID),
+			"resourcequota": rq.Name,
+		}))
+	}
+	return out
+}
+
+//--------------------------------------------------------------------------
+//  Helpers
+//--------------------------------------------------------------------------
+
+// isDisabled returns true if the named metric appears in the disabled map.
+func isDisabled(disabled map[string]struct{}, name string) bool {
+	_, ok := disabled[name]
+	return ok
+}
+
+// kubeLabelsMetric builds a labels metric for a resource, adding the resource
+// uid as a fixed label alongside the k8s labels (prefixed with "label_").
+func kubeLabelsMetric(name, uid string, k8sLabels map[string]string) kubeModelMetric {
+	labelNames, labelValues := promutil.KubeLabelsToLabels(promutil.SanitizeLabels(k8sLabels))
+	m := make(map[string]string, len(labelNames)+1)
+	m["uid"] = uid
+	for i, k := range labelNames {
+		m[k] = labelValues[i]
+	}
+	return newInfoMetric(name, m)
+}
+
+// kubeAnnotationsMetric builds an annotations metric for a resource.
+func kubeAnnotationsMetric(name, uid string, k8sAnnotations map[string]string) kubeModelMetric {
+	annoNames, annoValues := promutil.KubeAnnotationsToLabels(k8sAnnotations)
+	m := make(map[string]string, len(annoNames)+1)
+	m["uid"] = uid
+	for i, k := range annoNames {
+		m[k] = annoValues[i]
+	}
+	return newInfoMetric(name, m)
+}
+
+// kubeModelResourceValue converts a Kubernetes resource quantity to a float64 value.
+// It mirrors the collector-source toResourceUnitValue logic for the cases we need.
+func kubeModelResourceValue(resourceName v1.ResourceName, quantity resource.Quantity) float64 {
+	switch resourceName {
+	case v1.ResourceCPU:
+		return float64(quantity.MilliValue()) / 1000.0
+	default:
+		return float64(quantity.Value())
+	}
+}


### PR DESCRIPTION
## Description
Implements the remaining stub Prometheus queries in PrometheusMetricsQuerier for the kubemodel data source and adds a new KubeModelCollector that emits the corresponding Prometheus metrics.
                                                                                                                                                                                                
  Prometheus query implementations (modules/prometheus-source/pkg/prom/metricsquerier.go):                                                                                                      
  Previously returning nil, the following queries are now fully implemented:                                                                                                                    
                                                                                                                                                                                                
  - Node: QueryNodeInfo, QueryNodeUptime, QueryNodeResourceCapacities, QueryNodeResourcesAllocatable                                                                                            
  - Cluster: QueryClusterInfo                                                                                                                                                                   
  - Pod: QueryPodInfo, QueryPodUptime, QueryPodOwners, QueryPodPVCVolumes                                                                                                                       
  - PVC/PV: QueryPVCUptime, QueryPVUptime                                                                                                                                                       
  - Namespace: QueryNamespaceInfo                                                                                                                                                               
  - Service: QueryServiceInfo, QueryServiceUptime                                                                                                                                               
  - Deployment: QueryDeploymentInfo, QueryDeploymentUptime, QueryDeploymentLabels, QueryDeploymentAnnotations                                                                                   
  - StatefulSet: QueryStatefulSetInfo, QueryStatefulSetUptime, QueryStatefulSetLabels                        
  - DCGM (GPU): QueryDCGMDeviceInfo, QueryDCGMDeviceUptime, QueryDCGMContainerUsageAvg, QueryDCGMContainerUsageMax                                                                              
                  
  New KubeModelCollector (pkg/metrics/kubemodel.go):                                                                                                                                            
  Adds a Prometheus collector that emits the full set of kubemodel info/labels/annotations metrics (node_info, cluster_info, pod_info, namespace_info, deployment_info, statefulset_info,
  daemonset_info, job_info, cronjob_info, replicaset_info, resourcequota_info, and associated labels/annotations variants) sourced directly from the cluster cache.                             
                  
  Also fixes a copy-paste bug where NamespaceInfoID was incorrectly assigned the string value "NamespaceUptime" instead of "NamespaceInfo" in collector-source.

## Related Issues
[<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->](https://apptio.atlassian.net/browse/KCM-5496)

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

## Testing
- Existing unit tests pass                                                                                                                                                 
  - Manual verification: queries build correct PromQL strings with expected label selectors and time windows
  - Integration testing against a live Prometheus instance recommended to validate query correctness for each resource type        
