### PR TITLE
Add scheduler-level GPU saturation metrics

### DIFF
--- a/pkg/costmodel/gpu_scheduler_metrics.go
+++ b/pkg/costmodel/gpu_scheduler_metrics.go
@@ -1,0 +1,158 @@
+package costmodel
+
+import (
+	"strings"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
+)
+
+// Scheduler-level GPU saturation metrics (USE method). Unlike the
+// DCGM-derived device signals, these come from the Kubernetes scheduler's
+// view: pods waiting for GPUs and how oversubscribed the schedulable GPU
+// capacity is. Series are emitted per GPU resource name and only for
+// resource names actually observed in the cluster (allocatable on a node or
+// requested by a pod), so clusters without GPUs emit nothing.
+
+var (
+	gpuPendingPodCountGv          *prometheus.GaugeVec
+	gpuPendingRequestTotalGv      *prometheus.GaugeVec
+	gpuRequestedAllocatableRatGv  *prometheus.GaugeVec
+	gpuSchedulerMetricsRegistered bool
+)
+
+// initGPUSchedulerMetrics creates and registers the scheduler-level GPU
+// gauges. Called from initCostModelMetrics inside its sync.Once.
+func initGPUSchedulerMetrics(disabledMetrics map[string]struct{}, register func(gv *prometheus.GaugeVec)) {
+	gpuPendingPodCountGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cluster_gpu_pending_pod_count",
+		Help: "cluster_gpu_pending_pod_count Number of Pending pods requesting the GPU resource",
+	}, []string{"resource"})
+	if _, disabled := disabledMetrics["cluster_gpu_pending_pod_count"]; !disabled {
+		register(gpuPendingPodCountGv)
+	}
+
+	gpuPendingRequestTotalGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cluster_gpu_pending_request_total",
+		Help: "cluster_gpu_pending_request_total Sum of GPU units requested by Pending pods",
+	}, []string{"resource"})
+	if _, disabled := disabledMetrics["cluster_gpu_pending_request_total"]; !disabled {
+		register(gpuPendingRequestTotalGv)
+	}
+
+	gpuRequestedAllocatableRatGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cluster_gpu_requested_allocatable_ratio",
+		Help: "cluster_gpu_requested_allocatable_ratio GPU units requested by non-terminated pods divided by allocatable units; values near or above 1 indicate scheduler-level GPU saturation, including time-sliced or MPS-shared replica exhaustion",
+	}, []string{"resource"})
+	if _, disabled := disabledMetrics["cluster_gpu_requested_allocatable_ratio"]; !disabled {
+		register(gpuRequestedAllocatableRatGv)
+	}
+
+	gpuSchedulerMetricsRegistered = true
+}
+
+// isGPUResourceName reports whether the resource name represents NVIDIA GPU
+// capacity: whole GPUs, time-sliced/MPS shared replicas, or MIG profiles.
+func isGPUResourceName(name v1.ResourceName) bool {
+	resource := string(name)
+	return resource == "nvidia.com/gpu" ||
+		resource == "nvidia.com/gpu.shared" ||
+		strings.HasPrefix(resource, "nvidia.com/mig-")
+}
+
+// gpuSchedulerStats accumulates scheduler-level saturation inputs for one
+// GPU resource name.
+type gpuSchedulerStats struct {
+	PendingPodCount     float64
+	PendingRequestTotal float64
+	Allocatable         float64
+	ActiveRequested     float64
+}
+
+// computeGPUSchedulerStats derives scheduler-level GPU saturation inputs
+// from the cluster cache: per GPU resource name, the number of Pending pods
+// requesting it, their total requested units, allocatable units across
+// nodes, and units requested by all non-terminated pods.
+func computeGPUSchedulerStats(pods []*clustercache.Pod, nodes []*clustercache.Node) map[v1.ResourceName]*gpuSchedulerStats {
+	stats := make(map[v1.ResourceName]*gpuSchedulerStats)
+	get := func(name v1.ResourceName) *gpuSchedulerStats {
+		if _, ok := stats[name]; !ok {
+			stats[name] = &gpuSchedulerStats{}
+		}
+		return stats[name]
+	}
+
+	for _, node := range nodes {
+		for name, quantity := range node.Status.Allocatable {
+			if isGPUResourceName(name) {
+				get(name).Allocatable += quantity.AsApproximateFloat64()
+			}
+		}
+	}
+
+	for _, pod := range pods {
+		phase := pod.Status.Phase
+		if phase != v1.PodPending && phase != v1.PodRunning {
+			continue
+		}
+
+		requests := make(map[v1.ResourceName]float64)
+		for _, container := range pod.Spec.Containers {
+			// GPUs are extended resources, so it is common to set only
+			// Limits; mirror costmodel.go and fall back to the Limit when a
+			// GPU resource is absent from Requests, else it is undercounted.
+			for name, quantity := range container.Resources.Requests {
+				if isGPUResourceName(name) {
+					requests[name] += quantity.AsApproximateFloat64()
+				}
+			}
+			for name, quantity := range container.Resources.Limits {
+				if !isGPUResourceName(name) {
+					continue
+				}
+				if _, ok := container.Resources.Requests[name]; ok {
+					continue
+				}
+				requests[name] += quantity.AsApproximateFloat64()
+			}
+		}
+
+		for name, requested := range requests {
+			if requested <= 0 {
+				continue
+			}
+			s := get(name)
+			s.ActiveRequested += requested
+			if phase == v1.PodPending {
+				s.PendingPodCount++
+				s.PendingRequestTotal += requested
+			}
+		}
+	}
+
+	return stats
+}
+
+// recordGPUSchedulerMetrics resets and re-emits the scheduler-level GPU
+// gauges from the current cluster state. The requested/allocatable ratio is
+// only emitted for resources with allocatable capacity, so a missing series
+// is "no schedulable capacity observed" rather than zero pressure.
+func recordGPUSchedulerMetrics(pods []*clustercache.Pod, nodes []*clustercache.Node) {
+	if !gpuSchedulerMetricsRegistered {
+		return
+	}
+
+	gpuPendingPodCountGv.Reset()
+	gpuPendingRequestTotalGv.Reset()
+	gpuRequestedAllocatableRatGv.Reset()
+
+	for name, s := range computeGPUSchedulerStats(pods, nodes) {
+		resource := string(name)
+		gpuPendingPodCountGv.WithLabelValues(resource).Set(s.PendingPodCount)
+		gpuPendingRequestTotalGv.WithLabelValues(resource).Set(s.PendingRequestTotal)
+		if s.Allocatable > 0 {
+			gpuRequestedAllocatableRatGv.WithLabelValues(resource).Set(s.ActiveRequested / s.Allocatable)
+		}
+	}
+}

