### PR TITLE
Remove literal from description, which was failing the action

### DIFF
--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -18,8 +18,8 @@ inputs:
         required: true
     run-started-at:
         description: >-
-          ISO-8601 workflow run start time (typically the workflow's
-          run_started_at value) from the caller. Recorded as
+          ISO-8601 workflow run start time (typically
+          `github.run_started_at` from the caller workflow). Recorded as
           `runDetails.metadata.startedOn` in the SLSA provenance predicate.
         required: true
 

--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -18,9 +18,9 @@ inputs:
         required: true
     run-started-at:
         description: >-
-          ISO-8601 workflow run start time, typically `${{ github.run_started_at }}`
-          from the caller. Recorded as `runDetails.metadata.startedOn` in the
-          SLSA provenance predicate.
+          ISO-8601 workflow run start time (typically the workflow's
+          run_started_at value) from the caller. Recorded as
+          `runDetails.metadata.startedOn` in the SLSA provenance predicate.
         required: true
 
 runs:


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
The literal in this description is causing the release Action to fail, as the comment is interpreted literally

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
N/A

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
