### PR TITLE
Fix missing cluster filter in GPU usage queries

### DIFF
--- a/modules/prometheus-source/pkg/prom/metricsquerier.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier.go
@@ -1163,7 +1163,7 @@ func (pds *PrometheusMetricsQuerier) QueryGPUsRequested(start, end time.Time) *s
 
 func (pds *PrometheusMetricsQuerier) QueryGPUsUsageAvg(start, end time.Time) *source.Future[source.GPUsUsageAvgResult] {
 	const queryName = "QueryGPUsUsageAvg"
-	const queryFmtGPUsUsageAvg = `avg(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!=""}[%s])) by (container, pod, namespace, pod_uid, %s)`
+	const queryFmtGPUsUsageAvg = `avg(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!="",%s}[%s])) by (container, pod, namespace, pod_uid, %s)`
 
 	cfg := pds.promConfig
 
@@ -1172,7 +1172,7 @@ func (pds *PrometheusMetricsQuerier) QueryGPUsUsageAvg(start, end time.Time) *so
 		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
 	}
 
-	queryGPUsUsageAvg := fmt.Sprintf(queryFmtGPUsUsageAvg, durStr, cfg.ClusterLabel)
+	queryGPUsUsageAvg := fmt.Sprintf(queryFmtGPUsUsageAvg, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
 	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryGPUsUsageAvg)
 
 	ctx := pds.promContexts.NewNamedContext(AllocationContextName)
@@ -1181,7 +1181,7 @@ func (pds *PrometheusMetricsQuerier) QueryGPUsUsageAvg(start, end time.Time) *so
 
 func (pds *PrometheusMetricsQuerier) QueryGPUsUsageMax(start, end time.Time) *source.Future[source.GPUsUsageMaxResult] {
 	const queryName = "QueryGPUsUsageMax"
-	const queryFmtGPUsUsageMax = `max(max_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!=""}[%s])) by (container, pod, namespace, pod_uid, %s)`
+	const queryFmtGPUsUsageMax = `max(max_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!="",%s}[%s])) by (container, pod, namespace, pod_uid, %s)`
 
 	cfg := pds.promConfig
 
@@ -1190,7 +1190,7 @@ func (pds *PrometheusMetricsQuerier) QueryGPUsUsageMax(start, end time.Time) *so
 		panic(fmt.Sprintf("failed to parse duration string passed to %s", queryName))
 	}
 
-	queryGPUsUsageMax := fmt.Sprintf(queryFmtGPUsUsageMax, durStr, cfg.ClusterLabel)
+	queryGPUsUsageMax := fmt.Sprintf(queryFmtGPUsUsageMax, cfg.ClusterFilter, durStr, cfg.ClusterLabel)
 	log.Debugf(PrometheusMetricsQueryLogFormat, queryName, end.Unix(), queryGPUsUsageMax)
 
 	ctx := pds.promContexts.NewNamedContext(AllocationContextName)

--- a/modules/prometheus-source/pkg/prom/metricsquerier_test.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -195,6 +196,58 @@ func TestQueryLogs(t *testing.T) {
 	for testName, queryFunc := range tests {
 		t.Run(fmt.Sprintf("TestQueryLog_%s", testName), func(t *testing.T) {
 			checkQueryLog(t, logWriter, queryFunc, testName, queryStart, queryEnd)
+		})
+	}
+}
+
+// TestGPUUsageQueriesIncludeClusterFilter verifies that the GPU usage queries
+// scope their underlying DCGM metrics to the current cluster when the cluster
+// ID filter is enabled, matching the behavior of every other metric query.
+func TestGPUUsageQueriesIncludeClusterFilter(t *testing.T) {
+	initLogging(t, "debug", false)
+
+	logWriter := new(SingleLogWriter)
+	zerologger.Logger = zerologger.Output(zerolog.ConsoleWriter{
+		Out:        logWriter,
+		TimeFormat: "",
+		NoColor:    true,
+		PartsExclude: []string{
+			zerolog.TimestampFieldName,
+			zerolog.LevelFieldName,
+			zerolog.CallerFieldName,
+		},
+	})
+	defer initLogging(t, "debug", false)
+
+	t.Setenv("PROMETHEUS_SERVER_ENDPOINT", "nowhere")
+	t.Setenv("CURRENT_CLUSTER_ID_FILTER_ENABLED", "true")
+	t.Setenv("CLUSTER_ID", "test-cluster")
+
+	config, err := NewOpenCostPrometheusConfigFromEnv()
+	if err != nil {
+		t.Fatalf("Failed to create OpenCost Prometheus config: %v", err)
+	}
+
+	mock := new(NoOpPromClient)
+	contextFactory := NewContextFactory(mock, config)
+	querier := newPrometheusMetricsQuerier(config, mock, contextFactory)
+
+	queryEnd := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	queryStart := queryEnd.Add(-24 * time.Hour)
+
+	const wantFilter = `cluster_id="test-cluster"`
+
+	tests := map[string]func(time.Time, time.Time){
+		"QueryGPUsUsageAvg": func(s, e time.Time) { querier.QueryGPUsUsageAvg(s, e) },
+		"QueryGPUsUsageMax": func(s, e time.Time) { querier.QueryGPUsUsageMax(s, e) },
+	}
+
+	for testName, queryFunc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			queryFunc(queryStart, queryEnd)
+			if !strings.Contains(logWriter.Log, wantFilter) {
+				t.Errorf("expected query to contain cluster filter %q, got log: %s", wantFilter, logWriter.Log)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Intent

Make GPU **usage** metric queries respect the current-cluster filter, so GPU usage from other clusters sharing a Prometheus cannot leak into this cluster's cost allocation.

## Problem

`PrometheusMetricsQuerier` injects `cfg.ClusterFilter` into every metric query so that, when `CURRENT_CLUSTER_ID_FILTER_ENABLED` is set, each query is scoped to the local cluster. Two queries were missed:

- `QueryGPUsUsageAvg`
- `QueryGPUsUsageMax`

Both selected `DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!=""}` with **no** cluster filter:

```promql
avg(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!=""}[%s])) by (container, pod, namespace, pod_uid, %s)
```

In a multi-cluster Prometheus (cluster filtering enabled), these two queries return GPU engine-activity series from **every** cluster, so GPU usage — and therefore `max(request, usage)` GPU cost — from other clusters is attributed to this cluster's workloads.

## Fix

Inject `cfg.ClusterFilter` into both templates, matching every other query in the querier:

```promql
avg(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{container!="",%s}[%s])) by (container, pod, namespace, pod_uid, %s)
```

The trailing comma when `ClusterFilter` is empty (filtering disabled) is valid PromQL and matches the existing pattern used throughout the querier.

## Tests

`TestGPUUsageQueriesIncludeClusterFilter` asserts both `QueryGPUsUsageAvg` and `QueryGPUsUsageMax` interpolate the configured cluster filter.

## Scope

Pre-existing bug, independent of the GPU saturation work. Split out from the larger saturation branch so it can be reviewed and merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
