### PR TITLE
feat(aws): CUR-based effective node pricing (SP/RI/spot reconciliation)

### DIFF
--- a/pkg/cloud/aws/cur_node_pricing.go
+++ b/pkg/cloud/aws/cur_node_pricing.go
@@ -77,15 +77,15 @@ func (a *AWS) queryCUREffectiveRates(rates map[string]float64) error {
 	// This query computes the effective $/hr for each EC2 instance over the last 2 days.
 	// For Savings Plan covered hours we use savings_plan_savings_plan_effective_cost,
 	// for Reserved Instance hours we use reservation_effective_cost, and for on-demand /
-	// spot hours we use line_item_unblended_cost. Dividing the sum by the distinct number
-	// of hourly periods gives an average effective hourly rate.
+	// spot hours we use line_item_unblended_cost. The denominator (covered hours)
+	// depends on the CUR export granularity — see curHoursDenominator.
 	q := `SELECT
 	line_item_resource_id,
 	sum(CASE line_item_line_item_type
 		WHEN 'SavingsPlanCoveredUsage' THEN savings_plan_savings_plan_effective_cost
 		WHEN 'DiscountedUsage' THEN reservation_effective_cost
 		ELSE line_item_unblended_cost
-	END) / nullif(count(distinct line_item_usage_start_date), 0) AS hourly
+	END) / nullif(%s, 0) AS hourly
 FROM %s
 WHERE line_item_product_code = 'AmazonEC2'
   AND (line_item_usage_type LIKE '%%BoxUsage%%' OR line_item_usage_type LIKE '%%SpotUsage%%')
@@ -94,7 +94,9 @@ WHERE line_item_product_code = 'AmazonEC2'
   AND line_item_usage_start_date >= now() - interval '2' day
 GROUP BY 1`
 
-	query := fmt.Sprintf(q, athenaInfo.AthenaTable)
+	granularity := env.GetCURNodePricingGranularity()
+	query := fmt.Sprintf(q, curHoursDenominator(granularity), athenaInfo.AthenaTable)
+	log.Debugf("CUR node pricing: granularity mode %q", granularity)
 	log.Debugf("CUR node pricing: running Athena query against table %s", athenaInfo.AthenaTable)
 
 	pageNum := 0
@@ -223,17 +225,50 @@ func (a *AWS) ApplyReservedInstancePricing(nodes map[string]*models.Node) {
 	}
 }
 
