### PR TITLE
Add fallback for missing startup time

### DIFF
--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -21,11 +21,21 @@ inputs:
           ISO-8601 workflow run start time (typically
           `github.run_started_at` from the caller workflow). Recorded as
           `runDetails.metadata.startedOn` in the SLSA provenance predicate.
+          If empty, the action falls back to the time at which it began
+          executing — `github.run_started_at` is reported empty in some
+          edge cases and `required: true` on a composite-action input
+          does not reject empty strings.
         required: true
 
 runs:
     using: "composite"
     steps:
+      - name: Capture fallback start timestamp
+        id: start
+        shell: bash
+        run: |
+          echo "STARTED_ON=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
@@ -59,10 +69,14 @@ runs:
         env:
           WORKFLOW_PATH: ${{ inputs.workflow-path }}
           STARTED_ON: ${{ inputs.run-started-at }}
+          FALLBACK_STARTED_ON: ${{ steps.start.outputs.STARTED_ON }}
         run: |
           set -euo pipefail
+          if [[ -z "${STARTED_ON:-}" ]]; then
+            STARTED_ON="$FALLBACK_STARTED_ON"
+          fi
           RESOLVED_GIT_COMMIT="$(git rev-parse HEAD)"
-          export RESOLVED_GIT_COMMIT
+          export RESOLVED_GIT_COMMIT STARTED_ON
           python3 - <<'PY' > predicate.json
           import json
           import os


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Fix for: 
```
Error: signing ghcr.io/opencost/opencost@sha256:5f37f689557dbb6737a9182b70625bba55bbba843a2caaba5a79746945a56cc6: unmarshal Provenance predicate: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
error during command execution: signing ghcr.io/opencost/opencost@sha256:5f37f689557dbb6737a9182b70625bba55bbba843a2caaba5a79746945a56cc6: unmarshal Provenance predicate: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
Error: Process completed with exit code 1.
```

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
N/A

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
