### PR TITLE
Set `location` on BigQuery `Query`

### DIFF
--- a/pkg/cloud/gcp/bigqueryquerier.go
+++ b/pkg/cloud/gcp/bigqueryquerier.go
@@ -45,6 +45,8 @@ func (bqq *BigQueryQuerier) Query(ctx context.Context, queryStr string) (*bigque
 	}
 
 	query := client.Query(queryStr)
+	query.Location = client.Location
+
 	iter, err := query.Read(ctx)
 
 	// If result is empty and connection status is not already successful update status to missing data


### PR DESCRIPTION
## Description
Although the clients location gets configured, the location of the BigQuery `Query` needs to be set as well.

## Related Issues
Relates to #3795 

## User Impact

None, because if the location is not set in the configuration the value of `query.Location` will still be the zero value.

## Testing

I tested the setup with a custom image build in a pre-production environment.
