### PR TITLE
fix(azure): recognize CSI disk skuname for PV pricing

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1344,7 +1344,11 @@ func (key *azurePvKey) GetStorageClass() string {
 
 func (key *azurePvKey) Features() string {
 	storageClass := key.StorageClassParameters["storageaccounttype"]
-	storageSKU := key.StorageClassParameters["skuName"]
+	diskSKU := key.StorageClassParameters["skuname"]
+	fileSKU := key.StorageClassParameters["skuName"]
+	if storageClass == "" {
+		storageClass = diskSKU
+	}
 	if storageClass != "" {
 		if strings.EqualFold(storageClass, "Premium_LRS") {
 			storageClass = AzureDiskPremiumSSDStorageClass
@@ -1354,9 +1358,9 @@ func (key *azurePvKey) Features() string {
 			storageClass = AzureDiskStandardStorageClass
 		}
 	} else {
-		if strings.EqualFold(storageSKU, "Premium_LRS") {
+		if strings.EqualFold(fileSKU, "Premium_LRS") {
 			storageClass = AzureFilePremiumStorageClass
-		} else if strings.EqualFold(storageSKU, "Standard_LRS") {
+		} else if strings.EqualFold(fileSKU, "Standard_LRS") {
 			storageClass = AzureFileStandardStorageClass
 		}
 	}

--- a/pkg/cloud/azure/provider_test.go
+++ b/pkg/cloud/azure/provider_test.go
@@ -254,6 +254,68 @@ func TestAzure_findCostForDisk(t *testing.T) {
 	}
 }
 
+func TestAzurePVKeyFeatures(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "managed disk storageaccounttype premium",
+			parameters: map[string]string{
+				"storageaccounttype": "Premium_LRS",
+			},
+			expected: "eastus,premium_ssd",
+		},
+		{
+			name: "managed disk csi skuname premium",
+			parameters: map[string]string{
+				"skuname": "Premium_LRS",
+			},
+			expected: "eastus,premium_ssd",
+		},
+		{
+			name: "managed disk csi skuname standard ssd",
+			parameters: map[string]string{
+				"skuname": "StandardSSD_LRS",
+			},
+			expected: "eastus,standard_ssd",
+		},
+		{
+			name: "managed disk csi skuname standard hdd",
+			parameters: map[string]string{
+				"skuname": "Standard_LRS",
+			},
+			expected: "eastus,standard_hdd",
+		},
+		{
+			name: "azure files skuName remains file pricing",
+			parameters: map[string]string{
+				"skuName": "Premium_LRS",
+			},
+			expected: "eastus,premium_smb",
+		},
+		{
+			name: "azure files skuName standard remains file pricing",
+			parameters: map[string]string{
+				"skuName": "Standard_LRS",
+			},
+			expected: "eastus,standard_smb",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := &azurePvKey{
+				StorageClassParameters: tc.parameters,
+				DefaultRegion:          "eastus",
+			}
+
+			require.Equal(t, tc.expected, key.Features())
+		})
+	}
+}
+
 func Test_buildAzureRetailPricesURL(t *testing.T) {
 	testCases := []struct {
 		name         string


### PR DESCRIPTION
## Description
Recognizes the Azure Disk CSI driver's lowercase `skuname` StorageClass parameter when building PV pricing keys. This lets CSI-managed disks using values like `Premium_LRS` and `StandardSSD_LRS` map to the existing managed disk pricing classes instead of falling back to the default PV rate.

## Related Issues
Fixes #3633

## User Impact
AKS users with CSI disk StorageClasses such as `managed-csi-premium` should see PV costs use the correct Premium SSD or Standard SSD rate. Existing Azure Files `skuName` handling is preserved.

## Testing
- `CGO_ENABLED=0 go test ./pkg/cloud/azure`