### PR TITLE
fix: guard cloudcost Status coverage read and stop ClusterMap ticker

### DIFF
--- a/modules/prometheus-source/pkg/prom/clustermap.go
+++ b/modules/prometheus-source/pkg/prom/clustermap.go
@@ -47,6 +47,7 @@ func newPrometheusClusterMap(contextFactory *ContextFactory, cip clusters.Cluste
 
 		// Tick on interval and refresh clusters
 		ticker := time.NewTicker(refresh)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/pkg/cloudcost/ingestor.go
+++ b/pkg/cloudcost/ingestor.go
@@ -188,12 +188,18 @@ func (ing *ingestor) Stop() {
 
 // Status returns an IngestorStatus that describes the current state of the ingestor
 func (ing *ingestor) Status() IngestorStatus {
+	// Read coverage under the lock; the build loop reassigns it under
+	// coverageLock, so an unlocked read here is a data race.
+	ing.coverageLock.Lock()
+	coverage := ing.coverage
+	ing.coverageLock.Unlock()
+
 	return IngestorStatus{
 		Created:          ing.creationTime,
 		LastRun:          ing.lastRun,
 		NextRun:          ing.lastRun.Add(ing.config.RefreshRate).UTC(),
 		Runs:             ing.runs,
-		Coverage:         ing.coverage,
+		Coverage:         coverage,
 		ConnectionStatus: ing.integration.GetStatus(),
 	}
 }

--- a/pkg/cloudcost/ingestor_test.go
+++ b/pkg/cloudcost/ingestor_test.go
@@ -1,0 +1,47 @@
+package cloudcost
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/pkg/cloud"
+)
+
+type fakeIntegration struct{}
+
+func (fakeIntegration) GetCloudCost(time.Time, time.Time) (*opencost.CloudCostSetRange, error) {
+	return nil, nil
+}
+func (fakeIntegration) GetStatus() cloud.ConnectionStatus     { return cloud.InitialStatus }
+func (fakeIntegration) RefreshStatus() cloud.ConnectionStatus { return cloud.InitialStatus }
+
+// TestIngestor_Status_ConcurrentWithCoverageWrite guards against a data race on
+// the coverage window: Status() read it without holding coverageLock while the
+// build loop reassigns it under the lock. Run with -race to detect it.
+func TestIngestor_Status_ConcurrentWithCoverageWrite(t *testing.T) {
+	now := time.Now().UTC()
+	ing := &ingestor{
+		integration: fakeIntegration{},
+		coverage:    opencost.NewClosedWindow(now, now.Add(time.Hour)),
+	}
+
+	window := opencost.NewClosedWindow(now, now.Add(2*time.Hour))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			ing.expandCoverage(window)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			_ = ing.Status()
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Description

Two small concurrency/cleanup fixes I came across while reading through the ingestion code:

1. **cloudcost `ingestor.Status()` data race.** It read `ing.coverage` without holding `coverageLock`, while the build loop reassigns `ing.coverage` under that lock (`ContractStart` / `ExpandStart`). `coverage` is an `opencost.Window` (two `*time.Time` fields), so a `Status()` read concurrent with a build is a torn read. Same shape as the customcost one in #3838, just a struct instead of a map (so it's a race rather than a hard crash). Fixed by reading the value under the lock.

2. **ClusterMap refresh ticker never stopped.** The refresher goroutine in `clustermap.go` creates `time.NewTicker(refresh)` but never calls `Stop()` before it returns on `<-cm.stop`. Added `defer ticker.Stop()`.

## Related Issues

No existing issue for either, found them reading the code. Happy to open one if you'd prefer.

## User Impact

No behavior change. `Status()` returns the same data; the ticker change just releases the ticker when the refresher exits. The cloudcost fix removes a data race that `go test -race` flags.

## Testing

- Added `TestIngestor_Status_ConcurrentWithCoverageWrite` (cloudcost), which runs `Status()` against `expandCoverage()` concurrently. It trips the race detector on the old code and passes with the fix. One caveat: it only fails under `-race` (a struct torn read can't be asserted deterministically), so it's mainly a guard for local `-race` runs.
- `go test ./pkg/cloudcost/ -race` green; full `go build ./...`, `go vet`, and the prometheus-source module build + vet all clean.
