### PR TITLE
fix(mcp): sanitize non-finite floats before SDK marshal

### DIFF
--- a/pkg/mcp/sanitize_test.go
+++ b/pkg/mcp/sanitize_test.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// TestSanitizeNonFiniteFloatsAssetResponseMarshals reproduces the integration
+// failure (TestMCPAssetVsHTTP: "marshaling output: json: unsupported value:
+// NaN") and verifies the sanitizer fixes it: encoding/json must reject the
+// response before sanitization and accept it after, with non-finite floats
+// zeroed and finite ones preserved.
+func TestSanitizeNonFiniteFloatsAssetResponseMarshals(t *testing.T) {
+	usedBytes := math.NaN()
+	resp := &AssetResponse{
+		Assets: map[string]*AssetSet{
+			"assets": {
+				Name: "assets",
+				Assets: []*Asset{
+					{
+						Type:          "Node",
+						Minutes:       math.NaN(),
+						Adjustment:    math.Inf(1),
+						TotalCost:     math.Inf(-1),
+						CPUCost:       math.NaN(),
+						GPUCost:       5.0, // finite, must be preserved
+						ByteHoursUsed: &usedBytes,
+						Overhead:      &NodeOverhead{OverheadCostFraction: math.NaN()},
+						CPUBreakdown:  &AssetBreakdown{Idle: math.NaN()},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := json.Marshal(resp); err == nil {
+		t.Fatal("expected json.Marshal to fail before sanitization (NaN/Inf present)")
+	}
+
+	sanitizeNonFiniteFloats(resp)
+
+	if _, err := json.Marshal(resp); err != nil {
+		t.Fatalf("expected json.Marshal to succeed after sanitization, got %v", err)
+	}
+
+	a := resp.Assets["assets"].Assets[0]
+	if a.Minutes != 0 || a.Adjustment != 0 || a.TotalCost != 0 || a.CPUCost != 0 {
+		t.Fatalf("expected non-finite base floats zeroed, got %+v", a)
+	}
+	if a.GPUCost != 5.0 {
+		t.Fatalf("expected finite GPUCost preserved, got %v", a.GPUCost)
+	}
+	if a.ByteHoursUsed == nil || *a.ByteHoursUsed != 0 {
+		t.Fatalf("expected non-finite *float64 zeroed, got %v", a.ByteHoursUsed)
+	}
+	if a.Overhead.OverheadCostFraction != 0 {
+		t.Fatalf("expected nested overhead fraction zeroed, got %v", a.Overhead.OverheadCostFraction)
+	}
+	if a.CPUBreakdown.Idle != 0 {
+		t.Fatalf("expected nested breakdown value zeroed, got %v", a.CPUBreakdown.Idle)
+	}
+}
+
+func TestSanitizeNonFiniteFloatsNilSafe(t *testing.T) {
+	sanitizeNonFiniteFloats(nil)
+	var p *AssetResponse
+	sanitizeNonFiniteFloats(p)
+	sanitizeNonFiniteFloats(&AssetResponse{})
+}

--- a/pkg/mcp/sanitize_test.go
+++ b/pkg/mcp/sanitize_test.go
@@ -15,10 +15,10 @@ func TestSanitizeNonFiniteFloatsAssetResponseMarshals(t *testing.T) {
 	usedBytes := math.NaN()
 	resp := &AssetResponse{
 		Assets: map[string]*AssetSet{
-			"assets": {
+			"assets": &AssetSet{
 				Name: "assets",
 				Assets: []*Asset{
-					{
+					&Asset{
 						Type:          "Node",
 						Minutes:       math.NaN(),
 						Adjustment:    math.Inf(1),
@@ -38,7 +38,7 @@ func TestSanitizeNonFiniteFloatsAssetResponseMarshals(t *testing.T) {
 		t.Fatal("expected json.Marshal to fail before sanitization (NaN/Inf present)")
 	}
 
-	sanitizeNonFiniteFloats(resp)
+	resp = sanitizeNonFiniteFloats(resp).(*AssetResponse)
 
 	if _, err := json.Marshal(resp); err != nil {
 		t.Fatalf("expected json.Marshal to succeed after sanitization, got %v", err)
@@ -62,8 +62,26 @@ func TestSanitizeNonFiniteFloatsAssetResponseMarshals(t *testing.T) {
 	}
 }
 
+// TestSanitizeNonFiniteFloatsValueType verifies a non-pointer (value) input is
+// sanitized via the returned copy, not just pointers.
+func TestSanitizeNonFiniteFloatsValueType(t *testing.T) {
+	in := Asset{TotalCost: math.NaN(), GPUCost: 3.0}
+	out, ok := sanitizeNonFiniteFloats(in).(Asset)
+	if !ok {
+		t.Fatalf("expected Asset back, got %T", sanitizeNonFiniteFloats(in))
+	}
+	if out.TotalCost != 0 {
+		t.Fatalf("expected NaN zeroed in returned value, got %v", out.TotalCost)
+	}
+	if out.GPUCost != 3.0 {
+		t.Fatalf("expected finite value preserved, got %v", out.GPUCost)
+	}
+}
+
 func TestSanitizeNonFiniteFloatsNilSafe(t *testing.T) {
-	sanitizeNonFiniteFloats(nil)
+	if got := sanitizeNonFiniteFloats(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
 	var p *AssetResponse
 	sanitizeNonFiniteFloats(p)
 	sanitizeNonFiniteFloats(&AssetResponse{})

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"math"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -410,6 +412,12 @@ func (s *MCPServer) ProcessMCPRequest(ctx context.Context, request *MCPRequest) 
 		return nil, err
 	}
 
+	// The MCP SDK marshals tool output with encoding/json, which errors on
+	// non-finite floats. Upstream cost calculations can yield NaN or Inf (e.g.
+	// a 0/0 breakdown or overhead fraction), so scrub them before they reach the
+	// SDK and fail the whole tool call.
+	sanitizeNonFiniteFloats(data)
+
 	processingTime := time.Since(queryStart)
 
 	// 3. Construct Final Response
@@ -422,6 +430,59 @@ func (s *MCPServer) ProcessMCPRequest(ctx context.Context, request *MCPRequest) 
 		},
 	}
 	return mcpResponse, nil
+}
+
+// sanitizeNonFiniteFloats walks v and replaces every non-finite float (NaN,
+// +Inf, -Inf) with 0 so the value can be marshaled by encoding/json, which the
+// MCP SDK uses and which rejects non-finite floats. It is best-effort: any
+// reflection panic is recovered so the sanitizer can never break a request.
+func sanitizeNonFiniteFloats(v any) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("mcp: sanitizeNonFiniteFloats recovered: %v", r)
+		}
+	}()
+	if v == nil {
+		return
+	}
+	sanitizeFloatsValue(reflect.ValueOf(v))
+}
+
+func sanitizeFloatsValue(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if !v.IsNil() {
+			sanitizeFloatsValue(v.Elem())
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			sanitizeFloatsValue(v.Field(i))
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			sanitizeFloatsValue(v.Index(i))
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			elem := v.MapIndex(key)
+			// Map elements aren't addressable. Pointer/interface/slice/map
+			// values are mutated in place by recursing; value-type elements
+			// (e.g. a float or struct) must be rebuilt and reassigned.
+			switch elem.Kind() {
+			case reflect.Pointer, reflect.Interface, reflect.Slice, reflect.Map:
+				sanitizeFloatsValue(elem)
+			default:
+				tmp := reflect.New(elem.Type()).Elem()
+				tmp.Set(elem)
+				sanitizeFloatsValue(tmp)
+				v.SetMapIndex(key, tmp)
+			}
+		}
+	case reflect.Float32, reflect.Float64:
+		if v.CanSet() && (math.IsNaN(v.Float()) || math.IsInf(v.Float(), 0)) {
+			v.SetFloat(0)
+		}
+	}
 }
 
 // validate is the singleton validator instance.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -416,7 +416,7 @@ func (s *MCPServer) ProcessMCPRequest(ctx context.Context, request *MCPRequest) 
 	// non-finite floats. Upstream cost calculations can yield NaN or Inf (e.g.
 	// a 0/0 breakdown or overhead fraction), so scrub them before they reach the
 	// SDK and fail the whole tool call.
-	sanitizeNonFiniteFloats(data)
+	data = sanitizeNonFiniteFloats(data)
 
 	processingTime := time.Since(queryStart)
 
@@ -432,25 +432,34 @@ func (s *MCPServer) ProcessMCPRequest(ctx context.Context, request *MCPRequest) 
 	return mcpResponse, nil
 }
 
-// sanitizeNonFiniteFloats walks v and replaces every non-finite float (NaN,
-// +Inf, -Inf) with 0 so the value can be marshaled by encoding/json, which the
-// MCP SDK uses and which rejects non-finite floats. It is best-effort: any
-// reflection panic is recovered so the sanitizer can never break a request.
-func sanitizeNonFiniteFloats(v any) {
+// sanitizeNonFiniteFloats returns v with every non-finite float (NaN, +Inf,
+// -Inf) replaced by 0 so the value can be marshaled by encoding/json, which the
+// MCP SDK uses and which rejects non-finite floats. Callers must use the return
+// value, since value-type inputs are sanitized on a copy. It is best-effort:
+// any reflection panic is recovered and the original value returned unchanged.
+func sanitizeNonFiniteFloats(v any) (out any) {
+	out = v
 	defer func() {
 		if r := recover(); r != nil {
 			log.Warnf("mcp: sanitizeNonFiniteFloats recovered: %v", r)
+			out = v
 		}
 	}()
 	if v == nil {
-		return
+		return nil
 	}
-	sanitizeFloatsValue(reflect.ValueOf(v))
+	// Work on an addressable copy so value-type inputs are sanitized too, not
+	// only pointers. For a pointer input this copies the pointer and mutates the
+	// pointed-to value in place; for a value input it yields a sanitized copy.
+	box := reflect.New(reflect.TypeOf(v))
+	box.Elem().Set(reflect.ValueOf(v))
+	sanitizeFloatsValue(box.Elem())
+	return box.Elem().Interface()
 }
 
 func sanitizeFloatsValue(v reflect.Value) {
 	switch v.Kind() {
-	case reflect.Pointer, reflect.Interface:
+	case reflect.Ptr, reflect.Interface:
 		if !v.IsNil() {
 			sanitizeFloatsValue(v.Elem())
 		}
@@ -469,7 +478,7 @@ func sanitizeFloatsValue(v reflect.Value) {
 			// values are mutated in place by recursing; value-type elements
 			// (e.g. a float or struct) must be rebuilt and reassigned.
 			switch elem.Kind() {
-			case reflect.Pointer, reflect.Interface, reflect.Slice, reflect.Map:
+			case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map:
 				sanitizeFloatsValue(elem)
 			default:
 				tmp := reflect.New(elem.Type()).Elem()


### PR DESCRIPTION
## Description

The MCP integration test `TestMCPAssetVsHTTP` (historical assets) has been failing the merge queue with:

```
asset_mcp_vs_http_test.go:174: Failed to get MCP tool response:
MCP error (code 0): marshaling output: json: unsupported value: NaN
```

The MCP SDK marshals tool output with the standard library `encoding/json`, which returns an error for non-finite floats (`NaN`, `+Inf`, `-Inf`). Upstream cost calculations can produce these, for example a 0/0 breakdown or overhead fraction on an asset with zero cost or zero capacity. The HTTP `/assets` path doesn't hit this because it serializes through OpenCost's own JSON library, but the MCP path uses stdlib json, so a single non-finite float anywhere in the response fails the whole tool call.

This adds a small sanitization pass in `ProcessMCPRequest` that walks the response and replaces any non-finite float with 0 before it reaches the SDK. It runs for every query type (allocation, asset, cloud cost, efficiency), so it covers the asset case that's failing now and prevents the same class of failure elsewhere. The walk is best effort: any reflection panic is recovered and logged so the sanitizer can never break a request.

This is independent of #3838 and #3865 (their code is correct and approved) — it's a pre-existing bug that fails the merge queue for everyone, so fixing it here unblocks the queue.

## Related

Surfaced by the merge queue failures on #3838 and #3865, and the scheduled `develop` integration run hits it too.

## User Impact

No API or schema change. MCP responses that previously errored out on a non-finite float now return that field as 0 and marshal successfully. The HTTP API path is untouched.

## Testing

- Added `pkg/mcp/sanitize_test.go`: builds an `AssetResponse` with `NaN`/`Inf` in nested fields (base floats, a `*float64`, a nested `*NodeOverhead`, a nested `*AssetBreakdown`, inside a `map[string]*AssetSet`), asserts `encoding/json` rejects it before sanitization and accepts it after, that non-finite values are zeroed, and that finite values are preserved. Plus a nil-safety case.
- `go build ./...`, `go vet ./pkg/mcp/`, and the full `pkg/mcp` package tests pass locally.

I can't run the live integration stack from here, so this is verified via the unit test that reproduces the exact marshal failure rather than a full stack run.

cc @ameijer — this is the second, unrelated blocker on the merge queue we discussed (the NaN one, separate from the conn-reset retry in opencost/opencost-integration-tests#106).
