### PR TITLE
Support GKE Workload Identity Federation to Provider Pricing Data

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1373,9 +1373,12 @@ func (gcp *GCP) getReservedInstances() ([]*GCPReservedInstance, error) {
 		return nil, err
 	}
 
-	projID, err := gcp.MetadataClient.ProjectID()
-	if err != nil {
-		return nil, err
+	projID := gcp.ProjectID
+	if projID == "" {
+		projID, err = gcp.MetadataClient.ProjectID()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	commitments, err := computeService.RegionCommitments.AggregatedList(projID).Do()

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -39,6 +39,7 @@ import (
 const GKE_GPU_TAG = "cloud.google.com/gke-accelerator"
 const BigqueryUpdateType = "bigqueryupdate"
 const BillingAPIURL = "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus"
+const GCPCloudOAuthScope = "https://www.googleapis.com/auth/cloud-platform"
 
 const (
 	GCPHourlyPublicIPCost = 0.01
@@ -981,7 +982,7 @@ func (gcp *GCP) getBillingAPIClientAndURL(apiKey, currencyCode string) (*http.Cl
 		return http.DefaultClient, url.String(), nil
 	}
 
-	googleHttpClient, err := google.DefaultClient(context.TODO(), "https://www.googleapis.com/auth/cloud-platform")
+	googleHttpClient, err := google.DefaultClient(context.TODO(), GCPCloudOAuthScope)
 	if err != nil {
 		log.Errorf("GCP Billing API: Workload Identity detected but failed to create authenticated client: %v", err)
 		return nil, "", err

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1373,7 +1373,12 @@ func (gcp *GCP) getReservedInstances() ([]*GCPReservedInstance, error) {
 		return nil, err
 	}
 
-	commitments, err := computeService.RegionCommitments.AggregatedList(gcp.ProjectID).Do()
+	projID, err := gcp.MetadataClient.ProjectID()
+	if err != nil {
+		return nil, err
+	}
+
+	commitments, err := computeService.RegionCommitments.AggregatedList(projID).Do()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"regexp"
@@ -37,7 +38,7 @@ import (
 
 const GKE_GPU_TAG = "cloud.google.com/gke-accelerator"
 const BigqueryUpdateType = "bigqueryupdate"
-const BillingAPIURLFmt = "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus?key=%s&currencyCode=%s"
+const BillingAPIURL = "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus"
 
 const (
 	GCPHourlyPublicIPCost = 0.01
@@ -955,8 +956,38 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 	return gcpPricingList, nextPageToken, nil
 }
 
-func (gcp *GCP) getBillingAPIURL(apiKey, currencyCode string) string {
-	return fmt.Sprintf(BillingAPIURLFmt, apiKey, currencyCode)
+func (gcp *GCP) buildBillingAPIURL(apiKey, currencyCode string) *url.URL {
+	url, err := url.Parse(BillingAPIURL)
+	if err != nil {
+		panic("BillingAPIURL must be a valid URL")
+	}
+
+	query := url.Query()
+	query.Add("currencyCode", currencyCode)
+
+	if apiKey != "" {
+		query.Add("key", apiKey)
+	}
+
+	url.RawQuery = query.Encode()
+
+	return url
+}
+
+func (gcp *GCP) getBillingAPIClientAndURL(apiKey, currencyCode string) (*http.Client, string, error) {
+	url := gcp.buildBillingAPIURL(apiKey, currencyCode)
+
+	if apiKey != "" {
+		return http.DefaultClient, url.String(), nil
+	}
+
+	googleHttpClient, err := google.DefaultClient(context.TODO(), "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		log.Errorf("GCP Billing API: Workload Identity detected but failed to create authenticated client: %v", err)
+		return nil, "", err
+	}
+
+	return googleHttpClient, url.String(), nil
 }
 
 func (gcp *GCP) parsePages(inputKeys map[string]models.Key, pvKeys map[string]models.PVKey) (map[string]*GCPPricing, error) {
@@ -966,7 +997,10 @@ func (gcp *GCP) parsePages(inputKeys map[string]models.Key, pvKeys map[string]mo
 		return nil, err
 	}
 
-	url := gcp.getBillingAPIURL(gcp.APIKey, c.CurrencyCode)
+	httpClient, url, err := gcp.getBillingAPIClientAndURL(gcp.APIKey, c.CurrencyCode)
+	if err != nil {
+		return nil, err
+	}
 
 	var parsePagesHelper func(string) error
 	parsePagesHelper = func(pageToken string) error {
@@ -975,7 +1009,7 @@ func (gcp *GCP) parsePages(inputKeys map[string]models.Key, pvKeys map[string]mo
 		} else if pageToken != "" {
 			url = url + "&pageToken=" + pageToken
 		}
-		resp, err := http.Get(url)
+		resp, err := httpClient.Get(url)
 		if err != nil {
 			return err
 		}
@@ -1568,7 +1602,7 @@ func (gcp *GCP) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 		log.Debugf("Returning pricing for node %s: %+v from SKU %s", key, n.Node, n.Name)
 
 		// Add pricing URL, but redact the key (hence, "***"")
-		meta.Source = fmt.Sprintf("Downloaded pricing from %s", gcp.getBillingAPIURL("***", c.CurrencyCode))
+		meta.Source = fmt.Sprintf("Downloaded pricing from %s", gcp.buildBillingAPIURL("***", c.CurrencyCode))
 
 		n.Node.BaseCPUPrice = gcp.BaseCPUPrice
 
@@ -1588,7 +1622,7 @@ func (gcp *GCP) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 			log.Debugf("Returning pricing for node %s: %+v from SKU %s", key, n.Node, n.Name)
 
 			// Add pricing URL, but redact the key (hence, "***"")
-			meta.Source = fmt.Sprintf("Downloaded pricing from %s", gcp.getBillingAPIURL("***", c.CurrencyCode))
+			meta.Source = fmt.Sprintf("Downloaded pricing from %s", gcp.buildBillingAPIURL("***", c.CurrencyCode))
 
 			n.Node.BaseCPUPrice = gcp.BaseCPUPrice
 

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -707,11 +709,62 @@ func TestGCP_findCostForDisk(t *testing.T) {
 }
 
 func TestGCP_getBillingAPIURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiKey         string
+		currency       string
+		expectedParams map[string]string
+		absentParams   []string
+	}{
+		{
+			name:           "with API key and currency",
+			apiKey:         "test-key",
+			currency:       "USD",
+			expectedParams: map[string]string{"key": "test-key", "currencyCode": "USD"},
+		},
+		{
+			name:           "empty API key omits key param",
+			apiKey:         "",
+			currency:       "USD",
+			expectedParams: map[string]string{"currencyCode": "USD"},
+			absentParams:   []string{"key"},
+		},
+		{
+			name:           "non-USD currency",
+			apiKey:         "my-key",
+			currency:       "EUR",
+			expectedParams: map[string]string{"key": "my-key", "currencyCode": "EUR"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gcp := &GCP{}
+			query := gcp.buildBillingAPIURL(tt.apiKey, tt.currency).Query()
+
+			for param, expected := range tt.expectedParams {
+				assert.Equal(t, expected, query.Get(param), "query param %q", param)
+			}
+			for _, param := range tt.absentParams {
+				assert.False(t, query.Has(param), "query param %q should be absent", param)
+			}
+		})
+	}
+}
+
+func TestGCP_getBillingAPIClientAndURL(t *testing.T) {
 	gcp := &GCP{}
 
-	url := gcp.getBillingAPIURL("test-key", "USD")
-	expected := "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus?key=test-key&currencyCode=USD"
-	assert.Equal(t, expected, url)
+	client, rawURL, err := gcp.getBillingAPIClientAndURL("test-key", "USD")
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.DefaultClient, client)
+
+	parsedURL, err := url.Parse(rawURL)
+	assert.NoError(t, err)
+	query := parsedURL.Query()
+	assert.Equal(t, "test-key", query.Get("key"))
+	assert.Equal(t, "USD", query.Get("currencyCode"))
 }
 
 func TestGCP_GpuPricing(t *testing.T) {

--- a/pkg/cloud/provider/provider.go
+++ b/pkg/cloud/provider/provider.go
@@ -143,9 +143,6 @@ func NewProvider(cache clustercache.ClusterCache, apiKey string, config *config.
 		}, nil
 	case opencost.GCPProvider:
 		log.Info("Found ProviderID starting with \"gce\", using GCP Provider")
-		if apiKey == "" {
-			return nil, errors.New("Supply a GCP Key to start getting data")
-		}
 		return &gcp.GCP{
 			Clientset:        cache,
 			APIKey:           apiKey,

--- a/pkg/cloud/provider/provider.go
+++ b/pkg/cloud/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"


### PR DESCRIPTION
## Description
* Removed hardcoded panic when no API key is provided
* If no API key is provided and the workload is running on GKE, the implementation will automatically fall back to workload identity federation to fetch pricing data

## Related Issues
Replaces #3819, closes https://github.com/opencost/opencost/issues/3140

## User Impact
Users are now able to use workload identity federation to fetch pricing information of their GKE nodes.

## Testing
I added unit tests covering URL construction with and without an API key, as well as the workload identity federation fallback path. I also tested these changes on a live GKE cluster, successfully validating that pricing data was fetched via workload identity and that the no-API-key path behaved correctly.

Here is an OpenTofu based infrastructure as code that will create a new GKE cluster and deploy and configure three instances of OpenCost using the official Helm chart and my built container image:

```hcl
terraform {
  required_providers {
    random = {
      source = "hashicorp/random"
    }
  }
}

resource "random_id" "api_key_suffix" {
  byte_length = 4
}

variable "project" {
  description = "GCP project ID"
  type        = string
}

variable "region" {
  description = "GCP region"
  type        = string
}

variable "billing_project" {
  description = "GCP billing project number"
  type        = string
}

variable "image_registry" {
  description = "Container image registry"
  type        = string
  default     = "docker.io"
}

variable "image_repository" {
  description = "Container image repository"
  type        = string
  default     = "ioboi/opencost"
}

variable "image_tag" {
  description = "Container image tag"
  type        = string
  default     = "support-gke-workload-identity-federation-to-provider-pricing-data@sha256:646977078747c6e50cfb2ac7490e76ab2084ae489b6bd6a2069c6e6748b57495"
}

data "google_client_config" "provider" {}

provider "google" {
  project               = var.project
  region                = var.region
  user_project_override = true
  billing_project       = var.billing_project
}

provider "helm" {
  kubernetes = {
    host  = "https://${google_container_cluster.primary.endpoint}"
    token = data.google_client_config.provider.access_token
    cluster_ca_certificate = base64decode(
      google_container_cluster.primary.master_auth[0].cluster_ca_certificate
    )
  }
}

resource "google_service_account" "default" {
  account_id   = "service-account-id"
  display_name = "Service Account"
}

resource "google_service_account" "opencost" {
  account_id   = "opencost"
  display_name = "OpenCost"
}

resource "google_service_account_iam_member" "opencost_workload_identity" {
  service_account_id = google_service_account.opencost.name
  role               = "roles/iam.workloadIdentityUser"
  member             = "serviceAccount:${var.project}.svc.id.goog[opencost-workload-identity/opencost-workload-identity]"
}

resource "google_project_iam_member" "opencost_compute_viewer" {
  project = var.project
  role    = "roles/compute.viewer"
  member  = "serviceAccount:${google_service_account.opencost.email}"
}

resource "google_project_iam_member" "default_compute_viewer" {
  project = var.project
  role    = "roles/compute.viewer"
  member  = "serviceAccount:${google_service_account.default.email}"
}

resource "google_container_cluster" "primary" {
  name                     = "my-gke-cluster"
  location                 = var.region
  remove_default_node_pool = true
  initial_node_count       = 1
  deletion_protection      = false

  workload_identity_config {
    workload_pool = "${var.project}.svc.id.goog"
  }
}


resource "google_container_node_pool" "primary_preemptible_nodes" {
  name       = "my-node-pool"
  location   = var.region
  cluster    = google_container_cluster.primary.name
  node_count = 1

  node_config {
    preemptible  = true
    machine_type = "e2-medium"

    service_account = google_service_account.default.email
    oauth_scopes = [
      "https://www.googleapis.com/auth/cloud-platform"
    ]

    workload_metadata_config {
      mode = "GKE_METADATA"
    }
  }
}

resource "google_apikeys_key" "default" {
  name         = "opencost-${random_id.api_key_suffix.hex}"
  display_name = "OpenCost API Key"

  restrictions {
    api_targets {
      service = "cloudbilling.googleapis.com"
    }
    api_targets {
      service = "compute.googleapis.com"
    }
  }
}

resource "helm_release" "opencost-workload-identity" {
  name             = "opencost-workload-identity"
  repository       = "oci://ghcr.io/opencost/charts"
  chart            = "opencost"
  version          = "2.5.22"
  namespace        = "opencost-workload-identity"
  create_namespace = true

  values = [
    yamlencode({
      extraVolumes = [
        {
          name     = "configs"
          emptyDir = {}
        }
      ]
      loglevel = "info"
      podSecurityContext = {
        fsGroup = 1000
      }
      serviceAccount = {
        annotations = {
          "iam.gke.io/gcp-service-account" = "opencost@${var.project}.iam.gserviceaccount.com"
        }
      }
      opencost = {
        exporter = {
          collectorDataSource = {
            enabled = true
          }
          prometheus = {
            enabled = false
          }
          persistence = {
            enabled    = true
            accessMode = "ReadWriteOnce"
            size       = "1Gi"
          }
          extraVolumeMounts = [
            {
              name      = "configs"
              mountPath = "/var/configs"
            }
          ]
          image = {
            registry   = var.image_registry
            repository = var.image_repository
            tag        = var.image_tag
          }
        }
      }
    })
  ]
}

resource "helm_release" "opencost_no_api" {
  name             = "opencost-no-api"
  repository       = "oci://ghcr.io/opencost/charts"
  chart            = "opencost"
  version          = "2.5.22"
  namespace        = "opencost-no-api"
  create_namespace = true

  values = [
    yamlencode({
      extraVolumes = [
        {
          name     = "configs"
          emptyDir = {}
        }
      ]
      loglevel = "info"
      podSecurityContext = {
        fsGroup = 1002
      }
      opencost = {
        exporter = {
          cloudProviderApiKey = ""
          collectorDataSource = {
            enabled = true
          }
          prometheus = {
            enabled = false
          }
          persistence = {
            enabled    = true
            accessMode = "ReadWriteOnce"
            size       = "1Gi"
          }
          extraVolumeMounts = [
            {
              name      = "configs"
              mountPath = "/var/configs"
            }
          ]
          extraEnv = {
            CONFIG_PATH = "/mnt/export/configs"
          }
          image = {
            registry   = var.image_registry
            repository = var.image_repository
            tag        = var.image_tag
          }
        }
      }
    })
  ]
}

resource "helm_release" "opencost_api" {
  name             = "opencost-api"
  repository       = "oci://ghcr.io/opencost/charts"
  chart            = "opencost"
  version          = "2.5.22"
  namespace        = "opencost-api"
  create_namespace = true

  values = [
    yamlencode({
      extraVolumes = [
        {
          name     = "configs"
          emptyDir = {}
        }
      ]
      loglevel = "info"
      podSecurityContext = {
        fsGroup = 1001
      }
      opencost = {
        exporter = {
          cloudProviderApiKey = google_apikeys_key.default.key_string
          collectorDataSource = {
            enabled = true
          }
          prometheus = {
            enabled = false
          }
          persistence = {
            enabled    = true
            accessMode = "ReadWriteOnce"
            size       = "1Gi"
          }
          extraVolumeMounts = [
            {
              name      = "configs"
              mountPath = "/var/configs"
            }
          ]
          extraEnv = {
            CONFIG_PATH = "/mnt/export/configs"
          }
          image = {
            registry   = var.image_registry
            repository = var.image_repository
            tag        = var.image_tag
          }
        }
      }
    })
  ]
}
```

Easy setup is to create a `terraform.tfvars` configuring the following variables:

```hcl
project         = ""
region          = ""
billing_project = "" # If using a different project for billing, else use the ID of `project`
```

> [!note]
> You may need to activate some Google Cloud APIs to get this working.

### Output of the Deployment using Workload Identity Federation

```sh
$ kubectl -n opencost-workload-identity logs deployments/opencost-workload-identity --container opencost-workload-identity

2026-06-15T11:59:09.751209645Z ??? Log level set to info
2026-06-15T11:59:09.751402125Z INF Starting cost-model version develop (61d484b4)
2026-06-15T11:59:09.751423345Z INF Kubernetes enabled: true
2026-06-15T11:59:09.751433835Z INF Carbon Estimates enabled: false
2026-06-15T11:59:09.751442965Z INF Cloud Costs enabled: false
2026-06-15T11:59:09.751451435Z INF Custom Costs enabled: false
2026-06-15T11:59:09.751460255Z INF MCP Server enabled: true
2026-06-15T11:59:09.751498675Z INF Custom Costs enabled: false
2026-06-15T11:59:10.039792298Z INF Found ProviderID starting with "gce", using GCP Provider
2026-06-15T11:59:10.043733946Z ERR failed to scrape target: failed to fetch URL: Get "http://localhost:9003/metrics": dial tcp 127.0.0.1:9003: connect: connection refused
2026-06-15T11:59:10.142687423Z INF Starting *v1.ConfigMap controller
2026-06-15T11:59:10.15268254Z INF No pricing-configs configmap found at install time, using existing configs: configmaps "pricing-configs" not found
2026-06-15T11:59:10.162531946Z INF No metrics-config configmap found at install time, using existing configs: configmaps "metrics-config" not found
2026-06-15T11:59:10.162988517Z WRN Failed to load auth secret, or was not mounted: Secret does not exist
2026-06-15T11:59:17.883698084Z INF EXPORT_CSV_FILE is not set, CSV export is disabled
2026-06-15T11:59:17.884981624Z INF Initializing MCP server...
2026-06-15T11:59:17.886002134Z INF Starting MCP HTTP server on port 8081...
2026-06-15T11:59:17.886042834Z INF MCP server started successfully
2026-06-15T11:59:17.886274863Z INF HTTP server starting on port 9003
```

### Output of the Deployment using an API Key

```sh
$ kubectl -n opencost-api logs deployments/opencost-api --container opencost-api

2026-06-15T11:59:06.259663085Z ??? Log level set to info
2026-06-15T11:59:06.259768675Z INF Starting cost-model version develop (61d484b4)
2026-06-15T11:59:06.259786305Z INF Kubernetes enabled: true
2026-06-15T11:59:06.259797795Z INF Carbon Estimates enabled: false
2026-06-15T11:59:06.259807475Z INF Cloud Costs enabled: false
2026-06-15T11:59:06.259840735Z INF Custom Costs enabled: false
2026-06-15T11:59:06.259854785Z INF MCP Server enabled: true
2026-06-15T11:59:06.259864735Z INF Custom Costs enabled: false
2026-06-15T11:59:06.560161936Z INF Found ProviderID starting with "gce", using GCP Provider
2026-06-15T11:59:06.563635762Z ERR failed to scrape target: failed to fetch URL: Get "http://localhost:9003/metrics": dial tcp 127.0.0.1:9003: connect: connection refused
2026-06-15T11:59:06.661822331Z INF Starting *v1.ConfigMap controller
2026-06-15T11:59:06.676574283Z INF No pricing-configs configmap found at install time, using existing configs: configmaps "pricing-configs" not found
2026-06-15T11:59:06.687757619Z INF No metrics-config configmap found at install time, using existing configs: configmaps "metrics-config" not found
2026-06-15T11:59:06.688343548Z WRN Failed to load auth secret, or was not mounted: Secret does not exist
2026-06-15T11:59:07.082642444Z WRN Failed to lookup reserved instance data: googleapi: Error 403: Required 'compute.commitments.list' permission for 'projects/***', forbidden
2026-06-15T11:59:13.931606769Z INF EXPORT_CSV_FILE is not set, CSV export is disabled
2026-06-15T11:59:13.931653569Z INF Initializing MCP server...
2026-06-15T11:59:13.932449718Z INF Starting MCP HTTP server on port 8081...
2026-06-15T11:59:13.932486048Z INF MCP server started successfully
2026-06-15T11:59:13.932941257Z INF HTTP server starting on port 9003
```

>[!note]
> I was not able to make the download of the commitments work, though pricing data was still downloaded.

### Output of the Deployment without API Key and Workload Identity Federation

```sh
$ kubectl -n opencost-no-api logs deployments/opencost-no-api --container opencost-no-api

2026-06-15T11:59:34.795949201Z INF EXPORT_CSV_FILE is not set, CSV export is disabled
2026-06-15T11:59:34.795981361Z INF Initializing MCP server...
2026-06-15T11:59:34.797214162Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-396a87f3-wd82: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T11:59:34.797354832Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-9712e985-2jt3: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T11:59:34.797585382Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-b32ba7b3-lfg1: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T11:59:34.797622662Z INF Starting MCP HTTP server on port 8081...
2026-06-15T11:59:34.798062923Z INF MCP server started successfully
2026-06-15T11:59:34.798370173Z INF HTTP server starting on port 9003
2026-06-15T11:59:35.183730475Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-396a87f3-wd82: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T11:59:35.183777385Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-9712e985-2jt3: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T11:59:35.183825905Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-b32ba7b3-lfg1: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T12:00:35.186697649Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-b32ba7b3-lfg1: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T12:00:35.18675618Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-396a87f3-wd82: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T12:00:35.186801189Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-9712e985-2jt3: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T12:00:35.432968557Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-396a87f3-wd82: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing.
2026-06-15T12:00:35.433006787Z INF Could not get node pricing for node gke-my-gke-cluster-my-node-pool-396a87f3-wd82: no pricing data found for europe-west6,e2medium,preemptible. Falling back to default pricing. logged 10 times: suppressing future logs
```