### PR TITLE
Add field `location` to `BigQueryConfiguration`

### DIFF
--- a/pkg/cloud/gcp/bigqueryconfiguration.go
+++ b/pkg/cloud/gcp/bigqueryconfiguration.go
@@ -77,6 +77,10 @@ func (bqc *BigQueryConfiguration) Equals(config cloud.Config) bool {
 		return false
 	}
 
+	if bqc.Location != thatConfig.Location {
+		return false
+	}
+
 	return true
 }
 
@@ -85,6 +89,7 @@ func (bqc *BigQueryConfiguration) Sanitize() cloud.Config {
 		ProjectID:  bqc.ProjectID,
 		Dataset:    bqc.Dataset,
 		Table:      bqc.Table,
+		Location:   bqc.Location,
 		Authorizer: bqc.Authorizer.Sanitize().(Authorizer),
 	}
 }
@@ -145,6 +150,14 @@ func (bqc *BigQueryConfiguration) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("BigQueryConfiguration: FromInterface: %s", err.Error())
 	}
 	bqc.Table = table
+
+	if _, ok := fmap["location"]; ok {
+		location, err := cloud.GetInterfaceValue[string](fmap, "location")
+		if err != nil {
+			return fmt.Errorf("BigQueryConfiguration: FromInterface: %s", err.Error())
+		}
+		bqc.Location = location
+	}
 
 	authAny, ok := fmap["authorizer"]
 	if !ok {

--- a/pkg/cloud/gcp/bigqueryconfiguration.go
+++ b/pkg/cloud/gcp/bigqueryconfiguration.go
@@ -16,6 +16,7 @@ type BigQueryConfiguration struct {
 	Dataset              string     `json:"dataset"`
 	Table                string     `json:"table"`
 	ExcludePartitionTime bool       `json:"excludePartitionTime"`
+	Location             string     `json:"location"`
 	Authorizer           Authorizer `json:"authorizer"`
 }
 
@@ -106,7 +107,15 @@ func (bqc *BigQueryConfiguration) GetBigQueryClient(ctx context.Context) (*bigqu
 	if err != nil {
 		return nil, err
 	}
-	return bigquery.NewClient(ctx, bqc.ProjectID, clientOpts...)
+
+	client, err := bigquery.NewClient(ctx, bqc.ProjectID, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	client.Location = bqc.Location
+
+	return client, nil
 }
 
 // UnmarshalJSON assumes data is save as an BigQueryConfigurationDTO

--- a/pkg/cloud/gcp/bigqueryconfiguration_test.go
+++ b/pkg/cloud/gcp/bigqueryconfiguration_test.go
@@ -320,6 +320,33 @@ func TestBigQueryConfiguration_Equals(t *testing.T) {
 			},
 			expected: false,
 		},
+		"different location": {
+			left: BigQueryConfiguration{
+				ProjectID: "projectID",
+				Dataset:   "dataset",
+				Table:     "table",
+				Location:  "EU",
+				Authorizer: &ServiceAccountKey{
+					Key: map[string]string{
+						"Key":  "Key",
+						"key1": "key2",
+					},
+				},
+			},
+			right: &BigQueryConfiguration{
+				ProjectID: "projectID",
+				Dataset:   "dataset2",
+				Table:     "table",
+				Location:  "US",
+				Authorizer: &ServiceAccountKey{
+					Key: map[string]string{
+						"Key":  "Key",
+						"key1": "key2",
+					},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/pkg/cloud/gcp/bigqueryconfiguration_test.go
+++ b/pkg/cloud/gcp/bigqueryconfiguration_test.go
@@ -138,6 +138,7 @@ func TestBigQueryConfiguration_Equals(t *testing.T) {
 						"key1": "key2",
 					},
 				},
+				Location: "EU",
 			},
 			right: &BigQueryConfiguration{
 				ProjectID: "projectID",
@@ -149,6 +150,7 @@ func TestBigQueryConfiguration_Equals(t *testing.T) {
 						"key1": "key2",
 					},
 				},
+				Location: "EU",
 			},
 			expected: true,
 		},


### PR DESCRIPTION
## Description

This PR adds the ability to configure the location for BigQuery.

## Related Issues

https://github.com/opencost/opencost/issues/2755 (not fixed)

## User Impact

This is not a breaking change. Users are now able to specify the default BigQuery location in their `cloud-integration.json` like:

```json
{
  "gcp": {
    "bigQuery": [
      {
        "projectID": "<GCP_PROJECT_ID>",
        "dataset": "detailedbilling",
        "table": "gcp_billing_export_resource_v1_0121AC_C6F51B_690771",
        "location": "EU"
        "authorizer": {
          "authorizerType": "GCPWorkloadIdentity"
        }
      }
    ]
  }
}
```

Before this change there was no way to specify the location and it was determined by the API like [this](https://docs.cloud.google.com/bigquery/docs/locations).

## Testing

Only local testing so far, but I can test the changes on a production environment if needed.