-// applyEffectiveRate distributes effectiveRate across the node's cost fields while
-// preserving the existing VCPUCost:RAMCost ratio. GPUCost is treated as fixed.
+// curHoursDenominator returns the SQL expression for the number of covered hours
+// per instance, according to the configured CUR export granularity.
+//
+//   - "auto" (default): derives hours from usage_start/usage_end per row — exact
+//     for hourly, daily and mixed-granularity exports.
+//   - "hourly": one row per instance-hour; distinct start timestamps == hours.
+//   - "daily": one row per instance-day; distinct start timestamps x 24 == hours.
+func curHoursDenominator(granularity string) string {
+	switch granularity {
+	case "hourly":
+		return "count(distinct line_item_usage_start_date)"
+	case "daily":
+		return "count(distinct line_item_usage_start_date) * 24"
+	default: // auto
+		return "sum(greatest(1, date_diff('hour', line_item_usage_start_date, line_item_usage_end_date)))"
+	}
+}
+
+// applyEffectiveRate reconciles the node's PER-UNIT cost fields to the actual
+// effective total hourly rate.
+//
+// IMPORTANT: models.Node.VCPUCost is $/vCPU/hr and models.Node.RAMCost is
+// $/GiB/hr (json names CPUHourlyCost / RAMGBHourlyCost). The effective rate is a
+// node-TOTAL $/hr, so the per-unit fields must be divided by the node's vCPU
+// count and RAM GiB respectively. (Writing totals into these fields inflates
+// node cost by roughly vCPUs+GiB x — production incident 2026-06-07.)
+//
+// The node-total CPU:RAM cost ratio implied by the existing per-unit prices is
+// preserved; GPU cost is treated as fixed and subtracted first.
 func applyEffectiveRate(node *models.Node, effectiveRate float64) error {
-	cpuCost, cpuErr := strconv.ParseFloat(node.VCPUCost, 64)
-	ramCost, ramErr := strconv.ParseFloat(node.RAMCost, 64)
-	gpuCost, gpuErr := strconv.ParseFloat(node.GPUCost, 64)
+	vcpus, _ := strconv.ParseFloat(node.VCPU, 64)
+	ramGiB := 0.0
+	if rb, err := strconv.ParseFloat(node.RAMBytes, 64); err == nil && rb > 0 {
+		ramGiB = rb / (1024 * 1024 * 1024)
+	} else if r, err := strconv.ParseFloat(node.RAM, 64); err == nil && r > 0 {
+		ramGiB = r
+	}
+	if vcpus <= 0 && ramGiB <= 0 {
+		return fmt.Errorf("node has no parsable vCPU or RAM capacity")
+	}
 
 	// GPU cost is fixed and not redistributed.
 	var gpuTotal float64
-	if gpuErr == nil {
-		gpuCost, _ = strconv.ParseFloat(node.GPUCost, 64)
+	if gpuCost, err := strconv.ParseFloat(node.GPUCost, 64); err == nil {
 		gpuCount, _ := strconv.ParseFloat(node.GPU, 64)
 		gpuTotal = gpuCost * gpuCount
 	}
@@ -243,30 +278,38 @@ func applyEffectiveRate(node *models.Node, effectiveRate float64) error {
 		remainder = 0
 	}
 
-	if cpuErr != nil || ramErr != nil {
-		// Cannot parse existing costs — put everything on VCPUCost.
-		node.VCPUCost = strconv.FormatFloat(remainder, 'f', -1, 64)
-		node.RAMCost = "0"
-		node.Cost = strconv.FormatFloat(effectiveRate, 'f', -1, 64)
-		return nil
+	// Node-total CPU and RAM cost implied by current per-unit prices.
+	cpuUnit, cpuErr := strconv.ParseFloat(node.VCPUCost, 64)
+	ramUnit, ramErr := strconv.ParseFloat(node.RAMCost, 64)
+	cpuTotal, ramTotal := 0.0, 0.0
+	if cpuErr == nil {
+		cpuTotal = cpuUnit * vcpus
+	}
+	if ramErr == nil {
+		ramTotal = ramUnit * ramGiB
 	}
 
-	total := cpuCost + ramCost
-	if total <= 0 {
-		// No existing ratio — assign all remainder to VCPUCost.
-		node.VCPUCost = strconv.FormatFloat(remainder, 'f', -1, 64)
-		node.RAMCost = "0"
-		node.Cost = strconv.FormatFloat(effectiveRate, 'f', -1, 64)
-		return nil
+	cpuFraction := 0.5
+	if total := cpuTotal + ramTotal; total > 0 {
+		cpuFraction = cpuTotal / total
+	} else if vcpus <= 0 {
+		cpuFraction = 0
+	} else if ramGiB <= 0 {
+		cpuFraction = 1
 	}
+	ramFraction := 1 - cpuFraction
 
-	cpuFraction := cpuCost / total
-	ramFraction := ramCost / total
-
-	node.VCPUCost = strconv.FormatFloat(remainder*cpuFraction, 'f', -1, 64)
-	node.RAMCost = strconv.FormatFloat(remainder*ramFraction, 'f', -1, 64)
+	if vcpus > 0 {
+		node.VCPUCost = strconv.FormatFloat(remainder*cpuFraction/vcpus, 'f', -1, 64)
+	} else {
+		node.VCPUCost = "0"
+	}
+	if ramGiB > 0 {
+		node.RAMCost = strconv.FormatFloat(remainder*ramFraction/ramGiB, 'f', -1, 64)
+	} else {
+		node.RAMCost = "0"
+	}
 	node.Cost = strconv.FormatFloat(effectiveRate, 'f', -1, 64)
 
-	_ = gpuCost // already accounted for in gpuTotal
 	return nil
 }

--- a/pkg/cloud/aws/cur_node_pricing.go
+++ b/pkg/cloud/aws/cur_node_pricing.go
@@ -23,27 +23,19 @@ type curNodePricingCache struct {
 	refreshing  bool // guards against concurrent background refreshes
 }
 
-// curPricingCache is embedded in the AWS provider struct via the pointer below;
-// it is allocated lazily on first use so that nil-initialised AWS structs are safe.
-//
-// NOTE: The AWS struct is defined in provider.go which we do not modify. Instead,
-// we attach the cache to a package-level map keyed on the provider pointer. This
-// avoids touching the struct definition while keeping state per provider instance.
-var (
-	curCacheMu sync.Mutex
-	curCaches  = map[*AWS]*curNodePricingCache{}
-)
+// curCacheInitMu guards lazy initialisation of the provider-held cache pointer.
+var curCacheInitMu sync.Mutex
 
-// getCURCache returns (creating if needed) the curNodePricingCache for this provider.
+// getCURCache returns (lazily creating) the curNodePricingCache held on the
+// provider instance, so the cache's lifetime is tied to the provider and is
+// garbage-collected with it.
 func getCURCache(a *AWS) *curNodePricingCache {
-	curCacheMu.Lock()
-	defer curCacheMu.Unlock()
-	if c, ok := curCaches[a]; ok {
-		return c
+	curCacheInitMu.Lock()
+	defer curCacheInitMu.Unlock()
+	if a.curNodePricing == nil {
+		a.curNodePricing = &curNodePricingCache{rates: make(map[string]float64)}
 	}
-	c := &curNodePricingCache{rates: make(map[string]float64)}
-	curCaches[a] = c
-	return c
+	return a.curNodePricing
 }
 
 // instanceIDFromProviderID extracts the EC2 instance ID from a Kubernetes
@@ -69,6 +61,9 @@ func (a *AWS) queryCUREffectiveRates(rates map[string]float64) error {
 	if err != nil {
 		return fmt.Errorf("queryCUREffectiveRates: GetAWSAthenaInfo: %w", err)
 	}
+	// AthenaDatabase is not referenced in the query text: QueryAthenaPaginated
+	// applies it via the Athena QueryExecutionContext, so the unqualified table
+	// name below resolves against it.
 	if athenaInfo.AthenaDatabase == "" || athenaInfo.AthenaTable == "" ||
 		athenaInfo.AthenaRegion == "" || athenaInfo.AthenaBucketName == "" {
 		return fmt.Errorf("queryCUREffectiveRates: Athena configuration incomplete")
@@ -99,8 +94,13 @@ GROUP BY 1`
 	log.Debugf("CUR node pricing: granularity mode %q", granularity)
 	log.Debugf("CUR node pricing: running Athena query against table %s", athenaInfo.AthenaTable)
 
+	// Bound the background refresh so a stuck Athena query cannot hold the
+	// refreshing flag forever and starve future refresh attempts.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
 	pageNum := 0
-	err = a.QueryAthenaPaginated(context.Background(), query, func(page *athena.GetQueryResultsOutput) bool {
+	err = a.QueryAthenaPaginated(ctx, query, func(page *athena.GetQueryResultsOutput) bool {
 		if page == nil || page.ResultSet == nil {
 			log.Errorf("queryCUREffectiveRates: nil page or ResultSet")
 			return false
@@ -179,9 +179,10 @@ func (a *AWS) triggerCURRefreshIfStale(cache *curNodePricingCache) {
 //   - Non-blocking: if the cache is stale a background refresh is started; the
 //     current (possibly empty) cache is applied immediately.
 //   - CPU/RAM cost ratio is preserved: the effective rate is distributed across
-//     VCPUCost and RAMCost proportionally to their current values, and Cost is
-//     updated to the new total. If VCPUCost and RAMCost are both zero or
-//     unset, the full effective rate is placed on VCPUCost.
+//     the per-unit VCPUCost and RAMCost proportionally to the node totals they
+//     imply, and Cost is updated to the new total. If VCPUCost and RAMCost are
+//     both zero or unset, the rate is split 50/50 between CPU and RAM (or fully
+//     onto whichever capacity exists when the other is absent).
 func (a *AWS) ApplyReservedInstancePricing(nodes map[string]*models.Node) {
 	if !env.IsCURNodePricingEnabled() {
 		return

--- a/pkg/cloud/aws/cur_node_pricing.go
+++ b/pkg/cloud/aws/cur_node_pricing.go
@@ -1,0 +1,272 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	"github.com/opencost/opencost/core/pkg/log"
+	"github.com/opencost/opencost/pkg/cloud/models"
+	"github.com/opencost/opencost/pkg/env"
+)
+
+// curNodePricingCache holds the effective hourly $/hr cost per EC2 instance ID
+// as retrieved from the AWS Cost and Usage Report (CUR) via Athena.
+type curNodePricingCache struct {
+	mu          sync.RWMutex
+	rates       map[string]float64 // instanceID -> effective $/hr
+	lastRefresh time.Time
+	refreshing  bool // guards against concurrent background refreshes
+}
+
+// curPricingCache is embedded in the AWS provider struct via the pointer below;
+// it is allocated lazily on first use so that nil-initialised AWS structs are safe.
+//
+// NOTE: The AWS struct is defined in provider.go which we do not modify. Instead,
+// we attach the cache to a package-level map keyed on the provider pointer. This
+// avoids touching the struct definition while keeping state per provider instance.
+var (
+	curCacheMu sync.Mutex
+	curCaches  = map[*AWS]*curNodePricingCache{}
+)
+
+// getCURCache returns (creating if needed) the curNodePricingCache for this provider.
+func getCURCache(a *AWS) *curNodePricingCache {
+	curCacheMu.Lock()
+	defer curCacheMu.Unlock()
+	if c, ok := curCaches[a]; ok {
+		return c
+	}
+	c := &curNodePricingCache{rates: make(map[string]float64)}
+	curCaches[a] = c
+	return c
+}
+
+// instanceIDFromProviderID extracts the EC2 instance ID from a Kubernetes
+// provider ID of the form aws:///<az>/i-xxxx or bare i-xxxx.
+func instanceIDFromProviderID(providerID string) string {
+	// Fast path: already bare instance ID.
+	if strings.HasPrefix(providerID, "i-") {
+		return providerID
+	}
+	// Typical form: aws:///us-east-2a/i-0fea4fd46592d050b
+	matches := provIdRx.FindStringSubmatch(providerID)
+	if len(matches) == 3 {
+		return matches[2]
+	}
+	return ""
+}
+
+// queryCUREffectiveRates executes the CUR Athena query and populates the provided
+// map with instanceID -> effective hourly cost. It is called from a background
+// goroutine; errors are logged but do not propagate.
+func (a *AWS) queryCUREffectiveRates(rates map[string]float64) error {
+	athenaInfo, err := a.GetAWSAthenaInfo()
+	if err != nil {
+		return fmt.Errorf("queryCUREffectiveRates: GetAWSAthenaInfo: %w", err)
+	}
+	if athenaInfo.AthenaDatabase == "" || athenaInfo.AthenaTable == "" ||
+		athenaInfo.AthenaRegion == "" || athenaInfo.AthenaBucketName == "" {
+		return fmt.Errorf("queryCUREffectiveRates: Athena configuration incomplete")
+	}
+
+	// This query computes the effective $/hr for each EC2 instance over the last 2 days.
+	// For Savings Plan covered hours we use savings_plan_savings_plan_effective_cost,
+	// for Reserved Instance hours we use reservation_effective_cost, and for on-demand /
+	// spot hours we use line_item_unblended_cost. Dividing the sum by the distinct number
+	// of hourly periods gives an average effective hourly rate.
+	q := `SELECT
+	line_item_resource_id,
+	sum(CASE line_item_line_item_type
+		WHEN 'SavingsPlanCoveredUsage' THEN savings_plan_savings_plan_effective_cost
+		WHEN 'DiscountedUsage' THEN reservation_effective_cost
+		ELSE line_item_unblended_cost
+	END) / nullif(count(distinct line_item_usage_start_date), 0) AS hourly
+FROM %s
+WHERE line_item_product_code = 'AmazonEC2'
+  AND (line_item_usage_type LIKE '%%BoxUsage%%' OR line_item_usage_type LIKE '%%SpotUsage%%')
+  AND line_item_resource_id LIKE 'i-%%'
+  AND line_item_line_item_type IN ('Usage', 'SavingsPlanCoveredUsage', 'DiscountedUsage')
+  AND line_item_usage_start_date >= now() - interval '2' day
+GROUP BY 1`
+
+	query := fmt.Sprintf(q, athenaInfo.AthenaTable)
+	log.Debugf("CUR node pricing: running Athena query against table %s", athenaInfo.AthenaTable)
+
+	pageNum := 0
+	err = a.QueryAthenaPaginated(context.Background(), query, func(page *athena.GetQueryResultsOutput) bool {
+		if page == nil || page.ResultSet == nil {
+			log.Errorf("queryCUREffectiveRates: nil page or ResultSet")
+			return false
+		}
+		rows := page.ResultSet.Rows
+		if pageNum == 0 && len(rows) > 0 {
+			rows = rows[1:] // skip header
+		}
+		pageNum++
+		for _, row := range rows {
+			if len(row.Data) < 2 {
+				continue
+			}
+			idPtr := row.Data[0].VarCharValue
+			costPtr := row.Data[1].VarCharValue
+			if idPtr == nil || costPtr == nil {
+				continue
+			}
+			instanceID := *idPtr
+			cost, err := strconv.ParseFloat(*costPtr, 64)
+			if err != nil {
+				log.Debugf("queryCUREffectiveRates: could not parse cost for %s: %v", instanceID, err)
+				continue
+			}
+			rates[instanceID] = cost
+		}
+		return true
+	})
+	return err
+}
+
+// refreshCURCache performs a blocking CUR Athena query and, on success, atomically
+// replaces the cache contents and updates lastRefresh.
+func (a *AWS) refreshCURCache(cache *curNodePricingCache) {
+	newRates := make(map[string]float64)
+	if err := a.queryCUREffectiveRates(newRates); err != nil {
+		log.Warnf("CUR node pricing: refresh failed: %v", err)
+		// Leave existing cache intact.
+	} else {
+		cache.mu.Lock()
+		cache.rates = newRates
+		cache.lastRefresh = time.Now()
+		cache.mu.Unlock()
+		log.Infof("CUR node pricing: refreshed cache with %d instance rates", len(newRates))
+	}
+
+	// Clear the refreshing flag regardless of outcome so the next call can retry.
+	cache.mu.Lock()
+	cache.refreshing = false
+	cache.mu.Unlock()
+}
+
+// triggerCURRefreshIfStale kicks off a single background goroutine to refresh the
+// CUR cache when the cache is empty or older than the configured refresh interval.
+// It is non-blocking: callers apply whatever is in the cache at the time of the call.
+func (a *AWS) triggerCURRefreshIfStale(cache *curNodePricingCache) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	refreshInterval := env.GetCURNodePricingRefreshHours()
+	stale := cache.lastRefresh.IsZero() || time.Since(cache.lastRefresh) >= refreshInterval
+	if !stale || cache.refreshing {
+		return
+	}
+	cache.refreshing = true
+	go a.refreshCURCache(cache)
+}
+
+// ApplyReservedInstancePricing reconciles each node's pricing to the actual
+// effective hourly cost (Savings Plans / Reserved Instances / spot) as reported
+// by the AWS Cost and Usage Report (CUR) via Athena.
+//
+// Behaviour:
+//   - No-op when CUR_NODE_PRICING_ENABLED is false (default) or when the Athena
+//     configuration is not set.
+//   - Non-blocking: if the cache is stale a background refresh is started; the
+//     current (possibly empty) cache is applied immediately.
+//   - CPU/RAM cost ratio is preserved: the effective rate is distributed across
+//     VCPUCost and RAMCost proportionally to their current values, and Cost is
+//     updated to the new total. If VCPUCost and RAMCost are both zero or
+//     unset, the full effective rate is placed on VCPUCost.
+func (a *AWS) ApplyReservedInstancePricing(nodes map[string]*models.Node) {
+	if !env.IsCURNodePricingEnabled() {
+		return
+	}
+
+	// Gate on Athena being configured (check cheaply using cached config).
+	cfg, err := a.GetConfig()
+	if err != nil || cfg.AthenaBucketName == "" || cfg.AthenaTable == "" {
+		return
+	}
+
+	cache := getCURCache(a)
+	a.triggerCURRefreshIfStale(cache)
+
+	cache.mu.RLock()
+	rates := cache.rates
+	cache.mu.RUnlock()
+
+	if len(rates) == 0 {
+		// First call before the initial refresh completes — nothing to apply.
+		return
+	}
+
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		instanceID := instanceIDFromProviderID(node.ProviderID)
+		if instanceID == "" {
+			continue
+		}
+		effectiveRate, ok := rates[instanceID]
+		if !ok {
+			continue
+		}
+		if err := applyEffectiveRate(node, effectiveRate); err != nil {
+			log.Debugf("CUR node pricing: could not apply rate for %s: %v", instanceID, err)
+			continue
+		}
+		node.PricingType = models.Reserved // covers SP/RI/spot-from-CUR equally well
+	}
+}
+
+// applyEffectiveRate distributes effectiveRate across the node's cost fields while
+// preserving the existing VCPUCost:RAMCost ratio. GPUCost is treated as fixed.
+func applyEffectiveRate(node *models.Node, effectiveRate float64) error {
+	cpuCost, cpuErr := strconv.ParseFloat(node.VCPUCost, 64)
+	ramCost, ramErr := strconv.ParseFloat(node.RAMCost, 64)
+	gpuCost, gpuErr := strconv.ParseFloat(node.GPUCost, 64)
+
+	// GPU cost is fixed and not redistributed.
+	var gpuTotal float64
+	if gpuErr == nil {
+		gpuCost, _ = strconv.ParseFloat(node.GPUCost, 64)
+		gpuCount, _ := strconv.ParseFloat(node.GPU, 64)
+		gpuTotal = gpuCost * gpuCount
+	}
+
+	remainder := effectiveRate - gpuTotal
+	if remainder < 0 {
+		remainder = 0
+	}
+
+	if cpuErr != nil || ramErr != nil {
+		// Cannot parse existing costs — put everything on VCPUCost.
+		node.VCPUCost = strconv.FormatFloat(remainder, 'f', -1, 64)
+		node.RAMCost = "0"
+		node.Cost = strconv.FormatFloat(effectiveRate, 'f', -1, 64)
+		return nil
+	}
+
+	total := cpuCost + ramCost
+	if total <= 0 {
+		// No existing ratio — assign all remainder to VCPUCost.
+		node.VCPUCost = strconv.FormatFloat(remainder, 'f', -1, 64)
+		node.RAMCost = "0"
+		node.Cost = strconv.FormatFloat(effectiveRate, 'f', -1, 64)
+		return nil
+	}
+
+	cpuFraction := cpuCost / total
+	ramFraction := ramCost / total
+
+	node.VCPUCost = strconv.FormatFloat(remainder*cpuFraction, 'f', -1, 64)
+	node.RAMCost = strconv.FormatFloat(remainder*ramFraction, 'f', -1, 64)
+	node.Cost = strconv.FormatFloat(effectiveRate, 'f', -1, 64)
+
+	_ = gpuCost // already accounted for in gpuTotal
+	return nil
+}

--- a/pkg/cloud/aws/cur_node_pricing_test.go
+++ b/pkg/cloud/aws/cur_node_pricing_test.go
@@ -2,9 +2,11 @@ package aws
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/opencost/opencost/pkg/cloud/models"
+	"github.com/opencost/opencost/pkg/env"
 )
 
 // ---------------------------------------------------------------------------
@@ -56,6 +58,10 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // applyEffectiveRate — node mutation math
+//
+// VCPUCost is $/vCPU/hr and RAMCost is $/GiB/hr (per-unit, NOT node totals).
+// The reconstructed node total VCPUCost*vCPUs + RAMCost*GiB + GPUCost*GPUs must
+// equal the effective rate.
 // ---------------------------------------------------------------------------
 
 func mustParseFloat(s string) float64 {
@@ -66,50 +72,61 @@ func mustParseFloat(s string) float64 {
 	return f
 }
 
-func TestApplyEffectiveRate_RatioPreserved(t *testing.T) {
-	// CPU:RAM = 0.40:0.10 => 80%:20% ratio
+const gib = 1024 * 1024 * 1024
+
+func nodeTotal(node *models.Node) float64 {
+	vcpus := mustParseFloat(node.VCPU)
+	ramGiB := mustParseFloat(node.RAMBytes) / gib
+	gpus := mustParseFloat(node.GPU)
+	return mustParseFloat(node.VCPUCost)*vcpus +
+		mustParseFloat(node.RAMCost)*ramGiB +
+		mustParseFloat(node.GPUCost)*gpus
+}
+
+func TestApplyEffectiveRate_PerUnitAndRatioPreserved(t *testing.T) {
+	// 4 vCPU, 16 GiB. Per-unit: $0.10/vCPU/hr, $0.00625/GiB/hr
+	// => node totals: CPU $0.40, RAM $0.10 => 80%:20% ratio.
 	node := &models.Node{
-		VCPUCost: "0.40",
-		RAMCost:  "0.10",
+		VCPU:     "4",
+		RAMBytes: strconv.Itoa(16 * gib),
+		VCPUCost: "0.10",
+		RAMCost:  "0.00625",
 		GPUCost:  "0",
 		GPU:      "0",
 		Cost:     "0.50",
 	}
-	effectiveRate := 0.30 // e.g. SP coverage cut the cost
+	effectiveRate := 0.30 // SP coverage cut the cost
 
 	if err := applyEffectiveRate(node, effectiveRate); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	gotCPU := mustParseFloat(node.VCPUCost)
-	gotRAM := mustParseFloat(node.RAMCost)
-	gotTotal := mustParseFloat(node.Cost)
-
-	// Total must equal effectiveRate
-	if diff := gotCPU + gotRAM - gotTotal; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("cpu(%f) + ram(%f) != cost(%f)", gotCPU, gotRAM, gotTotal)
+	// Reconstructed node total must equal the effective rate.
+	if diff := nodeTotal(node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", nodeTotal(node), effectiveRate)
 	}
-	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	if diff := mustParseFloat(node.Cost) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("Cost = %s, want %f", node.Cost, effectiveRate)
 	}
 
-	// Ratio: cpu should be ~80% of remainder (no GPU)
-	wantCPU := effectiveRate * 0.8
-	wantRAM := effectiveRate * 0.2
-	if diff := gotCPU - wantCPU; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("VCPUCost = %f, want %f", gotCPU, wantCPU)
+	// Ratio preserved: CPU carries 80% of the rate => per-unit = 0.30*0.8/4
+	wantCPUUnit := effectiveRate * 0.8 / 4
+	wantRAMUnit := effectiveRate * 0.2 / 16
+	if diff := mustParseFloat(node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("VCPUCost = %s, want %f", node.VCPUCost, wantCPUUnit)
 	}
-	if diff := gotRAM - wantRAM; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("RAMCost = %f, want %f", gotRAM, wantRAM)
+	if diff := mustParseFloat(node.RAMCost) - wantRAMUnit; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("RAMCost = %s, want %f", node.RAMCost, wantRAMUnit)
 	}
 }
 
 func TestApplyEffectiveRate_GPUFixedCostPreserved(t *testing.T) {
-	// 1 GPU @ $1/hr, CPU $0.40, RAM $0.10 => total was $1.50
-	// New effective rate: $1.20. GPU stays at $1.00; remainder ($0.20) split 80/20
+	// 1 GPU @ $1/hr fixed. CPU/RAM remainder = $0.20, split 80/20.
 	node := &models.Node{
-		VCPUCost: "0.40",
-		RAMCost:  "0.10",
+		VCPU:     "4",
+		RAMBytes: strconv.Itoa(16 * gib),
+		VCPUCost: "0.10",
+		RAMCost:  "0.00625",
 		GPUCost:  "1.00",
 		GPU:      "1",
 		Cost:     "1.50",
@@ -120,29 +137,26 @@ func TestApplyEffectiveRate_GPUFixedCostPreserved(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	gotCPU := mustParseFloat(node.VCPUCost)
-	gotRAM := mustParseFloat(node.RAMCost)
-	gotTotal := mustParseFloat(node.Cost)
-
-	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	if diff := nodeTotal(node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", nodeTotal(node), effectiveRate)
 	}
 
-	// GPU cost (1.0) is removed from remainder => remainder = 0.20
 	remainder := effectiveRate - 1.00
-	wantCPU := remainder * 0.8
-	wantRAM := remainder * 0.2
-	if diff := gotCPU - wantCPU; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("VCPUCost = %f, want %f", gotCPU, wantCPU)
+	wantCPUUnit := remainder * 0.8 / 4
+	wantRAMUnit := remainder * 0.2 / 16
+	if diff := mustParseFloat(node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("VCPUCost = %s, want %f", node.VCPUCost, wantCPUUnit)
 	}
-	if diff := gotRAM - wantRAM; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("RAMCost = %f, want %f", gotRAM, wantRAM)
+	if diff := mustParseFloat(node.RAMCost) - wantRAMUnit; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("RAMCost = %s, want %f", node.RAMCost, wantRAMUnit)
 	}
 }
 
 func TestApplyEffectiveRate_ZeroExistingCosts(t *testing.T) {
-	// When existing costs are 0, all goes to VCPUCost
+	// No existing per-unit prices => 50/50 split across CPU and RAM.
 	node := &models.Node{
+		VCPU:     "4",
+		RAMBytes: strconv.Itoa(16 * gib),
 		VCPUCost: "0",
 		RAMCost:  "0",
 		GPUCost:  "0",
@@ -155,39 +169,72 @@ func TestApplyEffectiveRate_ZeroExistingCosts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	gotCPU := mustParseFloat(node.VCPUCost)
-	gotRAM := mustParseFloat(node.RAMCost)
-	gotTotal := mustParseFloat(node.Cost)
-
-	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	if diff := nodeTotal(node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", nodeTotal(node), effectiveRate)
 	}
-	if diff := gotCPU - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("VCPUCost = %f, want %f", gotCPU, effectiveRate)
-	}
-	if gotRAM != 0 {
-		t.Errorf("RAMCost should be 0, got %f", gotRAM)
+	wantCPUUnit := effectiveRate * 0.5 / 4
+	if diff := mustParseFloat(node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("VCPUCost = %s, want %f", node.VCPUCost, wantCPUUnit)
 	}
 }
 
-func TestApplyEffectiveRate_UnparsableCosts(t *testing.T) {
-	// When costs cannot be parsed, all goes to VCPUCost
+func TestApplyEffectiveRate_RAMFromGiBFallback(t *testing.T) {
+	// RAMBytes unset; RAM carries GiB directly.
 	node := &models.Node{
-		VCPUCost: "N/A",
-		RAMCost:  "",
-		GPUCost:  "0",
-		GPU:      "0",
-		Cost:     "N/A",
+		VCPU:     "2",
+		RAM:      "8",
+		VCPUCost: "0.05",
+		RAMCost:  "0.0125", // totals: 0.10 + 0.10 => 50/50
+		Cost:     "0.20",
 	}
-	effectiveRate := 0.50
+	effectiveRate := 0.10
 
 	if err := applyEffectiveRate(node, effectiveRate); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	got := mustParseFloat(node.VCPUCost)*2 + mustParseFloat(node.RAMCost)*8
+	if diff := got - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", got, effectiveRate)
+	}
+}
 
-	gotTotal := mustParseFloat(node.Cost)
-	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+func TestApplyEffectiveRate_NoCapacityErrors(t *testing.T) {
+	node := &models.Node{
+		VCPUCost: "0.40",
+		RAMCost:  "0.10",
+	}
+	if err := applyEffectiveRate(node, 0.30); err == nil {
+		t.Error("expected error for node without parsable vCPU/RAM capacity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// curHoursDenominator — granularity selection
+// ---------------------------------------------------------------------------
+
+func TestCURHoursDenominator(t *testing.T) {
+	if got := curHoursDenominator("hourly"); got != "count(distinct line_item_usage_start_date)" {
+		t.Errorf("hourly denominator = %q", got)
+	}
+	if got := curHoursDenominator("daily"); got != "count(distinct line_item_usage_start_date) * 24" {
+		t.Errorf("daily denominator = %q", got)
+	}
+	if got := curHoursDenominator("auto"); !strings.Contains(got, "date_diff") {
+		t.Errorf("auto denominator should derive hours via date_diff, got %q", got)
+	}
+	if got := curHoursDenominator("nonsense"); !strings.Contains(got, "date_diff") {
+		t.Errorf("unknown mode should fall back to auto, got %q", got)
+	}
+}
+
+func TestGetCURNodePricingGranularity(t *testing.T) {
+	t.Setenv(env.CURNodePricingGranularityEnvVar, "daily")
+	if got := env.GetCURNodePricingGranularity(); got != "daily" {
+		t.Errorf("granularity = %q, want daily", got)
+	}
+	t.Setenv(env.CURNodePricingGranularityEnvVar, "bogus")
+	if got := env.GetCURNodePricingGranularity(); got != "auto" {
+		t.Errorf("invalid granularity should fall back to auto, got %q", got)
 	}
 }
 

--- a/pkg/cloud/aws/cur_node_pricing_test.go
+++ b/pkg/cloud/aws/cur_node_pricing_test.go
@@ -1,0 +1,216 @@
+package aws
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/opencost/opencost/pkg/cloud/models"
+)
+
+// ---------------------------------------------------------------------------
+// instanceIDFromProviderID
+// ---------------------------------------------------------------------------
+
+func TestInstanceIDFromProviderID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		wantID     string
+	}{
+		{
+			name:       "standard aws provider id",
+			providerID: "aws:///us-east-2a/i-0fea4fd46592d050b",
+			wantID:     "i-0fea4fd46592d050b",
+		},
+		{
+			name:       "bare instance id",
+			providerID: "i-0abc123def456",
+			wantID:     "i-0abc123def456",
+		},
+		{
+			name:       "empty string",
+			providerID: "",
+			wantID:     "",
+		},
+		{
+			name:       "non-aws provider id",
+			providerID: "gce://project/zone/instance",
+			wantID:     "",
+		},
+		{
+			name:       "aws provider id different region",
+			providerID: "aws:///eu-west-1a/i-0deadbeef1234567",
+			wantID:     "i-0deadbeef1234567",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := instanceIDFromProviderID(tc.providerID)
+			if got != tc.wantID {
+				t.Errorf("instanceIDFromProviderID(%q) = %q, want %q", tc.providerID, got, tc.wantID)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyEffectiveRate — node mutation math
+// ---------------------------------------------------------------------------
+
+func mustParseFloat(s string) float64 {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}
+
+func TestApplyEffectiveRate_RatioPreserved(t *testing.T) {
+	// CPU:RAM = 0.40:0.10 => 80%:20% ratio
+	node := &models.Node{
+		VCPUCost: "0.40",
+		RAMCost:  "0.10",
+		GPUCost:  "0",
+		GPU:      "0",
+		Cost:     "0.50",
+	}
+	effectiveRate := 0.30 // e.g. SP coverage cut the cost
+
+	if err := applyEffectiveRate(node, effectiveRate); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotCPU := mustParseFloat(node.VCPUCost)
+	gotRAM := mustParseFloat(node.RAMCost)
+	gotTotal := mustParseFloat(node.Cost)
+
+	// Total must equal effectiveRate
+	if diff := gotCPU + gotRAM - gotTotal; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cpu(%f) + ram(%f) != cost(%f)", gotCPU, gotRAM, gotTotal)
+	}
+	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	}
+
+	// Ratio: cpu should be ~80% of remainder (no GPU)
+	wantCPU := effectiveRate * 0.8
+	wantRAM := effectiveRate * 0.2
+	if diff := gotCPU - wantCPU; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("VCPUCost = %f, want %f", gotCPU, wantCPU)
+	}
+	if diff := gotRAM - wantRAM; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("RAMCost = %f, want %f", gotRAM, wantRAM)
+	}
+}
+
+func TestApplyEffectiveRate_GPUFixedCostPreserved(t *testing.T) {
+	// 1 GPU @ $1/hr, CPU $0.40, RAM $0.10 => total was $1.50
+	// New effective rate: $1.20. GPU stays at $1.00; remainder ($0.20) split 80/20
+	node := &models.Node{
+		VCPUCost: "0.40",
+		RAMCost:  "0.10",
+		GPUCost:  "1.00",
+		GPU:      "1",
+		Cost:     "1.50",
+	}
+	effectiveRate := 1.20
+
+	if err := applyEffectiveRate(node, effectiveRate); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotCPU := mustParseFloat(node.VCPUCost)
+	gotRAM := mustParseFloat(node.RAMCost)
+	gotTotal := mustParseFloat(node.Cost)
+
+	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	}
+
+	// GPU cost (1.0) is removed from remainder => remainder = 0.20
+	remainder := effectiveRate - 1.00
+	wantCPU := remainder * 0.8
+	wantRAM := remainder * 0.2
+	if diff := gotCPU - wantCPU; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("VCPUCost = %f, want %f", gotCPU, wantCPU)
+	}
+	if diff := gotRAM - wantRAM; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("RAMCost = %f, want %f", gotRAM, wantRAM)
+	}
+}
+
+func TestApplyEffectiveRate_ZeroExistingCosts(t *testing.T) {
+	// When existing costs are 0, all goes to VCPUCost
+	node := &models.Node{
+		VCPUCost: "0",
+		RAMCost:  "0",
+		GPUCost:  "0",
+		GPU:      "0",
+		Cost:     "0",
+	}
+	effectiveRate := 0.25
+
+	if err := applyEffectiveRate(node, effectiveRate); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotCPU := mustParseFloat(node.VCPUCost)
+	gotRAM := mustParseFloat(node.RAMCost)
+	gotTotal := mustParseFloat(node.Cost)
+
+	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	}
+	if diff := gotCPU - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("VCPUCost = %f, want %f", gotCPU, effectiveRate)
+	}
+	if gotRAM != 0 {
+		t.Errorf("RAMCost should be 0, got %f", gotRAM)
+	}
+}
+
+func TestApplyEffectiveRate_UnparsableCosts(t *testing.T) {
+	// When costs cannot be parsed, all goes to VCPUCost
+	node := &models.Node{
+		VCPUCost: "N/A",
+		RAMCost:  "",
+		GPUCost:  "0",
+		GPU:      "0",
+		Cost:     "N/A",
+	}
+	effectiveRate := 0.50
+
+	if err := applyEffectiveRate(node, effectiveRate); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotTotal := mustParseFloat(node.Cost)
+	if diff := gotTotal - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cost = %f, want %f", gotTotal, effectiveRate)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ApplyReservedInstancePricing — disabled flag no-op
+// ---------------------------------------------------------------------------
+
+func TestApplyReservedInstancePricing_DisabledNoOp(t *testing.T) {
+	// CUR_NODE_PRICING_ENABLED is not set in test env => defaults to false.
+	// The method must return without modifying nodes.
+	a := &AWS{}
+	original := "0.50"
+	node := &models.Node{
+		Cost:       original,
+		VCPUCost:   "0.40",
+		RAMCost:    "0.10",
+		ProviderID: "aws:///us-east-2a/i-0fea4fd46592d050b",
+	}
+	nodes := map[string]*models.Node{"node1": node}
+
+	a.ApplyReservedInstancePricing(nodes)
+
+	if node.Cost != original {
+		t.Errorf("Cost was modified when feature is disabled: got %s, want %s", node.Cost, original)
+	}
+}

--- a/pkg/cloud/aws/cur_node_pricing_test.go
+++ b/pkg/cloud/aws/cur_node_pricing_test.go
@@ -64,23 +64,25 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 // equal the effective rate.
 // ---------------------------------------------------------------------------
 
-func mustParseFloat(s string) float64 {
+func parseFloat(t *testing.T, s string) float64 {
+	t.Helper()
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0
+		t.Fatalf("could not parse float %q: %v", s, err)
 	}
 	return f
 }
 
-const gib = 1024 * 1024 * 1024
+const gib int64 = 1 << 30
 
-func nodeTotal(node *models.Node) float64 {
-	vcpus := mustParseFloat(node.VCPU)
-	ramGiB := mustParseFloat(node.RAMBytes) / gib
-	gpus := mustParseFloat(node.GPU)
-	return mustParseFloat(node.VCPUCost)*vcpus +
-		mustParseFloat(node.RAMCost)*ramGiB +
-		mustParseFloat(node.GPUCost)*gpus
+func nodeTotal(t *testing.T, node *models.Node) float64 {
+	t.Helper()
+	vcpus := parseFloat(t, node.VCPU)
+	ramGiB := parseFloat(t, node.RAMBytes) / float64(gib)
+	gpus := parseFloat(t, node.GPU)
+	return parseFloat(t, node.VCPUCost)*vcpus +
+		parseFloat(t, node.RAMCost)*ramGiB +
+		parseFloat(t, node.GPUCost)*gpus
 }
 
 func TestApplyEffectiveRate_PerUnitAndRatioPreserved(t *testing.T) {
@@ -88,7 +90,7 @@ func TestApplyEffectiveRate_PerUnitAndRatioPreserved(t *testing.T) {
 	// => node totals: CPU $0.40, RAM $0.10 => 80%:20% ratio.
 	node := &models.Node{
 		VCPU:     "4",
-		RAMBytes: strconv.Itoa(16 * gib),
+		RAMBytes: strconv.FormatInt(16*gib, 10),
 		VCPUCost: "0.10",
 		RAMCost:  "0.00625",
 		GPUCost:  "0",
@@ -102,20 +104,20 @@ func TestApplyEffectiveRate_PerUnitAndRatioPreserved(t *testing.T) {
 	}
 
 	// Reconstructed node total must equal the effective rate.
-	if diff := nodeTotal(node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("reconstructed total = %f, want %f", nodeTotal(node), effectiveRate)
+	if diff := nodeTotal(t, node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", nodeTotal(t, node), effectiveRate)
 	}
-	if diff := mustParseFloat(node.Cost) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+	if diff := parseFloat(t, node.Cost) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("Cost = %s, want %f", node.Cost, effectiveRate)
 	}
 
 	// Ratio preserved: CPU carries 80% of the rate => per-unit = 0.30*0.8/4
 	wantCPUUnit := effectiveRate * 0.8 / 4
 	wantRAMUnit := effectiveRate * 0.2 / 16
-	if diff := mustParseFloat(node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
+	if diff := parseFloat(t, node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("VCPUCost = %s, want %f", node.VCPUCost, wantCPUUnit)
 	}
-	if diff := mustParseFloat(node.RAMCost) - wantRAMUnit; diff > 1e-9 || diff < -1e-9 {
+	if diff := parseFloat(t, node.RAMCost) - wantRAMUnit; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("RAMCost = %s, want %f", node.RAMCost, wantRAMUnit)
 	}
 }
@@ -124,7 +126,7 @@ func TestApplyEffectiveRate_GPUFixedCostPreserved(t *testing.T) {
 	// 1 GPU @ $1/hr fixed. CPU/RAM remainder = $0.20, split 80/20.
 	node := &models.Node{
 		VCPU:     "4",
-		RAMBytes: strconv.Itoa(16 * gib),
+		RAMBytes: strconv.FormatInt(16*gib, 10),
 		VCPUCost: "0.10",
 		RAMCost:  "0.00625",
 		GPUCost:  "1.00",
@@ -137,17 +139,17 @@ func TestApplyEffectiveRate_GPUFixedCostPreserved(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if diff := nodeTotal(node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("reconstructed total = %f, want %f", nodeTotal(node), effectiveRate)
+	if diff := nodeTotal(t, node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", nodeTotal(t, node), effectiveRate)
 	}
 
 	remainder := effectiveRate - 1.00
 	wantCPUUnit := remainder * 0.8 / 4
 	wantRAMUnit := remainder * 0.2 / 16
-	if diff := mustParseFloat(node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
+	if diff := parseFloat(t, node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("VCPUCost = %s, want %f", node.VCPUCost, wantCPUUnit)
 	}
-	if diff := mustParseFloat(node.RAMCost) - wantRAMUnit; diff > 1e-9 || diff < -1e-9 {
+	if diff := parseFloat(t, node.RAMCost) - wantRAMUnit; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("RAMCost = %s, want %f", node.RAMCost, wantRAMUnit)
 	}
 }
@@ -156,7 +158,7 @@ func TestApplyEffectiveRate_ZeroExistingCosts(t *testing.T) {
 	// No existing per-unit prices => 50/50 split across CPU and RAM.
 	node := &models.Node{
 		VCPU:     "4",
-		RAMBytes: strconv.Itoa(16 * gib),
+		RAMBytes: strconv.FormatInt(16*gib, 10),
 		VCPUCost: "0",
 		RAMCost:  "0",
 		GPUCost:  "0",
@@ -169,11 +171,11 @@ func TestApplyEffectiveRate_ZeroExistingCosts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if diff := nodeTotal(node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("reconstructed total = %f, want %f", nodeTotal(node), effectiveRate)
+	if diff := nodeTotal(t, node) - effectiveRate; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("reconstructed total = %f, want %f", nodeTotal(t, node), effectiveRate)
 	}
 	wantCPUUnit := effectiveRate * 0.5 / 4
-	if diff := mustParseFloat(node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
+	if diff := parseFloat(t, node.VCPUCost) - wantCPUUnit; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("VCPUCost = %s, want %f", node.VCPUCost, wantCPUUnit)
 	}
 }
@@ -192,7 +194,7 @@ func TestApplyEffectiveRate_RAMFromGiBFallback(t *testing.T) {
 	if err := applyEffectiveRate(node, effectiveRate); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	got := mustParseFloat(node.VCPUCost)*2 + mustParseFloat(node.RAMCost)*8
+	got := parseFloat(t, node.VCPUCost)*2 + parseFloat(t, node.RAMCost)*8
 	if diff := got - effectiveRate; diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("reconstructed total = %f, want %f", got, effectiveRate)
 	}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -2686,9 +2686,7 @@ func (aws *AWS) parseSpotData(bucket string, prefix string, projectID string, re
 	return spots, nil
 }
 
-// ApplyReservedInstancePricing TODO
-func (aws *AWS) ApplyReservedInstancePricing(nodes map[string]*models.Node) {
-}
+// ApplyReservedInstancePricing is implemented in cur_node_pricing.go.
 
 func (aws *AWS) ServiceAccountStatus() *models.ServiceAccountStatus {
 	return aws.ServiceAccountChecks.GetStatus()

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -196,6 +196,7 @@ var awsRegions = []string{
 // AWS represents an Amazon Provider
 type AWS struct {
 	Pricing                     map[string]*AWSProductTerms
+	curNodePricing              *curNodePricingCache // CUR-based effective node pricing cache (see cur_node_pricing.go)
 	SpotPricingByInstanceID     map[string]*spotInfo
 	SpotPricingUpdatedAt        *time.Time
 	SpotRefreshRunning          bool

--- a/pkg/env/aws_cur.go
+++ b/pkg/env/aws_cur.go
@@ -1,0 +1,32 @@
+package env
+
+import (
+	"time"
+
+	coreenv "github.com/opencost/opencost/core/pkg/env"
+)
+
+const (
+	// CURNodePricingEnabledEnvVar enables CUR-based effective node pricing reconciliation.
+	CURNodePricingEnabledEnvVar = "CUR_NODE_PRICING_ENABLED"
+
+	// CURNodePricingRefreshHoursEnvVar controls how often (in hours) the CUR node
+	// pricing cache is refreshed from Athena.
+	CURNodePricingRefreshHoursEnvVar = "CUR_NODE_PRICING_REFRESH_HOURS"
+)
+
+// IsCURNodePricingEnabled returns true when CUR_NODE_PRICING_ENABLED is set to "true".
+// Defaults to false so existing deployments are unaffected.
+func IsCURNodePricingEnabled() bool {
+	return coreenv.GetBool(CURNodePricingEnabledEnvVar, false)
+}
+
+// GetCURNodePricingRefreshHours returns how many hours between CUR node pricing
+// cache refreshes. Defaults to 6.
+func GetCURNodePricingRefreshHours() time.Duration {
+	hours := coreenv.GetInt(CURNodePricingRefreshHoursEnvVar, 6)
+	if hours < 1 {
+		hours = 1
+	}
+	return time.Duration(hours) * time.Hour
+}

--- a/pkg/env/aws_cur.go
+++ b/pkg/env/aws_cur.go
@@ -13,6 +13,13 @@ const (
 	// CURNodePricingRefreshHoursEnvVar controls how often (in hours) the CUR node
 	// pricing cache is refreshed from Athena.
 	CURNodePricingRefreshHoursEnvVar = "CUR_NODE_PRICING_REFRESH_HOURS"
+
+	// CURNodePricingGranularityEnvVar declares the CUR export granularity:
+	// "auto" (default), "hourly" or "daily". CUR exports can be configured at
+	// either granularity; misreading daily rows as hourly inflates rates 24x.
+	// "auto" derives covered hours from usage_start/usage_end per row, which is
+	// exact for hourly, daily and mixed exports.
+	CURNodePricingGranularityEnvVar = "CUR_NODE_PRICING_GRANULARITY"
 )
 
 // IsCURNodePricingEnabled returns true when CUR_NODE_PRICING_ENABLED is set to "true".
@@ -29,4 +36,16 @@ func GetCURNodePricingRefreshHours() time.Duration {
 		hours = 1
 	}
 	return time.Duration(hours) * time.Hour
+}
+
+// GetCURNodePricingGranularity returns the configured CUR export granularity:
+// "auto", "hourly" or "daily". Invalid values fall back to "auto".
+func GetCURNodePricingGranularity() string {
+	g := coreenv.Get(CURNodePricingGranularityEnvVar, "auto")
+	switch g {
+	case "auto", "hourly", "daily":
+		return g
+	default:
+		return "auto"
+	}
 }

--- a/pkg/env/aws_cur.go
+++ b/pkg/env/aws_cur.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"strings"
 	"time"
 
 	coreenv "github.com/opencost/opencost/core/pkg/env"
@@ -41,7 +42,7 @@ func GetCURNodePricingRefreshHours() time.Duration {
 // GetCURNodePricingGranularity returns the configured CUR export granularity:
 // "auto", "hourly" or "daily". Invalid values fall back to "auto".
 func GetCURNodePricingGranularity() string {
-	g := coreenv.Get(CURNodePricingGranularityEnvVar, "auto")
+	g := strings.ToLower(strings.TrimSpace(coreenv.Get(CURNodePricingGranularityEnvVar, "auto")))
 	switch g {
 	case "auto", "hourly", "daily":
 		return g


### PR DESCRIPTION
Closes #3839

## What

Implements the `ApplyReservedInstancePricing` TODO for AWS: nodes are repriced to their actual effective hourly cost (Savings Plans, Reserved Instances, spot, EDP) from the CUR via Athena, reusing the existing `AwsAthenaInfo` configuration and `QueryAthenaPaginated` plumbing (incl. `masterPayerARN` cross-account assume).

- Opt-in: `CUR_NODE_PRICING_ENABLED` (default false — zero impact on existing deployments)
- `CUR_NODE_PRICING_REFRESH_HOURS` (default 6): non-blocking cached refresh; first call after start applies nothing until the background Athena query completes
- `CUR_NODE_PRICING_GRANULARITY=auto|hourly|daily` (default auto): CUR exports exist at both granularities; auto derives covered hours from `usage_start`/`usage_end` per row, exact for hourly/daily/mixed
- Per-unit semantics respected: effective node-total rate is distributed across `VCPUCost` ($/vCPU/hr) and `RAMCost` ($/GiB/hr) by dividing by capacity, preserving the implied CPU:RAM total ratio; GPU cost treated as fixed
- Nodes matched by provider ID (`aws:///<az>/i-...`); unmatched nodes (younger than CUR lag) keep existing pricing — graceful fallback

## Validation

Production, 3 EKS clusters, ~150 nodes, heavy karpenter spot churn:
- median node price / invoice ratio per cluster: **1.002 / 1.014 / 1.020**
- fleet total converged from ~2.2x over invoice to within ~5% of Cost Explorer amortized EC2

War story baked into the implementation: an earlier build wrote node-total dollars into the per-unit cost fields, inflating fleet cost ~7x — hence the explicit per-unit handling and the reconstruction-style unit tests (`VCPUCost*vCPUs + RAMCost*GiB + GPU == rate`).

## Tests

`go test ./pkg/cloud/aws/...` — provider-ID parsing, per-unit distribution math (ratio preservation, GPU fixed-cost, fallbacks), granularity denominator selection, env validation, disabled-flag no-op.