### PR TITLE
fix(oracle): tolerate nil/empty AttributedCost during cloudcost ingestion

### DIFF
--- a/pkg/cloud/oracle/usageapiintegration.go
+++ b/pkg/cloud/oracle/usageapiintegration.go
@@ -108,14 +108,9 @@ func (uai *UsageApiIntegration) GetCloudCost(start time.Time, end time.Time) (*o
 			listRate = float64(*item.ListRate)
 		}
 
-		attrCostToParse := ""
-		if item.AttributedCost != nil {
-			attrCostToParse = *item.AttributedCost
-		}
-
-		attrCost, err := strconv.ParseFloat(attrCostToParse, 64)
+		attrCost, err := parseAttributedCost(item.AttributedCost)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse float '%s': %s", attrCostToParse, err.Error())
+			return nil, err
 		}
 
 		computedAmt := 0.0
@@ -162,6 +157,17 @@ func (uai *UsageApiIntegration) GetStatus() cloud.ConnectionStatus {
 func (uai *UsageApiIntegration) RefreshStatus() cloud.ConnectionStatus {
 	log.Warn("status refresh is not supported for the Oracle provider")
 	return uai.ConnectionStatus
+}
+
+func parseAttributedCost(s *string) (float64, error) {
+	if s == nil || *s == "" {
+		return 0, nil
+	}
+	f, err := strconv.ParseFloat(*s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse float '%s': %s", *s, err.Error())
+	}
+	return f, nil
 }
 
 func SelectOCICategory(service string) string {

--- a/pkg/cloud/oracle/usageapiintegration_test.go
+++ b/pkg/cloud/oracle/usageapiintegration_test.go
@@ -9,6 +9,34 @@ import (
 	"github.com/opencost/opencost/core/pkg/util/timeutil"
 )
 
+func TestParseAttributedCost(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	cases := map[string]struct {
+		input   *string
+		want    float64
+		wantErr bool
+	}{
+		"nil":        {nil, 0, false},
+		"empty":      {strPtr(""), 0, false},
+		"zero":       {strPtr("0"), 0, false},
+		"valid":      {strPtr("1.23"), 1.23, false},
+		"negative":   {strPtr("-0.5"), -0.5, false},
+		"unparsable": {strPtr("abc"), 0, true},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseAttributedCost(c.input)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, c.wantErr)
+			}
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 func TestUsageAPIIntegration_GetCloudCost(t *testing.T) {
 	usageApiConfigPath := os.Getenv("USAGEAPI_CONFIGURATION")
 	if usageApiConfigPath == "" {


### PR DESCRIPTION
## Description

OCI's `UsageSummary.AttributedCost` is declared `mandatory:"false"` in the OCI Go SDK and may legitimately be returned as `nil` or an empty string for valid line items. The current code feeds the empty value into `strconv.ParseFloat`, which always errors. Because the loop in `GetCloudCost` returns on that error, **a single line item with a missing/empty `AttributedCost` aborts the entire ingestion window** — every other line item in that window is lost.

This matches the symptoms reported in #3794:

```
ERR CloudCost[…]: ingestor: build failed for window […]: unable to parse float '': strconv.ParseFloat: parsing "": invalid syntax
```

The other nullable cost fields in the same loop (`ListRate`, `ComputedAmount`) already default to `0` when their pointers are nil. This change brings `AttributedCost` in line with that pattern.

## Related Issues

Fixes #3794

## User Impact

OCI / OKE users who currently see ingestion windows fail with the `parse float ''` error will now successfully ingest cloud cost data. No configuration changes required, no breaking changes, no behavior change for existing parseable values.

## Testing

- **New unit test** `TestParseAttributedCost` covering `nil`, empty string, zero, valid positive, valid negative, and unparseable cases.
- Existing live integration test `TestUsageAPIIntegration_GetCloudCost` is unchanged and still skips locally when `USAGEAPI_CONFIGURATION` is not set.
- `go fmt ./...`, `go vet ./pkg/cloud/oracle/...`, and `go test ./pkg/cloud/oracle/...` all pass.

## Fix detail

Extracted a small `parseAttributedCost` helper:
- `nil` pointer → `0` (no error)
- empty string → `0` (no error)
- non-empty unparseable string → same error as before (window still aborts)
- valid numeric string → parsed value

The pre-existing error message format (`"unable to parse float '%s': %s"`) is preserved so any log scrapers continue to match.

## Out of scope

Whitespace-only strings (e.g. `" "`, `"\n"`) still abort the window. The bug report and OCI SDK documentation describe nil/empty values; trimming wasn't part of the reported behavior, so it's deliberately not addressed here. Happy to expand the helper if reviewers want that included.

## References

- OCI SDK doc confirming `attributed_cost` is optional: https://docs.oracle.com/en-us/iaas/tools/python/latest/api/usage_api/models/oci.usage_api.models.UsageSummary.html