### PR TITLE
fix(customcost): copy coverage map in Status() to fix data race

### DIFF
--- a/pkg/customcost/ingestor.go
+++ b/pkg/customcost/ingestor.go
@@ -311,9 +311,25 @@ func (ing *CustomCostIngestor) Status() IngestorStatus {
 		LastRun:     ing.lastRun,
 		NextRun:     ing.lastRun.Add(ing.refreshRate).UTC(),
 		Runs:        ing.runs,
-		Coverage:    ing.coverage,
+		Coverage:    ing.copyCoverage(),
 		RefreshRate: ing.refreshRate,
 	}
+}
+
+// copyCoverage returns a shallow copy of the coverage map taken under the lock.
+// Returning ing.coverage directly hands a live reference to callers (the
+// /customCost/status handler serializes it, which iterates it), racing
+// expandCoverage() writing under coverageLock and risking a fatal "concurrent
+// map iteration and map write" crash. expandCoverage replaces Window values
+// wholesale, so a shallow copy is sufficient.
+func (ing *CustomCostIngestor) copyCoverage() map[string]opencost.Window {
+	ing.coverageLock.Lock()
+	defer ing.coverageLock.Unlock()
+	coverage := make(map[string]opencost.Window, len(ing.coverage))
+	for plugin, window := range ing.coverage {
+		coverage[plugin] = window
+	}
+	return coverage
 }
 
 func (ing *CustomCostIngestor) build(rebuild bool) {

--- a/pkg/customcost/ingestor_test.go
+++ b/pkg/customcost/ingestor_test.go
@@ -326,6 +326,12 @@ func TestIngestor_Status_ConcurrentWithExpandCoverage(t *testing.T) {
 	}()
 
 	wg.Wait()
+
+	// The writer touched 16 distinct plugins, so coverage should hold 16 entries
+	// once the race-free reads settle.
+	if got := len(ingestor.Status().Coverage); got != 16 {
+		t.Fatalf("expected 16 coverage entries after concurrent writes, got %d", got)
+	}
 }
 
 func TestBuildSingleDomain_ClientError(t *testing.T) {

--- a/pkg/customcost/ingestor_test.go
+++ b/pkg/customcost/ingestor_test.go
@@ -260,6 +260,74 @@ func TestBuildSingleDomain_DispenseError(t *testing.T) {
 	ingestor.BuildWindow(now.Add(-time.Hour), now)
 }
 
+// TestIngestor_Status_ReturnsCopyOfCoverage deterministically proves Status()
+// hands back a copy, not the live map: mutating the returned Coverage must not
+// leak into the ingestor's internal state. Unlike the concurrent test below,
+// this fails without needing the race detector.
+func TestIngestor_Status_ReturnsCopyOfCoverage(t *testing.T) {
+	ingestor := &CustomCostIngestor{
+		coverage: map[string]opencost.Window{},
+	}
+	start := time.Now().UTC()
+	end := start.Add(time.Hour)
+	ingestor.expandCoverage(opencost.NewWindow(&start, &end), "plugin-a")
+
+	status := ingestor.Status()
+	if len(status.Coverage) != 1 {
+		t.Fatalf("expected 1 coverage entry, got %d", len(status.Coverage))
+	}
+
+	// Mutating the returned map must not affect the ingestor.
+	status.Coverage["plugin-b"] = opencost.NewWindow(&start, &end)
+	delete(status.Coverage, "plugin-a")
+
+	again := ingestor.Status()
+	if _, ok := again.Coverage["plugin-a"]; !ok {
+		t.Error("plugin-a should remain in the ingestor's coverage; Status() leaked a live reference")
+	}
+	if _, ok := again.Coverage["plugin-b"]; ok {
+		t.Error("plugin-b leaked into the ingestor's coverage; Status() returned a live reference")
+	}
+}
+
+// TestIngestor_Status_ConcurrentWithExpandCoverage guards against a data race:
+// Status() returns the coverage map by reference while expandCoverage() writes
+// to it under coverageLock. The /customCost/status handler serializes the
+// returned map (which iterates it), racing the writer and crashing the process
+// with "concurrent map iteration and map write". Run with -race to detect it.
+func TestIngestor_Status_ConcurrentWithExpandCoverage(t *testing.T) {
+	ingestor := &CustomCostIngestor{
+		coverage: map[string]opencost.Window{},
+	}
+
+	start := time.Now().UTC()
+	end := start.Add(time.Hour)
+	window := opencost.NewWindow(&start, &end)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// writer: continuously expands coverage under the lock
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			ingestor.expandCoverage(window, fmt.Sprintf("plugin-%d", i%16))
+		}
+	}()
+
+	// reader: reads Status() and iterates the returned map, mimicking the JSON
+	// serialization the /customCost/status handler performs on the response
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			for range ingestor.Status().Coverage {
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestBuildSingleDomain_ClientError(t *testing.T) {
 	mock := &mockPluginConnector{
 		clientErr: fmt.Errorf("connection failed"),


### PR DESCRIPTION
## Description

Was reading through the custom-cost ingestor and noticed `Status()` returns the `coverage` map directly:

```go
return IngestorStatus{
    ...
    Coverage: ing.coverage,
    ...
}
```

The problem: `expandCoverage()` writes to that same map under `coverageLock`, but `Status()` reads and returns it without taking the lock. And `Status()` is called by the `/customCost/status` HTTP handler, which JSON-serializes the result - serializing a map iterates it. So if a status request lands while an ingestion cycle is writing coverage, you get concurrent iteration + write on the same map, i.e. `fatal error: concurrent map iteration and map write`. That one's not a normal panic - `recover()` can't catch it, the whole process goes down.

Since `/customCost/status` is unauthenticated and monitoring tends to poll status endpoints, it's not hard to hit once custom-cost plugins are enabled.

Fix is just to copy the map under the lock and return the copy. `expandCoverage` replaces the `Window` values wholesale (the `Window` methods are value receivers that return new `Window`s rather than mutating in place), so a shallow copy is enough - nothing shared stays mutable.

## Related Issues

No existing issue - found it reading the code. Happy to open one first if you'd prefer.

## User Impact

No behavior change - `Status()` returns the same data, just a private copy now. It removes a crash that can take the pod down when custom-cost plugins are enabled and the status endpoint is polled during ingestion.

## Testing

- Added `TestIngestor_Status_ConcurrentWithExpandCoverage`, which runs `Status()` and `expandCoverage()` concurrently. It trips the race detector on the old code (and can fatally crash), and passes with the fix.
- `go test ./pkg/customcost/ -race` - green
- `go vet`, `go build ./...`, `gofmt` - all clean
