### PR TITLE
test: add OCI cloud cost configuration serialization test

### DIFF
--- a/pkg/cloud/config/configurations_test.go
+++ b/pkg/cloud/config/configurations_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opencost/opencost/pkg/cloud/aws"
 	"github.com/opencost/opencost/pkg/cloud/azure"
 	"github.com/opencost/opencost/pkg/cloud/gcp"
+	"github.com/opencost/opencost/pkg/cloud/oracle"
 )
 
 var (
@@ -207,6 +208,24 @@ var (
 			},
 		},
 	}
+
+	OCIUsageAPIConfigurations = &Configurations{
+		OCI: &OCIConfigs{
+			UsageAPI: []*oracle.UsageApiConfiguration{
+				{
+					TenancyID: "ocid1.tenancy.oc1..tenancyID",
+					Region:    "us-ashburn-1",
+					Authorizer: &oracle.RawConfigProvider{
+						TenancyID:   "ocid1.tenancy.oc1..tenancyID",
+						UserID:      "ocid1.user.oc1..userID",
+						Region:      "us-ashburn-1",
+						Fingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+						PrivateKey:  "dummy-private-key",
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestConfigurations_UnmarshalJSON(t *testing.T) {
@@ -269,6 +288,10 @@ func TestConfigurations_UnmarshalJSON(t *testing.T) {
 		"AWS S3 Assume Role Service Access Key": {
 			input:    AWSS3AssumeRoleAccessKeyMultiCloudConfig,
 			expected: AWSS3AssumeRoleAccessKeyConfigurations,
+		},
+		"OCI UsageAPI RawConfigProvider": {
+			input:    OCIUsageAPIConfigurations,
+			expected: OCIUsageAPIConfigurations,
 		},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary

This PR adds a JSON round-trip test for OCI cloud cost configuration.

Other cloud providers (AWS, Azure, GCP) already have similar tests, but OCI was missing coverage.

## Changes
- Added OCI configuration serialization/deserialization test
- Ensures compatibility with cloud-integration.json

## Why this matters
- Confirms OCI integration works as expected
- Documents expected configuration format
- Improves consistency across cloud providers

## Testing
- Ran `go test ./pkg/...`
- Test passes successfully

Ref: #3003