### PR TITLE
Fix Bug in sign-image/action.yaml

### DIFF
--- a/.github/actions/sign-image/action.yaml
+++ b/.github/actions/sign-image/action.yaml
@@ -73,8 +73,14 @@ runs:
         run: |
           set -euo pipefail
           if [[ -z "${STARTED_ON:-}" ]]; then
+            echo "inputs.run-started-at is empty; using fallback ${FALLBACK_STARTED_ON}"
             STARTED_ON="$FALLBACK_STARTED_ON"
           fi
+          if [[ -z "${STARTED_ON:-}" ]]; then
+            echo "::error::startedOn resolved empty after fallback; predicate would be unparseable"
+            exit 1
+          fi
+          echo "Using startedOn=${STARTED_ON}"
           RESOLVED_GIT_COMMIT="$(git rev-parse HEAD)"
           export RESOLVED_GIT_COMMIT STARTED_ON
           python3 - <<'PY' > predicate.json


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Image signing failed on the most recent release of OpenCost. This PR adds two small defensive measures inside the `Generate SLSA v1 provenance predicate` step:

- Echo the resolved `startedOn` so the value is visible in the runner log.
- Hard-fail (with a `::error::` annotation) if `STARTED_ON` is still empty
  after the fallback, rather than emitting a malformed predicate.

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
Follow-up to #3790

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
N/A

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
Ran the action via a temporary debug workflow on a personal fork. A matrix
exercised both code paths:

- Empty `run-started-at` → fallback applied, predicate `startedOn` populated
  with the fallback timestamp.
- Populated `run-started-at` → passed through verbatim.

For each case the predicate was fed into `cosign attest --no-upload` and
accepted, confirming the exact unmarshal code path that originally failed
now succeeds. 