### PR TITLE
fix(prometheus): support KSM v2 node capacity/allocatable metrics

### DIFF
--- a/modules/prometheus-source/pkg/prom/metricsquerier.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier.go
@@ -205,7 +205,10 @@ func (pds *PrometheusMetricsQuerier) QueryLocalStorageActiveMinutes(start, end t
 
 func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresCapacity(start, end time.Time) *source.Future[source.NodeCPUCoresCapacityResult] {
 	const queryName = "QueryNodeCPUCoresCapacity"
-	const nodeCPUCoresCapacityQuery = `avg(avg_over_time(kube_node_status_capacity_cpu_cores{%s}[%s])) by (%s, node, uid)`
+	// KSM v1 emits kube_node_status_capacity_cpu_cores; KSM v2 (kube-prometheus-stack default)
+	// emits kube_node_status_capacity{resource="cpu"} instead. The or-clause prefers v1 and
+	// falls back to v2 so both KSM versions are supported without a recording rule.
+	const nodeCPUCoresCapacityQuery = `(avg(avg_over_time(kube_node_status_capacity_cpu_cores{%s}[%s])) by (%s, node, uid) or avg(avg_over_time(kube_node_status_capacity{resource="cpu",%s}[%s])) by (%s, node, uid))`
 
 	cfg := pds.promConfig
 
@@ -214,7 +217,7 @@ func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresCapacity(start, end time.T
 		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
 	}
 
-	queryNodeCPUCoresCapacity := fmt.Sprintf(nodeCPUCoresCapacityQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	queryNodeCPUCoresCapacity := fmt.Sprintf(nodeCPUCoresCapacityQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
 	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeCPUCoresCapacity)
 
 	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
@@ -223,7 +226,9 @@ func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresCapacity(start, end time.T
 
 func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresAllocatable(start, end time.Time) *source.Future[source.NodeCPUCoresAllocatableResult] {
 	const queryName = "QueryNodeCPUCoresAllocatable"
-	const nodeCPUCoresAllocatableQuery = `avg(avg_over_time(kube_node_status_allocatable_cpu_cores{%s}[%s])) by (%s, node, uid)`
+	// KSM v1 emits kube_node_status_allocatable_cpu_cores; KSM v2 emits
+	// kube_node_status_allocatable{resource="cpu"} instead.
+	const nodeCPUCoresAllocatableQuery = `(avg(avg_over_time(kube_node_status_allocatable_cpu_cores{%s}[%s])) by (%s, node, uid) or avg(avg_over_time(kube_node_status_allocatable{resource="cpu",%s}[%s])) by (%s, node, uid))`
 	// `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", node!="", %s}[%s])) by (container, pod, namespace, node, %s)`
 
 	cfg := pds.promConfig
@@ -233,7 +238,7 @@ func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresAllocatable(start, end tim
 		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
 	}
 
-	queryNodeCPUCoresAllocatable := fmt.Sprintf(nodeCPUCoresAllocatableQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	queryNodeCPUCoresAllocatable := fmt.Sprintf(nodeCPUCoresAllocatableQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
 	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeCPUCoresAllocatable)
 
 	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
@@ -242,7 +247,9 @@ func (pds *PrometheusMetricsQuerier) QueryNodeCPUCoresAllocatable(start, end tim
 
 func (pds *PrometheusMetricsQuerier) QueryNodeRAMBytesCapacity(start, end time.Time) *source.Future[source.NodeRAMBytesCapacityResult] {
 	const queryName = "QueryNodeRAMBytesCapacity"
-	const nodeRAMBytesCapacityQuery = `avg(avg_over_time(kube_node_status_capacity_memory_bytes{%s}[%s])) by (%s, node, uid)`
+	// KSM v1 emits kube_node_status_capacity_memory_bytes; KSM v2 emits
+	// kube_node_status_capacity{resource="memory"} instead.
+	const nodeRAMBytesCapacityQuery = `(avg(avg_over_time(kube_node_status_capacity_memory_bytes{%s}[%s])) by (%s, node, uid) or avg(avg_over_time(kube_node_status_capacity{resource="memory",%s}[%s])) by (%s, node, uid))`
 
 	cfg := pds.promConfig
 
@@ -251,7 +258,7 @@ func (pds *PrometheusMetricsQuerier) QueryNodeRAMBytesCapacity(start, end time.T
 		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
 	}
 
-	queryNodeRAMBytesCapacity := fmt.Sprintf(nodeRAMBytesCapacityQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	queryNodeRAMBytesCapacity := fmt.Sprintf(nodeRAMBytesCapacityQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
 	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeRAMBytesCapacity)
 
 	ctx := pds.promContexts.NewNamedContext(ClusterContextName)
@@ -260,7 +267,9 @@ func (pds *PrometheusMetricsQuerier) QueryNodeRAMBytesCapacity(start, end time.T
 
 func (pds *PrometheusMetricsQuerier) QueryNodeRAMBytesAllocatable(start, end time.Time) *source.Future[source.NodeRAMBytesAllocatableResult] {
 	const queryName = "QueryNodeRAMBytesAllocatable"
-	const nodeRAMBytesAllocatableQuery = `avg(avg_over_time(kube_node_status_allocatable_memory_bytes{%s}[%s])) by (%s, node, uid)`
+	// KSM v1 emits kube_node_status_allocatable_memory_bytes; KSM v2 emits
+	// kube_node_status_allocatable{resource="memory"} instead.
+	const nodeRAMBytesAllocatableQuery = `(avg(avg_over_time(kube_node_status_allocatable_memory_bytes{%s}[%s])) by (%s, node, uid) or avg(avg_over_time(kube_node_status_allocatable{resource="memory",%s}[%s])) by (%s, node, uid))`
 
 	cfg := pds.promConfig
 
@@ -269,7 +278,7 @@ func (pds *PrometheusMetricsQuerier) QueryNodeRAMBytesAllocatable(start, end tim
 		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
 	}
 
-	queryNodeRAMBytesAllocatable := fmt.Sprintf(nodeRAMBytesAllocatableQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
+	queryNodeRAMBytesAllocatable := fmt.Sprintf(nodeRAMBytesAllocatableQuery, cfg.ClusterFilter, durStr, cfg.ClusterLabel, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
 	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryNodeRAMBytesAllocatable)
 
 	ctx := pds.promContexts.NewNamedContext(ClusterContextName)

--- a/modules/prometheus-source/pkg/prom/metricsquerier_test.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,5 +219,84 @@ func checkQueryLog(t *testing.T, logWriter *SingleLogWriter, query func(time.Tim
 	if actual != expectedHeader {
 		t.Errorf("Expected log header '%s', but got '%s'", expectedHeader, actual)
 		return
+	}
+}
+
+// TestKSMV2QueryFallback verifies that the four node capacity/allocatable queries
+// contain both the KSM v1 metric name and the KSM v2 metric name so that clusters
+// running either kube-state-metrics version return correct node capacity data.
+func TestKSMV2QueryFallback(t *testing.T) {
+	initLogging(t, "debug", false)
+
+	logWriter := new(SingleLogWriter)
+	zerologger.Logger = zerologger.Output(zerolog.ConsoleWriter{
+		Out:        logWriter,
+		TimeFormat: "",
+		NoColor:    true,
+		PartsExclude: []string{
+			zerolog.TimestampFieldName,
+			zerolog.LevelFieldName,
+			zerolog.CallerFieldName,
+		},
+	})
+	defer initLogging(t, "debug", false)
+
+	t.Setenv("PROMETHEUS_SERVER_ENDPOINT", "nowhere")
+
+	config, err := NewOpenCostPrometheusConfigFromEnv()
+	if err != nil {
+		t.Fatalf("Failed to create OpenCost Prometheus config: %v", err)
+	}
+
+	mock := new(NoOpPromClient)
+	contextFactory := NewContextFactory(mock, config)
+	querier := newPrometheusMetricsQuerier(config, mock, contextFactory)
+
+	queryEnd := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	queryStart := queryEnd.Add(-24 * time.Hour)
+
+	tests := []struct {
+		name   string
+		fn     func(time.Time, time.Time)
+		v1Name string
+		v2Name string
+	}{
+		{
+			name:   "QueryNodeCPUCoresCapacity",
+			fn:     func(s, e time.Time) { querier.QueryNodeCPUCoresCapacity(s, e) },
+			v1Name: "kube_node_status_capacity_cpu_cores",
+			v2Name: `kube_node_status_capacity{resource="cpu"`,
+		},
+		{
+			name:   "QueryNodeCPUCoresAllocatable",
+			fn:     func(s, e time.Time) { querier.QueryNodeCPUCoresAllocatable(s, e) },
+			v1Name: "kube_node_status_allocatable_cpu_cores",
+			v2Name: `kube_node_status_allocatable{resource="cpu"`,
+		},
+		{
+			name:   "QueryNodeRAMBytesCapacity",
+			fn:     func(s, e time.Time) { querier.QueryNodeRAMBytesCapacity(s, e) },
+			v1Name: "kube_node_status_capacity_memory_bytes",
+			v2Name: `kube_node_status_capacity{resource="memory"`,
+		},
+		{
+			name:   "QueryNodeRAMBytesAllocatable",
+			fn:     func(s, e time.Time) { querier.QueryNodeRAMBytesAllocatable(s, e) },
+			v1Name: "kube_node_status_allocatable_memory_bytes",
+			v2Name: `kube_node_status_allocatable{resource="memory"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fn(queryStart, queryEnd)
+			got := logWriter.Log
+			if !strings.Contains(got, tc.v1Name) {
+				t.Errorf("KSM v1 metric %q missing from query: %s", tc.v1Name, got)
+			}
+			if !strings.Contains(got, tc.v2Name) {
+				t.Errorf("KSM v2 metric %q missing from query: %s", tc.v2Name, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #3477

## Description
OpenCost queries `kube_node_status_capacity_cpu_cores`, `kube_node_status_capacity_memory_bytes`, `kube_node_status_allocatable_cpu_cores`, and `kube_node_status_allocatable_memory_bytes`, metrics that only exist in kube-state-metrics (KSM) v1. kube-prometheus-stack ships KSM v2 by default, which emits `kube_node_status_capacity{resource="cpu|memory"}` and `kube_node_status_allocatable{resource="cpu|memory"}` instead. On v2-only clusters all four queries return empty, node capacity resolves to 0, idle costs go negative, and dashboard greys out.

Each of the four query constants in `QueryNodeCPUCoresCapacity`, `QueryNodeCPUCoresAllocatable`, `QueryNodeRAMBytesCapacity`, and `QueryNodeRAMBytesAllocatable` is extended with a PromQL `or`-clause that tries the v1 metric first and falls back to the v2 form. Both sides aggregate to `(clusterLabel, node, uid)`, so PromQL resolves the union correctly and v1 clusters are unaffected.

## Related Issues
Fixes #3477

## User Impact
Clusters running kube-prometheus-stack (KSM v2) showed node capacity = 0, causing negative idle costs and a greyed-out dashboard. Both KSM v1 and v2 clusters now return correct capacity data.

## Testing
`TestKSMV2QueryFallback` in `modules/prometheus-source/pkg/prom/metricsquerier_test.go` covers all four functions. Each sub-test asserts that the logged query string contains both the v1 and v2 metric names. The test fails on unpatched code.

```
=== RUN   TestKSMV2QueryFallback
=== RUN   TestKSMV2QueryFallback/QueryNodeCPUCoresCapacity
=== RUN   TestKSMV2QueryFallback/QueryNodeCPUCoresAllocatable
=== RUN   TestKSMV2QueryFallback/QueryNodeRAMBytesCapacity
=== RUN   TestKSMV2QueryFallback/QueryNodeRAMBytesAllocatable
--- PASS: TestKSMV2QueryFallback (0.00s)
    --- PASS: TestKSMV2QueryFallback/QueryNodeCPUCoresCapacity (0.00s)
    --- PASS: TestKSMV2QueryFallback/QueryNodeCPUCoresAllocatable (0.00s)
    --- PASS: TestKSMV2QueryFallback/QueryNodeRAMBytesCapacity (0.00s)
    --- PASS: TestKSMV2QueryFallback/QueryNodeRAMBytesAllocatable (0.00s)
PASS
ok      github.com/opencost/opencost/modules/prometheus-source/pkg/prom 0.099s
```