--- a/pkg/costmodel/gpu_scheduler_metrics_test.go
+++ b/pkg/costmodel/gpu_scheduler_metrics_test.go
@@ -1,0 +1,174 @@
+package costmodel
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/clustercache"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestIsGPUResourceName(t *testing.T) {
+	cases := map[v1.ResourceName]bool{
+		"nvidia.com/gpu":            true,
+		"nvidia.com/gpu.shared":     true,
+		"nvidia.com/mig-1g.5gb":     true,
+		"nvidia.com/mig-3g.20gb":    true,
+		"cpu":                       false,
+		"memory":                    false,
+		"amd.com/gpu":               false,
+		"nvidia.com/gpu-misc":       false,
+		"example.com/nvidia.com":    false,
+		"nvidia.com/gpufake.shared": false,
+	}
+	for name, want := range cases {
+		if got := isGPUResourceName(name); got != want {
+			t.Errorf("isGPUResourceName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func gpuPod(phase v1.PodPhase, resourceName v1.ResourceName, quantity string) *clustercache.Pod {
+	return &clustercache.Pod{
+		Status: clustercache.PodStatus{Phase: phase},
+		Spec: clustercache.PodSpec{
+			Containers: []clustercache.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							resourceName: resource.MustParse(quantity),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func gpuNode(resourceName v1.ResourceName, quantity string) *clustercache.Node {
+	return &clustercache.Node{
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				resourceName: resource.MustParse(quantity),
+			},
+		},
+	}
+}
+
+func TestComputeGPUSchedulerStats(t *testing.T) {
+	pods := []*clustercache.Pod{
+		gpuPod(v1.PodPending, "nvidia.com/gpu", "2"),
+		gpuPod(v1.PodPending, "nvidia.com/gpu", "1"),
+		gpuPod(v1.PodRunning, "nvidia.com/gpu", "4"),
+		gpuPod(v1.PodPending, "nvidia.com/gpu.shared", "3"),
+		gpuPod(v1.PodRunning, "nvidia.com/gpu.shared", "5"),
+		// terminated pods must not count
+		gpuPod(v1.PodSucceeded, "nvidia.com/gpu", "8"),
+		gpuPod(v1.PodFailed, "nvidia.com/gpu.shared", "8"),
+		// non-GPU pods must not appear at all
+		gpuPod(v1.PodPending, "cpu", "1"),
+	}
+	nodes := []*clustercache.Node{
+		gpuNode("nvidia.com/gpu", "4"),
+		gpuNode("nvidia.com/gpu", "4"),
+		gpuNode("nvidia.com/gpu.shared", "8"),
+	}
+
+	stats := computeGPUSchedulerStats(pods, nodes)
+
+	if len(stats) != 2 {
+		t.Fatalf("expected stats for 2 resources, got %d: %v", len(stats), stats)
+	}
+
+	gpu := stats["nvidia.com/gpu"]
+	if gpu == nil {
+		t.Fatalf("missing stats for nvidia.com/gpu")
+	}
+	if gpu.PendingPodCount != 2 || gpu.PendingRequestTotal != 3 {
+		t.Errorf("nvidia.com/gpu pending = (%v pods, %v units), want (2, 3)", gpu.PendingPodCount, gpu.PendingRequestTotal)
+	}
+	if gpu.Allocatable != 8 || gpu.ActiveRequested != 7 {
+		t.Errorf("nvidia.com/gpu capacity = (%v allocatable, %v requested), want (8, 7)", gpu.Allocatable, gpu.ActiveRequested)
+	}
+
+	shared := stats["nvidia.com/gpu.shared"]
+	if shared == nil {
+		t.Fatalf("missing stats for nvidia.com/gpu.shared")
+	}
+	if shared.PendingPodCount != 1 || shared.PendingRequestTotal != 3 {
+		t.Errorf("shared pending = (%v pods, %v units), want (1, 3)", shared.PendingPodCount, shared.PendingRequestTotal)
+	}
+	if shared.Allocatable != 8 || shared.ActiveRequested != 8 {
+		t.Errorf("shared capacity = (%v allocatable, %v requested), want (8, 8)", shared.Allocatable, shared.ActiveRequested)
+	}
+}
+
+func TestComputeGPUSchedulerStats_Empty(t *testing.T) {
+	if stats := computeGPUSchedulerStats(nil, nil); len(stats) != 0 {
+		t.Errorf("expected no stats for empty cluster, got %v", stats)
+	}
+
+	// GPU resource requested but no allocatable capacity anywhere: stats
+	// exist (pending is real) but allocatable stays zero so the ratio is
+	// not emitted
+	pods := []*clustercache.Pod{gpuPod(v1.PodPending, "nvidia.com/gpu", "1")}
+	stats := computeGPUSchedulerStats(pods, nil)
+	if len(stats) != 1 {
+		t.Fatalf("expected stats for 1 resource, got %d", len(stats))
+	}
+	if gpu := stats["nvidia.com/gpu"]; gpu.Allocatable != 0 || gpu.PendingPodCount != 1 {
+		t.Errorf("unexpected stats: %+v", gpu)
+	}
+}
+
+func TestComputeGPUSchedulerStats_MultiContainerPod(t *testing.T) {
+	pod := &clustercache.Pod{
+		Status: clustercache.PodStatus{Phase: v1.PodPending},
+		Spec: clustercache.PodSpec{
+			Containers: []clustercache.Container{
+				{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}}},
+			},
+		},
+	}
+
+	stats := computeGPUSchedulerStats([]*clustercache.Pod{pod}, nil)
+	gpu := stats["nvidia.com/gpu"]
+	if gpu.PendingPodCount != 1 {
+		t.Errorf("multi-container pod counted %v times, want once", gpu.PendingPodCount)
+	}
+	if gpu.PendingRequestTotal != 3 {
+		t.Errorf("PendingRequestTotal = %v, want 3 (sum across containers)", gpu.PendingRequestTotal)
+	}
+}
+
+// GPUs are extended resources commonly specified via Limits only; the Limit
+// must be counted when Requests omits the GPU resource, and must not be
+// double-counted when both are present.
+func TestComputeGPUSchedulerStats_LimitsFallback(t *testing.T) {
+	pods := []*clustercache.Pod{
+		{ // Limits only -> count the limit
+			Status: clustercache.PodStatus{Phase: v1.PodPending},
+			Spec: clustercache.PodSpec{Containers: []clustercache.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}}},
+			}},
+		},
+		{ // Requests and Limits both set -> count request once, no double count
+			Status: clustercache.PodStatus{Phase: v1.PodRunning},
+			Spec: clustercache.PodSpec{Containers: []clustercache.Container{
+				{Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+					Limits:   v1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+				}},
+			}},
+		},
+	}
+
+	gpu := computeGPUSchedulerStats(pods, nil)["nvidia.com/gpu"]
+	if gpu.PendingRequestTotal != 2 {
+		t.Errorf("PendingRequestTotal = %v, want 2 (limit-only pending pod)", gpu.PendingRequestTotal)
+	}
+	if gpu.ActiveRequested != 3 {
+		t.Errorf("ActiveRequested = %v, want 3 (2 limit-only + 1 request, no double count)", gpu.ActiveRequested)
+	}
+}

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -291,6 +291,10 @@ func initCostModelMetrics(clusterInfo clusters.ClusterInfoProvider, metricsConfi
 			toRegisterGV = append(toRegisterGV, lbCostGv)
 		}
 
