### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -1,9 +1,6 @@
 name: Trivy Vulnerability Scanner
 
-permissions:
-  issues: write
-  contents: read
-  security-events: write
+permissions: {}
 
 on:
   pull_request:
@@ -19,6 +16,10 @@ jobs:
   scan:
     name: Scan for Vulnerabilities
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Description

Currently the score for the Token Permissions is 9 because a few top level permissions and some job level permissions are missing in the workflows. With this change, the score will improve to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

## Related Issues

Fixes #3739

## User Impact

No user-facing changes. This is a CI/CD hardening change that sets minimal required permissions on GitHub Actions workflows to improve the OSSF Scorecard Token-Permissions check.

## Testing

No functional code changes. The existing workflows continue to run with the same behavior but with tightened permissions. Verified that each job still has the permissions it needs (e.g., `packages: write` for image publishing, `security-events: write` for vulnerability scanning) while defaulting top-level permissions to the minimum required.
