### PR TITLE
Updated UI image build commands from parcel → react-router/vite && Th…

### DIFF
--- a/Tiltfile.opencost
+++ b/Tiltfile.opencost
@@ -78,9 +78,9 @@ def run_opencost(options):
     local_resource(
         name='build-ui',
         dir='../opencost-ui',
-        cmd='npx parcel build src/index.html',
+        cmd='npm run build',
         deps=[
-            '../opencost-ui/src',
+            '../opencost-ui/app',
             '../opencost-ui/package.json',
         ],
         allow_parallel=True,
@@ -93,13 +93,14 @@ def run_opencost(options):
         context='../opencost-ui',
         dockerfile='../opencost-ui/Dockerfile.debug',
         only=[
-            'dist',
+            'build/client',
             'nginx.conf',
             'default.nginx.conf.template',
             'docker-entrypoint.sh',
+            'THIRD_PARTY_LICENSES.txt',
         ],
         live_update=[
-            sync('../opencost-ui/dist', '/var/www'),
+            sync('../opencost-ui/build/client', '/var/www'),
         ],
     )
 


### PR DESCRIPTION
## Description
The UI image build in tilt up was failing because the build command, source directory, and output directory in Tiltfile.opencost were still from the parcel era. 
The UI has since migrated to react-router/vite. 
Updating these to match the new framework gets the UI image building again on tilt up.

## Changes
Tiltfile.opencost — build-ui resource and opencost-ui docker_build:
* Build command: npx parcel build src/index.html → npm run build
* Source dir (in deps): src/ → app/ (there is no longer a src/ or src/index.html)
* Build output (in docker_build only + live_update sync): dist → build/client
* Added THIRD_PARTY_LICENSES.txt to the only list — this got me past a build-context checksum error I was hitting. Happy to drop it if a reviewer knows it shouldn't be needed.

A matching one-line change is also required in opencost-ui/Dockerfile.debug:
* COPY ./dist /opt/ui/dist → COPY ./build/client /opt/ui/dist

Since that file lives in the opencost-ui repo, it'll go up as a separate PR. Both changes are needed together for the UI build to work. The /opt/ui/dist target stays the same since the entrypoint copies from there to /var/www.

## Related Issues
Couldn't find any open issues related to this.

## User Impact
No user-facing or runtime changes. This affects the local dev environment only, for those devs using tilt. Not a breaking change. Contributors who previously hit the COPY ./dist ... /dist: not found failure will now get a working UI build.

## Testing
Manual verification via tilt up against a local cluster:
* build-npm-install → ✓
* build-ui → ✓ (previously failed at COPY ./dist)
* opencost-ui docker_build → ✓ (COPY ./build/client /opt/ui/dist)
* UI loads on localhost:9090
* opencost pod reached 2/2 Running and the OpenCost UI rendered in the browser