+		initGPUSchedulerMetrics(disabledMetrics, func(gv *prometheus.GaugeVec) {
+			toRegisterGV = append(toRegisterGV, gv)
+		})
+
 		// Register cost-model metrics for emission
 		for _, gv := range toRegisterGV {
 			prometheus.MustRegister(gv)
@@ -464,6 +468,9 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 			for _, node := range nodeList {
 				nodeUIDs[node.Name] = string(node.UID)
 			}
+
+			// Scheduler-level GPU saturation (pending pods, oversubscription)
+			recordGPUSchedulerMetrics(podlist, nodeList)
 
 			// Create PV UID lookup map
 			pvList := cmme.KubeClusterCache.GetAllPersistentVolumes()


### PR DESCRIPTION
## Intent

Add **scheduler-level** GPU saturation signals (USE method) to complement the DCGM device-level signals: surface how much GPU *scheduling* pressure the cluster is under, per GPU resource name.

## Problem

DCGM device metrics tell you how hard the GPUs you already scheduled onto are working (utilization, memory, throttling). They cannot tell you whether the cluster has **run out of GPUs to schedule onto**. Two real situations are invisible to device-level signals:

- Pods stuck `Pending` because no node has an allocatable GPU.
- Time-sliced / MPS deployments where the bottleneck is exhausted *allocatable replicas* (e.g. `nvidia.com/gpu.shared`), not physical-device utilization.

Operators need a saturation signal answering "are we GPU-bound at the scheduler?" to drive capacity decisions and autoscaling.

## What this adds

Three Prometheus gauges, emitted **per GPU resource name** and only for names actually observed in the cluster (allocatable on a node or requested by a pod), so clusters without GPUs emit nothing:

| Metric | Meaning |
|--------|---------|
| `cluster_gpu_pending_pod_count` | Number of `Pending` pods requesting the GPU resource |
| `cluster_gpu_pending_request_total` | Sum of GPU units requested by those `Pending` pods |
| `cluster_gpu_requested_allocatable_ratio` | GPU units requested by non-terminated pods ÷ allocatable units; values near or above 1 indicate scheduler-level saturation, including time-sliced/MPS replica exhaustion |

Computed from the cluster cache (pods + nodes); the requested/allocatable ratio is only emitted for resources with allocatable capacity, so a missing series means "no schedulable capacity observed" rather than zero pressure.

GPU resource names recognized: NVIDIA whole-GPU (`nvidia.com/gpu`), time-sliced/MPS shared (`nvidia.com/gpu.shared`), and MIG profiles (`nvidia.com/mig-*`).

### Requests vs Limits

GPUs are extended resources, so it is common to specify them only in `Limits`. Request resolution falls back to the container `Limit` when a GPU resource is absent from `Requests` (mirroring `costmodel.go`), and skips the `Limit` when `Requests` already has it, so neither path under- nor double-counts.

## Tests

- `TestIsGPUResourceName` — resource-name classification
- `TestComputeGPUSchedulerStats` / `_Empty` / `_MultiContainerPod` — stat aggregation
- `TestComputeGPUSchedulerStats_LimitsFallback` — Limits-only and Requests+Limits paths

## Scope

Independent of the DCGM device-saturation modeling (different signal source: the Kubernetes scheduler's view, not dcgm-exporter). Split out from the larger saturation branch for focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
