### PR TITLE
Hostnetwork network sharing

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -41,6 +41,7 @@ type PodStatus struct {
 
 type PodSpec struct {
 	NodeName      string
+	HostNetwork   bool
 	Containers    []Container
 	Volumes       []v1.Volume
 	RestartPolicy v1.RestartPolicy
@@ -263,6 +264,7 @@ func TransformPodSpec(input v1.PodSpec) PodSpec {
 	}
 	return PodSpec{
 		NodeName:      input.NodeName,
+		HostNetwork:   input.HostNetwork,
 		Containers:    containers,
 		Volumes:       input.Volumes,
 		RestartPolicy: input.RestartPolicy,

--- a/core/pkg/source/decoders.go
+++ b/core/pkg/source/decoders.go
@@ -634,6 +634,7 @@ type PodInfoResult struct {
 	Pod          string
 	NamespaceUID string
 	NodeUID      string
+	HostNetwork  bool
 }
 
 func DecodePodInfoResult(result *QueryResult) *PodInfoResult {
@@ -642,6 +643,7 @@ func DecodePodInfoResult(result *QueryResult) *PodInfoResult {
 	pod, _ := result.GetPod()
 	namespaceUID, _ := result.GetString(NamespaceUIDLabel)
 	nodeUID, _ := result.GetString(NodeUIDLabel)
+	hostNetwork, _ := result.GetString("host_network")
 
 	return &PodInfoResult{
 		UID:          uid,
@@ -649,6 +651,7 @@ func DecodePodInfoResult(result *QueryResult) *PodInfoResult {
 		Pod:          pod,
 		NamespaceUID: namespaceUID,
 		NodeUID:      nodeUID,
+		HostNetwork:  hostNetwork == "true",
 	}
 }
 
@@ -1385,12 +1388,13 @@ func DecodeNetNatGatewayIngressGiBResult(result *QueryResult) *NetNatGatewayIngr
 }
 
 type NetReceiveBytesResult struct {
-	UID       string
-	Cluster   string
-	Namespace string
-	Pod       string
-	Container string
-	Data      []*util.Vector
+	UID         string
+	Cluster     string
+	Namespace   string
+	Pod         string
+	Container   string
+	HostNetwork bool
+	Data        []*util.Vector
 }
 
 func DecodeNetReceiveBytesResult(result *QueryResult) *NetReceiveBytesResult {
@@ -1399,23 +1403,26 @@ func DecodeNetReceiveBytesResult(result *QueryResult) *NetReceiveBytesResult {
 	namespace, _ := result.GetNamespace()
 	pod, _ := result.GetPod()
 	container, _ := result.GetContainer()
+	hostNetwork, _ := result.GetString("host_network")
 
 	return &NetReceiveBytesResult{
-		UID:       uid,
-		Cluster:   cluster,
-		Namespace: namespace,
-		Pod:       pod,
-		Container: container,
-		Data:      result.Values,
+		UID:         uid,
+		Cluster:     cluster,
+		Namespace:   namespace,
+		Pod:         pod,
+		Container:   container,
+		HostNetwork: hostNetwork == "true",
+		Data:        result.Values,
 	}
 }
 
 type NetTransferBytesResult struct {
-	UID       string
-	Cluster   string
-	Namespace string
-	Pod       string
-	Container string
+	UID         string
+	Cluster     string
+	Namespace   string
+	Pod         string
+	Container   string
+	HostNetwork bool
 
 	Data []*util.Vector
 }
@@ -1426,14 +1433,16 @@ func DecodeNetTransferBytesResult(result *QueryResult) *NetTransferBytesResult {
 	namespace, _ := result.GetNamespace()
 	pod, _ := result.GetPod()
 	container, _ := result.GetContainer()
+	hostNetwork, _ := result.GetString("host_network")
 
 	return &NetTransferBytesResult{
-		UID:       uid,
-		Cluster:   cluster,
-		Namespace: namespace,
-		Pod:       pod,
-		Container: container,
-		Data:      result.Values,
+		UID:         uid,
+		Cluster:     cluster,
+		Namespace:   namespace,
+		Pod:         pod,
+		Container:   container,
+		HostNetwork: hostNetwork == "true",
+		Data:        result.Values,
 	}
 }
 

--- a/modules/collector-source/pkg/scrape/clustercache.go
+++ b/modules/collector-source/pkg/scrape/clustercache.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -381,6 +382,7 @@ func (ccs *ClusterCacheScraper) scrapePods(
 			source.PodLabel:          pod.Name,
 			source.NamespaceUIDLabel: string(nsUID),
 			source.NodeUIDLabel:      string(nodeUID),
+			"host_network":           strconv.FormatBool(pod.Spec.HostNetwork),
 		}
 		scrapeResults = append(scrapeResults, metric.Update{
 			Name:           metric.PodInfo,

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -340,6 +340,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 
 	resChPodLabels := source.WithGroup(grp, ds.QueryPodLabels(start, end))
 	resChPodAnnotations := source.WithGroup(grp, ds.QueryPodAnnotations(start, end))
+	resChPodInfo := source.WithGroup(grp, ds.QueryPodInfo(start, end))
 
 	resChServiceSelectorLabels := source.WithGroup(grp, ds.QueryServiceSelectorLabels(start, end))
 	resChDeploymentMatchLabels := source.WithGroup(grp, ds.QueryDeploymentMatchLabels(start, end))
@@ -408,6 +409,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 	resNamespaceAnnotations, _ := resChNamespaceAnnotations.Await()
 	resPodLabels, _ := resChPodLabels.Await()
 	resPodAnnotations, _ := resChPodAnnotations.Await()
+	resPodInfo, _ := resChPodInfo.Await()
 	resServiceSelectorLabels, _ := resChServiceSelectorLabels.Await()
 	resDeploymentMatchLabels, _ := resChDeploymentMatchLabels.Await()
 	resStatefulSetMatchLabels, _ := resChStatefulSetMatchLabels.Await()
@@ -445,7 +447,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 	applyGPUUsageShared(podMap, resIsGpuShared, podUIDKeyMap)
 	applyGPUInfo(podMap, resGetGPUInfo, podUIDKeyMap)
 	applyGPUsAllocated(podMap, resGPUsRequested, resGPUsAllocated, podUIDKeyMap)
-	applyNetworkTotals(podMap, resNetTransferBytes, resNetReceiveBytes, podUIDKeyMap)
+	applyNetworkTotals(podMap, resNetTransferBytes, resNetReceiveBytes, resPodInfo, podUIDKeyMap)
 	applyNetworkAllocation(podMap, resNetZoneGiB, resNetZonePricePerGiB, podUIDKeyMap, applyCrossZoneNetworkAllocation)
 	applyNetworkAllocation(podMap, resNetRegionGiB, resNetRegionPricePerGiB, podUIDKeyMap, applyCrossRegionNetworkAllocation)
 	applyNetworkAllocation(podMap, resNetInternetGiB, resNetInternetPricePerGiB, podUIDKeyMap, applyInternetNetworkAllocation)

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -915,7 +915,32 @@ func applyGPUsAllocated(podMap map[podKey]*pod, resGPUsRequested []*source.GPUsR
 	}
 }
 
-func applyNetworkTotals(podMap map[podKey]*pod, resNetworkTransferBytes []*source.NetTransferBytesResult, resNetworkReceiveBytes []*source.NetReceiveBytesResult, podUIDKeyMap map[podKey][]podKey) {
+func applyNetworkTotals(podMap map[podKey]*pod, resNetworkTransferBytes []*source.NetTransferBytesResult, resNetworkReceiveBytes []*source.NetReceiveBytesResult, resPodInfo []*source.PodInfoResult, podUIDKeyMap map[podKey][]podKey) {
+	hostNetworkPodCountByNode := getHostNetworkPodCountByNode(resPodInfo)
+
+	applyNetworkMetric := func(podKey podKey, value float64, hostNetwork bool, setAllocation func(*opencost.Allocation, float64)) {
+		pods := resolvePods(podMap, podUIDKeyMap, podKey)
+		if len(pods) == 0 {
+			return
+		}
+
+		divisor := float64(len(pods))
+		if hostNetwork {
+			nodePodCount := hostNetworkPodCountByNode[podKey.Cluster+","+podKey.Namespace]
+			if nodePodCount == 0 {
+				return
+			}
+
+			divisor = divisor * float64(nodePodCount)
+		}
+
+		for _, thisPod := range pods {
+			for _, alloc := range thisPod.Allocations {
+				setAllocation(alloc, value/float64(len(thisPod.Allocations))/divisor)
+			}
+		}
+	}
+
 	for _, res := range resNetworkTransferBytes {
 		podKey, err := newResultPodKey(res.Cluster, res.Namespace, res.Pod)
 		if err != nil {
@@ -923,29 +948,11 @@ func applyNetworkTotals(podMap map[podKey]*pod, resNetworkTransferBytes []*sourc
 			continue
 		}
 
-		var pods []*pod
-
-		if thisPod, ok := podMap[podKey]; !ok {
-			if uidKeys, ok := podUIDKeyMap[podKey]; ok {
-				for _, uidKey := range uidKeys {
-					thisPod, ok = podMap[uidKey]
-					if ok {
-						pods = append(pods, thisPod)
-					}
-				}
-			} else {
-				continue
-			}
-		} else {
-			pods = []*pod{thisPod}
-		}
-
-		for _, thisPod := range pods {
-			for _, alloc := range thisPod.Allocations {
-				alloc.NetworkTransferBytes = res.Data[0].Value / float64(len(thisPod.Allocations)) / float64(len(pods))
-			}
-		}
+		applyNetworkMetric(podKey, res.Data[0].Value, res.HostNetwork, func(alloc *opencost.Allocation, value float64) {
+			alloc.NetworkTransferBytes = value
+		})
 	}
+
 	for _, res := range resNetworkReceiveBytes {
 		podKey, err := newResultPodKey(res.Cluster, res.Namespace, res.Pod)
 		if err != nil {
@@ -953,29 +960,40 @@ func applyNetworkTotals(podMap map[podKey]*pod, resNetworkTransferBytes []*sourc
 			continue
 		}
 
-		var pods []*pod
+		applyNetworkMetric(podKey, res.Data[0].Value, res.HostNetwork, func(alloc *opencost.Allocation, value float64) {
+			alloc.NetworkReceiveBytes = value
+		})
+	}
+}
 
-		if thisPod, ok := podMap[podKey]; !ok {
-			if uidKeys, ok := podUIDKeyMap[podKey]; ok {
-				for _, uidKey := range uidKeys {
-					thisPod, ok = podMap[uidKey]
-					if ok {
-						pods = append(pods, thisPod)
-					}
-				}
-			} else {
-				continue
-			}
-		} else {
-			pods = []*pod{thisPod}
-		}
+func resolvePods(podMap map[podKey]*pod, podUIDKeyMap map[podKey][]podKey, key podKey) []*pod {
+	if thisPod, ok := podMap[key]; ok {
+		return []*pod{thisPod}
+	}
 
-		for _, thisPod := range pods {
-			for _, alloc := range thisPod.Allocations {
-				alloc.NetworkReceiveBytes = res.Data[0].Value / float64(len(thisPod.Allocations)) / float64(len(pods))
+	var pods []*pod
+	if uidKeys, ok := podUIDKeyMap[key]; ok {
+		for _, uidKey := range uidKeys {
+			thisPod, ok := podMap[uidKey]
+			if ok {
+				pods = append(pods, thisPod)
 			}
 		}
 	}
+
+	return pods
+}
+
+func getHostNetworkPodCountByNode(resPodInfo []*source.PodInfoResult) map[string]int {
+	hostNetworkPodCountByNode := map[string]int{}
+
+	for _, res := range resPodInfo {
+		if res.HostNetwork {
+			hostNetworkPodCountByNode[res.Cluster+","+res.NodeUID]++
+		}
+	}
+
+	return hostNetworkPodCountByNode
 }
 
 func applyCrossZoneNetworkAllocation(alloc *opencost.Allocation, networkSubCost float64) {

--- a/pkg/costmodel/allocation_helpers_test.go
+++ b/pkg/costmodel/allocation_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/core/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 const Ki = 1024
@@ -621,4 +622,194 @@ func TestCalculateStartAndEnd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyNetworkTotals(t *testing.T) {
+	newAllocation := func(name string) *opencost.Allocation {
+		return &opencost.Allocation{
+			Name: name,
+			Properties: &opencost.AllocationProperties{
+				Cluster:   "c1",
+				Namespace: "ns1",
+				Pod:       name,
+				Container: "container1",
+			},
+		}
+	}
+
+	t.Run("non-host-network pod keeps full value", func(t *testing.T) {
+		key := newPodKey("c1", "ns1", "pod1")
+		podMap := map[podKey]*pod{
+			key: {
+				Key: key,
+				Allocations: map[string]*opencost.Allocation{
+					"container1": newAllocation("pod1"),
+				},
+			},
+		}
+
+		applyNetworkTotals(
+			podMap,
+			[]*source.NetTransferBytesResult{
+				{
+					Cluster:   "c1",
+					Namespace: "ns1",
+					Pod:       "pod1",
+					Data:      []*util.Vector{{Value: 8}},
+				},
+			},
+			[]*source.NetReceiveBytesResult{
+				{
+					Cluster:   "c1",
+					Namespace: "ns1",
+					Pod:       "pod1",
+					Data:      []*util.Vector{{Value: 6}},
+				},
+			},
+			nil,
+			nil,
+		)
+
+		alloc := podMap[key].Allocations["container1"]
+		assert.Equal(t, 8.0, alloc.NetworkTransferBytes)
+		assert.Equal(t, 6.0, alloc.NetworkReceiveBytes)
+	})
+
+	t.Run("host-network pod shares node value across host-network pods", func(t *testing.T) {
+		key1 := newPodKey("c1", "node1", "pod1")
+		key2 := newPodKey("c1", "node1", "pod2")
+		podMap := map[podKey]*pod{
+			key1: {
+				Key: key1,
+				Allocations: map[string]*opencost.Allocation{
+					"container1": newAllocation("pod1"),
+				},
+			},
+			key2: {
+				Key: key2,
+				Allocations: map[string]*opencost.Allocation{
+					"container1": newAllocation("pod2"),
+				},
+			},
+		}
+
+		podInfo := []*source.PodInfoResult{
+			{Cluster: "c1", NodeUID: "node1", HostNetwork: true},
+			{Cluster: "c1", NodeUID: "node1", HostNetwork: true},
+		}
+
+		applyNetworkTotals(
+			podMap,
+			[]*source.NetTransferBytesResult{
+				{
+					Cluster:     "c1",
+					Namespace:   "node1",
+					Pod:         "pod1",
+					HostNetwork: true,
+					Data:        []*util.Vector{{Value: 8}},
+				},
+				{
+					Cluster:     "c1",
+					Namespace:   "node1",
+					Pod:         "pod2",
+					HostNetwork: true,
+					Data:        []*util.Vector{{Value: 8}},
+				},
+			},
+			[]*source.NetReceiveBytesResult{
+				{
+					Cluster:     "c1",
+					Namespace:   "node1",
+					Pod:         "pod1",
+					HostNetwork: true,
+					Data:        []*util.Vector{{Value: 4}},
+				},
+				{
+					Cluster:     "c1",
+					Namespace:   "node1",
+					Pod:         "pod2",
+					HostNetwork: true,
+					Data:        []*util.Vector{{Value: 4}},
+				},
+			},
+			podInfo,
+			nil,
+		)
+
+		alloc1 := podMap[key1].Allocations["container1"]
+		alloc2 := podMap[key2].Allocations["container1"]
+
+		assert.Equal(t, 4.0, alloc1.NetworkTransferBytes)
+		assert.Equal(t, 4.0, alloc2.NetworkTransferBytes)
+		assert.Equal(t, 2.0, alloc1.NetworkReceiveBytes)
+		assert.Equal(t, 2.0, alloc2.NetworkReceiveBytes)
+	})
+
+	t.Run("host-network pod does not share with non-host-network pod", func(t *testing.T) {
+		key1 := newPodKey("c1", "node1", "pod1")
+		key2 := newPodKey("c1", "ns1", "pod2")
+		podMap := map[podKey]*pod{
+			key1: {
+				Key: key1,
+				Allocations: map[string]*opencost.Allocation{
+					"container1": newAllocation("pod1"),
+				},
+			},
+			key2: {
+				Key: key2,
+				Allocations: map[string]*opencost.Allocation{
+					"container1": newAllocation("pod2"),
+				},
+			},
+		}
+
+		podInfo := []*source.PodInfoResult{
+			{Cluster: "c1", NodeUID: "node1", HostNetwork: true},
+			{Cluster: "c1", NodeUID: "node1", HostNetwork: false},
+		}
+
+		applyNetworkTotals(
+			podMap,
+			[]*source.NetTransferBytesResult{
+				{
+					Cluster:     "c1",
+					Namespace:   "node1",
+					Pod:         "pod1",
+					HostNetwork: true,
+					Data:        []*util.Vector{{Value: 8}},
+				},
+				{
+					Cluster:   "c1",
+					Namespace: "ns1",
+					Pod:       "pod2",
+					Data:      []*util.Vector{{Value: 6}},
+				},
+			},
+			[]*source.NetReceiveBytesResult{
+				{
+					Cluster:     "c1",
+					Namespace:   "node1",
+					Pod:         "pod1",
+					HostNetwork: true,
+					Data:        []*util.Vector{{Value: 4}},
+				},
+				{
+					Cluster:   "c1",
+					Namespace: "ns1",
+					Pod:       "pod2",
+					Data:      []*util.Vector{{Value: 2}},
+				},
+			},
+			podInfo,
+			nil,
+		)
+
+		alloc1 := podMap[key1].Allocations["container1"]
+		alloc2 := podMap[key2].Allocations["container1"]
+
+		assert.Equal(t, 8.0, alloc1.NetworkTransferBytes)
+		assert.Equal(t, 4.0, alloc1.NetworkReceiveBytes)
+		assert.Equal(t, 6.0, alloc2.NetworkTransferBytes)
+		assert.Equal(t, 2.0, alloc2.NetworkReceiveBytes)
+	})
 }


### PR DESCRIPTION
Summary
Share host-network pod network usage across host-networked pods on the same node instead of attributing full node traffic to each pod.

Changes
add host-network metadata to cached pod specs and scraped pod info
propagate host-network state through network metric decoding
update allocation network totals logic to divide host-network RX/TX across host-networked pods per measurement
add simple unit tests covering normal, shared host-network, and mixed host/non-host-network cases
Validation
go test ./pkg/costmodel