### PR TITLE
fix(ovh): ignore monthly volume prices for hourly PV rates

### DIFF
--- a/pkg/cloud/ovh/provider.go
+++ b/pkg/cloud/ovh/provider.go
@@ -278,7 +278,6 @@ func parseVolumeAddon(addon ovhAddon, volumePricing map[string]float64) {
 			return
 		}
 	}
-	volumePricing[volumeType] = float64(addon.Pricings[0].Price) / microcentsPerUnit
 }
 
 // ovhKey implements models.Key for OVH nodes.

--- a/pkg/cloud/ovh/testdata/ovh_catalog.json
+++ b/pkg/cloud/ovh/testdata/ovh_catalog.json
@@ -21,6 +21,7 @@
           "name": "volume",
           "addons": [
             "volume.high-speed-gen2.consumption",
+            "volume.high-speed-gen2.monthly.postpaid",
             "volume.high-speed.consumption",
             "volume.classic.consumption"
           ]
@@ -182,6 +183,18 @@
         {
           "price": 11900,
           "type": "consumption"
+        }
+      ]
+    },
+    {
+      "planCode": "volume.high-speed-gen2.monthly.postpaid",
+      "invoiceName": "Volume High Speed Gen2 - Monthly",
+      "product": "publiccloud-volume",
+      "pricingType": "consumption",
+      "pricings": [
+        {
+          "price": 8687000,
+          "type": "monthly.postpaid"
         }
       ]
     },


### PR DESCRIPTION
## Description
Updates OVH volume catalog parsing so only `consumption` pricing entries populate per-hour PV rates. Monthly `monthly.postpaid` entries for the same volume type are skipped instead of overwriting the hourly price.

## Related Issues
Fixes #3766

## User Impact
OVHcloud users should see `pv_hourly_cost` use the hourly High speed Gen2 volume price rather than the monthly payment value. Other OVH volume types continue to use their consumption prices.

## Testing
- `CGO_ENABLED=0 go test ./pkg/cloud/ovh`