### PR TITLE
feat: server-side currency conversion for cost APIs

### DIFF
--- a/pkg/cloudcost/queryservice.go
+++ b/pkg/cloudcost/queryservice.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/util/httputil"
+	"github.com/opencost/opencost/pkg/currency"
 	"go.opentelemetry.io/otel"
 )
 
@@ -19,8 +21,9 @@ const (
 
 // QueryService surfaces endpoints for accessing CloudCost data in raw form or for display in views
 type QueryService struct {
-	Querier     Querier
-	ViewQuerier ViewQuerier
+	Querier          Querier
+	ViewQuerier      ViewQuerier
+	CurrencyConverter currency.Converter
 }
 
 func NewQueryService(querier Querier, viewQuerier ViewQuerier) *QueryService {
@@ -59,6 +62,16 @@ func (s *QueryService) GetCloudCostHandler() func(w http.ResponseWriter, r *http
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Internal server error: %s", err), http.StatusInternalServerError)
 			return
+		}
+
+		// Extract currency parameter and convert if needed
+		currencyParam := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
+		if currencyParam != "USD" && s.CurrencyConverter != nil && resp != nil {
+			err = convertCloudCostSetRange(resp, s.CurrencyConverter, currencyParam)
+			if err != nil {
+				log.Warnf("Currency conversion failed for currency %s: %v", currencyParam, err)
+				// Continue with USD values if conversion fails
+			}
 		}
 
 		_, spanResp := tracer.Start(ctx, "write response")
@@ -202,4 +215,54 @@ func (s *QueryService) GetCloudCostViewTableHandler(tokenHook func(ViewTableRows
 		w.Header().Set("Content-Type", "application/json")
 		protocol.WriteResponse(w, resp)
 	}
+}
+
+// convertCloudCostSetRange converts all cloud costs in a range from USD to target currency
+func convertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter currency.Converter, targetCurrency string) error {
+	if ccsr == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+
+	// Helper to convert CostMetric (only the Cost field, not KubernetesPercent)
+	convertCostMetric := func(cm *opencost.CostMetric) error {
+		if cm.Cost != 0 {
+			converted, err := converter.Convert(cm.Cost, "USD", targetCurrency)
+			if err != nil {
+				return err
+			}
+			cm.Cost = converted
+		}
+		return nil
+	}
+
+	// Convert all cloud cost sets in the range
+	for _, set := range ccsr.CloudCostSets {
+		if set == nil {
+			continue
+		}
+		for _, cc := range set.CloudCosts {
+			if cc == nil {
+				continue
+			}
+			if err := convertCostMetric(&cc.ListCost); err != nil {
+				return fmt.Errorf("failed to convert ListCost: %w", err)
+			}
+			if err := convertCostMetric(&cc.NetCost); err != nil {
+				return fmt.Errorf("failed to convert NetCost: %w", err)
+			}
+			if err := convertCostMetric(&cc.AmortizedNetCost); err != nil {
+				return fmt.Errorf("failed to convert AmortizedNetCost: %w", err)
+			}
+			if err := convertCostMetric(&cc.InvoicedCost); err != nil {
+				return fmt.Errorf("failed to convert InvoicedCost: %w", err)
+			}
+			if err := convertCostMetric(&cc.AmortizedCost); err != nil {
+				return fmt.Errorf("failed to convert AmortizedCost: %w", err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/cloudcost/queryservice.go
+++ b/pkg/cloudcost/queryservice.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-const tracerName = "github.com/opencost/ooencost/pkg/cloudcost"
+const tracerName = "github.com/opencost/opencost/pkg/cloudcost"
 
 const (
 	csvFormat = "csv"

--- a/pkg/cloudcost/queryservice.go
+++ b/pkg/cloudcost/queryservice.go
@@ -21,8 +21,8 @@ const (
 
 // QueryService surfaces endpoints for accessing CloudCost data in raw form or for display in views
 type QueryService struct {
-	Querier          Querier
-	ViewQuerier      ViewQuerier
+	Querier           Querier
+	ViewQuerier       ViewQuerier
 	CurrencyConverter currency.Converter
 }
 

--- a/pkg/cloudcost/queryservice.go
+++ b/pkg/cloudcost/queryservice.go
@@ -218,16 +218,23 @@ func (s *QueryService) GetCloudCostViewTableHandler(tokenHook func(ViewTableRows
 }
 
 // convertCloudCostSetRange converts all cloud costs in a range from USD
-// to target currency in place. Best-effort: per-field converter failures
-// are logged and the field is left in USD rather than rolling the whole
-// response back to USD. Only CostMetric.Cost is mutated; KubernetesPercent
-// and other non-cost fields are untouched.
+// to target currency in place. Returns an error if the target rate
+// cannot be looked up upfront (no mutation occurs). Per-field converter
+// failures after the probe succeeded are handled best-effort: the field
+// is left in USD and a warning is logged. Only CostMetric.Cost is
+// mutated; KubernetesPercent and other non-cost fields are untouched.
 func convertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter currency.Converter, targetCurrency string) error {
-	if ccsr == nil || converter == nil || targetCurrency == "USD" {
+	if ccsr == nil || converter == nil {
 		return nil
 	}
 
 	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+	if targetCurrency == "" || targetCurrency == "USD" {
+		return nil
+	}
+	if _, err := converter.GetRate("USD", targetCurrency); err != nil {
+		return fmt.Errorf("currency rate lookup USD->%s failed: %w", targetCurrency, err)
+	}
 
 	tryConvert := func(val float64, logCtx string) float64 {
 		if val == 0 {

--- a/pkg/cloudcost/queryservice.go
+++ b/pkg/cloudcost/queryservice.go
@@ -217,7 +217,11 @@ func (s *QueryService) GetCloudCostViewTableHandler(tokenHook func(ViewTableRows
 	}
 }
 
-// convertCloudCostSetRange converts all cloud costs in a range from USD to target currency
+// convertCloudCostSetRange converts all cloud costs in a range from USD
+// to target currency in place. Best-effort: per-field converter failures
+// are logged and the field is left in USD rather than rolling the whole
+// response back to USD. Only CostMetric.Cost is mutated; KubernetesPercent
+// and other non-cost fields are untouched.
 func convertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter currency.Converter, targetCurrency string) error {
 	if ccsr == nil || converter == nil || targetCurrency == "USD" {
 		return nil
@@ -225,19 +229,18 @@ func convertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter curren
 
 	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
 
-	// Helper to convert CostMetric (only the Cost field, not KubernetesPercent)
-	convertCostMetric := func(cm *opencost.CostMetric) error {
-		if cm.Cost != 0 {
-			converted, err := converter.Convert(cm.Cost, "USD", targetCurrency)
-			if err != nil {
-				return err
-			}
-			cm.Cost = converted
+	tryConvert := func(val float64, logCtx string) float64 {
+		if val == 0 {
+			return val
 		}
-		return nil
+		converted, err := converter.Convert(val, "USD", targetCurrency)
+		if err != nil {
+			log.Warnf("currency: leaving %s in USD (convert to %s failed): %v", logCtx, targetCurrency, err)
+			return val
+		}
+		return converted
 	}
 
-	// Convert all cloud cost sets in the range
 	for _, set := range ccsr.CloudCostSets {
 		if set == nil {
 			continue
@@ -246,21 +249,11 @@ func convertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter curren
 			if cc == nil {
 				continue
 			}
-			if err := convertCostMetric(&cc.ListCost); err != nil {
-				return fmt.Errorf("failed to convert ListCost: %w", err)
-			}
-			if err := convertCostMetric(&cc.NetCost); err != nil {
-				return fmt.Errorf("failed to convert NetCost: %w", err)
-			}
-			if err := convertCostMetric(&cc.AmortizedNetCost); err != nil {
-				return fmt.Errorf("failed to convert AmortizedNetCost: %w", err)
-			}
-			if err := convertCostMetric(&cc.InvoicedCost); err != nil {
-				return fmt.Errorf("failed to convert InvoicedCost: %w", err)
-			}
-			if err := convertCostMetric(&cc.AmortizedCost); err != nil {
-				return fmt.Errorf("failed to convert AmortizedCost: %w", err)
-			}
+			cc.ListCost.Cost = tryConvert(cc.ListCost.Cost, "CloudCost.ListCost")
+			cc.NetCost.Cost = tryConvert(cc.NetCost.Cost, "CloudCost.NetCost")
+			cc.AmortizedNetCost.Cost = tryConvert(cc.AmortizedNetCost.Cost, "CloudCost.AmortizedNetCost")
+			cc.InvoicedCost.Cost = tryConvert(cc.InvoicedCost.Cost, "CloudCost.InvoicedCost")
+			cc.AmortizedCost.Cost = tryConvert(cc.AmortizedCost.Cost, "CloudCost.AmortizedCost")
 		}
 	}
 

--- a/pkg/cloudcost/queryservice_test.go
+++ b/pkg/cloudcost/queryservice_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 type mockConverter struct {
-	rate       float64
-	failValues map[float64]bool
-	calls      int
+	rate         float64
+	failValues   map[float64]bool
+	getRateFail  bool
+	getRateCalls int
+	calls        int
 }
 
 func (m *mockConverter) Convert(amount float64, from, to string) (float64, error) {
@@ -26,6 +28,10 @@ func (m *mockConverter) Convert(amount float64, from, to string) (float64, error
 }
 
 func (m *mockConverter) GetRate(from, to string) (float64, error) {
+	m.getRateCalls++
+	if m.getRateFail {
+		return 0, fmt.Errorf("simulated rate lookup failure USD->%s", to)
+	}
 	return m.rate, nil
 }
 
@@ -104,6 +110,36 @@ func TestConvertCloudCostSetRange_MutatesAllCostMetrics(t *testing.T) {
 	// KubernetesPercent must be preserved exactly.
 	if cc.ListCost.KubernetesPercent != 0.5 {
 		t.Errorf("KubernetesPercent must not be touched: got %v want 0.5", cc.ListCost.KubernetesPercent)
+	}
+}
+
+func TestConvertCloudCostSetRange_GetRateFailsReturnsError(t *testing.T) {
+	ccsr := newCCSR(t)
+	m := &mockConverter{rate: 2.0, getRateFail: true}
+	err := convertCloudCostSetRange(ccsr, m, "XXX")
+	if err == nil {
+		t.Fatal("expected error when GetRate fails")
+	}
+	if m.calls != 0 {
+		t.Errorf("no Convert calls expected on precheck failure; got %d", m.calls)
+	}
+	for _, v := range ccsr.CloudCostSets[0].CloudCosts {
+		if v.ListCost.Cost != 100 {
+			t.Errorf("data must not be mutated on precheck failure; ListCost=%v", v.ListCost.Cost)
+		}
+	}
+}
+
+func TestConvertCloudCostSetRange_USDNormalized(t *testing.T) {
+	for _, target := range []string{"usd", " USD ", ""} {
+		ccsr := newCCSR(t)
+		m := &mockConverter{rate: 2.0}
+		if err := convertCloudCostSetRange(ccsr, m, target); err != nil {
+			t.Fatalf("target %q: %v", target, err)
+		}
+		if m.calls != 0 || m.getRateCalls != 0 {
+			t.Errorf("target %q: expected zero converter activity", target)
+		}
 	}
 }
 

--- a/pkg/cloudcost/queryservice_test.go
+++ b/pkg/cloudcost/queryservice_test.go
@@ -1,0 +1,132 @@
+package cloudcost
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+type mockConverter struct {
+	rate       float64
+	failValues map[float64]bool
+	calls      int
+}
+
+func (m *mockConverter) Convert(amount float64, from, to string) (float64, error) {
+	m.calls++
+	if from != "USD" {
+		return 0, fmt.Errorf("mock only converts from USD, got %q", from)
+	}
+	if m.failValues[amount] {
+		return 0, fmt.Errorf("simulated converter failure for amount %v", amount)
+	}
+	return amount * m.rate, nil
+}
+
+func (m *mockConverter) GetRate(from, to string) (float64, error) {
+	return m.rate, nil
+}
+
+func newCCSR(t *testing.T) *opencost.CloudCostSetRange {
+	t.Helper()
+	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	set := opencost.NewCloudCostSet(start, end)
+	cc := opencost.NewCloudCost(
+		start, end,
+		&opencost.CloudCostProperties{ProviderID: "cc-a"},
+		0.5, // kubernetesPercent -- must remain untouched
+		100, // listCost
+		90,  // netCost
+		80,  // amortizedNetCost
+		110, // invoicedCost
+		85,  // amortizedCost
+	)
+	set.Insert(cc)
+	return &opencost.CloudCostSetRange{
+		CloudCostSets: []*opencost.CloudCostSet{set},
+		Window:        opencost.NewWindow(&start, &end),
+	}
+}
+
+func TestConvertCloudCostSetRange_USDIsNoOp(t *testing.T) {
+	ccsr := newCCSR(t)
+	m := &mockConverter{rate: 2.0}
+	if err := convertCloudCostSetRange(ccsr, m, "USD"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.calls != 0 {
+		t.Fatalf("USD must not call converter, got %d calls", m.calls)
+	}
+}
+
+func TestConvertCloudCostSetRange_NilGuards(t *testing.T) {
+	if err := convertCloudCostSetRange(nil, &mockConverter{rate: 2.0}, "EUR"); err != nil {
+		t.Fatalf("nil range: %v", err)
+	}
+	ccsr := newCCSR(t)
+	if err := convertCloudCostSetRange(ccsr, nil, "EUR"); err != nil {
+		t.Fatalf("nil converter: %v", err)
+	}
+}
+
+func TestConvertCloudCostSetRange_MutatesAllCostMetrics(t *testing.T) {
+	ccsr := newCCSR(t)
+	m := &mockConverter{rate: 2.0}
+	if err := convertCloudCostSetRange(ccsr, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var cc *opencost.CloudCost
+	for _, v := range ccsr.CloudCostSets[0].CloudCosts {
+		cc = v
+		break
+	}
+	if cc == nil {
+		t.Fatal("CloudCost missing from set")
+	}
+
+	checks := map[string]struct{ got, want float64 }{
+		"ListCost.Cost":         {cc.ListCost.Cost, 200},
+		"NetCost.Cost":          {cc.NetCost.Cost, 180},
+		"AmortizedNetCost.Cost": {cc.AmortizedNetCost.Cost, 160},
+		"InvoicedCost.Cost":     {cc.InvoicedCost.Cost, 220},
+		"AmortizedCost.Cost":    {cc.AmortizedCost.Cost, 170},
+	}
+	for name, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %v want %v", name, c.got, c.want)
+		}
+	}
+
+	// KubernetesPercent must be preserved exactly.
+	if cc.ListCost.KubernetesPercent != 0.5 {
+		t.Errorf("KubernetesPercent must not be touched: got %v want 0.5", cc.ListCost.KubernetesPercent)
+	}
+}
+
+func TestConvertCloudCostSetRange_BestEffortOnPartialFailure(t *testing.T) {
+	ccsr := newCCSR(t)
+	// Fail only NetCost (90), leave others to convert.
+	m := &mockConverter{
+		rate:       2.0,
+		failValues: map[float64]bool{90: true},
+	}
+	if err := convertCloudCostSetRange(ccsr, m, "EUR"); err != nil {
+		t.Fatalf("best-effort helper must not return error; got %v", err)
+	}
+
+	var cc *opencost.CloudCost
+	for _, v := range ccsr.CloudCostSets[0].CloudCosts {
+		cc = v
+		break
+	}
+	if cc.NetCost.Cost != 90 {
+		t.Errorf("failed field must retain USD: NetCost got %v want 90", cc.NetCost.Cost)
+	}
+	if cc.ListCost.Cost != 200 {
+		t.Errorf("other fields must still convert: ListCost got %v want 200", cc.ListCost.Cost)
+	}
+}

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/util/apiutil"
 	"github.com/opencost/opencost/pkg/cloudcost"
 	"github.com/opencost/opencost/pkg/customcost"
+	"github.com/opencost/opencost/pkg/currency"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 
@@ -42,9 +43,38 @@ func Execute(conf *Config) error {
 
 	router := httprouter.New()
 	var a *costmodel.Accesses
+	var cp models.Provider
+	
+	// Initialize currency converter
+	var currencyConverter currency.Converter
+	currencyAPIKey := env.GetCurrencyAPIKey()
+	currencyProvider := env.GetCurrencyProvider()
+
+	if currencyProvider == "exchangerateapi" && currencyAPIKey != "" {
+		config := currency.Config{
+			APIKey:     currencyAPIKey,
+			CacheTTL:   24 * time.Hour,
+			APITimeout: 10 * time.Second,
+		}
+		var err error
+		currencyConverter, err = currency.NewConverter(config)
+		if err != nil {
+			log.Errorf("Failed to initialize currency converter: %v", err)
+			log.Warnf("Currency conversion disabled - will return USD values only")
+		} else {
+			log.Infof("Currency converter initialized successfully")
+		}
+	} else {
+		log.Infof("Currency conversion disabled (provider=%s, hasKey=%v)", 
+			currencyProvider, currencyAPIKey != "")
+	}
 
 	if conf.KubernetesEnabled {
 		a = costmodel.Initialize(router)
+		// Set currency converter in Accesses
+		if a != nil {
+			a.CurrencyConverter = currencyConverter
+		}
 		err := StartExportWorker(context.Background(), a.Model)
 		if err != nil {
 			log.Errorf("couldn't start CSV export worker: %v", err)
@@ -62,13 +92,16 @@ func Execute(conf *Config) error {
 
 	var cloudCostPipelineService *cloudcost.PipelineService
 	if conf.CloudCostEnabled {
-
-		cloudCostPipelineService = costmodel.InitializeCloudCost(router)
+		var providerConfig models.ProviderConfig
+		if cp != nil {
+			providerConfig = provider.ExtractConfigFromProviders(cp)
+		}
+		cloudCostPipelineService = costmodel.InitializeCloudCost(router, providerConfig, currencyConverter)
 	}
 
 	var customCostPipelineService *customcost.PipelineService
 	if conf.CustomCostEnabled {
-		customCostPipelineService = costmodel.InitializeCustomCost(router)
+		customCostPipelineService = costmodel.InitializeCustomCost(router, currencyConverter)
 	}
 
 	// this endpoint is intentionally left out of the "if env.IsCustomCostEnabled()" conditional; in the handler, it is

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -12,8 +12,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/opencost/opencost/core/pkg/util/apiutil"
 	"github.com/opencost/opencost/pkg/cloudcost"
-	"github.com/opencost/opencost/pkg/customcost"
 	"github.com/opencost/opencost/pkg/currency"
+	"github.com/opencost/opencost/pkg/customcost"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 
@@ -64,7 +64,7 @@ func Execute(conf *Config) error {
 			log.Infof("Currency converter initialized successfully")
 		}
 	} else {
-		log.Infof("Currency conversion disabled (provider=%s, hasKey=%v)", 
+		log.Infof("Currency conversion disabled (provider=%s, hasKey=%v)",
 			currencyProvider, currencyAPIKey != "")
 	}
 

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -43,8 +43,7 @@ func Execute(conf *Config) error {
 
 	router := httprouter.New()
 	var a *costmodel.Accesses
-	var cp models.Provider
-	
+
 	// Initialize currency converter
 	var currencyConverter currency.Converter
 	currencyAPIKey := env.GetCurrencyAPIKey()
@@ -92,11 +91,7 @@ func Execute(conf *Config) error {
 
 	var cloudCostPipelineService *cloudcost.PipelineService
 	if conf.CloudCostEnabled {
-		var providerConfig models.ProviderConfig
-		if cp != nil {
-			providerConfig = provider.ExtractConfigFromProviders(cp)
-		}
-		cloudCostPipelineService = costmodel.InitializeCloudCost(router, providerConfig, currencyConverter)
+		cloudCostPipelineService = costmodel.InitializeCloudCost(router, currencyConverter)
 	}
 
 	var customCostPipelineService *customcost.PipelineService

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -157,34 +157,24 @@ func (a *Accesses) ComputeAllocationHandlerSummary(w http.ResponseWriter, r *htt
 		}
 	}
 
+	// Convert the underlying AllocationSetRange *before* building the
+	// summary so we don't pay for two summary constructions on non-USD
+	// requests. The helper returns a non-nil error only on the upfront
+	// rate-lookup failure, which happens before any mutation, so on
+	// error we proceed with untouched USD data.
+	currency := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
+	if currency != "USD" && a.CurrencyConverter != nil {
+		if err = ConvertAllocationSetRange(asr, a.CurrencyConverter, currency); err != nil {
+			log.Warnf("Currency conversion failed for currency %s: %v", currency, err)
+		}
+	}
+
 	sasl := []*opencost.SummaryAllocationSet{}
 	for _, as := range asr.Slice() {
 		sas := opencost.NewSummaryAllocationSet(as, nil, nil, false, false)
 		sasl = append(sasl, sas)
 	}
 	sasr := opencost.NewSummaryAllocationSetRange(sasl...)
-
-	// Extract currency parameter and convert if needed. Currency conversion
-	// is best-effort: individual field failures are logged at source and
-	// leave USD values in place. A non-nil error from the helper means the
-	// upfront rate lookup failed and no mutation occurred.
-	currency := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
-	if currency != "USD" && a.CurrencyConverter != nil {
-		if err = ConvertAllocationSetRange(asr, a.CurrencyConverter, currency); err != nil {
-			log.Warnf("Currency conversion failed for currency %s: %v", currency, err)
-		}
-		// Always rebuild the summary: the helper may have partially
-		// mutated the underlying sets even when it returns an error
-		// (per-field best-effort), so the pre-conversion summary would
-		// otherwise be inconsistent with the (possibly partly converted)
-		// data.
-		sasl = sasl[:0]
-		for _, as := range asr.Slice() {
-			sas := opencost.NewSummaryAllocationSet(as, nil, nil, false, false)
-			sasl = append(sasl, sas)
-		}
-		sasr = opencost.NewSummaryAllocationSetRange(sasl...)
-	}
 
 	WriteData(w, sasr, nil)
 }

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -164,23 +164,26 @@ func (a *Accesses) ComputeAllocationHandlerSummary(w http.ResponseWriter, r *htt
 	}
 	sasr := opencost.NewSummaryAllocationSetRange(sasl...)
 
-	// Extract currency parameter and convert if needed
+	// Extract currency parameter and convert if needed. Currency conversion
+	// is best-effort: individual field failures are logged at source and
+	// leave USD values in place. A non-nil error from the helper means the
+	// upfront rate lookup failed and no mutation occurred.
 	currency := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
 	if currency != "USD" && a.CurrencyConverter != nil {
-		// Convert the underlying AllocationSetRange before creating summary
-		err = ConvertAllocationSetRange(asr, a.CurrencyConverter, currency)
-		if err != nil {
+		if err = ConvertAllocationSetRange(asr, a.CurrencyConverter, currency); err != nil {
 			log.Warnf("Currency conversion failed for currency %s: %v", currency, err)
-			// Continue with USD values if conversion fails
-		} else {
-			// Recreate summary allocation sets after conversion
-			sasl = []*opencost.SummaryAllocationSet{}
-			for _, as := range asr.Slice() {
-				sas := opencost.NewSummaryAllocationSet(as, nil, nil, false, false)
-				sasl = append(sasl, sas)
-			}
-			sasr = opencost.NewSummaryAllocationSetRange(sasl...)
 		}
+		// Always rebuild the summary: the helper may have partially
+		// mutated the underlying sets even when it returns an error
+		// (per-field best-effort), so the pre-conversion summary would
+		// otherwise be inconsistent with the (possibly partly converted)
+		// data.
+		sasl = sasl[:0]
+		for _, as := range asr.Slice() {
+			sas := opencost.NewSummaryAllocationSet(as, nil, nil, false, false)
+			sasl = append(sasl, sas)
+		}
+		sasr = opencost.NewSummaryAllocationSetRange(sasl...)
 	}
 
 	WriteData(w, sasr, nil)

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/opencost/opencost/core/pkg/filter/allocation"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/util/httputil"
 	"github.com/opencost/opencost/pkg/env"
@@ -163,6 +164,25 @@ func (a *Accesses) ComputeAllocationHandlerSummary(w http.ResponseWriter, r *htt
 	}
 	sasr := opencost.NewSummaryAllocationSetRange(sasl...)
 
+	// Extract currency parameter and convert if needed
+	currency := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
+	if currency != "USD" && a.CurrencyConverter != nil {
+		// Convert the underlying AllocationSetRange before creating summary
+		err = ConvertAllocationSetRange(asr, a.CurrencyConverter, currency)
+		if err != nil {
+			log.Warnf("Currency conversion failed for currency %s: %v", currency, err)
+			// Continue with USD values if conversion fails
+		} else {
+			// Recreate summary allocation sets after conversion
+			sasl = []*opencost.SummaryAllocationSet{}
+			for _, as := range asr.Slice() {
+				sas := opencost.NewSummaryAllocationSet(as, nil, nil, false, false)
+				sasl = append(sasl, sas)
+			}
+			sasr = opencost.NewSummaryAllocationSetRange(sasl...)
+		}
+	}
+
 	WriteData(w, sasr, nil)
 }
 
@@ -240,6 +260,16 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 		}
 
 		return
+	}
+
+	// Extract currency parameter and convert if needed
+	currency := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
+	if currency != "USD" && a.CurrencyConverter != nil {
+		err = ConvertAllocationSetRange(asr, a.CurrencyConverter, currency)
+		if err != nil {
+			log.Warnf("Currency conversion failed for currency %s: %v", currency, err)
+			// Continue with USD values if conversion fails
+		}
 	}
 
 	WriteData(w, asr, nil)

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -1,14 +1,37 @@
 package costmodel
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/pkg/currency"
 )
 
-// ConvertAllocation converts all cost fields in an Allocation from USD to target currency
+// Currency conversion uses best-effort semantics: if a single field fails
+// to convert, it is left in USD and a warning is logged. The response may
+// therefore contain mixed currencies under partial converter failures.
+// Callers treat a non-nil error from these helpers as advisory only --
+// the mutation has already been applied where it succeeded.
+
+// tryConvert converts val from USD to target, returning the original
+// value (and logging) on converter error. logCtx identifies the field
+// being converted so operators can triage which fields are failing.
+func tryConvert(converter currency.Converter, val float64, target, logCtx string) float64 {
+	if val == 0 {
+		return val
+	}
+	converted, err := converter.Convert(val, "USD", target)
+	if err != nil {
+		log.Warnf("currency: leaving %s in USD (convert to %s failed): %v", logCtx, target, err)
+		return val
+	}
+	return converted
+}
+
+// ConvertAllocation converts all cost fields in an Allocation from USD
+// to target currency in place. Best-effort: per-field failures are logged
+// and skipped rather than aborting the whole allocation.
 func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter, targetCurrency string) error {
 	if alloc == nil || converter == nil || targetCurrency == "USD" {
 		return nil
@@ -16,43 +39,38 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 
 	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
 
-	// List of all float64 cost fields to convert. Keep in sync with
-	// Allocation cost fields in core/pkg/opencost/allocation.go that appear
-	// in JSON API responses.
-	costFields := []*float64{
-		&alloc.CPUCost,
-		&alloc.CPUCostAdjustment,
-		&alloc.CPUCostIdle,
-		&alloc.GPUCost,
-		&alloc.GPUCostAdjustment,
-		&alloc.GPUCostIdle,
-		&alloc.NetworkCost,
-		&alloc.NetworkCrossZoneCost,
-		&alloc.NetworkCrossRegionCost,
-		&alloc.NetworkInternetCost,
-		&alloc.NetworkCostAdjustment,
-		&alloc.NetworkNatGatewayEgressCost,
-		&alloc.NetworkNatGatewayIngressCost,
-		&alloc.LoadBalancerCost,
-		&alloc.LoadBalancerCostAdjustment,
-		&alloc.PVCostAdjustment,
-		&alloc.RAMCost,
-		&alloc.RAMCostAdjustment,
-		&alloc.RAMCostIdle,
-		&alloc.SharedCost,
-		&alloc.ExternalCost,
-		&alloc.UnmountedPVCost,
+	// Named cost fields. Keep in sync with Allocation cost fields in
+	// core/pkg/opencost/allocation.go that appear in JSON API responses.
+	type namedCost struct {
+		name string
+		ptr  *float64
 	}
-
-	// Convert each cost field
-	for _, costPtr := range costFields {
-		if *costPtr != 0 {
-			converted, err := converter.Convert(*costPtr, "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert cost: %w", err)
-			}
-			*costPtr = converted
-		}
+	costFields := []namedCost{
+		{"CPUCost", &alloc.CPUCost},
+		{"CPUCostAdjustment", &alloc.CPUCostAdjustment},
+		{"CPUCostIdle", &alloc.CPUCostIdle},
+		{"GPUCost", &alloc.GPUCost},
+		{"GPUCostAdjustment", &alloc.GPUCostAdjustment},
+		{"GPUCostIdle", &alloc.GPUCostIdle},
+		{"NetworkCost", &alloc.NetworkCost},
+		{"NetworkCrossZoneCost", &alloc.NetworkCrossZoneCost},
+		{"NetworkCrossRegionCost", &alloc.NetworkCrossRegionCost},
+		{"NetworkInternetCost", &alloc.NetworkInternetCost},
+		{"NetworkCostAdjustment", &alloc.NetworkCostAdjustment},
+		{"NetworkNatGatewayEgressCost", &alloc.NetworkNatGatewayEgressCost},
+		{"NetworkNatGatewayIngressCost", &alloc.NetworkNatGatewayIngressCost},
+		{"LoadBalancerCost", &alloc.LoadBalancerCost},
+		{"LoadBalancerCostAdjustment", &alloc.LoadBalancerCostAdjustment},
+		{"PVCostAdjustment", &alloc.PVCostAdjustment},
+		{"RAMCost", &alloc.RAMCost},
+		{"RAMCostAdjustment", &alloc.RAMCostAdjustment},
+		{"RAMCostIdle", &alloc.RAMCostIdle},
+		{"SharedCost", &alloc.SharedCost},
+		{"ExternalCost", &alloc.ExternalCost},
+		{"UnmountedPVCost", &alloc.UnmountedPVCost},
+	}
+	for _, f := range costFields {
+		*f.ptr = tryConvert(converter, *f.ptr, targetCurrency, "Allocation."+f.name)
 	}
 
 	// Convert PV costs (nested structure). Both Cost and Adjustment appear
@@ -61,20 +79,9 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		if pv == nil {
 			continue
 		}
-		if pv.Cost != 0 {
-			converted, err := converter.Convert(pv.Cost, "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert PV cost: %w", err)
-			}
-			pv.Cost = converted
-		}
-		if pv.Adjustment != 0 {
-			converted, err := converter.Convert(pv.Adjustment, "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert PV adjustment: %w", err)
-			}
-			pv.Adjustment = converted
-		}
+		pvCtx := "Allocation.PVs." + pvKey.String()
+		pv.Cost = tryConvert(converter, pv.Cost, targetCurrency, pvCtx+".Cost")
+		pv.Adjustment = tryConvert(converter, pv.Adjustment, targetCurrency, pvCtx+".Adjustment")
 		alloc.PVs[pvKey] = pv
 	}
 
@@ -83,155 +90,54 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		if lb == nil {
 			continue
 		}
-		if lb.Cost != 0 {
-			converted, err := converter.Convert(lb.Cost, "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert LB cost: %w", err)
-			}
-			lb.Cost = converted
-			alloc.LoadBalancers[lbKey] = lb
-		}
+		lb.Cost = tryConvert(converter, lb.Cost, targetCurrency, "Allocation.LoadBalancers."+lbKey+".Cost")
+		alloc.LoadBalancers[lbKey] = lb
 	}
 
 	// Convert SharedCostBreakdown entries. SharedCostBreakdowns is a
 	// map[string]SharedCostBreakdown (value, not pointer), so mutate a
 	// local copy and re-assign.
 	for key, scb := range alloc.SharedCostBreakdown {
-		scbFields := []*float64{
-			&scb.TotalCost,
-			&scb.CPUCost,
-			&scb.GPUCost,
-			&scb.RAMCost,
-			&scb.PVCost,
-			&scb.NetworkCost,
-			&scb.LBCost,
-			&scb.ExternalCost,
-		}
-		mutated := false
-		for _, costPtr := range scbFields {
-			if *costPtr == 0 {
-				continue
-			}
-			converted, err := converter.Convert(*costPtr, "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert SharedCostBreakdown %q: %w", key, err)
-			}
-			*costPtr = converted
-			mutated = true
-		}
-		if mutated {
-			alloc.SharedCostBreakdown[key] = scb
-		}
+		scb.TotalCost = tryConvert(converter, scb.TotalCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".TotalCost")
+		scb.CPUCost = tryConvert(converter, scb.CPUCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".CPUCost")
+		scb.GPUCost = tryConvert(converter, scb.GPUCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".GPUCost")
+		scb.RAMCost = tryConvert(converter, scb.RAMCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".RAMCost")
+		scb.PVCost = tryConvert(converter, scb.PVCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".PVCost")
+		scb.NetworkCost = tryConvert(converter, scb.NetworkCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".NetworkCost")
+		scb.LBCost = tryConvert(converter, scb.LBCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".LBCost")
+		scb.ExternalCost = tryConvert(converter, scb.ExternalCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".ExternalCost")
+		alloc.SharedCostBreakdown[key] = scb
 	}
 
 	return nil
 }
 
-// ConvertAllocationSet converts all allocations in a set
+// ConvertAllocationSet converts all allocations in a set (best-effort).
 func ConvertAllocationSet(set *opencost.AllocationSet, converter currency.Converter, targetCurrency string) error {
 	if set == nil || converter == nil || targetCurrency == "USD" {
 		return nil
 	}
 
 	for _, alloc := range set.Allocations {
-		if err := ConvertAllocation(alloc, converter, targetCurrency); err != nil {
-			return err
-		}
+		// ConvertAllocation is best-effort and never returns a non-nil
+		// error today, but retain the error-return contract in case the
+		// helper is extended later.
+		_ = ConvertAllocation(alloc, converter, targetCurrency)
 	}
 
 	return nil
 }
 
-// ConvertAllocationSetRange converts all sets in a range
+// ConvertAllocationSetRange converts all sets in a range (best-effort).
 func ConvertAllocationSetRange(asr *opencost.AllocationSetRange, converter currency.Converter, targetCurrency string) error {
 	if asr == nil || converter == nil || targetCurrency == "USD" {
 		return nil
 	}
 
 	for _, set := range asr.Allocations {
-		if err := ConvertAllocationSet(set, converter, targetCurrency); err != nil {
-			return err
-		}
+		_ = ConvertAllocationSet(set, converter, targetCurrency)
 	}
 
 	return nil
 }
 
-// ConvertCloudCost converts all cost metrics in a CloudCost
-func ConvertCloudCost(cc *opencost.CloudCost, converter currency.Converter, targetCurrency string) error {
-	if cc == nil || converter == nil || targetCurrency == "USD" {
-		return nil
-	}
-
-	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
-
-	// Helper to convert CostMetric (only the Cost field, not KubernetesPercent)
-	convertCostMetric := func(cm *opencost.CostMetric) error {
-		if cm.Cost != 0 {
-			converted, err := converter.Convert(cm.Cost, "USD", targetCurrency)
-			if err != nil {
-				return err
-			}
-			cm.Cost = converted
-		}
-		return nil
-	}
-
-	// Convert all cost metrics
-	if err := convertCostMetric(&cc.ListCost); err != nil {
-		return fmt.Errorf("failed to convert ListCost: %w", err)
-	}
-	if err := convertCostMetric(&cc.NetCost); err != nil {
-		return fmt.Errorf("failed to convert NetCost: %w", err)
-	}
-	if err := convertCostMetric(&cc.AmortizedNetCost); err != nil {
-		return fmt.Errorf("failed to convert AmortizedNetCost: %w", err)
-	}
-	if err := convertCostMetric(&cc.InvoicedCost); err != nil {
-		return fmt.Errorf("failed to convert InvoicedCost: %w", err)
-	}
-	if err := convertCostMetric(&cc.AmortizedCost); err != nil {
-		return fmt.Errorf("failed to convert AmortizedCost: %w", err)
-	}
-
-	return nil
-}
-
-// ConvertCloudCostSet converts all cloud costs in a set
-func ConvertCloudCostSet(set *opencost.CloudCostSet, converter currency.Converter, targetCurrency string) error {
-	if set == nil || converter == nil || targetCurrency == "USD" {
-		return nil
-	}
-
-	for _, cc := range set.CloudCosts {
-		if cc == nil {
-			continue
-		}
-		if err := ConvertCloudCost(cc, converter, targetCurrency); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// ConvertCloudCostSetRange converts all sets in a range
-func ConvertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter currency.Converter, targetCurrency string) error {
-	if ccsr == nil || converter == nil || targetCurrency == "USD" {
-		return nil
-	}
-
-	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
-
-	// Convert all cloud cost sets in the range
-	for _, set := range ccsr.CloudCostSets {
-		if set == nil {
-			continue
-		}
-		if err := ConvertCloudCostSet(set, converter, targetCurrency); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -1,6 +1,7 @@
 package costmodel
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/opencost/opencost/core/pkg/log"
@@ -8,15 +9,21 @@ import (
 	"github.com/opencost/opencost/pkg/currency"
 )
 
-// Currency conversion uses best-effort semantics: if a single field fails
-// to convert, it is left in USD and a warning is logged. The response may
-// therefore contain mixed currencies under partial converter failures.
-// Callers treat a non-nil error from these helpers as advisory only --
-// the mutation has already been applied where it succeeded.
+// Currency conversion uses a two-layer approach:
+//   - The handler-facing entry (Range / Set / top-level Allocation) calls
+//     Converter.GetRate once to validate the target currency. If that
+//     fails, the helper returns an error without mutating anything and
+//     the caller logs a single per-request warning -- preventing log
+//     floods when the API is unreachable or the currency code is bogus.
+//   - Per-field conversion is best-effort: if an individual Convert call
+//     fails after the rate probe succeeded (exotic case) the original
+//     USD value is retained and logged. Responses may therefore contain
+//     mixed currencies under partial converter failures.
 
 // tryConvert converts val from USD to target, returning the original
-// value (and logging) on converter error. logCtx identifies the field
-// being converted so operators can triage which fields are failing.
+// value (and logging) on converter error. Only fires after the outer
+// helper has already validated the target currency, so this path is
+// rarely hit in practice. logCtx identifies the field being converted.
 func tryConvert(converter currency.Converter, val float64, target, logCtx string) float64 {
 	if val == 0 {
 		return val
@@ -29,15 +36,49 @@ func tryConvert(converter currency.Converter, val float64, target, logCtx string
 	return converted
 }
 
+// normalizeAndProbe normalizes the target currency code and, if it is
+// not a no-op (USD or empty), probes the converter for the rate. Returns
+// the normalized currency, a no-op flag, and any rate-lookup error.
+func normalizeAndProbe(converter currency.Converter, target string) (normalized string, noop bool, err error) {
+	normalized = strings.ToUpper(strings.TrimSpace(target))
+	if normalized == "" || normalized == "USD" {
+		return normalized, true, nil
+	}
+	if _, rateErr := converter.GetRate("USD", normalized); rateErr != nil {
+		return normalized, false, fmt.Errorf("currency rate lookup USD->%s failed: %w", normalized, rateErr)
+	}
+	return normalized, false, nil
+}
+
 // ConvertAllocation converts all cost fields in an Allocation from USD
-// to target currency in place. Best-effort: per-field failures are logged
-// and skipped rather than aborting the whole allocation.
+// to target currency in place. Returns an error if the target rate
+// cannot be looked up (no mutation occurs); per-field converter failures
+// encountered after the rate probe succeeded are handled best-effort and
+// logged in place.
 func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter, targetCurrency string) error {
-	if alloc == nil || converter == nil || targetCurrency == "USD" {
+	if alloc == nil || converter == nil {
 		return nil
 	}
 
-	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+	targetCurrency, noop, err := normalizeAndProbe(converter, targetCurrency)
+	if err != nil {
+		return err
+	}
+	if noop {
+		return nil
+	}
+
+	return convertAllocationFields(alloc, converter, targetCurrency)
+}
+
+// convertAllocationFields performs the per-field best-effort conversion.
+// The caller must have already normalised the target currency and
+// probed the rate. Returns nil today; retains the error return so the
+// signature can carry structured failure info in the future.
+func convertAllocationFields(alloc *opencost.Allocation, converter currency.Converter, targetCurrency string) error {
+	if alloc == nil {
+		return nil
+	}
 
 	// Named cost fields. Keep in sync with Allocation cost fields in
 	// core/pkg/opencost/allocation.go that appear in JSON API responses.
@@ -73,8 +114,6 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		*f.ptr = tryConvert(converter, *f.ptr, targetCurrency, "Allocation."+f.name)
 	}
 
-	// Convert PV costs (nested structure). Both Cost and Adjustment appear
-	// in JSON responses and must be converted.
 	for pvKey, pv := range alloc.PVs {
 		if pv == nil {
 			continue
@@ -85,7 +124,6 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		alloc.PVs[pvKey] = pv
 	}
 
-	// Convert LoadBalancer costs (nested structure)
 	for lbKey, lb := range alloc.LoadBalancers {
 		if lb == nil {
 			continue
@@ -94,9 +132,8 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		alloc.LoadBalancers[lbKey] = lb
 	}
 
-	// Convert SharedCostBreakdown entries. SharedCostBreakdowns is a
-	// map[string]SharedCostBreakdown (value, not pointer), so mutate a
-	// local copy and re-assign.
+	// SharedCostBreakdowns is map[string]SharedCostBreakdown (value type);
+	// mutate a local copy and re-assign.
 	for key, scb := range alloc.SharedCostBreakdown {
 		scb.TotalCost = tryConvert(converter, scb.TotalCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".TotalCost")
 		scb.CPUCost = tryConvert(converter, scb.CPUCost, targetCurrency, "Allocation.SharedCostBreakdown."+key+".CPUCost")
@@ -112,31 +149,49 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 	return nil
 }
 
-// ConvertAllocationSet converts all allocations in a set (best-effort).
+// ConvertAllocationSet converts all allocations in a set. Returns an
+// error if the target rate cannot be looked up (no mutation occurs).
+// Per-allocation conversion itself is best-effort.
 func ConvertAllocationSet(set *opencost.AllocationSet, converter currency.Converter, targetCurrency string) error {
-	if set == nil || converter == nil || targetCurrency == "USD" {
+	if set == nil || converter == nil {
+		return nil
+	}
+	targetCurrency, noop, err := normalizeAndProbe(converter, targetCurrency)
+	if err != nil {
+		return err
+	}
+	if noop {
 		return nil
 	}
 
 	for _, alloc := range set.Allocations {
-		// ConvertAllocation is best-effort and never returns a non-nil
-		// error today, but retain the error-return contract in case the
-		// helper is extended later.
-		_ = ConvertAllocation(alloc, converter, targetCurrency)
+		_ = convertAllocationFields(alloc, converter, targetCurrency)
 	}
-
 	return nil
 }
 
-// ConvertAllocationSetRange converts all sets in a range (best-effort).
+// ConvertAllocationSetRange converts all sets in a range. Returns an
+// error if the target rate cannot be looked up (no mutation occurs).
+// Per-allocation conversion itself is best-effort.
 func ConvertAllocationSetRange(asr *opencost.AllocationSetRange, converter currency.Converter, targetCurrency string) error {
-	if asr == nil || converter == nil || targetCurrency == "USD" {
+	if asr == nil || converter == nil {
+		return nil
+	}
+	targetCurrency, noop, err := normalizeAndProbe(converter, targetCurrency)
+	if err != nil {
+		return err
+	}
+	if noop {
 		return nil
 	}
 
 	for _, set := range asr.Allocations {
-		_ = ConvertAllocationSet(set, converter, targetCurrency)
+		if set == nil {
+			continue
+		}
+		for _, alloc := range set.Allocations {
+			_ = convertAllocationFields(alloc, converter, targetCurrency)
+		}
 	}
-
 	return nil
 }

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -128,7 +128,9 @@ func convertAllocationFields(alloc *opencost.Allocation, converter currency.Conv
 		if lb == nil {
 			continue
 		}
-		lb.Cost = tryConvert(converter, lb.Cost, targetCurrency, "Allocation.LoadBalancers."+lbKey+".Cost")
+		lbCtx := "Allocation.LoadBalancers." + lbKey
+		lb.Cost = tryConvert(converter, lb.Cost, targetCurrency, lbCtx+".Cost")
+		lb.Adjustment = tryConvert(converter, lb.Adjustment, targetCurrency, lbCtx+".Adjustment")
 		alloc.LoadBalancers[lbKey] = lb
 	}
 

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -140,4 +140,3 @@ func ConvertAllocationSetRange(asr *opencost.AllocationSetRange, converter curre
 
 	return nil
 }
-

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -16,7 +16,9 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 
 	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
 
-	// List of all float64 cost fields to convert
+	// List of all float64 cost fields to convert. Keep in sync with
+	// Allocation cost fields in core/pkg/opencost/allocation.go that appear
+	// in JSON API responses.
 	costFields := []*float64{
 		&alloc.CPUCost,
 		&alloc.CPUCostAdjustment,
@@ -29,6 +31,8 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		&alloc.NetworkCrossRegionCost,
 		&alloc.NetworkInternetCost,
 		&alloc.NetworkCostAdjustment,
+		&alloc.NetworkNatGatewayEgressCost,
+		&alloc.NetworkNatGatewayIngressCost,
 		&alloc.LoadBalancerCost,
 		&alloc.LoadBalancerCostAdjustment,
 		&alloc.PVCostAdjustment,
@@ -51,20 +55,34 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 		}
 	}
 
-	// Convert PV costs (nested structure)
+	// Convert PV costs (nested structure). Both Cost and Adjustment appear
+	// in JSON responses and must be converted.
 	for pvKey, pv := range alloc.PVs {
+		if pv == nil {
+			continue
+		}
 		if pv.Cost != 0 {
 			converted, err := converter.Convert(pv.Cost, "USD", targetCurrency)
 			if err != nil {
 				return fmt.Errorf("failed to convert PV cost: %w", err)
 			}
 			pv.Cost = converted
-			alloc.PVs[pvKey] = pv
 		}
+		if pv.Adjustment != 0 {
+			converted, err := converter.Convert(pv.Adjustment, "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert PV adjustment: %w", err)
+			}
+			pv.Adjustment = converted
+		}
+		alloc.PVs[pvKey] = pv
 	}
 
 	// Convert LoadBalancer costs (nested structure)
 	for lbKey, lb := range alloc.LoadBalancers {
+		if lb == nil {
+			continue
+		}
 		if lb.Cost != 0 {
 			converted, err := converter.Convert(lb.Cost, "USD", targetCurrency)
 			if err != nil {
@@ -72,6 +90,37 @@ func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter,
 			}
 			lb.Cost = converted
 			alloc.LoadBalancers[lbKey] = lb
+		}
+	}
+
+	// Convert SharedCostBreakdown entries. SharedCostBreakdowns is a
+	// map[string]SharedCostBreakdown (value, not pointer), so mutate a
+	// local copy and re-assign.
+	for key, scb := range alloc.SharedCostBreakdown {
+		scbFields := []*float64{
+			&scb.TotalCost,
+			&scb.CPUCost,
+			&scb.GPUCost,
+			&scb.RAMCost,
+			&scb.PVCost,
+			&scb.NetworkCost,
+			&scb.LBCost,
+			&scb.ExternalCost,
+		}
+		mutated := false
+		for _, costPtr := range scbFields {
+			if *costPtr == 0 {
+				continue
+			}
+			converted, err := converter.Convert(*costPtr, "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert SharedCostBreakdown %q: %w", key, err)
+			}
+			*costPtr = converted
+			mutated = true
+		}
+		if mutated {
+			alloc.SharedCostBreakdown[key] = scb
 		}
 	}
 

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -81,7 +81,11 @@ func convertAllocationFields(alloc *opencost.Allocation, converter currency.Conv
 	}
 
 	// Named cost fields. Keep in sync with Allocation cost fields in
-	// core/pkg/opencost/allocation.go that appear in JSON API responses.
+	// core/pkg/opencost/allocation.go. Includes both JSON-serialised
+	// costs and internal ones like UnmountedPVCost (json:"-") which are
+	// used downstream in SummaryAllocation / Totals computations --
+	// leaving those in USD would cause unit mismatches with the
+	// converted primary costs.
 	type namedCost struct {
 		name string
 		ptr  *float64

--- a/pkg/costmodel/currency_helper.go
+++ b/pkg/costmodel/currency_helper.go
@@ -1,0 +1,188 @@
+package costmodel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/pkg/currency"
+)
+
+// ConvertAllocation converts all cost fields in an Allocation from USD to target currency
+func ConvertAllocation(alloc *opencost.Allocation, converter currency.Converter, targetCurrency string) error {
+	if alloc == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+
+	// List of all float64 cost fields to convert
+	costFields := []*float64{
+		&alloc.CPUCost,
+		&alloc.CPUCostAdjustment,
+		&alloc.CPUCostIdle,
+		&alloc.GPUCost,
+		&alloc.GPUCostAdjustment,
+		&alloc.GPUCostIdle,
+		&alloc.NetworkCost,
+		&alloc.NetworkCrossZoneCost,
+		&alloc.NetworkCrossRegionCost,
+		&alloc.NetworkInternetCost,
+		&alloc.NetworkCostAdjustment,
+		&alloc.LoadBalancerCost,
+		&alloc.LoadBalancerCostAdjustment,
+		&alloc.PVCostAdjustment,
+		&alloc.RAMCost,
+		&alloc.RAMCostAdjustment,
+		&alloc.RAMCostIdle,
+		&alloc.SharedCost,
+		&alloc.ExternalCost,
+		&alloc.UnmountedPVCost,
+	}
+
+	// Convert each cost field
+	for _, costPtr := range costFields {
+		if *costPtr != 0 {
+			converted, err := converter.Convert(*costPtr, "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert cost: %w", err)
+			}
+			*costPtr = converted
+		}
+	}
+
+	// Convert PV costs (nested structure)
+	for pvKey, pv := range alloc.PVs {
+		if pv.Cost != 0 {
+			converted, err := converter.Convert(pv.Cost, "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert PV cost: %w", err)
+			}
+			pv.Cost = converted
+			alloc.PVs[pvKey] = pv
+		}
+	}
+
+	// Convert LoadBalancer costs (nested structure)
+	for lbKey, lb := range alloc.LoadBalancers {
+		if lb.Cost != 0 {
+			converted, err := converter.Convert(lb.Cost, "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert LB cost: %w", err)
+			}
+			lb.Cost = converted
+			alloc.LoadBalancers[lbKey] = lb
+		}
+	}
+
+	return nil
+}
+
+// ConvertAllocationSet converts all allocations in a set
+func ConvertAllocationSet(set *opencost.AllocationSet, converter currency.Converter, targetCurrency string) error {
+	if set == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	for _, alloc := range set.Allocations {
+		if err := ConvertAllocation(alloc, converter, targetCurrency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ConvertAllocationSetRange converts all sets in a range
+func ConvertAllocationSetRange(asr *opencost.AllocationSetRange, converter currency.Converter, targetCurrency string) error {
+	if asr == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	for _, set := range asr.Allocations {
+		if err := ConvertAllocationSet(set, converter, targetCurrency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ConvertCloudCost converts all cost metrics in a CloudCost
+func ConvertCloudCost(cc *opencost.CloudCost, converter currency.Converter, targetCurrency string) error {
+	if cc == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+
+	// Helper to convert CostMetric (only the Cost field, not KubernetesPercent)
+	convertCostMetric := func(cm *opencost.CostMetric) error {
+		if cm.Cost != 0 {
+			converted, err := converter.Convert(cm.Cost, "USD", targetCurrency)
+			if err != nil {
+				return err
+			}
+			cm.Cost = converted
+		}
+		return nil
+	}
+
+	// Convert all cost metrics
+	if err := convertCostMetric(&cc.ListCost); err != nil {
+		return fmt.Errorf("failed to convert ListCost: %w", err)
+	}
+	if err := convertCostMetric(&cc.NetCost); err != nil {
+		return fmt.Errorf("failed to convert NetCost: %w", err)
+	}
+	if err := convertCostMetric(&cc.AmortizedNetCost); err != nil {
+		return fmt.Errorf("failed to convert AmortizedNetCost: %w", err)
+	}
+	if err := convertCostMetric(&cc.InvoicedCost); err != nil {
+		return fmt.Errorf("failed to convert InvoicedCost: %w", err)
+	}
+	if err := convertCostMetric(&cc.AmortizedCost); err != nil {
+		return fmt.Errorf("failed to convert AmortizedCost: %w", err)
+	}
+
+	return nil
+}
+
+// ConvertCloudCostSet converts all cloud costs in a set
+func ConvertCloudCostSet(set *opencost.CloudCostSet, converter currency.Converter, targetCurrency string) error {
+	if set == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	for _, cc := range set.CloudCosts {
+		if cc == nil {
+			continue
+		}
+		if err := ConvertCloudCost(cc, converter, targetCurrency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ConvertCloudCostSetRange converts all sets in a range
+func ConvertCloudCostSetRange(ccsr *opencost.CloudCostSetRange, converter currency.Converter, targetCurrency string) error {
+	if ccsr == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+
+	// Convert all cloud cost sets in the range
+	for _, set := range ccsr.CloudCostSets {
+		if set == nil {
+			continue
+		}
+		if err := ConvertCloudCostSet(set, converter, targetCurrency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/costmodel/currency_helper_test.go
+++ b/pkg/costmodel/currency_helper_test.go
@@ -72,7 +72,7 @@ func newFullAllocation() *opencost.Allocation {
 			opencost.PVKey{Cluster: "c1", Name: "pv-a"}: {Cost: 100, Adjustment: 5, ByteHours: 1},
 		},
 		LoadBalancers: opencost.LbAllocations{
-			"lb-a": {Service: "svc-a", Cost: 80},
+			"lb-a": {Service: "svc-a", Cost: 80, Adjustment: 3},
 		},
 		SharedCostBreakdown: opencost.SharedCostBreakdowns{
 			"shared-a": {
@@ -186,6 +186,9 @@ func TestConvertAllocation_NestedStructures(t *testing.T) {
 	}
 	if lb.Cost != 160 {
 		t.Errorf("LB.Cost: got %v want 160", lb.Cost)
+	}
+	if lb.Adjustment != 6 {
+		t.Errorf("LB.Adjustment: got %v want 6", lb.Adjustment)
 	}
 	if lb.Service != "svc-a" {
 		t.Errorf("LB.Service must not be touched: got %q", lb.Service)

--- a/pkg/costmodel/currency_helper_test.go
+++ b/pkg/costmodel/currency_helper_test.go
@@ -1,0 +1,287 @@
+package costmodel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+// mockConverter is a test double for currency.Converter. Rate is applied
+// uniformly unless failFields contains the specific source amount, in
+// which case Convert returns an error (useful for testing partial-
+// failure / best-effort behavior).
+type mockConverter struct {
+	rate       float64
+	failValues map[float64]bool
+	calls      int
+}
+
+func (m *mockConverter) Convert(amount float64, from, to string) (float64, error) {
+	m.calls++
+	if from != "USD" {
+		return 0, fmt.Errorf("mock only converts from USD, got %q", from)
+	}
+	if m.failValues[amount] {
+		return 0, fmt.Errorf("simulated converter failure for amount %v", amount)
+	}
+	return amount * m.rate, nil
+}
+
+func (m *mockConverter) GetRate(from, to string) (float64, error) {
+	return m.rate, nil
+}
+
+func newFullAllocation() *opencost.Allocation {
+	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	return &opencost.Allocation{
+		Name:                         "ns/pod/container",
+		Start:                        start,
+		End:                          end,
+		CPUCost:                      10,
+		CPUCostAdjustment:            1,
+		CPUCostIdle:                  2,
+		GPUCost:                      20,
+		GPUCostAdjustment:            3,
+		GPUCostIdle:                  4,
+		NetworkCost:                  30,
+		NetworkCrossZoneCost:         5,
+		NetworkCrossRegionCost:       6,
+		NetworkInternetCost:          7,
+		NetworkCostAdjustment:        8,
+		NetworkNatGatewayEgressCost:  11,
+		NetworkNatGatewayIngressCost: 12,
+		LoadBalancerCost:             40,
+		LoadBalancerCostAdjustment:   9,
+		PVCostAdjustment:             13,
+		RAMCost:                      50,
+		RAMCostAdjustment:            14,
+		RAMCostIdle:                  15,
+		SharedCost:                   60,
+		ExternalCost:                 70,
+		UnmountedPVCost:              16,
+		PVs: opencost.PVAllocations{
+			opencost.PVKey{Cluster: "c1", Name: "pv-a"}: {Cost: 100, Adjustment: 5, ByteHours: 1},
+		},
+		LoadBalancers: opencost.LbAllocations{
+			"lb-a": {Service: "svc-a", Cost: 80},
+		},
+		SharedCostBreakdown: opencost.SharedCostBreakdowns{
+			"shared-a": {
+				Name:         "shared-a",
+				TotalCost:    200,
+				CPUCost:      40,
+				GPUCost:      41,
+				RAMCost:      42,
+				PVCost:       43,
+				NetworkCost:  44,
+				LBCost:       45,
+				ExternalCost: 46,
+			},
+		},
+	}
+}
+
+func TestConvertAllocation_USDIsNoOp(t *testing.T) {
+	a := newFullAllocation()
+	before := *a
+	m := &mockConverter{rate: 2.0}
+	if err := ConvertAllocation(a, m, "USD"); err != nil {
+		t.Fatalf("ConvertAllocation(USD) returned error: %v", err)
+	}
+	if m.calls != 0 {
+		t.Fatalf("expected zero converter calls for USD, got %d", m.calls)
+	}
+	if a.CPUCost != before.CPUCost || a.RAMCost != before.RAMCost {
+		t.Fatalf("USD path mutated allocation")
+	}
+}
+
+func TestConvertAllocation_NilSafe(t *testing.T) {
+	if err := ConvertAllocation(nil, &mockConverter{rate: 2.0}, "EUR"); err != nil {
+		t.Fatalf("nil Allocation: unexpected error %v", err)
+	}
+	a := newFullAllocation()
+	if err := ConvertAllocation(a, nil, "EUR"); err != nil {
+		t.Fatalf("nil Converter: unexpected error %v", err)
+	}
+	// nil converter must not mutate
+	if a.CPUCost != 10 {
+		t.Fatalf("nil converter mutated CPUCost: got %v want 10", a.CPUCost)
+	}
+}
+
+func TestConvertAllocation_MutatesAllCostFields(t *testing.T) {
+	a := newFullAllocation()
+	m := &mockConverter{rate: 2.0}
+
+	if err := ConvertAllocation(a, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	checks := map[string]struct{ got, want float64 }{
+		"CPUCost":                      {a.CPUCost, 20},
+		"CPUCostAdjustment":            {a.CPUCostAdjustment, 2},
+		"CPUCostIdle":                  {a.CPUCostIdle, 4},
+		"GPUCost":                      {a.GPUCost, 40},
+		"GPUCostAdjustment":            {a.GPUCostAdjustment, 6},
+		"GPUCostIdle":                  {a.GPUCostIdle, 8},
+		"NetworkCost":                  {a.NetworkCost, 60},
+		"NetworkCrossZoneCost":         {a.NetworkCrossZoneCost, 10},
+		"NetworkCrossRegionCost":       {a.NetworkCrossRegionCost, 12},
+		"NetworkInternetCost":          {a.NetworkInternetCost, 14},
+		"NetworkCostAdjustment":        {a.NetworkCostAdjustment, 16},
+		"NetworkNatGatewayEgressCost":  {a.NetworkNatGatewayEgressCost, 22},
+		"NetworkNatGatewayIngressCost": {a.NetworkNatGatewayIngressCost, 24},
+		"LoadBalancerCost":             {a.LoadBalancerCost, 80},
+		"LoadBalancerCostAdjustment":   {a.LoadBalancerCostAdjustment, 18},
+		"PVCostAdjustment":             {a.PVCostAdjustment, 26},
+		"RAMCost":                      {a.RAMCost, 100},
+		"RAMCostAdjustment":            {a.RAMCostAdjustment, 28},
+		"RAMCostIdle":                  {a.RAMCostIdle, 30},
+		"SharedCost":                   {a.SharedCost, 120},
+		"ExternalCost":                 {a.ExternalCost, 140},
+		"UnmountedPVCost":              {a.UnmountedPVCost, 32},
+	}
+	for name, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %v want %v", name, c.got, c.want)
+		}
+	}
+}
+
+func TestConvertAllocation_NestedStructures(t *testing.T) {
+	a := newFullAllocation()
+	m := &mockConverter{rate: 2.0}
+
+	if err := ConvertAllocation(a, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pv := a.PVs[opencost.PVKey{Cluster: "c1", Name: "pv-a"}]
+	if pv == nil {
+		t.Fatal("PV was lost")
+	}
+	if pv.Cost != 200 {
+		t.Errorf("PV.Cost: got %v want 200", pv.Cost)
+	}
+	if pv.Adjustment != 10 {
+		t.Errorf("PV.Adjustment: got %v want 10", pv.Adjustment)
+	}
+	if pv.ByteHours != 1 {
+		t.Errorf("PV.ByteHours must not be touched: got %v want 1", pv.ByteHours)
+	}
+
+	lb := a.LoadBalancers["lb-a"]
+	if lb == nil {
+		t.Fatal("LB was lost")
+	}
+	if lb.Cost != 160 {
+		t.Errorf("LB.Cost: got %v want 160", lb.Cost)
+	}
+	if lb.Service != "svc-a" {
+		t.Errorf("LB.Service must not be touched: got %q", lb.Service)
+	}
+
+	scb, ok := a.SharedCostBreakdown["shared-a"]
+	if !ok {
+		t.Fatal("SharedCostBreakdown entry was lost")
+	}
+	if scb.TotalCost != 400 {
+		t.Errorf("SCB.TotalCost: got %v want 400", scb.TotalCost)
+	}
+	if scb.CPUCost != 80 {
+		t.Errorf("SCB.CPUCost: got %v want 80", scb.CPUCost)
+	}
+	if scb.ExternalCost != 92 {
+		t.Errorf("SCB.ExternalCost: got %v want 92", scb.ExternalCost)
+	}
+	if scb.Name != "shared-a" {
+		t.Errorf("SCB.Name must not be touched: got %q", scb.Name)
+	}
+}
+
+func TestConvertAllocation_BestEffortOnPartialFailure(t *testing.T) {
+	a := newFullAllocation()
+	// Inject a failure for the exact CPUCost value. All other fields
+	// should still convert.
+	m := &mockConverter{
+		rate:       2.0,
+		failValues: map[float64]bool{10: true},
+	}
+
+	if err := ConvertAllocation(a, m, "EUR"); err != nil {
+		t.Fatalf("best-effort helper must not return error; got %v", err)
+	}
+
+	if a.CPUCost != 10 {
+		t.Errorf("failed field must retain USD value: CPUCost got %v want 10", a.CPUCost)
+	}
+	if a.RAMCost != 100 {
+		t.Errorf("unrelated field must convert: RAMCost got %v want 100", a.RAMCost)
+	}
+}
+
+func TestConvertAllocation_ZeroValuesSkipped(t *testing.T) {
+	a := &opencost.Allocation{Name: "zero"} // everything is 0
+	m := &mockConverter{rate: 2.0}
+
+	if err := ConvertAllocation(a, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.calls != 0 {
+		t.Errorf("zero-valued fields must not call the converter; got %d calls", m.calls)
+	}
+}
+
+func TestConvertAllocationSet(t *testing.T) {
+	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	set := opencost.NewAllocationSet(start, end)
+	set.Insert(&opencost.Allocation{Name: "a1", Start: start, End: end, CPUCost: 5})
+	set.Insert(&opencost.Allocation{Name: "a2", Start: start, End: end, CPUCost: 7})
+
+	m := &mockConverter{rate: 3.0}
+	if err := ConvertAllocationSet(set, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if set.Allocations["a1"].CPUCost != 15 {
+		t.Errorf("a1 CPUCost: got %v want 15", set.Allocations["a1"].CPUCost)
+	}
+	if set.Allocations["a2"].CPUCost != 21 {
+		t.Errorf("a2 CPUCost: got %v want 21", set.Allocations["a2"].CPUCost)
+	}
+}
+
+func TestConvertAllocationSetRange(t *testing.T) {
+	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	set1 := opencost.NewAllocationSet(start, end)
+	set1.Insert(&opencost.Allocation{Name: "a1", Start: start, End: end, CPUCost: 5})
+	set2 := opencost.NewAllocationSet(end, end.Add(time.Hour))
+	set2.Insert(&opencost.Allocation{Name: "a2", Start: end, End: end.Add(time.Hour), CPUCost: 9})
+	asr := opencost.NewAllocationSetRange(set1, set2)
+
+	m := &mockConverter{rate: 4.0}
+	if err := ConvertAllocationSetRange(asr, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := set1.Allocations["a1"].CPUCost; got != 20 {
+		t.Errorf("set1.a1.CPUCost: got %v want 20", got)
+	}
+	if got := set2.Allocations["a2"].CPUCost; got != 36 {
+		t.Errorf("set2.a2.CPUCost: got %v want 36", got)
+	}
+}
+
+func TestConvertAllocationSetRange_NilGuards(t *testing.T) {
+	if err := ConvertAllocationSetRange(nil, &mockConverter{rate: 2}, "EUR"); err != nil {
+		t.Fatalf("nil range: %v", err)
+	}
+	asr := opencost.NewAllocationSetRange()
+	if err := ConvertAllocationSetRange(asr, nil, "EUR"); err != nil {
+		t.Fatalf("nil converter: %v", err)
+	}
+}

--- a/pkg/costmodel/currency_helper_test.go
+++ b/pkg/costmodel/currency_helper_test.go
@@ -13,9 +13,11 @@ import (
 // which case Convert returns an error (useful for testing partial-
 // failure / best-effort behavior).
 type mockConverter struct {
-	rate       float64
-	failValues map[float64]bool
-	calls      int
+	rate         float64
+	failValues   map[float64]bool
+	getRateFail  bool
+	getRateCalls int
+	calls        int
 }
 
 func (m *mockConverter) Convert(amount float64, from, to string) (float64, error) {
@@ -30,6 +32,10 @@ func (m *mockConverter) Convert(amount float64, from, to string) (float64, error
 }
 
 func (m *mockConverter) GetRate(from, to string) (float64, error) {
+	m.getRateCalls++
+	if m.getRateFail {
+		return 0, fmt.Errorf("simulated rate lookup failure USD->%s", to)
+	}
 	return m.rate, nil
 }
 
@@ -283,5 +289,65 @@ func TestConvertAllocationSetRange_NilGuards(t *testing.T) {
 	asr := opencost.NewAllocationSetRange()
 	if err := ConvertAllocationSetRange(asr, nil, "EUR"); err != nil {
 		t.Fatalf("nil converter: %v", err)
+	}
+}
+
+// TestConvertAllocation_USDNormalized exercises the normalize-before-
+// USD-check fix: lowercase and whitespace-padded "USD" must be treated
+// as a no-op without invoking the converter.
+func TestConvertAllocation_USDNormalized(t *testing.T) {
+	for _, target := range []string{"usd", " USD ", "Usd", ""} {
+		a := newFullAllocation()
+		m := &mockConverter{rate: 2.0}
+		if err := ConvertAllocation(a, m, target); err != nil {
+			t.Fatalf("target %q: unexpected error %v", target, err)
+		}
+		if m.calls != 0 || m.getRateCalls != 0 {
+			t.Errorf("target %q: expected zero converter activity, got convert=%d rate=%d",
+				target, m.calls, m.getRateCalls)
+		}
+		if a.CPUCost != 10 {
+			t.Errorf("target %q: mutated CPUCost to %v", target, a.CPUCost)
+		}
+	}
+}
+
+// TestConvertAllocation_GetRateFailsReturnsErrorNoMutation exercises the
+// upfront rate probe: when GetRate fails, the helper returns an error
+// and does NOT attempt any per-field conversion (prevents log-storms
+// when the converter is down or the currency code is invalid).
+func TestConvertAllocation_GetRateFailsReturnsErrorNoMutation(t *testing.T) {
+	a := newFullAllocation()
+	m := &mockConverter{rate: 2.0, getRateFail: true}
+
+	err := ConvertAllocation(a, m, "XXX")
+	if err == nil {
+		t.Fatal("expected error when GetRate fails")
+	}
+	if m.calls != 0 {
+		t.Errorf("expected zero Convert calls when GetRate fails; got %d", m.calls)
+	}
+	if a.CPUCost != 10 {
+		t.Errorf("allocation must not be mutated when precheck fails: CPUCost got %v want 10", a.CPUCost)
+	}
+}
+
+func TestConvertAllocationSetRange_GetRateFailsReturnsError(t *testing.T) {
+	start := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	set := opencost.NewAllocationSet(start, end)
+	set.Insert(&opencost.Allocation{Name: "a1", Start: start, End: end, CPUCost: 5})
+	asr := opencost.NewAllocationSetRange(set)
+
+	m := &mockConverter{rate: 2.0, getRateFail: true}
+	err := ConvertAllocationSetRange(asr, m, "XXX")
+	if err == nil {
+		t.Fatal("expected error when GetRate fails")
+	}
+	if m.calls != 0 {
+		t.Errorf("no Convert calls expected when precheck fails; got %d", m.calls)
+	}
+	if set.Allocations["a1"].CPUCost != 5 {
+		t.Errorf("data must not be mutated on precheck failure")
 	}
 }

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -40,6 +40,7 @@ import (
 	"github.com/opencost/opencost/modules/prometheus-source/pkg/prom"
 	"github.com/opencost/opencost/pkg/cloud/models"
 	clusterc "github.com/opencost/opencost/pkg/clustercache"
+	"github.com/opencost/opencost/pkg/currency"
 	"github.com/opencost/opencost/pkg/env"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -79,6 +80,8 @@ type Accesses struct {
 	// settings will be published in a pub/sub model
 	settingsSubscribers map[string][]chan string
 	settingsMutex       sync.Mutex
+	// CurrencyConverter handles currency conversion for cost values
+	CurrencyConverter currency.Converter
 }
 
 func filterFields(fields string, data map[string]*CostData) map[string]CostData {
@@ -607,7 +610,7 @@ func GetDefaultCollectorStorage() storage.Storage {
 }
 
 // InitializeCloudCost Initializes Cloud Cost pipeline and querier and registers endpoints
-func InitializeCloudCost(router *httprouter.Router) *cloudcost.PipelineService {
+func InitializeCloudCost(router *httprouter.Router, providerConfig models.ProviderConfig, currencyConverter currency.Converter) *cloudcost.PipelineService {
 	log.Debugf("Cloud Cost config path: %s", env.GetCloudCostConfigPath())
 	cloudConfigController := cloudconfig.NewMemoryController(nil)
 
@@ -615,6 +618,7 @@ func InitializeCloudCost(router *httprouter.Router) *cloudcost.PipelineService {
 	cloudCostPipelineService := cloudcost.NewPipelineService(repo, cloudConfigController, cloudcost.DefaultIngestorConfiguration())
 	repoQuerier := cloudcost.NewRepositoryQuerier(repo)
 	cloudCostQueryService := cloudcost.NewQueryService(repoQuerier, repoQuerier)
+	cloudCostQueryService.CurrencyConverter = currencyConverter
 
 	router.GET("/cloudCost", cloudCostQueryService.GetCloudCostHandler())
 	router.GET("/cloudCost/view/graph", cloudCostQueryService.GetCloudCostViewGraphHandler())
@@ -632,7 +636,7 @@ func InitializeCloudCost(router *httprouter.Router) *cloudcost.PipelineService {
 	return cloudCostPipelineService
 }
 
-func InitializeCustomCost(router *httprouter.Router) *customcost.PipelineService {
+func InitializeCustomCost(router *httprouter.Router, currencyConverter currency.Converter) *customcost.PipelineService {
 	hourlyRepo := customcost.NewMemoryRepository()
 	dailyRepo := customcost.NewMemoryRepository()
 	ingConfig := customcost.DefaultIngestorConfiguration()
@@ -645,6 +649,7 @@ func InitializeCustomCost(router *httprouter.Router) *customcost.PipelineService
 
 	customCostQuerier := customcost.NewRepositoryQuerier(hourlyRepo, dailyRepo, ingConfig.HourlyDuration, ingConfig.DailyDuration)
 	customCostQueryService := customcost.NewQueryService(customCostQuerier)
+	customCostQueryService.CurrencyConverter = currencyConverter
 
 	router.GET("/customCost/total", customCostQueryService.GetCustomCostTotalHandler())
 	router.GET("/customCost/timeseries", customCostQueryService.GetCustomCostTimeseriesHandler())

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -610,7 +610,7 @@ func GetDefaultCollectorStorage() storage.Storage {
 }
 
 // InitializeCloudCost Initializes Cloud Cost pipeline and querier and registers endpoints
-func InitializeCloudCost(router *httprouter.Router, providerConfig models.ProviderConfig, currencyConverter currency.Converter) *cloudcost.PipelineService {
+func InitializeCloudCost(router *httprouter.Router, currencyConverter currency.Converter) *cloudcost.PipelineService {
 	log.Debugf("Cloud Cost config path: %s", env.GetCloudCostConfigPath())
 	cloudConfigController := cloudconfig.NewMemoryController(nil)
 

--- a/pkg/customcost/queryservice.go
+++ b/pkg/customcost/queryservice.go
@@ -160,7 +160,7 @@ func convertResponseFields(resp *CostResponse, converter currency.Converter, tar
 		return float32(converted)
 	}
 
-	resp.TotalCost = tryConvert32(resp.TotalCost, "CustomCost.TotalCost")
+	resp.TotalCost = tryConvert32(resp.TotalCost, "CostResponse.TotalCost")
 
 	for _, cc := range resp.CustomCosts {
 		if cc == nil {

--- a/pkg/customcost/queryservice.go
+++ b/pkg/customcost/queryservice.go
@@ -3,16 +3,20 @@ package customcost
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/util/httputil"
+	"github.com/opencost/opencost/pkg/currency"
 	"go.opentelemetry.io/otel"
 )
 
 const tracerName = "github.com/opencost/opencost/pkg/customcost"
 
 type QueryService struct {
-	Querier Querier
+	Querier          Querier
+	CurrencyConverter currency.Converter
 }
 
 func NewQueryService(querier Querier) *QueryService {
@@ -49,6 +53,16 @@ func (qs *QueryService) GetCustomCostTotalHandler() func(w http.ResponseWriter, 
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Internal server error: %s", err), http.StatusInternalServerError)
 			return
+		}
+
+		// Extract currency parameter and convert if needed
+		currencyParam := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
+		if currencyParam != "USD" && qs.CurrencyConverter != nil && resp != nil {
+			err = convertCustomCostResponse(resp, qs.CurrencyConverter, currencyParam)
+			if err != nil {
+				log.Warnf("Currency conversion failed for currency %s: %v", currencyParam, err)
+				// Continue with USD values if conversion fails
+			}
 		}
 
 		_, spanResp := tracer.Start(ctx, "write response")
@@ -88,9 +102,78 @@ func (qs *QueryService) GetCustomCostTimeseriesHandler() func(w http.ResponseWri
 			return
 		}
 
+		// Extract currency parameter and convert if needed
+		currencyParam := strings.ToUpper(strings.TrimSpace(qp.Get("currency", "USD")))
+		if currencyParam != "USD" && qs.CurrencyConverter != nil && resp != nil {
+			err = convertCustomCostTimeseriesResponse(resp, qs.CurrencyConverter, currencyParam)
+			if err != nil {
+				log.Warnf("Currency conversion failed for currency %s: %v", currencyParam, err)
+				// Continue with USD values if conversion fails
+			}
+		}
+
 		_, spanResp := tracer.Start(ctx, "write response")
 		w.Header().Set("Content-Type", "application/json")
 		protocol.WriteData(w, resp)
 		spanResp.End()
 	}
+}
+
+// convertCustomCostResponse converts all cost values in a CostResponse from USD to target currency
+func convertCustomCostResponse(resp *CostResponse, converter currency.Converter, targetCurrency string) error {
+	if resp == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+
+	// Convert TotalCost
+	if resp.TotalCost != 0 {
+		converted, err := converter.Convert(float64(resp.TotalCost), "USD", targetCurrency)
+		if err != nil {
+			return fmt.Errorf("failed to convert TotalCost: %w", err)
+		}
+		resp.TotalCost = float32(converted)
+	}
+
+	// Convert all CustomCost items
+	for _, cc := range resp.CustomCosts {
+		if cc == nil {
+			continue
+		}
+		// Convert Cost
+		if cc.Cost != 0 {
+			converted, err := converter.Convert(float64(cc.Cost), "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert CustomCost.Cost: %w", err)
+			}
+			cc.Cost = float32(converted)
+		}
+		// Convert ListUnitPrice
+		if cc.ListUnitPrice != 0 {
+			converted, err := converter.Convert(float64(cc.ListUnitPrice), "USD", targetCurrency)
+			if err != nil {
+				return fmt.Errorf("failed to convert CustomCost.ListUnitPrice: %w", err)
+			}
+			cc.ListUnitPrice = float32(converted)
+		}
+	}
+
+	return nil
+}
+
+// convertCustomCostTimeseriesResponse converts all cost values in a CostTimeseriesResponse
+func convertCustomCostTimeseriesResponse(resp *CostTimeseriesResponse, converter currency.Converter, targetCurrency string) error {
+	if resp == nil || converter == nil || targetCurrency == "USD" {
+		return nil
+	}
+
+	// Convert each CostResponse in the timeseries
+	for _, costResp := range resp.Timeseries {
+		if err := convertCustomCostResponse(costResp, converter, targetCurrency); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/customcost/queryservice.go
+++ b/pkg/customcost/queryservice.go
@@ -15,7 +15,7 @@ import (
 const tracerName = "github.com/opencost/opencost/pkg/customcost"
 
 type QueryService struct {
-	Querier          Querier
+	Querier           Querier
 	CurrencyConverter currency.Converter
 }
 

--- a/pkg/customcost/queryservice.go
+++ b/pkg/customcost/queryservice.go
@@ -120,19 +120,34 @@ func (qs *QueryService) GetCustomCostTimeseriesHandler() func(w http.ResponseWri
 }
 
 // convertCustomCostResponse converts all cost values in a CostResponse
-// from USD to target currency in place. Best-effort: per-field converter
-// failures are logged and the field is left in USD rather than rolling
-// the whole response back to USD.
+// from USD to target currency in place. Returns an error if the target
+// rate cannot be looked up upfront (no mutation occurs). Per-field
+// converter failures after the probe succeeded are handled best-effort:
+// the field is left in USD and a warning is logged.
 //
 // CustomCost uses float32; conversion is done in float64 to avoid
 // compounding precision loss, then cast back.
 func convertCustomCostResponse(resp *CostResponse, converter currency.Converter, targetCurrency string) error {
-	if resp == nil || converter == nil || targetCurrency == "USD" {
+	if resp == nil || converter == nil {
 		return nil
 	}
 
 	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+	if targetCurrency == "" || targetCurrency == "USD" {
+		return nil
+	}
+	if _, err := converter.GetRate("USD", targetCurrency); err != nil {
+		return fmt.Errorf("currency rate lookup USD->%s failed: %w", targetCurrency, err)
+	}
 
+	convertResponseFields(resp, converter, targetCurrency)
+	return nil
+}
+
+// convertResponseFields applies the per-field conversion without
+// re-probing the rate. The caller must have already validated the
+// target currency.
+func convertResponseFields(resp *CostResponse, converter currency.Converter, targetCurrency string) {
 	tryConvert32 := func(val float32, logCtx string) float32 {
 		if val == 0 {
 			return val
@@ -154,19 +169,30 @@ func convertCustomCostResponse(resp *CostResponse, converter currency.Converter,
 		cc.Cost = tryConvert32(cc.Cost, "CustomCost.Cost")
 		cc.ListUnitPrice = tryConvert32(cc.ListUnitPrice, "CustomCost.ListUnitPrice")
 	}
-
-	return nil
 }
 
 // convertCustomCostTimeseriesResponse converts all cost values in a
-// CostTimeseriesResponse (best-effort).
+// CostTimeseriesResponse. Returns an error if the target rate cannot be
+// looked up upfront (no mutation occurs). Per-field conversion is
+// best-effort thereafter.
 func convertCustomCostTimeseriesResponse(resp *CostTimeseriesResponse, converter currency.Converter, targetCurrency string) error {
-	if resp == nil || converter == nil || targetCurrency == "USD" {
+	if resp == nil || converter == nil {
 		return nil
 	}
 
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+	if targetCurrency == "" || targetCurrency == "USD" {
+		return nil
+	}
+	if _, err := converter.GetRate("USD", targetCurrency); err != nil {
+		return fmt.Errorf("currency rate lookup USD->%s failed: %w", targetCurrency, err)
+	}
+
 	for _, costResp := range resp.Timeseries {
-		_ = convertCustomCostResponse(costResp, converter, targetCurrency)
+		if costResp == nil {
+			continue
+		}
+		convertResponseFields(costResp, converter, targetCurrency)
 	}
 
 	return nil

--- a/pkg/customcost/queryservice.go
+++ b/pkg/customcost/queryservice.go
@@ -119,7 +119,13 @@ func (qs *QueryService) GetCustomCostTimeseriesHandler() func(w http.ResponseWri
 	}
 }
 
-// convertCustomCostResponse converts all cost values in a CostResponse from USD to target currency
+// convertCustomCostResponse converts all cost values in a CostResponse
+// from USD to target currency in place. Best-effort: per-field converter
+// failures are logged and the field is left in USD rather than rolling
+// the whole response back to USD.
+//
+// CustomCost uses float32; conversion is done in float64 to avoid
+// compounding precision loss, then cast back.
 func convertCustomCostResponse(resp *CostResponse, converter currency.Converter, targetCurrency string) error {
 	if resp == nil || converter == nil || targetCurrency == "USD" {
 		return nil
@@ -127,52 +133,40 @@ func convertCustomCostResponse(resp *CostResponse, converter currency.Converter,
 
 	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
 
-	// Convert TotalCost
-	if resp.TotalCost != 0 {
-		converted, err := converter.Convert(float64(resp.TotalCost), "USD", targetCurrency)
-		if err != nil {
-			return fmt.Errorf("failed to convert TotalCost: %w", err)
+	tryConvert32 := func(val float32, logCtx string) float32 {
+		if val == 0 {
+			return val
 		}
-		resp.TotalCost = float32(converted)
+		converted, err := converter.Convert(float64(val), "USD", targetCurrency)
+		if err != nil {
+			log.Warnf("currency: leaving %s in USD (convert to %s failed): %v", logCtx, targetCurrency, err)
+			return val
+		}
+		return float32(converted)
 	}
 
-	// Convert all CustomCost items
+	resp.TotalCost = tryConvert32(resp.TotalCost, "CustomCost.TotalCost")
+
 	for _, cc := range resp.CustomCosts {
 		if cc == nil {
 			continue
 		}
-		// Convert Cost
-		if cc.Cost != 0 {
-			converted, err := converter.Convert(float64(cc.Cost), "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert CustomCost.Cost: %w", err)
-			}
-			cc.Cost = float32(converted)
-		}
-		// Convert ListUnitPrice
-		if cc.ListUnitPrice != 0 {
-			converted, err := converter.Convert(float64(cc.ListUnitPrice), "USD", targetCurrency)
-			if err != nil {
-				return fmt.Errorf("failed to convert CustomCost.ListUnitPrice: %w", err)
-			}
-			cc.ListUnitPrice = float32(converted)
-		}
+		cc.Cost = tryConvert32(cc.Cost, "CustomCost.Cost")
+		cc.ListUnitPrice = tryConvert32(cc.ListUnitPrice, "CustomCost.ListUnitPrice")
 	}
 
 	return nil
 }
 
-// convertCustomCostTimeseriesResponse converts all cost values in a CostTimeseriesResponse
+// convertCustomCostTimeseriesResponse converts all cost values in a
+// CostTimeseriesResponse (best-effort).
 func convertCustomCostTimeseriesResponse(resp *CostTimeseriesResponse, converter currency.Converter, targetCurrency string) error {
 	if resp == nil || converter == nil || targetCurrency == "USD" {
 		return nil
 	}
 
-	// Convert each CostResponse in the timeseries
 	for _, costResp := range resp.Timeseries {
-		if err := convertCustomCostResponse(costResp, converter, targetCurrency); err != nil {
-			return err
-		}
+		_ = convertCustomCostResponse(costResp, converter, targetCurrency)
 	}
 
 	return nil

--- a/pkg/customcost/queryservice_test.go
+++ b/pkg/customcost/queryservice_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 type mockConverter struct {
-	rate       float64
-	failValues map[float64]bool
-	calls      int
+	rate         float64
+	failValues   map[float64]bool
+	getRateFail  bool
+	getRateCalls int
+	calls        int
 }
 
 func (m *mockConverter) Convert(amount float64, from, to string) (float64, error) {
@@ -26,6 +28,10 @@ func (m *mockConverter) Convert(amount float64, from, to string) (float64, error
 }
 
 func (m *mockConverter) GetRate(from, to string) (float64, error) {
+	m.getRateCalls++
+	if m.getRateFail {
+		return 0, fmt.Errorf("simulated rate lookup failure USD->%s", to)
+	}
 	return m.rate, nil
 }
 
@@ -132,6 +138,34 @@ func TestConvertCustomCostTimeseriesResponse(t *testing.T) {
 	for i, cr := range ts.Timeseries {
 		if !fpEq(cr.TotalCost, 450) {
 			t.Errorf("ts[%d].TotalCost: got %v want 450", i, cr.TotalCost)
+		}
+	}
+}
+
+func TestConvertCustomCostResponse_GetRateFailsReturnsError(t *testing.T) {
+	resp := newCostResponse()
+	m := &mockConverter{rate: 2.0, getRateFail: true}
+	err := convertCustomCostResponse(resp, m, "XXX")
+	if err == nil {
+		t.Fatal("expected error when GetRate fails")
+	}
+	if m.calls != 0 {
+		t.Errorf("no Convert calls expected on precheck failure; got %d", m.calls)
+	}
+	if resp.TotalCost != 150 {
+		t.Errorf("data must not be mutated on precheck failure; TotalCost=%v", resp.TotalCost)
+	}
+}
+
+func TestConvertCustomCostResponse_USDNormalized(t *testing.T) {
+	for _, target := range []string{"usd", " USD ", ""} {
+		resp := newCostResponse()
+		m := &mockConverter{rate: 2.0}
+		if err := convertCustomCostResponse(resp, m, target); err != nil {
+			t.Fatalf("target %q: %v", target, err)
+		}
+		if m.calls != 0 || m.getRateCalls != 0 {
+			t.Errorf("target %q: expected zero converter activity", target)
 		}
 	}
 }

--- a/pkg/customcost/queryservice_test.go
+++ b/pkg/customcost/queryservice_test.go
@@ -1,0 +1,147 @@
+package customcost
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+type mockConverter struct {
+	rate       float64
+	failValues map[float64]bool
+	calls      int
+}
+
+func (m *mockConverter) Convert(amount float64, from, to string) (float64, error) {
+	m.calls++
+	if from != "USD" {
+		return 0, fmt.Errorf("mock only converts from USD, got %q", from)
+	}
+	if m.failValues[amount] {
+		return 0, fmt.Errorf("simulated converter failure for amount %v", amount)
+	}
+	return amount * m.rate, nil
+}
+
+func (m *mockConverter) GetRate(from, to string) (float64, error) {
+	return m.rate, nil
+}
+
+func newCostResponse() *CostResponse {
+	return &CostResponse{
+		Window:        opencost.NewWindow(nil, nil),
+		TotalCost:     150,
+		TotalCostType: CostTypeBlended,
+		CustomCosts: []*CustomCost{
+			{Id: "cc-a", Cost: 100, ListUnitPrice: 10, UsageQuantity: 7},
+			{Id: "cc-b", Cost: 50, ListUnitPrice: 5, UsageQuantity: 3},
+		},
+	}
+}
+
+// fpEq compares float32s with a small tolerance to absorb the
+// float64->float32 round-trip the helper performs.
+func fpEq(got, want float32) bool {
+	const tol = 1e-5
+	return math.Abs(float64(got-want)) < tol
+}
+
+func TestConvertCustomCostResponse_USDIsNoOp(t *testing.T) {
+	resp := newCostResponse()
+	m := &mockConverter{rate: 2.0}
+	if err := convertCustomCostResponse(resp, m, "USD"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.calls != 0 {
+		t.Fatalf("USD must not call converter, got %d calls", m.calls)
+	}
+	if resp.TotalCost != 150 {
+		t.Fatalf("USD path mutated TotalCost: got %v", resp.TotalCost)
+	}
+}
+
+func TestConvertCustomCostResponse_NilGuards(t *testing.T) {
+	if err := convertCustomCostResponse(nil, &mockConverter{rate: 2.0}, "EUR"); err != nil {
+		t.Fatalf("nil response: %v", err)
+	}
+	resp := newCostResponse()
+	if err := convertCustomCostResponse(resp, nil, "EUR"); err != nil {
+		t.Fatalf("nil converter: %v", err)
+	}
+	if resp.TotalCost != 150 {
+		t.Fatalf("nil converter mutated TotalCost: got %v", resp.TotalCost)
+	}
+}
+
+func TestConvertCustomCostResponse_MutatesAllCostFields(t *testing.T) {
+	resp := newCostResponse()
+	m := &mockConverter{rate: 2.0}
+	if err := convertCustomCostResponse(resp, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fpEq(resp.TotalCost, 300) {
+		t.Errorf("TotalCost: got %v want 300", resp.TotalCost)
+	}
+	if !fpEq(resp.CustomCosts[0].Cost, 200) {
+		t.Errorf("CustomCosts[0].Cost: got %v want 200", resp.CustomCosts[0].Cost)
+	}
+	if !fpEq(resp.CustomCosts[0].ListUnitPrice, 20) {
+		t.Errorf("CustomCosts[0].ListUnitPrice: got %v want 20", resp.CustomCosts[0].ListUnitPrice)
+	}
+	if !fpEq(resp.CustomCosts[1].Cost, 100) {
+		t.Errorf("CustomCosts[1].Cost: got %v want 100", resp.CustomCosts[1].Cost)
+	}
+	if !fpEq(resp.CustomCosts[1].ListUnitPrice, 10) {
+		t.Errorf("CustomCosts[1].ListUnitPrice: got %v want 10", resp.CustomCosts[1].ListUnitPrice)
+	}
+	// UsageQuantity must NOT be touched -- it is a quantity, not a cost.
+	if resp.CustomCosts[0].UsageQuantity != 7 {
+		t.Errorf("UsageQuantity must not be touched: got %v want 7", resp.CustomCosts[0].UsageQuantity)
+	}
+}
+
+func TestConvertCustomCostResponse_BestEffortOnPartialFailure(t *testing.T) {
+	resp := newCostResponse()
+	// Fail only the ListUnitPrice for cc-a (value 10).
+	m := &mockConverter{
+		rate:       2.0,
+		failValues: map[float64]bool{10: true},
+	}
+	if err := convertCustomCostResponse(resp, m, "EUR"); err != nil {
+		t.Fatalf("best-effort helper must not return error; got %v", err)
+	}
+	if !fpEq(resp.CustomCosts[0].ListUnitPrice, 10) {
+		t.Errorf("failed field must retain USD: got %v want 10", resp.CustomCosts[0].ListUnitPrice)
+	}
+	if !fpEq(resp.CustomCosts[0].Cost, 200) {
+		t.Errorf("other fields must still convert: got %v want 200", resp.CustomCosts[0].Cost)
+	}
+}
+
+func TestConvertCustomCostTimeseriesResponse(t *testing.T) {
+	ts := &CostTimeseriesResponse{
+		Window:     opencost.NewWindow(nil, nil),
+		Timeseries: []*CostResponse{newCostResponse(), newCostResponse()},
+	}
+	m := &mockConverter{rate: 3.0}
+	if err := convertCustomCostTimeseriesResponse(ts, m, "EUR"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, cr := range ts.Timeseries {
+		if !fpEq(cr.TotalCost, 450) {
+			t.Errorf("ts[%d].TotalCost: got %v want 450", i, cr.TotalCost)
+		}
+	}
+}
+
+func TestConvertCustomCostTimeseriesResponse_NilGuards(t *testing.T) {
+	if err := convertCustomCostTimeseriesResponse(nil, &mockConverter{rate: 2.0}, "EUR"); err != nil {
+		t.Fatalf("nil response: %v", err)
+	}
+	ts := &CostTimeseriesResponse{}
+	if err := convertCustomCostTimeseriesResponse(ts, nil, "EUR"); err != nil {
+		t.Fatalf("nil converter: %v", err)
+	}
+}

--- a/pkg/env/opencost.go
+++ b/pkg/env/opencost.go
@@ -17,6 +17,8 @@ const (
 const (
 	UTCOffsetEnvVar              = "UTC_OFFSET"
 	MCPQueryTimeoutSecondsEnvVar = "MCP_QUERY_TIMEOUT_SECONDS"
+	CurrencyProviderEnvVar       = "CURRENCY_PROVIDER"
+	CurrencyAPIKeyEnvVar         = "CURRENCY_API_KEY"
 )
 
 func GetOpencostAPIPort() int {
@@ -53,4 +55,16 @@ func GetMCPQueryTimeout() time.Duration {
 		seconds = 1
 	}
 	return time.Duration(seconds) * time.Second
+}
+
+// GetCurrencyProvider returns the currency provider name from environment variable.
+// Default is "default" which disables currency conversion.
+func GetCurrencyProvider() string {
+	return env.Get(CurrencyProviderEnvVar, "default")
+}
+
+// GetCurrencyAPIKey returns the currency API key from environment variable.
+// Returns empty string if not set.
+func GetCurrencyAPIKey() string {
+	return env.Get(CurrencyAPIKeyEnvVar, "")
 }


### PR DESCRIPTION
## Summary

Adopts and productionises the server-side currency conversion work from the closed (unmerged) #3553. Adds `?currency=XYZ` support across `/allocation`, `/allocation/summary`, `/cloudCost`, `/customCost/total`, and `/customCost/timeseries` by threading a `currency.Converter` through `Accesses` and the cloudcost/customcost query services, using the existing `pkg/currency` package.

Opt-in at startup via `CURRENCY_PROVIDER=exchangerateapi` and `CURRENCY_API_KEY`; without those set, behaviour is unchanged (USD only). API is fully backwards compatible — omitting the `currency` parameter returns USD as today.

### Over the upstream PR

- **Fixes compile failure.** #3553 referenced `models.Provider` / `provider.ExtractConfigFromProviders` without adding imports; a `var cp models.Provider` was declared, never assigned, guarded by `if cp != nil { … }` (always false), and threaded into `InitializeCloudCost` where the parameter was unused. Removed the entire dead plumbing.
- **Covers all Allocation cost fields that appear in JSON responses.** Audited `core/pkg/opencost/allocation.go` and added the fields the original PR missed: `NetworkNatGatewayEgressCost`, `NetworkNatGatewayIngressCost`, `PVAllocation.Adjustment`, and the 8-field `SharedCostBreakdown` struct. Without these, responses contained mixed currencies — USD NAT costs with EUR everything else — silently breaking client-side totals.
- **Best-effort conversion with per-field logging.** Original behaviour aborted on first `converter.Convert` error, leaving a partially-mutated response and logging a generic "conversion failed" at the handler. Now each field is attempted independently; on failure the original USD value is retained and a warning identifying the specific field (`Allocation.CPUCost`, `CloudCost.NetCost`, `CustomCost.ListUnitPrice`, etc.) is logged.
- **19 unit tests** covering USD no-op, nil guards, full-field mutation, nested PV/LB/SharedCostBreakdown, KubernetesPercent preservation, best-effort partial-failure, and set/range/timeseries propagation. Uses a local `mockConverter` per package (import-cycle avoidance).
- **Removes dead `ConvertCloudCost*` exports** from `pkg/costmodel/currency_helper.go` — they had no callers; `pkg/cloudcost` has its own inline helper.
- **gofmt + struct-field alignment** on all touched files.

### Verification

- `go mod verify` — all modules verified
- `go vet ./...` — clean
- `go build ./cmd/costmodel/` — produces a working binary
- `go test ./pkg/costmodel/ ./pkg/cloudcost/ ./pkg/customcost/ ./pkg/cmd/costmodel/ ./pkg/env/ ./pkg/currency/` — all pass
- `go test ./...` — one pre-existing failure in `pkg/cloud/gcp/TestGCP_UpdateConfig/BigQuery_update_type`, unrelated to this change (reproduces on `origin/develop`).

### Known gaps (deliberately out of scope)

- `/assets` still has no currency conversion. #3553 did not touch that endpoint; keeping parity.
- CloudCost conversion logic is still duplicated between `pkg/costmodel/currency_helper.go` and inline in `pkg/cloudcost/queryservice.go`. Proper DRY requires a new shared package to avoid an import cycle.

### Related issues

- Closes opencost/opencost-ui#5
- Addresses opencost/opencost-ui#3
- Supersedes #3553 (closed, unmerged)

### Credit

Original implementation by @adity-a34 in #3553, preserved via `Co-authored-by:` on the base commit.

## Test plan

- [ ] Reviewer runs `go test ./pkg/costmodel/ ./pkg/cloudcost/ ./pkg/customcost/ -v` and all currency tests pass
- [ ] Reviewer runs `go build ./cmd/costmodel/` and binary compiles
- [ ] With `CURRENCY_PROVIDER=exchangerateapi` + valid `CURRENCY_API_KEY`: `curl "http://localhost:9003/allocation/compute?window=today&currency=EUR"` returns converted costs; log line `Currency converter initialized successfully` appears at startup
- [ ] Without those env vars: `curl "…/allocation/compute?window=today&currency=EUR"` returns USD values; log line `Currency conversion disabled (provider=default, hasKey=false)` appears at startup
- [ ] `curl "…?currency=USD"` (explicit) behaves identically to omitting the parameter
- [ ] With a deliberately-invalid currency code: response is all-USD and a warning is logged (best-effort fallback)
- [ ] `/cloudCost?currency=INR` and `/customCost/total?currency=GBP` apply the requested rate
