### PR TITLE
fix(collector): avoid daily store for rolling 24h windows

### DIFF
--- a/modules/collector-source/pkg/collector/collectorprovider.go
+++ b/modules/collector-source/pkg/collector/collectorprovider.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/log"
@@ -54,14 +55,21 @@ func (r *repoStoreProvider) GetStore(start, end time.Time) metric.MetricStore {
 func (r *repoStoreProvider) getStoreKeys(start, end time.Time) (string, time.Time) {
 	windowDuration := int64(end.Sub(start))
 	type candidate struct {
-		diff  int64
-		key   string
-		start time.Time
-		set   bool
+		diff     int64
+		duration int64
+		key      string
+		start    time.Time
+		set      bool
 	}
 	var best candidate
 	var fallback candidate
-	for key, interval := range r.intervals {
+	keys := make([]string, 0, len(r.intervals))
+	for key := range r.intervals {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		interval := r.intervals[key]
 		intStart := interval.Truncate(start)
 		intEnd := interval.Add(intStart, 1)
 		intDuration := int64(intEnd.Sub(intStart))
@@ -70,12 +78,13 @@ func (r *repoStoreProvider) getStoreKeys(start, end time.Time) (string, time.Tim
 			diffDuration = -diffDuration
 		}
 
-		if !fallback.set || diffDuration < fallback.diff {
+		if !fallback.set || diffDuration < fallback.diff || diffDuration == fallback.diff && intDuration < fallback.duration {
 			fallback = candidate{
-				diff:  diffDuration,
-				key:   key,
-				start: intStart,
-				set:   true,
+				diff:     diffDuration,
+				duration: intDuration,
+				key:      key,
+				start:    intStart,
+				set:      true,
 			}
 		}
 
@@ -83,12 +92,13 @@ func (r *repoStoreProvider) getStoreKeys(start, end time.Time) (string, time.Tim
 			continue
 		}
 
-		if !best.set || diffDuration < best.diff {
+		if !best.set || diffDuration < best.diff || diffDuration == best.diff && intDuration < best.duration {
 			best = candidate{
-				diff:  diffDuration,
-				key:   key,
-				start: intStart,
-				set:   true,
+				diff:     diffDuration,
+				duration: intDuration,
+				key:      key,
+				start:    intStart,
+				set:      true,
 			}
 		}
 	}

--- a/modules/collector-source/pkg/collector/collectorprovider.go
+++ b/modules/collector-source/pkg/collector/collectorprovider.go
@@ -49,28 +49,53 @@ func (r *repoStoreProvider) GetStore(start, end time.Time) metric.MetricStore {
 }
 
 // getStoreKeys compares the given start and end against each resolution by truncating the start time and
-// add one interval to the truncated value. The duration between start and end is compared with the duration
-// between the interval generated times, with the lowest
+// adding one interval to the truncated value. The duration between start and end is compared with the
+// duration between the interval-generated times, with the lowest diff selected.
 func (r *repoStoreProvider) getStoreKeys(start, end time.Time) (string, time.Time) {
 	windowDuration := int64(end.Sub(start))
-	var minDiff *int64
-	var minKey string
-	var minStart time.Time
+	type candidate struct {
+		diff  int64
+		key   string
+		start time.Time
+		set   bool
+	}
+	var best candidate
+	var fallback candidate
 	for key, interval := range r.intervals {
 		intStart := interval.Truncate(start)
-		intEnd := interval.Add(start, 1)
+		intEnd := interval.Add(intStart, 1)
 		intDuration := int64(intEnd.Sub(intStart))
 		diffDuration := windowDuration - intDuration
 		if diffDuration < 0 {
 			diffDuration = -diffDuration
 		}
-		if minDiff == nil || diffDuration < *minDiff {
-			minDiff = &diffDuration
-			minKey = key
-			minStart = intStart
+
+		if !fallback.set || diffDuration < fallback.diff {
+			fallback = candidate{
+				diff:  diffDuration,
+				key:   key,
+				start: intStart,
+				set:   true,
+			}
+		}
+
+		if intDuration == windowDuration && !intStart.Equal(start) {
+			continue
+		}
+
+		if !best.set || diffDuration < best.diff {
+			best = candidate{
+				diff:  diffDuration,
+				key:   key,
+				start: intStart,
+				set:   true,
+			}
 		}
 	}
-	return minKey, minStart
+	if best.set {
+		return best.key, best.start
+	}
+	return fallback.key, fallback.start
 }
 
 // GetDailyDataCoverage this is a bit of a hacky add-on to help fulfill the metricsquerier interface

--- a/modules/collector-source/pkg/collector/collectorprovider_test.go
+++ b/modules/collector-source/pkg/collector/collectorprovider_test.go
@@ -49,6 +49,13 @@ func Test_repoStoreProvider_getStoreKeys(t *testing.T) {
 			intevalKey: "1d",
 			startKey:   time.Date(2025, time.May, 3, 0, 0, 0, 0, time.UTC),
 		},
+		"24h rolling window": {
+			configs:    defaultResConfigs,
+			start:      time.Date(2026, time.March, 3, 19, 0, 0, 0, time.UTC),
+			end:        time.Date(2026, time.March, 4, 19, 0, 0, 0, time.UTC),
+			intevalKey: "1h",
+			startKey:   time.Date(2026, time.March, 3, 19, 0, 0, 0, time.UTC),
+		},
 		"2m": {
 			configs:    defaultResConfigs,
 			start:      time.Date(2025, time.May, 3, 0, 0, 0, 0, time.UTC),

--- a/modules/collector-source/pkg/collector/collectorprovider_test.go
+++ b/modules/collector-source/pkg/collector/collectorprovider_test.go
@@ -56,6 +56,20 @@ func Test_repoStoreProvider_getStoreKeys(t *testing.T) {
 			intevalKey: "1h",
 			startKey:   time.Date(2026, time.March, 3, 19, 0, 0, 0, time.UTC),
 		},
+		"1h unaligned exact window": {
+			configs:    defaultResConfigs,
+			start:      time.Date(2026, time.March, 3, 19, 5, 0, 0, time.UTC),
+			end:        time.Date(2026, time.March, 3, 20, 5, 0, 0, time.UTC),
+			intevalKey: "10m",
+			startKey:   time.Date(2026, time.March, 3, 19, 0, 0, 0, time.UTC),
+		},
+		"35m tie prefers highest resolution": {
+			configs:    defaultResConfigs,
+			start:      time.Date(2026, time.March, 3, 19, 0, 0, 0, time.UTC),
+			end:        time.Date(2026, time.March, 3, 19, 35, 0, 0, time.UTC),
+			intevalKey: "10m",
+			startKey:   time.Date(2026, time.March, 3, 19, 0, 0, 0, time.UTC),
+		},
 		"2m": {
 			configs:    defaultResConfigs,
 			start:      time.Date(2025, time.May, 3, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Description
Updates collector-source store selection so exact-duration interval matches must align with the requested start time. A rolling 24h window aligned to the hour now uses the `1h` store instead of a midnight-aligned `1d` bucket, while non-exact daily-ish windows keep the previous nearest-interval fallback behavior.

## Related Issues
Fixes #3630

## User Impact
Collector-source queries for rolling windows such as `window=24h` should read data from the correctly aligned hourly store, avoiding data from outside the requested window.

## Testing
- `CGO_ENABLED=0 go test ./pkg/collector` from `modules/collector-source`