### PR TITLE
ci: enforce go fix and golangci-lint via Makefile

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,19 +1,38 @@
 name: golangci-lint
-on: workflow_dispatch
+on:
+  pull_request:
+    branches:
+      - develop
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  golangci:
+  lint:
     name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          # Full history so golangci-lint can compute the merge base with the
+          # target branch for --new-from-merge-base.
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        run: make ci-lint
+
+  go-fix:
+    name: go-fix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-go@v6
         with:
           go-version: stable
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.5
+      - name: go fix
+        run: make go-fix-check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  exclusions:
+    # bingen-generated *_codecs.go files use a non-standard header
+    # (ASCII-art "DO NOT MODIFY" banner) that golangci-lint does not
+    # recognize as generated, so exclude them from linting explicitly.
+    paths:
+      - "_codecs\\.go$"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 GO ?= go
 SHELL := bash
+# Go modules in this repo. golangci-lint and go fix only operate on the module
+# rooted at the working directory, so each must be run from its own directory.
+MODULES := . ./core ./modules/prometheus-source ./modules/collector-source
 IMAGE_TAG ?= $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
@@ -13,3 +16,31 @@ GO_FLAGS     := -ldflags "-extldflags \"-static\" -s -w $(GO_LDFLAGS)"
 .PHONY: go/bin
 go/bin:
 	CGO_ENABLED=0 $(GO) build $(GO_FLAGS) ./cmd/costmodel
+
+# LINT_BASE is the git ref used as the baseline for "new issues only" linting.
+# golangci-lint reports only findings introduced relative to the merge base
+# with this ref, so the large backlog of pre-existing issues does not block
+# PRs while every newly written/changed line is still gated. Override locally
+# to lint against a different base (e.g. LINT_BASE=HEAD~1).
+LINT_BASE ?= origin/develop
+
+# ci-lint installs the latest golangci-lint and runs it against every module,
+# failing only on issues introduced since the merge base with $(LINT_BASE).
+.PHONY: ci-lint
+ci-lint:
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@for mod in $(MODULES); do \
+		echo "==> golangci-lint run ($$mod)"; \
+		( cd $$mod && golangci-lint run --config=$(CURDIR)/.golangci.yml --new-from-merge-base=$(LINT_BASE) ) || exit 1; \
+	done
+
+# go-fix-check runs the Go fix tool to update deprecated or outdated API usage
+# to current equivalents (e.g. old error patterns, renamed stdlib identifiers).
+# -diff prints a unified diff instead of rewriting files, and exits non-zero
+# if the diff is non-empty, which causes CI to fail.
+.PHONY: go-fix-check
+go-fix-check:
+	@for mod in $(MODULES); do \
+		echo "==> go fix -diff ($$mod)"; \
+		( cd $$mod && $(GO) fix -diff ./... ) || exit 1; \
+	done

--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -5,7 +5,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -200,9 +199,9 @@ func GetControllerOf(pod *Pod) *metav1.OwnerReference {
 		return nil
 	}
 	cp := *ref
-	cp.Controller = ptr.To(*ref.Controller)
+	cp.Controller = new(*ref.Controller)
 	if ref.BlockOwnerDeletion != nil {
-		cp.BlockOwnerDeletion = ptr.To(*ref.BlockOwnerDeletion)
+		cp.BlockOwnerDeletion = new(*ref.BlockOwnerDeletion)
 	}
 	return &cp
 }

--- a/core/pkg/collections/idnamemap_test.go
+++ b/core/pkg/collections/idnamemap_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"errors"
+	"maps"
 	"testing"
 )
 
@@ -350,10 +351,7 @@ func TestIdNameMap_Keys(t *testing.T) {
 		m.Insert(item)
 	}
 
-	keys := make(map[string]string)
-	for id, name := range m.Keys() {
-		keys[id] = name
-	}
+	keys := maps.Collect(m.Keys())
 
 	if len(keys) != 3 {
 		t.Errorf("expected 3 keys, got %d", len(keys))

--- a/core/pkg/errors/panic.go
+++ b/core/pkg/errors/panic.go
@@ -29,7 +29,7 @@ func (pt PanicType) String() string {
 
 // Panic represents a panic that occurred, captured by a recovery.
 type Panic struct {
-	Error interface{}
+	Error any
 	Stack string
 	Type  PanicType
 }
@@ -110,7 +110,7 @@ func HandleHTTPPanic(rw http.ResponseWriter, rq *http.Request) {
 }
 
 // generate stacktrace, dispatch the panic via channel
-func dispatch(err interface{}, panicType PanicType) {
+func dispatch(err any, panicType PanicType) {
 	stack := make([]byte, 1024*8)
 	stack = stack[:runtime.Stack(stack, false)]
 

--- a/core/pkg/exporter/controller.go
+++ b/core/pkg/exporter/controller.go
@@ -42,7 +42,7 @@ func NewEventExportController[T any](source ExportSource[T], exporter EventExpor
 	return &EventExportController[T]{
 		source:   source,
 		exporter: exporter,
-		typeName: reflect.TypeOf((*T)(nil)).Elem().String(),
+		typeName: reflect.TypeFor[T]().String(),
 	}
 }
 

--- a/core/pkg/exporter/decoder_test.go
+++ b/core/pkg/exporter/decoder_test.go
@@ -26,7 +26,7 @@ type decoderTestCase[T any] struct {
 
 func generateBadBytes() []byte {
 	buff := util.NewBuffer()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		buff.WriteUInt64(9999999)
 	}
 

--- a/core/pkg/exporter/pathing/eventpath.go
+++ b/core/pkg/exporter/pathing/eventpath.go
@@ -3,6 +3,7 @@ package pathing
 import (
 	"fmt"
 	"path"
+	"slices"
 	"time"
 )
 
@@ -34,10 +35,8 @@ func NewEventStoragePathFormatter(rootDir, clusterId, event string, subPaths ...
 		return nil, fmt.Errorf("event cannot be empty")
 	}
 
-	for _, subPath := range subPaths {
-		if subPath == "" {
-			return nil, fmt.Errorf("subpaths cannot be empty")
-		}
+	if slices.Contains(subPaths, "") {
+		return nil, fmt.Errorf("subpaths cannot be empty")
 	}
 
 	return &EventStoragePathFormatter{

--- a/core/pkg/filter/ast/parser.go
+++ b/core/pkg/filter/ast/parser.go
@@ -6,6 +6,7 @@ package ast
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -73,11 +74,9 @@ func (p *parser) previous() token {
 // a kind that matches one of the arguments. Otherwise, it returns false and
 // DOES NOT advance the parser.
 func (p *parser) match(tokenKinds ...tokenKind) bool {
-	for _, kind := range tokenKinds {
-		if p.check(kind) {
-			p.advance()
-			return true
-		}
+	if slices.ContainsFunc(tokenKinds, p.check) {
+		p.advance()
+		return true
 	}
 	return false
 }
@@ -115,10 +114,8 @@ func (p *parser) synchronize(tokens ...tokenKind) {
 
 	for !p.atEnd() {
 		kind := p.peek().kind
-		for _, token := range tokens {
-			if kind == token {
-				return
-			}
+		if slices.Contains(tokens, kind) {
+			return
 		}
 
 		p.advance()

--- a/core/pkg/filter/matcher/and.go
+++ b/core/pkg/filter/matcher/and.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	"fmt"
+	"strings"
 )
 
 // And is a set of filters that should be evaluated as a logical
@@ -15,13 +16,14 @@ func (a *And[T]) Add(m Matcher[T]) {
 }
 
 func (a *And[T]) String() string {
-	s := "(and"
+	var s strings.Builder
+	s.WriteString("(and")
 	for _, f := range a.Matchers {
-		s += fmt.Sprintf(" %s", f)
+		fmt.Fprintf(&s, " %s", f)
 	}
 
-	s += ")"
-	return s
+	s.WriteString(")")
+	return s.String()
 }
 
 // Matches is the canonical in-Go function for determining if T

--- a/core/pkg/filter/matcher/or.go
+++ b/core/pkg/filter/matcher/or.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Or is a set of filters that should be evaluated as a logical
@@ -15,13 +16,14 @@ func (o *Or[T]) Add(m Matcher[T]) {
 }
 
 func (o *Or[T]) String() string {
-	s := "(or"
+	var s strings.Builder
+	s.WriteString("(or")
 	for _, f := range o.Matchers {
-		s += fmt.Sprintf(" %s", f)
+		fmt.Fprintf(&s, " %s", f)
 	}
 
-	s += ")"
-	return s
+	s.WriteString(")")
+	return s.String()
 }
 
 // Matches is the canonical in-Go function for determining if T

--- a/core/pkg/filter/matcher/stringslicematcher.go
+++ b/core/pkg/filter/matcher/stringslicematcher.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/opencost/opencost/core/pkg/filter/ast"
@@ -59,10 +60,8 @@ func (ssp *StringSliceMatcher[T]) Matches(that T) bool {
 			return ssp.Value == ""
 		}
 
-		for _, s := range thatSlice {
-			if s == ssp.Value {
-				return true
-			}
+		if slices.Contains(thatSlice, ssp.Value) {
+			return true
 		}
 
 	case ast.FilterOpContainsPrefix:

--- a/core/pkg/filter/ops/ops.go
+++ b/core/pkg/filter/ops/ops.go
@@ -110,12 +110,12 @@ type KeyedFieldType string
 
 func (k KeyedFieldType) Field() string {
 	str := string(k)
-	idx := strings.Index(str, "$")
-	if idx == -1 {
+	before, _, ok := strings.Cut(str, "$")
+	if !ok {
 		return ""
 	}
 
-	return str[0:idx]
+	return before
 }
 
 func (k KeyedFieldType) Key() string {

--- a/core/pkg/log/counter_test.go
+++ b/core/pkg/log/counter_test.go
@@ -48,13 +48,11 @@ func TestCounter_Threadsafety(t *testing.T) {
 
 	// Run 1000 goroutines, logging 10000 times each as fast as they can
 	for i := 1; i <= 1000; i++ {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			for j := 1; j <= 10000; j++ {
 				DedupedInfof(10, "this log seen %d times", j)
 			}
-			wg.Done()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/core/pkg/log/log.go
+++ b/core/pkg/log/log.go
@@ -77,11 +77,11 @@ func Error(msg string) {
 	log.Error().Msg(msg)
 }
 
-func Errorf(format string, a ...interface{}) {
+func Errorf(format string, a ...any) {
 	log.Error().Msgf(format, a...)
 }
 
-func DedupedErrorf(logTypeLimit int, format string, a ...interface{}) {
+func DedupedErrorf(logTypeLimit int, format string, a ...any) {
 	timesLogged := ctr.increment(format)
 
 	if timesLogged < logTypeLimit {
@@ -96,11 +96,11 @@ func Warn(msg string) {
 	log.Warn().Msg(msg)
 }
 
-func Warnf(format string, a ...interface{}) {
+func Warnf(format string, a ...any) {
 	log.Warn().Msgf(format, a...)
 }
 
-func DedupedWarningf(logTypeLimit int, format string, a ...interface{}) {
+func DedupedWarningf(logTypeLimit int, format string, a ...any) {
 	timesLogged := ctr.increment(format)
 
 	if timesLogged < logTypeLimit {
@@ -115,11 +115,11 @@ func Info(msg string) {
 	log.Info().Msg(msg)
 }
 
-func Infof(format string, a ...interface{}) {
+func Infof(format string, a ...any) {
 	log.Info().Msgf(format, a...)
 }
 
-func DedupedInfof(logTypeLimit int, format string, a ...interface{}) {
+func DedupedInfof(logTypeLimit int, format string, a ...any) {
 	timesLogged := ctr.increment(format)
 
 	if timesLogged < logTypeLimit {
@@ -130,7 +130,7 @@ func DedupedInfof(logTypeLimit int, format string, a ...interface{}) {
 	}
 }
 
-func Profilef(format string, a ...interface{}) {
+func Profilef(format string, a ...any) {
 	log.Info().Msgf(fmt.Sprintf("[Profiler] %s", format), a...)
 }
 
@@ -138,7 +138,7 @@ func Debug(msg string) {
 	log.Debug().Msg(msg)
 }
 
-func Debugf(format string, a ...interface{}) {
+func Debugf(format string, a ...any) {
 	log.Debug().Msgf(format, a...)
 }
 
@@ -146,7 +146,7 @@ func Trace(msg string) {
 	log.Trace().Msg(msg)
 }
 
-func Tracef(format string, a ...interface{}) {
+func Tracef(format string, a ...any) {
 	log.Trace().Msgf(format, a...)
 }
 
@@ -154,7 +154,7 @@ func Fatal(msg string) {
 	log.Fatal().Msg(msg)
 }
 
-func Fatalf(format string, a ...interface{}) {
+func Fatalf(format string, a ...any) {
 	log.Fatal().Msgf(format, a...)
 }
 

--- a/core/pkg/log/log_test.go
+++ b/core/pkg/log/log_test.go
@@ -59,8 +59,8 @@ func TestLoggerConsistency(t *testing.T) {
 	}
 }
 
-func parseLogMessage(t *testing.T, logMessage string) map[string]interface{} {
-	var loggedData map[string]interface{}
+func parseLogMessage(t *testing.T, logMessage string) map[string]any {
+	var loggedData map[string]any
 	if err := json.Unmarshal([]byte(strings.TrimSpace(logMessage)), &loggedData); err != nil {
 		t.Fatalf("Failed to parse logged message: %v", err)
 	}
@@ -218,31 +218,31 @@ func TestDedupedLogging(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		logFunc      func(int, string, ...interface{})
+		logFunc      func(int, string, ...any)
 		logTypeLimit int
 		format       string
-		args         []interface{}
+		args         []any
 	}{
 		{
 			name:         "DedupedErrorf",
 			logFunc:      DedupedErrorf,
 			logTypeLimit: 3,
 			format:       "test error %d",
-			args:         []interface{}{1},
+			args:         []any{1},
 		},
 		{
 			name:         "DedupedWarningf",
 			logFunc:      DedupedWarningf,
 			logTypeLimit: 2,
 			format:       "test warning %d",
-			args:         []interface{}{1},
+			args:         []any{1},
 		},
 		{
 			name:         "DedupedInfof",
 			logFunc:      DedupedInfof,
 			logTypeLimit: 4,
 			format:       "test info %d",
-			args:         []interface{}{1},
+			args:         []any{1},
 		},
 	}
 

--- a/core/pkg/log/profiler.go
+++ b/core/pkg/log/profiler.go
@@ -1,5 +1,7 @@
 package log
 
+import "maps"
+
 import "time"
 
 type Profiler struct {
@@ -47,9 +49,7 @@ func (p *Profiler) LogAll() {
 
 	// Print profiles, largest to smallest. (Inefficient, but shouldn't matter.)
 	print := map[string]time.Duration{}
-	for name, value := range p.profiles {
-		print[name] = value
-	}
+	maps.Copy(print, p.profiles)
 	for len(print) > 0 {
 		largest := ""
 		for name := range print {

--- a/core/pkg/model/kubemodel/device.go
+++ b/core/pkg/model/kubemodel/device.go
@@ -19,8 +19,8 @@ type Device struct {
 	PowerWattSeconds  float64     `json:"powerWattSeconds"`  // Device power consumption in watt-seconds (Joules)
 	PowerWattMax      float64     `json:"powerWattMax"`      // Device max power consumption in watts
 	// Version 2 fields - Lifecycle tracking
-	Start           time.Time   `json:"start,omitempty"` // Device availability start
-	End             time.Time   `json:"end,omitempty"`   // Device availability end
+	Start           time.Time   `json:"start"`           // Device availability start
+	End             time.Time   `json:"end"`             // Device availability end
 	DurationSeconds Measurement `json:"durationSeconds"` // Duration device was available
 }
 

--- a/core/pkg/model/kubemodel/kubemodel_codecs.go
+++ b/core/pkg/model/kubemodel/kubemodel_codecs.go
@@ -158,10 +158,10 @@ func isReaderBinaryTag(buff *util.Buffer, tag string) bool {
 
 // typeToString determines the basic properties of the type, the qualifier, package path, and
 // type name, and returns the qualified type
-func typeToString(f interface{}) string {
+func typeToString(f any) string {
 	qual := ""
 	t := reflect.TypeOf(f)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 		qual = "*"
 	}

--- a/core/pkg/model/kubemodel/merge.go
+++ b/core/pkg/model/kubemodel/merge.go
@@ -430,9 +430,7 @@ func copyResourceQuantities(rq ResourceQuantities) ResourceQuantities {
 		return nil
 	}
 	copied := make(ResourceQuantities, len(rq))
-	for k, v := range rq {
-		copied[k] = v
-	}
+	maps.Copy(copied, rq)
 	return copied
 }
 

--- a/core/pkg/model/kubemodel/namespace.go
+++ b/core/pkg/model/kubemodel/namespace.go
@@ -7,13 +7,13 @@ import (
 
 // @bingen:generate:Namespace
 type Namespace struct {
-	UID         string            `json:"uid"`             // @bingen:field[version=1]
-	ClusterUID  string            `json:"clusterUID"`      // @bingen:field[version=1]
-	Name        string            `json:"name"`            // @bingen:field[version=1]
-	Labels      map[string]string `json:"labels"`          // @bingen:field[version=1]
-	Annotations map[string]string `json:"annotations"`     // @bingen:field[version=1]
-	Start       time.Time         `json:"start,omitempty"` // @bingen:field[version=1]
-	End         time.Time         `json:"end,omitempty"`   // @bingen:field[version=1]
+	UID         string            `json:"uid"`         // @bingen:field[version=1]
+	ClusterUID  string            `json:"clusterUID"`  // @bingen:field[version=1]
+	Name        string            `json:"name"`        // @bingen:field[version=1]
+	Labels      map[string]string `json:"labels"`      // @bingen:field[version=1]
+	Annotations map[string]string `json:"annotations"` // @bingen:field[version=1]
+	Start       time.Time         `json:"start"`       // @bingen:field[version=1]
+	End         time.Time         `json:"end"`         // @bingen:field[version=1]
 }
 
 func (kms *KubeModelSet) RegisterNamespace(uid, name string) error {

--- a/core/pkg/model/kubemodel/node.go
+++ b/core/pkg/model/kubemodel/node.go
@@ -20,8 +20,8 @@ type Node struct {
 	AttachedVolumes      map[string]*NodeVolumeUsage `json:"attachedVolumes,omitempty"`
 	CpuMillicoreUsageMax Measurement                 `json:"cpuMillicoreUsageMax"` // Peak CPU usage observed
 	RAMByteUsageMax      Measurement                 `json:"ramByteUsageMax"`      // Peak RAM usage observed
-	Start                time.Time                   `json:"start,omitempty"`      // Node creation/start timestamp
-	End                  time.Time                   `json:"end,omitempty"`        // Node deletion/end timestamp (nil if still running)
+	Start                time.Time                   `json:"start"`                // Node creation/start timestamp
+	End                  time.Time                   `json:"end"`                  // Node deletion/end timestamp (nil if still running)
 }
 
 // NodeVolumeUsage tracks storage usage for a disk volume attached to a node.

--- a/core/pkg/model/kubemodel/owner.go
+++ b/core/pkg/model/kubemodel/owner.go
@@ -24,8 +24,8 @@ type Owner struct {
 	Kind         OwnerKind         `json:"kind"`
 	Labels       map[string]string `json:"labels,omitempty"`
 	Annotations  map[string]string `json:"annotations,omitempty"`
-	Start        time.Time         `json:"start,omitempty"`
-	End          time.Time         `json:"end,omitempty"`
+	Start        time.Time         `json:"start"`
+	End          time.Time         `json:"end"`
 }
 
 func (kms *KubeModelSet) RegisterOwner(uid, name, namespace, kind string) error {

--- a/core/pkg/model/kubemodel/pod.go
+++ b/core/pkg/model/kubemodel/pod.go
@@ -16,8 +16,8 @@ type Pod struct {
 	DurationSeconds      Measurement       `json:"durationSeconds"`
 	NetworkTransferBytes Measurement       `json:"networkTransferBytes"`
 	NetworkReceiveBytes  Measurement       `json:"networkReceiveBytes"`
-	Start                time.Time         `json:"start,omitempty"` // Pod creation/start timestamp
-	End                  time.Time         `json:"end,omitempty"`   // Pod deletion/end timestamp (nil if still running)
+	Start                time.Time         `json:"start"` // Pod creation/start timestamp
+	End                  time.Time         `json:"end"`   // Pod deletion/end timestamp (nil if still running)
 }
 
 func (kms *KubeModelSet) RegisterPod(uid, name, namespace string) error {

--- a/core/pkg/model/kubemodel/pv.go
+++ b/core/pkg/model/kubemodel/pv.go
@@ -30,8 +30,8 @@ type PersistentVolume struct {
 	// Availability zone for cross-AZ cost tracking
 	Zone string `json:"zone,omitempty"`
 	// Volume lifecycle timestamps
-	Start time.Time `json:"start"`         // Volume creation timestamp
-	End   time.Time `json:"end,omitempty"` // Volume deletion timestamp (nil if still active)
+	Start time.Time `json:"start"` // Volume creation timestamp
+	End   time.Time `json:"end"`   // Volume deletion timestamp (nil if still active)
 	// Duration volume existed within measurement window
 	DurationSeconds Measurement `json:"durationSeconds"`
 	// JSON-encoded node affinity for local volumes

--- a/core/pkg/model/kubemodel/pvc.go
+++ b/core/pkg/model/kubemodel/pvc.go
@@ -22,9 +22,9 @@ type PersistentVolumeClaim struct {
 	// ReadWriteOnce, ReadWriteMany, ReadOnlyMany
 	AccessModes           []string    `json:"accessModes,omitempty"`
 	ActualUsedByteSeconds Measurement `json:"actualUsedByteSeconds,omitempty"`
-	Start                 time.Time   `json:"start"`         // PVC creation timestamp
-	End                   time.Time   `json:"end,omitempty"` // PVC deletion timestamp (nil if still active)
-	BoundAt               time.Time   `json:"boundAt,omitempty"`
+	Start                 time.Time   `json:"start"` // PVC creation timestamp
+	End                   time.Time   `json:"end"`   // PVC deletion timestamp (nil if still active)
+	BoundAt               time.Time   `json:"boundAt"`
 	DurationSeconds       Measurement `json:"durationSeconds,omitempty"`
 }
 

--- a/core/pkg/model/kubemodel/stats.go
+++ b/core/pkg/model/kubemodel/stats.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 )
 
 // @bingen:generate:StatType
@@ -98,11 +99,12 @@ func (s Stats) Sanitize() error {
 	}
 
 	if len(errs) > 0 {
-		errStr := fmt.Sprintf("%d errors:", len(errs))
+		var errStr strings.Builder
+		fmt.Fprintf(&errStr, "%d errors:", len(errs))
 		for _, e := range errs {
-			errStr += fmt.Sprintf(" [%s]", e)
+			fmt.Fprintf(&errStr, " [%s]", e)
 		}
-		return errors.New(errStr)
+		return errors.New(errStr.String())
 	}
 
 	return nil

--- a/core/pkg/model/mock.go
+++ b/core/pkg/model/mock.go
@@ -42,7 +42,7 @@ func createCustomCost(postfix string) *pb.CustomCost {
 func GenerateMockCustomCostSet(start, end time.Time) *pb.CustomCostResponse {
 	costs := []*pb.CustomCost{}
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		costs = append(costs, createCustomCost(fmt.Sprintf("%d", i)))
 	}
 

--- a/core/pkg/nodestats/request.go
+++ b/core/pkg/nodestats/request.go
@@ -32,7 +32,7 @@ func NewNodeHttpClient(client HttpClient) *NodeHttpClient {
 func (c *NodeHttpClient) AttemptEndPoint(method string, URL string, bearerToken string) (*http.Response, error) {
 	attempts := uint(1)
 
-	for i := uint(0); i < attempts; i++ {
+	for i := range attempts {
 		if i > 0 {
 			time.Sleep(time.Duration(int64(math.Pow(2, float64(i)))) * time.Second)
 		}

--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -2,6 +2,7 @@ package opencost
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"strings"
@@ -472,9 +473,7 @@ type ProportionalAssetResourceCosts map[string]ProportionalAssetResourceCost
 func (parcs ProportionalAssetResourceCosts) Clone() ProportionalAssetResourceCosts {
 	cloned := ProportionalAssetResourceCosts{}
 
-	for key, parc := range parcs {
-		cloned[key] = parc
-	}
+	maps.Copy(cloned, parcs)
 	return cloned
 }
 
@@ -647,9 +646,7 @@ type SharedCostBreakdowns map[string]SharedCostBreakdown
 func (scbs SharedCostBreakdowns) Clone() SharedCostBreakdowns {
 	cloned := SharedCostBreakdowns{}
 
-	for key, scb := range scbs {
-		cloned[key] = scb
-	}
+	maps.Copy(cloned, scbs)
 	return cloned
 }
 
@@ -2874,14 +2871,10 @@ func (as *AllocationSet) Clone() *AllocationSet {
 	}
 
 	externalKeys := make(map[string]bool, len(as.ExternalKeys))
-	for k, v := range as.ExternalKeys {
-		externalKeys[k] = v
-	}
+	maps.Copy(externalKeys, as.ExternalKeys)
 
 	idleKeys := make(map[string]bool, len(as.IdleKeys))
-	for k, v := range as.IdleKeys {
-		idleKeys[k] = v
-	}
+	maps.Copy(idleKeys, as.IdleKeys)
 
 	var errors []string
 	var warnings []string

--- a/core/pkg/opencost/allocation_test.go
+++ b/core/pkg/opencost/allocation_test.go
@@ -3321,7 +3321,7 @@ func TestAllocationSet_Accumulate_Equals_AllocationSetRange_Accumulate(t *testin
 
 	var allocationSets []*AllocationSet
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		allocationSets = append(allocationSets, GenerateMockAllocationSet(start))
 		start = start.AddDate(0, 0, 1)
 	}

--- a/core/pkg/opencost/allocationprops.go
+++ b/core/pkg/opencost/allocationprops.go
@@ -2,6 +2,7 @@ package opencost
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -160,13 +161,13 @@ func ParseProperty(text string) (AllocationProperty, error) {
 		return AllocationTeamProp, nil
 	}
 
-	if strings.HasPrefix(text, "label:") {
-		label := promutil.SanitizeLabelName(strings.TrimSpace(strings.TrimPrefix(text, "label:")))
+	if after, ok := strings.CutPrefix(text, "label:"); ok {
+		label := promutil.SanitizeLabelName(strings.TrimSpace(after))
 		return AllocationProperty(fmt.Sprintf("label:%s", label)), nil
 	}
 
-	if strings.HasPrefix(text, "annotation:") {
-		annotation := promutil.SanitizeLabelName(strings.TrimSpace(strings.TrimPrefix(text, "annotation:")))
+	if after, ok := strings.CutPrefix(text, "annotation:"); ok {
+		annotation := promutil.SanitizeLabelName(strings.TrimSpace(after))
 		return AllocationProperty(fmt.Sprintf("annotation:%s", annotation)), nil
 	}
 
@@ -221,27 +222,19 @@ func (p *AllocationProperties) Clone() *AllocationProperties {
 	clone.Services = services
 
 	labels := make(map[string]string, len(p.Labels))
-	for k, v := range p.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, p.Labels)
 	clone.Labels = labels
 
 	nsLabels := make(map[string]string, len(p.NamespaceLabels))
-	for k, v := range p.NamespaceLabels {
-		nsLabels[k] = v
-	}
+	maps.Copy(nsLabels, p.NamespaceLabels)
 	clone.NamespaceLabels = nsLabels
 
 	annotations := make(map[string]string, len(p.Annotations))
-	for k, v := range p.Annotations {
-		annotations[k] = v
-	}
+	maps.Copy(annotations, p.Annotations)
 	clone.Annotations = annotations
 
 	nsAnnotations := make(map[string]string, len(p.NamespaceAnnotations))
-	for k, v := range p.NamespaceAnnotations {
-		nsAnnotations[k] = v
-	}
+	maps.Copy(nsAnnotations, p.NamespaceAnnotations)
 	clone.NamespaceAnnotations = nsAnnotations
 
 	clone.AggregatedMetadata = p.AggregatedMetadata
@@ -456,8 +449,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelNames := strings.Split(labelConfig.DepartmentLabel, ",")
-				for _, labelName := range labelNames {
+				labelNames := strings.SplitSeq(labelConfig.DepartmentLabel, ",")
+				for labelName := range labelNames {
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
@@ -474,8 +467,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelNames := strings.Split(labelConfig.EnvironmentLabel, ",")
-				for _, labelName := range labelNames {
+				labelNames := strings.SplitSeq(labelConfig.EnvironmentLabel, ",")
+				for labelName := range labelNames {
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
@@ -492,8 +485,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelNames := strings.Split(labelConfig.OwnerLabel, ",")
-				for _, labelName := range labelNames {
+				labelNames := strings.SplitSeq(labelConfig.OwnerLabel, ",")
+				for labelName := range labelNames {
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
@@ -510,8 +503,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelNames := strings.Split(labelConfig.ProductLabel, ",")
-				for _, labelName := range labelNames {
+				labelNames := strings.SplitSeq(labelConfig.ProductLabel, ",")
+				for labelName := range labelNames {
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
@@ -528,8 +521,8 @@ func (p *AllocationProperties) GenerateKey(aggregateBy []string, labelConfig *La
 			if labels == nil && annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelNames := strings.Split(labelConfig.TeamLabel, ",")
-				for _, labelName := range labelNames {
+				labelNames := strings.SplitSeq(labelConfig.TeamLabel, ",")
+				for labelName := range labelNames {
 					labelName = labelConfig.Sanitize(labelName)
 					if labelValue, ok := labels[labelName]; ok {
 						names = append(names, labelValue)
@@ -627,9 +620,7 @@ func (p *AllocationProperties) Intersection(that *AllocationProperties) *Allocat
 
 func copyStringMap(original map[string]string) map[string]string {
 	copy := make(map[string]string)
-	for key, value := range original {
-		copy[key] = value
-	}
+	maps.Copy(copy, original)
 
 	return copy
 }

--- a/core/pkg/opencost/asset.go
+++ b/core/pkg/opencost/asset.go
@@ -3,7 +3,9 @@ package opencost
 import (
 	"encoding"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -162,8 +164,8 @@ func getKeyFromLabelConfig(a Asset, labelConfig *LabelConfig, label string) stri
 		return UnallocatedSuffix
 	} else {
 		key := UnallocatedSuffix
-		labelNames := strings.Split(label, ",")
-		for _, labelName := range labelNames {
+		labelNames := strings.SplitSeq(label, ",")
+		for labelName := range labelNames {
 			name := labelConfig.Sanitize(labelName)
 			if labelValue, ok := labels[name]; ok {
 				key = labelValue
@@ -190,9 +192,7 @@ type AssetLabels map[string]string
 func (al AssetLabels) Clone() AssetLabels {
 	clone := make(AssetLabels, len(al))
 
-	for label, value := range al {
-		clone[label] = value
-	}
+	maps.Copy(clone, al)
 
 	return clone
 }
@@ -3830,12 +3830,7 @@ func sameContents(a, b []string) bool {
 }
 
 func contains(slice []string, item string) bool {
-	for _, element := range slice {
-		if element == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, item)
 }
 
 func GetNodePoolName(provider string, labels map[string]string) string {

--- a/core/pkg/opencost/asset_json.go
+++ b/core/pkg/opencost/asset_json.go
@@ -31,7 +31,7 @@ func (a *Any) MarshalJSON() ([]byte, error) {
 
 func (a *Any) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -47,17 +47,17 @@ func (a *Any) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to Any, carrying over relevant fields
-func (a *Any) InterfaceToAny(itf interface{}) error {
+func (a *Any) InterfaceToAny(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
@@ -77,7 +77,7 @@ func (a *Any) InterfaceToAny(itf interface{}) error {
 	a.End = end
 
 	if _, found := fmap["window"]; found {
-		a.Window = toWindow(fmap["window"].(map[string]interface{}))
+		a.Window = toWindow(fmap["window"].(map[string]any))
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
@@ -111,7 +111,7 @@ func (ca *Cloud) MarshalJSON() ([]byte, error) {
 
 func (ca *Cloud) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -127,17 +127,17 @@ func (ca *Cloud) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to Cloud, carrying over relevant fields
-func (ca *Cloud) InterfaceToCloud(itf interface{}) error {
+func (ca *Cloud) InterfaceToCloud(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
@@ -156,7 +156,7 @@ func (ca *Cloud) InterfaceToCloud(itf interface{}) error {
 	ca.Start = start
 	ca.End = end
 	if _, found := fmap["window"]; found {
-		ca.Window = toWindow(fmap["window"].(map[string]interface{}))
+		ca.Window = toWindow(fmap["window"].(map[string]any))
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
@@ -191,7 +191,7 @@ func (cm *ClusterManagement) MarshalJSON() ([]byte, error) {
 
 func (cm *ClusterManagement) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -207,24 +207,24 @@ func (cm *ClusterManagement) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to ClusterManagement, carrying over relevant fields
-func (cm *ClusterManagement) InterfaceToClusterManagement(itf interface{}) error {
+func (cm *ClusterManagement) InterfaceToClusterManagement(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
 	cm.Properties = &properties
 	cm.Labels = labels
 	if _, found := fmap["window"]; found {
-		cm.Window = toWindow(fmap["window"].(map[string]interface{}))
+		cm.Window = toWindow(fmap["window"].(map[string]any))
 	}
 
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
@@ -272,7 +272,7 @@ func (d *Disk) MarshalJSON() ([]byte, error) {
 
 func (d *Disk) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -288,17 +288,17 @@ func (d *Disk) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to Disk, carrying over relevant fields
-func (d *Disk) InterfaceToDisk(itf interface{}) error {
+func (d *Disk) InterfaceToDisk(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
@@ -312,7 +312,7 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 		return err
 	}
 
-	fbreakdown := fmap["breakdown"].(map[string]interface{})
+	fbreakdown := fmap["breakdown"].(map[string]any)
 
 	breakdown := toBreakdown(fbreakdown)
 
@@ -321,7 +321,7 @@ func (d *Disk) InterfaceToDisk(itf interface{}) error {
 	d.Start = start
 	d.End = end
 	if _, found := fmap["window"]; found {
-		d.Window = toWindow(fmap["window"].(map[string]interface{}))
+		d.Window = toWindow(fmap["window"].(map[string]any))
 	}
 	d.Breakdown = &breakdown
 
@@ -392,7 +392,7 @@ func (n *Network) MarshalJSON() ([]byte, error) {
 
 func (n *Network) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -408,17 +408,17 @@ func (n *Network) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to Network, carrying over relevant fields
-func (n *Network) InterfaceToNetwork(itf interface{}) error {
+func (n *Network) InterfaceToNetwork(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
@@ -437,7 +437,7 @@ func (n *Network) InterfaceToNetwork(itf interface{}) error {
 	n.Start = start
 	n.End = end
 	if _, found := fmap["window"]; found {
-		n.Window = toWindow(fmap["window"].(map[string]interface{}))
+		n.Window = toWindow(fmap["window"].(map[string]any))
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
@@ -492,7 +492,7 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 
 func (n *Node) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -508,17 +508,17 @@ func (n *Node) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to Node, carrying over relevant fields
-func (n *Node) InterfaceToNode(itf interface{}) error {
+func (n *Node) InterfaceToNode(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	if labelsInterface, ok := fmap["labels"].(map[string]interface{}); ok {
+	if labelsInterface, ok := fmap["labels"].(map[string]any); ok {
 		for k, v := range labelsInterface {
 			if strValue, ok := v.(string); ok {
 				labels[k] = strValue
@@ -536,8 +536,8 @@ func (n *Node) InterfaceToNode(itf interface{}) error {
 		return err
 	}
 
-	fcpuBreakdown := fmap["cpuBreakdown"].(map[string]interface{})
-	framBreakdown := fmap["ramBreakdown"].(map[string]interface{})
+	fcpuBreakdown := fmap["cpuBreakdown"].(map[string]any)
+	framBreakdown := fmap["ramBreakdown"].(map[string]any)
 
 	cpuBreakdown := toBreakdown(fcpuBreakdown)
 	ramBreakdown := toBreakdown(framBreakdown)
@@ -547,7 +547,7 @@ func (n *Node) InterfaceToNode(itf interface{}) error {
 	n.Start = start
 	n.End = end
 	if _, found := fmap["window"]; found {
-		n.Window = toWindow(fmap["window"].(map[string]interface{}))
+		n.Window = toWindow(fmap["window"].(map[string]any))
 	}
 	n.CPUBreakdown = &cpuBreakdown
 	n.RAMBreakdown = &ramBreakdown
@@ -612,7 +612,7 @@ func (lb *LoadBalancer) MarshalJSON() ([]byte, error) {
 
 func (lb *LoadBalancer) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -628,17 +628,17 @@ func (lb *LoadBalancer) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to LoadBalancer, carrying over relevant fields
-func (lb *LoadBalancer) InterfaceToLoadBalancer(itf interface{}) error {
+func (lb *LoadBalancer) InterfaceToLoadBalancer(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
@@ -657,7 +657,7 @@ func (lb *LoadBalancer) InterfaceToLoadBalancer(itf interface{}) error {
 	lb.Start = start
 	lb.End = end
 	if _, found := fmap["window"]; found {
-		lb.Window = toWindow(fmap["window"].(map[string]interface{}))
+		lb.Window = toWindow(fmap["window"].(map[string]any))
 	}
 
 	if adjustment, err := getTypedVal(fmap["adjustment"]); err == nil {
@@ -696,7 +696,7 @@ func (sa *SharedAsset) MarshalJSON() ([]byte, error) {
 
 func (sa *SharedAsset) UnmarshalJSON(b []byte) error {
 
-	var f interface{}
+	var f any
 
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -712,24 +712,24 @@ func (sa *SharedAsset) UnmarshalJSON(b []byte) error {
 }
 
 // Converts interface{} to SharedAsset, carrying over relevant fields
-func (sa *SharedAsset) InterfaceToSharedAsset(itf interface{}) error {
+func (sa *SharedAsset) InterfaceToSharedAsset(itf any) error {
 
-	fmap := itf.(map[string]interface{})
+	fmap := itf.(map[string]any)
 
 	// parse properties map to AssetProperties
-	fproperties := fmap["properties"].(map[string]interface{})
+	fproperties := fmap["properties"].(map[string]any)
 	properties := toAssetProp(fproperties)
 
 	// parse labels map to AssetLabels
 	labels := make(map[string]string)
-	for k, v := range fmap["labels"].(map[string]interface{}) {
+	for k, v := range fmap["labels"].(map[string]any) {
 		labels[k] = v.(string)
 	}
 
 	sa.Properties = &properties
 	sa.Labels = labels
 	if _, found := fmap["window"]; found {
-		sa.Window = toWindow(fmap["window"].(map[string]interface{}))
+		sa.Window = toWindow(fmap["window"].(map[string]any))
 	}
 
 	if Cost, err := getTypedVal(fmap["totalCost"]); err == nil {
@@ -778,14 +778,14 @@ func (asr *AssetSetResponse) RawMessageToAssetSetResponse(assetMap map[string]*j
 	// For each item in asset map, unmarshal to appropriate type
 	for key, rawMessage := range assetMap {
 
-		var f interface{}
+		var f any
 
 		err := json.Unmarshal(*rawMessage, &f)
 		if err != nil {
 			return err
 		}
 
-		fmap := f.(map[string]interface{})
+		fmap := f.(map[string]any)
 
 		switch t := fmap["type"]; t {
 		case "Cloud":
@@ -915,7 +915,7 @@ func (asrr *AssetSetRangeResponse) UnmarshalJSON(b []byte) error {
 // Extra decoding util functions, for clarity
 
 // Creates an AssetProperties directly from map[string]interface{}
-func toAssetProp(fproperties map[string]interface{}) AssetProperties {
+func toAssetProp(fproperties map[string]any) AssetProperties {
 	var properties AssetProperties
 
 	if category, v := fproperties["category"].(string); v {
@@ -947,7 +947,7 @@ func toAssetProp(fproperties map[string]interface{}) AssetProperties {
 
 }
 
-func toWindow(fproperties map[string]interface{}) Window {
+func toWindow(fproperties map[string]any) Window {
 
 	var start, end time.Time
 	var err error
@@ -977,7 +977,7 @@ func toWindow(fproperties map[string]interface{}) Window {
 }
 
 // Creates an Breakdown directly from map[string]interface{}
-func toBreakdown(fproperties map[string]interface{}) Breakdown {
+func toBreakdown(fproperties map[string]any) Breakdown {
 	var breakdown Breakdown
 
 	if idle, v := fproperties["idle"].(float64); v {
@@ -999,7 +999,7 @@ func toBreakdown(fproperties map[string]interface{}) Breakdown {
 
 // Not strictly nessesary, but cleans up the code and is a secondary check
 // for correct types
-func getTypedVal(itf interface{}) (interface{}, error) {
+func getTypedVal(itf any) (any, error) {
 	switch itf := itf.(type) {
 	case float64:
 		return float64(itf), nil

--- a/core/pkg/opencost/assetprops.go
+++ b/core/pkg/opencost/assetprops.go
@@ -2,6 +2,7 @@ package opencost
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/opencost/opencost/core/pkg/util/promutil"
@@ -124,8 +125,8 @@ func ParseAssetProperty(text string) (AssetProperty, error) {
 		return AssetTeamProp, nil
 	}
 
-	if strings.HasPrefix(text, "label:") {
-		label := promutil.SanitizeLabelName(strings.TrimSpace(strings.TrimPrefix(text, "label:")))
+	if after, ok := strings.CutPrefix(text, "label:"); ok {
+		label := promutil.SanitizeLabelName(strings.TrimSpace(after))
 		return AssetProperty(fmt.Sprintf("label:%s", label)), nil
 	}
 
@@ -437,10 +438,5 @@ func (ap *AssetProperties) String() string {
 }
 
 func hasProp(props []AssetProperty, prop AssetProperty) bool {
-	for _, p := range props {
-		if p == prop {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(props, prop)
 }

--- a/core/pkg/opencost/cloudcostprops.go
+++ b/core/pkg/opencost/cloudcostprops.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash/fnv"
+	maps0 "maps"
 	"sort"
 	"strings"
 
@@ -85,8 +86,8 @@ func ParseCloudCostProperty(text string) (CloudCostProperty, error) {
 		return CloudCostProperty(CloudCostServiceProp), nil
 	}
 
-	if strings.HasPrefix(text, "label:") {
-		label := strings.TrimSpace(strings.TrimPrefix(text, "label:"))
+	if after, ok := strings.CutPrefix(text, "label:"); ok {
+		label := strings.TrimSpace(after)
 		return CloudCostProperty(fmt.Sprintf("label:%s", label)), nil
 	}
 
@@ -117,9 +118,7 @@ type CloudCostLabels map[string]string
 
 func (ccl CloudCostLabels) Clone() CloudCostLabels {
 	result := make(map[string]string, len(ccl))
-	for k, v := range ccl {
-		result[k] = v
-	}
+	maps0.Copy(result, ccl)
 	return result
 }
 

--- a/core/pkg/opencost/config.go
+++ b/core/pkg/opencost/config.go
@@ -191,8 +191,8 @@ func (lc *LabelConfig) GetExternalAllocationName(labels map[string]string, aggre
 
 	// Determine if the aggregation property is, itself, a label or not. If
 	// not, determine the label associated with the given aggregation property.
-	if strings.HasPrefix(aggregateBy, "label:") {
-		labelNames = append(labelNames, promutil.SanitizeLabelName(strings.TrimPrefix(aggregateBy, "label:")))
+	if after, ok := strings.CutPrefix(aggregateBy, "label:"); ok {
+		labelNames = append(labelNames, promutil.SanitizeLabelName(after))
 		aggByLabel = true
 	} else {
 		// If lc is nil, use a default LabelConfig to do a best-effort match

--- a/core/pkg/opencost/exporter/exporter_test.go
+++ b/core/pkg/opencost/exporter/exporter_test.go
@@ -156,15 +156,16 @@ type PipelineData[T any] interface {
 	*T
 }
 
+//go:fix inline
 func ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 func TestExporters(t *testing.T) {
 	t.Run("allocation exporter", func(t *testing.T) {
 		allocSource := NewMockAllocationSource()
 		memStore := storage.NewMemoryStorage()
-		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AllocationPipelineName, ptr(TestResolution))
+		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AllocationPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create path formatter: %v", err)
 		}
@@ -193,7 +194,7 @@ func TestExporters(t *testing.T) {
 	t.Run("asset exporter", func(t *testing.T) {
 		assetSource := NewMockAssetSource()
 		memStore := storage.NewMemoryStorage()
-		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AssetsPipelineName, ptr(TestResolution))
+		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AssetsPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create path formatter: %v", err)
 		}
@@ -222,7 +223,7 @@ func TestExporters(t *testing.T) {
 	t.Run("network insight exporter", func(t *testing.T) {
 		netInsightSource := NewMockNetworkInsightSource()
 		memStore := storage.NewMemoryStorage()
-		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.NetworkInsightPipelineName, ptr(TestResolution))
+		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.NetworkInsightPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create path formatter: %v", err)
 		}
@@ -251,7 +252,7 @@ func TestExporters(t *testing.T) {
 	t.Run("KubeModel exporter", func(t *testing.T) {
 		kubeModelSource := NewMockKubeModelSource()
 		memStore := storage.NewMemoryStorage()
-		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.KubeModelPipelineName, ptr(TestResolution))
+		p, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.KubeModelPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create path formatter: %v", err)
 		}
@@ -315,15 +316,15 @@ func TestPipelineExportControllers(t *testing.T) {
 		time.Sleep(time.Second + (750 * time.Millisecond))
 		exportControllers.Stop()
 
-		allocPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AllocationPipelineName, ptr(TestResolution))
+		allocPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AllocationPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create allocations path formatter: %v", err)
 		}
-		assetPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AssetsPipelineName, ptr(TestResolution))
+		assetPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AssetsPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create assets path formatter: %v", err)
 		}
-		netPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.NetworkInsightPipelineName, ptr(TestResolution))
+		netPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.NetworkInsightPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create net insights path formatter: %v", err)
 		}
@@ -353,15 +354,15 @@ func TestPipelineExportControllers(t *testing.T) {
 		time.Sleep(time.Second + (750 * time.Millisecond))
 		exportControllers.Stop()
 
-		allocPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AllocationPipelineName, ptr(TestResolution))
+		allocPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AllocationPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create allocations path formatter: %v", err)
 		}
-		assetPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AssetsPipelineName, ptr(TestResolution))
+		assetPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.AssetsPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create assets path formatter: %v", err)
 		}
-		netPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.NetworkInsightPipelineName, ptr(TestResolution))
+		netPath, err := pathing.NewDefaultStoragePathFormatter(TestClusterId, pipelines.NetworkInsightPipelineName, new(TestResolution))
 		if err != nil {
 			t.Fatalf("failed to create net insights path formatter: %v", err)
 		}

--- a/core/pkg/opencost/json.go
+++ b/core/pkg/opencost/json.go
@@ -17,6 +17,6 @@ func jsonEncodeString(buffer *bytes.Buffer, name, val, comma string) {
 }
 
 // jsonEncode encodes any object to JSON
-func jsonEncode(buffer *bytes.Buffer, name string, obj interface{}, comma string) {
+func jsonEncode(buffer *bytes.Buffer, name string, obj any, comma string) {
 	jsonutil.Encode(buffer, name, obj, comma)
 }

--- a/core/pkg/opencost/networkinsight.go
+++ b/core/pkg/opencost/networkinsight.go
@@ -419,7 +419,7 @@ func (ni *NetworkInsight) filterNetworkDetails(networkDetailFilter NetworkInsigh
 
 // SetWithNetworkInsightProperty sets the corresponding property
 // variable in the struct with the value passed to the function.
-func (ni *NetworkInsight) SetWithNetworkInsightProperty(property NetworkInsightProperty, value interface{}) error {
+func (ni *NetworkInsight) SetWithNetworkInsightProperty(property NetworkInsightProperty, value any) error {
 	switch property {
 	case NetworkInsightsCluster:
 		ni.Cluster = value.(string)

--- a/core/pkg/opencost/opencost_codecs.go
+++ b/core/pkg/opencost/opencost_codecs.go
@@ -189,10 +189,10 @@ func isReaderBinaryTag(buff *util.Buffer, tag string) bool {
 
 // typeToString determines the basic properties of the type, the qualifier, package path, and
 // type name, and returns the qualified type
-func typeToString(f interface{}) string {
+func typeToString(f any) string {
 	qual := ""
 	t := reflect.TypeOf(f)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 		qual = "*"
 	}

--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -3,6 +3,7 @@ package opencost
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -545,13 +546,9 @@ func (sas *SummaryAllocationSet) Clone() *SummaryAllocationSet {
 	defer sas.RUnlock()
 
 	externalKeys := make(map[string]bool, len(sas.externalKeys))
-	for k, v := range sas.externalKeys {
-		externalKeys[k] = v
-	}
+	maps.Copy(externalKeys, sas.externalKeys)
 	idleKeys := make(map[string]bool, len(sas.idleKeys))
-	for k, v := range sas.idleKeys {
-		idleKeys[k] = v
-	}
+	maps.Copy(idleKeys, sas.idleKeys)
 	summaryAllocations := make(map[string]*SummaryAllocation, len(sas.SummaryAllocations))
 	for k, v := range sas.SummaryAllocations {
 		summaryAllocations[k] = v.Clone()

--- a/core/pkg/plugin/plugin_interface.go
+++ b/core/pkg/plugin/plugin_interface.go
@@ -30,6 +30,6 @@ func (p *CustomCostPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server)
 // this method is called for as part of the reference plugin implementation
 // see https://github.com/hashicorp/go-plugin/blob/main/examples/basic/shared/greeter_interface.go#L63
 // for context and details
-func (CustomCostPlugin) GRPCClient(context context.Context, b *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (CustomCostPlugin) GRPCClient(context context.Context, b *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &GRPCClient{client: pb.NewCustomCostsSourceClient(c)}, nil
 }

--- a/core/pkg/protocol/http.go
+++ b/core/pkg/protocol/http.go
@@ -85,16 +85,16 @@ func (hp HTTPProtocol) NotFound() HTTPError {
 
 // HTTPResponse represents a data envelope for our HTTP messaging
 type HTTPResponse struct {
-	Code    int                    `json:"code"`
-	Data    interface{}            `json:"data"`
-	Meta    map[string]interface{} `json:"meta,omitempty"`
-	Message string                 `json:"message,omitempty"`
-	Warning string                 `json:"warning,omitempty"`
+	Code    int            `json:"code"`
+	Data    any            `json:"data"`
+	Meta    map[string]any `json:"meta,omitempty"`
+	Message string         `json:"message,omitempty"`
+	Warning string         `json:"warning,omitempty"`
 }
 
 // ToResponse accepts a data payload and/or error to encode into a new HTTPResponse instance. Responses
 // which should not contain an error should pass nil for err.
-func (hp HTTPProtocol) ToResponse(data interface{}, err error) *HTTPResponse {
+func (hp HTTPProtocol) ToResponse(data any, err error) *HTTPResponse {
 	if err != nil {
 		return &HTTPResponse{
 			Code:    http.StatusInternalServerError,
@@ -122,7 +122,7 @@ func (hp HTTPProtocol) WriteRawNoContent(w http.ResponseWriter) {
 
 // WriteJSONData uses json content-type and json encoder with no data envelope allowing to remove
 // xss CWE as well as backwards compatibility to exisitng FE expectations
-func (hp HTTPProtocol) WriteJSONData(w http.ResponseWriter, data interface{}) {
+func (hp HTTPProtocol) WriteJSONData(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		log.Error("Failed to encode JSON response: " + err.Error())
@@ -138,7 +138,7 @@ func (hp HTTPProtocol) WriteRawError(w http.ResponseWriter, httpStatusCode int, 
 }
 
 // WriteEncodedError writes an error response in the format of HTTPResponse
-func (hp HTTPProtocol) WriteEncodedError(w http.ResponseWriter, httpStatusCode int, errorResponse interface{}) {
+func (hp HTTPProtocol) WriteEncodedError(w http.ResponseWriter, httpStatusCode int, errorResponse any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatusCode)
 	if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
@@ -150,7 +150,7 @@ func (hp HTTPProtocol) WriteEncodedError(w http.ResponseWriter, httpStatusCode i
 
 // WriteData wraps the data payload in an HTTPResponse and writes the resulting response using the
 // http.ResponseWriter
-func (hp HTTPProtocol) WriteData(w http.ResponseWriter, data interface{}) {
+func (hp HTTPProtocol) WriteData(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	status := http.StatusOK
 	w.WriteHeader(status)
@@ -167,7 +167,7 @@ func (hp HTTPProtocol) WriteData(w http.ResponseWriter, data interface{}) {
 }
 
 // WriteDataWithWarning writes the data payload similiar to WriteData except it provides an additional warning message.
-func (hp HTTPProtocol) WriteDataWithWarning(w http.ResponseWriter, data interface{}, warning string) {
+func (hp HTTPProtocol) WriteDataWithWarning(w http.ResponseWriter, data any, warning string) {
 	w.Header().Set("Content-Type", "application/json")
 	status := http.StatusOK
 	resp := &HTTPResponse{
@@ -184,7 +184,7 @@ func (hp HTTPProtocol) WriteDataWithWarning(w http.ResponseWriter, data interfac
 }
 
 // WriteDataWithMessage writes the data payload similiar to WriteData except it provides an additional string message.
-func (hp HTTPProtocol) WriteDataWithMessage(w http.ResponseWriter, data interface{}, message string) {
+func (hp HTTPProtocol) WriteDataWithMessage(w http.ResponseWriter, data any, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	status := http.StatusOK
 	resp := &HTTPResponse{
@@ -222,7 +222,7 @@ func (hp HTTPProtocol) WriteProtoWithMessage(w http.ResponseWriter, data proto.M
 }
 
 // WriteDataWithMessageAndWarning writes the data payload similiar to WriteData except it provides a warning and additional message string.
-func (hp HTTPProtocol) WriteDataWithMessageAndWarning(w http.ResponseWriter, data interface{}, message string, warning string) {
+func (hp HTTPProtocol) WriteDataWithMessageAndWarning(w http.ResponseWriter, data any, message string, warning string) {
 	w.Header().Set("Content-Type", "application/json")
 	status := http.StatusOK
 	resp := &HTTPResponse{
@@ -310,7 +310,7 @@ func (r *HTTPResponse) WithCode(code int) *HTTPResponse {
 	return r
 }
 
-func (r *HTTPResponse) WithData(data interface{}) *HTTPResponse {
+func (r *HTTPResponse) WithData(data any) *HTTPResponse {
 	if r == nil {
 		r = &HTTPResponse{}
 	}
@@ -320,7 +320,7 @@ func (r *HTTPResponse) WithData(data interface{}) *HTTPResponse {
 	return r
 }
 
-func (r *HTTPResponse) WithMeta(meta map[string]interface{}) *HTTPResponse {
+func (r *HTTPResponse) WithMeta(meta map[string]any) *HTTPResponse {
 	if r == nil {
 		r = &HTTPResponse{}
 	}

--- a/core/pkg/protocol/http_test.go
+++ b/core/pkg/protocol/http_test.go
@@ -198,7 +198,7 @@ func TestHTTPProtocol_HTTPResponse(t *testing.T) {
 		Bananas: 4,
 	}
 
-	meta := map[string]interface{}{
+	meta := map[string]any{
 		"lastUpdated": time.Date(2025, time.September, 5, 13, 27, 3, 0, time.UTC),
 	}
 

--- a/core/pkg/source/error.go
+++ b/core/pkg/source/error.go
@@ -11,7 +11,7 @@ import (
 )
 
 // errorType used to check HasError
-var errorType = reflect.TypeOf((*error)(nil)).Elem()
+var errorType = reflect.TypeFor[error]()
 
 // NoStoreAPIWarning is a warning that we would consider an error. It returns partial data relating only to the
 // store apis which were reachable. In order to ensure integrity of data across all clusters, we'll need to identify
@@ -230,7 +230,7 @@ func (ec *QueryErrorCollector) ToErrorAndWarningStrings() (errors []string, warn
 // As is a special method that implicitly works with the `errors.As()` go
 // helper to locate the _first_ instance of the provided target type in the
 // collection.
-func (ec *QueryErrorCollector) As(target interface{}) bool {
+func (ec *QueryErrorCollector) As(target any) bool {
 	if target == nil {
 		log.Errorf("ErrorCollection.As() target cannot be nil")
 		return false
@@ -238,7 +238,7 @@ func (ec *QueryErrorCollector) As(target interface{}) bool {
 
 	val := reflect.ValueOf(target)
 	typ := val.Type()
-	if typ.Kind() != reflect.Ptr || val.IsNil() {
+	if typ.Kind() != reflect.Pointer || val.IsNil() {
 		log.Errorf("ErrorCollection.As() target must be a non-nil pointer")
 		return false
 	}
@@ -253,7 +253,7 @@ func (ec *QueryErrorCollector) As(target interface{}) bool {
 			val.Elem().Set(reflect.ValueOf(err))
 			return true
 		}
-		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+		if x, ok := err.(interface{ As(any) bool }); ok && x.As(target) {
 			return true
 		}
 	}
@@ -304,7 +304,7 @@ func NewCommError(messages ...string) CommError {
 }
 
 // CommErrorf creates a new CommError using a string formatter
-func CommErrorf(format string, args ...interface{}) CommError {
+func CommErrorf(format string, args ...any) CommError {
 	return NewCommError(fmt.Sprintf(format, args...))
 }
 

--- a/core/pkg/source/queryresult.go
+++ b/core/pkg/source/queryresult.go
@@ -88,8 +88,8 @@ func NewQueryResults(query string) *QueryResults {
 // QueryResult contains a single result from a prometheus query. It's common
 // to refer to query results as a slice of QueryResult
 type QueryResult struct {
-	Metric map[string]interface{} `json:"metric"`
-	Values []*util.Vector         `json:"values"`
+	Metric map[string]any `json:"metric"`
+	Values []*util.Vector `json:"values"`
 
 	keys *ResultKeys
 }

--- a/core/pkg/storage/bucketstorage.go
+++ b/core/pkg/storage/bucketstorage.go
@@ -23,7 +23,7 @@ const (
 // specify the bucket storage implementation, and a configuration object specific to that storage implementation.
 type StorageConfig struct {
 	Type   StorageProvider `yaml:"type"`
-	Config interface{}     `yaml:"config"`
+	Config any             `yaml:"config"`
 	Prefix string          `yaml:"prefix"`
 }
 

--- a/core/pkg/storage/memfile/util.go
+++ b/core/pkg/storage/memfile/util.go
@@ -28,7 +28,7 @@ func Split(path string) ([]string, string) {
 func CreateSubdirectory(d *MemoryDirectory, paths []string) *MemoryDirectory {
 	currentDir := d
 
-	for i := 0; i < len(paths); i++ {
+	for i := range paths {
 		dirName := paths[i]
 		if _, ok := currentDir.dirs[dirName]; !ok {
 			currentDir.AddDirectory(NewMemoryDirectory(dirName))
@@ -45,7 +45,7 @@ func CreateSubdirectory(d *MemoryDirectory, paths []string) *MemoryDirectory {
 func FindSubdirectory(d *MemoryDirectory, paths []string) (*MemoryDirectory, error) {
 	currentDir := d
 
-	for i := 0; i < len(paths); i++ {
+	for i := range paths {
 		dirName := paths[i]
 		if _, ok := currentDir.dirs[dirName]; !ok {
 			return nil, fmt.Errorf("directory %s not found", filepath.Join(paths[:i+1]...))

--- a/core/pkg/util/buffer_test.go
+++ b/core/pkg/util/buffer_test.go
@@ -303,10 +303,7 @@ func (sbr *randomByteReader) Read(b []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	toCopy := rand.IntN(4) + 1
-	if toCopy > len(b) {
-		toCopy = len(b)
-	}
+	toCopy := min(rand.IntN(4)+1, len(b))
 
 	var err error
 	remaining := len(sbr.bytes) - sbr.pos

--- a/core/pkg/util/bufferpool.go
+++ b/core/pkg/util/bufferpool.go
@@ -14,7 +14,7 @@ type bufferPool struct {
 func newBufferPool() *bufferPool {
 	bp := new(bufferPool)
 
-	for i := 0; i < 17; i++ {
+	for i := range 17 {
 		length := 1 << i
 		bp.pools[i].New = func() any {
 			return make([]byte, length)

--- a/core/pkg/util/bufferpool_test.go
+++ b/core/pkg/util/bufferpool_test.go
@@ -193,7 +193,7 @@ func TestPutRestoresFullCapacity(t *testing.T) {
 }
 
 func TestIsPowerOfTwo(t *testing.T) {
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		cap := 1 << i
 
 		if !isPowerOfTwo(cap) {
@@ -232,11 +232,11 @@ func TestConcurrentGetPut(t *testing.T) {
 	const goroutines = 64
 	const iters = 1000
 
-	for g := 0; g < goroutines; g++ {
+	for g := range goroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for i := 0; i < iters; i++ {
+			for i := range iters {
 				n := (id*iters + i) % 4096
 				if n == 0 {
 					n = 1
@@ -262,7 +262,7 @@ func TestGetExactPowerOfTwo(t *testing.T) {
 	// Exact powers of two are the boundary between two pools; confirm correct
 	// bucket selection and full round-trip for each.
 	bp := newBufferPool()
-	for i := 0; i < 17; i++ {
+	for i := range 17 {
 		n := 1 << i
 		buf := bp.Get(n)
 		if len(buf) != n {

--- a/core/pkg/util/cache/cachegroup_test.go
+++ b/core/pkg/util/cache/cachegroup_test.go
@@ -121,7 +121,7 @@ func TestGroupCacheMany(t *testing.T) {
 	<-next
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(ii int) {
 			t.Logf("Created Go Routine: %d\n", ii)
 			now := time.Now()

--- a/core/pkg/util/httputil/roundtrip.go
+++ b/core/pkg/util/httputil/roundtrip.go
@@ -1,5 +1,7 @@
 package httputil
 
+import "maps"
+
 import "net/http"
 
 type userAgentTransport struct {
@@ -22,9 +24,7 @@ func (t userAgentTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	r2 := new(http.Request)
 	*r2 = *r
 	r2.Header = make(http.Header)
-	for k, s := range r.Header {
-		r2.Header[k] = s
-	}
+	maps.Copy(r2.Header, r.Header)
 	r2.Header.Set("User-Agent", t.userAgent)
 	r = r2
 	return t.base.RoundTrip(r)

--- a/core/pkg/util/jsonutil/jsonutil.go
+++ b/core/pkg/util/jsonutil/jsonutil.go
@@ -26,7 +26,7 @@ func EncodeString(buffer *bytes.Buffer, name, val, comma string) {
 }
 
 // Encode encodes any object to JSON
-func Encode(buffer *bytes.Buffer, name string, obj interface{}, comma string) {
+func Encode(buffer *bytes.Buffer, name string, obj any, comma string) {
 	buffer.WriteString(fmt.Sprintf("\"%s\":", name))
 	if bytes, err := json.Marshal(obj); err != nil {
 		buffer.WriteString("null")

--- a/core/pkg/util/mapper/mapper.go
+++ b/core/pkg/util/mapper/mapper.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -187,9 +188,7 @@ func (gm *GoMap) Set(key, value string) error {
 // data out of the argument.
 func NewGoMap(m map[string]string) Map {
 	copied := map[string]string{}
-	for k, v := range m {
-		copied[k] = v
-	}
+	maps.Copy(copied, m)
 	return &GoMap{m: copied}
 }
 

--- a/core/pkg/util/monitor/memory/memorylimitstats_test.go
+++ b/core/pkg/util/monitor/memory/memorylimitstats_test.go
@@ -118,7 +118,7 @@ func TestNoisyInputStability(t *testing.T) {
 	base := float64(256 * 1024 * 1024) // 256 MiB
 
 	var limits []uint64
-	for i := 0; i < 200; i++ {
+	for range 200 {
 		// ±10% noise around base
 		noise := (rng.Float64()*0.2 - 0.1) * base
 		_, _ = m.Record(uint64(base + noise))

--- a/core/pkg/util/pool.go
+++ b/core/pkg/util/pool.go
@@ -49,7 +49,7 @@ func NewFixedMapPool(size int) VectorMapPool {
 	}
 
 	// Pre-Populate the buffer with maps
-	for i := 0; i < size; i++ {
+	for range size {
 		mp.maps <- make(map[uint64]float64)
 	}
 
@@ -125,7 +125,7 @@ func (mp *UnboundedMapPool) Put(m map[uint64]float64) {
 func NewUnboundedMapPool() VectorMapPool {
 	return &UnboundedMapPool{
 		maps: &sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return make(map[uint64]float64)
 			},
 		},

--- a/core/pkg/util/promutil/promutil.go
+++ b/core/pkg/util/promutil/promutil.go
@@ -15,7 +15,7 @@ var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 // AnyToLabels will create prometheus labels based on the fields of the interface
 // passed. Note that this method is quite expensive and should only be used when absolutely
 // necessary.
-func AnyToLabels(a interface{}) (map[string]string, error) {
+func AnyToLabels(a any) (map[string]string, error) {
 	val := reflect.ValueOf(a)
 	if val.Kind() == reflect.Map {
 		return MapToLabels(a), nil
@@ -26,7 +26,7 @@ func AnyToLabels(a interface{}) (map[string]string, error) {
 		return nil, e
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	e = json.Unmarshal(b, &m)
 	if e != nil {
 		return nil, e
@@ -37,7 +37,7 @@ func AnyToLabels(a interface{}) (map[string]string, error) {
 
 // MapToLabels accepts a map type, and will return a new map containing all the nested
 // fields separated by _ with string versions of the values.
-func MapToLabels(m interface{}) map[string]string {
+func MapToLabels(m any) map[string]string {
 	val := reflect.ValueOf(m)
 	if val.Kind() != reflect.Map {
 		return map[string]string{}

--- a/core/pkg/util/promutil/promutil_test.go
+++ b/core/pkg/util/promutil/promutil_test.go
@@ -13,7 +13,7 @@ func checkSlice(s1, s2 []string) error {
 		return fmt.Errorf("len(s1) [%d] != len(s2) [%d]", len(s1), len(s2))
 	}
 
-	for i := 0; i < len(s1); i++ {
+	for i := range s1 {
 		if s1[i] != s2[i] {
 			return fmt.Errorf("At Index: %d. Different Values %s (s1) != %s (s2)", i, s1[i], s2[i])
 		}

--- a/core/pkg/util/sliceutil/sliceutil.go
+++ b/core/pkg/util/sliceutil/sliceutil.go
@@ -9,7 +9,7 @@ import (
 // slice, which are inserted into a new slice of type U.
 func Map[T any, U any](s []T, transform func(T) U) []U {
 	result := make([]U, len(s))
-	for i := 0; i < len(s); i++ {
+	for i := range s {
 		result[i] = transform(s[i])
 	}
 	return result

--- a/core/pkg/util/stringutil/lrubank_test.go
+++ b/core/pkg/util/stringutil/lrubank_test.go
@@ -126,7 +126,7 @@ func TestEviction_BelowCapacityNoEviction(t *testing.T) {
 	bank := NewLruStringBank(capacity, 200*time.Millisecond).(*lruStringBank)
 	defer bank.Stop()
 
-	for i := 0; i < capacity; i++ {
+	for i := range capacity {
 		bank.LoadOrStore(fmt.Sprintf("v%d", i), fmt.Sprintf("v%d", i))
 	}
 
@@ -147,7 +147,7 @@ func TestEviction_ExceedCapacityTrimsToCapacity(t *testing.T) {
 	bank := NewLruStringBank(capacity, 350*time.Millisecond).(*lruStringBank)
 	defer bank.Stop()
 
-	for i := 0; i < capacity+3; i++ {
+	for i := range capacity + 3 {
 		bank.LoadOrStore(fmt.Sprintf("v%d", i), fmt.Sprintf("v%d", i))
 		time.Sleep(20 * time.Millisecond) // ensure distinct timestamps
 	}
@@ -199,7 +199,7 @@ func TestClear_EmptiesMap(t *testing.T) {
 	bank := NewLruStringBank(10, time.Minute).(*lruStringBank)
 	defer bank.Stop()
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		bank.LoadOrStore(fmt.Sprintf("v%d", i), fmt.Sprintf("v%d", i))
 	}
 
@@ -308,10 +308,10 @@ func TestConcurrentLoadOrStore(t *testing.T) {
 	const opsEach = 100
 
 	var wg sync.WaitGroup
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		g := i
 		wg.Go(func() {
-			for i := 0; i < opsEach; i++ {
+			for i := range opsEach {
 				key := fmt.Sprintf("k%d", (g*opsEach+i)%30)
 				bank.LoadOrStore(key, key)
 			}
@@ -347,7 +347,7 @@ func TestConcurrentLoadOrStoreWithEviction(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		g := i
 		stop := time.After(duration)
 
@@ -389,19 +389,17 @@ func TestConcurrentClear(t *testing.T) {
 	defer bank.Stop()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			bank.LoadOrStore(fmt.Sprintf("k%d", i), "v")
 		}(i)
 	}
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 3 {
+		wg.Go(func() {
 			bank.Clear()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/core/pkg/util/stringutil/stringutil_test.go
+++ b/core/pkg/util/stringutil/stringutil_test.go
@@ -85,7 +85,7 @@ func benchmarkStringBank(b *testing.B, bt bankTest, totalStrings, totalUnique in
 	b.Run(b.Name(), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			b.StartTimer()
-			for bb := 0; bb < totalStrings; bb++ {
+			for bb := range totalStrings {
 				bytes := randStrings[bb]
 
 				if useBankFunc {

--- a/core/pkg/util/typeutil/typeutil.go
+++ b/core/pkg/util/typeutil/typeutil.go
@@ -9,14 +9,14 @@ import (
 
 // TypeOf is a utility that can covert a T type to a package + type name for generic types.
 func TypeOf[T any]() string {
-	var prefix string
+	var prefix strings.Builder
 
 	t := reflect.TypeFor[T]()
 
 	// pointer types do not carry the adequate type information, so we need to extract the
 	// underlying types until we reach the non-pointer type, we prepend a * each depth
 	for t != nil && t.Kind() == reflect.Pointer {
-		prefix += "*"
+		prefix.WriteString("*")
 		t = t.Elem()
 	}
 
@@ -34,11 +34,11 @@ func TypeOf[T any]() string {
 
 	// no package path, do not use a / separator
 	if t.PkgPath() == "" {
-		return prefix + name
+		return prefix.String() + name
 	}
 
 	// combine the prefix, package path, and the type name
-	return fmt.Sprintf("%s%s/%s", prefix, t.PkgPath(), name)
+	return fmt.Sprintf("%s%s/%s", prefix.String(), t.PkgPath(), name)
 }
 
 // TypeFor uses type inferencing to accept a value and returns the fully qualified package

--- a/core/pkg/util/typeutil/typeutil_test.go
+++ b/core/pkg/util/typeutil/typeutil_test.go
@@ -33,7 +33,7 @@ func cmp[T comparable](t *testing.T, result, expected T) {
 	}
 }
 
-type InterfaceType interface{}
+type InterfaceType any
 
 var packageScoped = typeutil.CurrentPackage()
 
@@ -48,7 +48,7 @@ func TestTypeOf(t *testing.T) {
 	cmp(t, typeutil.TypeOf[int](), "int")
 	cmp(t, typeutil.TypeOf[int8](), "int8")
 	cmp(t, typeutil.TypeOf[any](), "interface {}")
-	cmp(t, typeutil.TypeOf[interface{}](), "interface {}")
+	cmp(t, typeutil.TypeOf[any](), "interface {}")
 	cmp(t, typeutil.TypeOf[struct{}](), "struct {}")
 
 	// Specific Types

--- a/core/pkg/util/worker/example_worker_test.go
+++ b/core/pkg/util/worker/example_worker_test.go
@@ -31,7 +31,7 @@ func Example_concurrentWorkers() {
 	defer workerPool.Shutdown()
 
 	// Loop over 100 inputs and run slowAddTenToFloat
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		// Run accepts a receive channel for each input, but it is not required.
 		// To demonstrate receiving, we'll receive the results when the input
 		// is 50:
@@ -78,7 +78,7 @@ func Example_concurrentOrdered() {
 	orderedGroup := worker.NewOrderedGroup(workerPool, numInputs)
 
 	// loop over our inputs and pass them to the group
-	for i := 0; i < numInputs; i++ {
+	for i := range numInputs {
 		// ordered group has a strict size constraint (set in the NewOrderedGroup func), and will
 		// error if the number of inputs pushed exceeds that size constraint
 		err := orderedGroup.Push(i)
@@ -120,7 +120,7 @@ func Example_concurrentOrderedSimple() {
 	// Let's create our inputs 0-12 like in the previous example
 	const numInputs = 12
 	inputs := make([]int, numInputs)
-	for i := 0; i < numInputs; i++ {
+	for i := range numInputs {
 		inputs[i] = i
 	}
 
@@ -128,7 +128,7 @@ func Example_concurrentOrderedSimple() {
 	results := worker.ConcurrentDo(slowAddTenToFloat, inputs)
 
 	// Note that the order of the results is consistent with the order of inputs
-	for i := 0; i < numInputs; i++ {
+	for i := range numInputs {
 		fmt.Printf("Received Result: %.2f for Input: %d\n", results[i], inputs[i])
 	}
 

--- a/core/pkg/util/worker/worker.go
+++ b/core/pkg/util/worker/worker.go
@@ -71,7 +71,7 @@ func NewWorkerPool[T any, U any](workers int, work Worker[T, U]) WorkerPool[T, U
 	}
 
 	// startup the designated workers
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go owq.worker()
 	}
 
@@ -291,10 +291,7 @@ func (ow *collector[T, U]) Push(input T) error {
 		return err
 	}
 
-	ow.wg.Add(1)
-
-	go func() {
-		defer ow.wg.Done()
+	ow.wg.Go(func() {
 		defer close(onComplete)
 
 		result := <-onComplete
@@ -303,7 +300,7 @@ func (ow *collector[T, U]) Push(input T) error {
 			ow.results = append(ow.results, result)
 			ow.resultLock.Unlock()
 		}
-	}()
+	})
 
 	return nil
 }

--- a/core/pkg/util/worker/worker_test.go
+++ b/core/pkg/util/worker/worker_test.go
@@ -55,7 +55,7 @@ func TestWorkerPoolExactWorkers(t *testing.T) {
 	wg.Add(workers)
 
 	pool := NewWorkerPool(workers, work)
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		onComplete := make(chan void)
 
 		go func() {
@@ -94,7 +94,7 @@ func TestOrderedWorkGroup(t *testing.T) {
 	input := make([]int, tasks)
 
 	// we create more tasks than workers to test queueing
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		input[i] = i + 1
 		err := ordered.Push(input[i])
 		if err != nil {
@@ -104,7 +104,7 @@ func TestOrderedWorkGroup(t *testing.T) {
 
 	// get results and verify they match the recorded inputs
 	results := ordered.Wait()
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		if results[i] != input[i] {
 			t.Errorf("Expected Results[%d](%d) to equal Input[%d](%d)\n", i, results[i], i, input[i])
 		}
@@ -133,7 +133,7 @@ func TestConcurrentRun(t *testing.T) {
 
 	// pre-build inputs
 	input := make([]int, tasks)
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		input[i] = i + 1
 	}
 
@@ -162,13 +162,13 @@ func TestConcurrentDoOrdered(t *testing.T) {
 
 	// pre-build inputs
 	input := make([]int, tasks)
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		input[i] = i + 1
 	}
 
 	// get results and verify they match the recorded inputs
 	results := ConcurrentDo(work, input)
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		if results[i] != input[i] {
 			t.Errorf("Expected Results[%d](%d) to equal Input[%d](%d)\n", i, results[i], i, input[i])
 		}
@@ -193,7 +193,7 @@ func TestConcurrentCollect(t *testing.T) {
 	const expectedResults = 50
 
 	var inputs []*A
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		inputs = append(inputs, &A{Value: i})
 	}
 
@@ -308,7 +308,7 @@ func TestConcurrentOrderedProcess(t *testing.T) {
 
 	// create tasks
 	inputs := make([]int, tasks)
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		inputs[i] = i + 1
 	}
 

--- a/modules/collector-source/pkg/metric/metric_codecs.go
+++ b/modules/collector-source/pkg/metric/metric_codecs.go
@@ -148,10 +148,10 @@ func isReaderBinaryTag(buff *util.Buffer, tag string) bool {
 
 // typeToString determines the basic properties of the type, the qualifier, package path, and
 // type name, and returns the qualified type
-func typeToString(f interface{}) string {
+func typeToString(f any) string {
 	qual := ""
 	t := reflect.TypeOf(f)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 		qual = "*"
 	}

--- a/modules/collector-source/pkg/scrape/clustercache_test.go
+++ b/modules/collector-source/pkg/scrape/clustercache_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/modules/collector-source/pkg/metric"
-	"github.com/opencost/opencost/modules/collector-source/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -331,7 +330,7 @@ func Test_kubernetesScraper_scrapePods(t *testing.T) {
 							UID:       "uuid1",
 							Spec: v1.PersistentVolumeClaimSpec{
 								VolumeName:       "vol1",
-								StorageClassName: util.Ptr("storageClass1"),
+								StorageClassName: new("storageClass1"),
 								Resources: v1.VolumeResourceRequirements{
 									Requests: v1.ResourceList{
 										v1.ResourceStorage: resource.MustParse("4096"),
@@ -575,7 +574,7 @@ func Test_kubernetesScraper_scrapePVCs(t *testing.T) {
 							UID:       "uuid1",
 							Spec: v1.PersistentVolumeClaimSpec{
 								VolumeName:       "vol1",
-								StorageClassName: util.Ptr("storageClass1"),
+								StorageClassName: new("storageClass1"),
 								Resources: v1.VolumeResourceRequirements{
 									Requests: v1.ResourceList{
 										v1.ResourceStorage: resource.MustParse("4096"),

--- a/modules/collector-source/pkg/scrape/statsummary_test.go
+++ b/modules/collector-source/pkg/scrape/statsummary_test.go
@@ -131,11 +131,11 @@ func TestStatScraper_Scrape(t *testing.T) {
 						NodeName: "node1",
 						CPU: &stats.CPUStats{
 							Time:                 metav1.Time{Time: start1},
-							UsageCoreNanoSeconds: util.Ptr(uint64(2000000000)),
+							UsageCoreNanoSeconds: new(uint64(2000000000)),
 						},
 						Fs: &stats.FsStats{
 							Time:          metav1.Time{Time: start1},
-							CapacityBytes: util.Ptr(uint64(2 * util.GB)),
+							CapacityBytes: new(uint64(2 * util.GB)),
 						},
 					},
 					Pods: []stats.PodStats{
@@ -148,8 +148,8 @@ func TestStatScraper_Scrape(t *testing.T) {
 							Network: &stats.NetworkStats{
 								Time: metav1.Time{Time: start1},
 								InterfaceStats: stats.InterfaceStats{
-									RxBytes: util.Ptr(uint64(1 * util.MB)),
-									TxBytes: util.Ptr(uint64(2 * util.MB)),
+									RxBytes: new(uint64(1 * util.MB)),
+									TxBytes: new(uint64(2 * util.MB)),
 								},
 							},
 							VolumeStats: []stats.VolumeStats{
@@ -157,7 +157,7 @@ func TestStatScraper_Scrape(t *testing.T) {
 									Name: "ignoreVol1",
 									FsStats: stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 								{
@@ -168,7 +168,7 @@ func TestStatScraper_Scrape(t *testing.T) {
 									},
 									FsStats: stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 							},
@@ -177,15 +177,15 @@ func TestStatScraper_Scrape(t *testing.T) {
 									Name: "container1",
 									CPU: &stats.CPUStats{
 										Time:                 metav1.Time{Time: start1},
-										UsageCoreNanoSeconds: util.Ptr(uint64(1000000000)),
+										UsageCoreNanoSeconds: new(uint64(1000000000)),
 									},
 									Memory: &stats.MemoryStats{
 										Time:            metav1.Time{Time: start1},
-										WorkingSetBytes: util.Ptr(uint64(5 * util.MB)),
+										WorkingSetBytes: new(uint64(5 * util.MB)),
 									},
 									Rootfs: &stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 							},
@@ -279,11 +279,11 @@ func TestStatScraper_Scrape(t *testing.T) {
 						NodeName: "node1",
 						CPU: &stats.CPUStats{
 							Time:                 metav1.Time{Time: start1},
-							UsageCoreNanoSeconds: util.Ptr(uint64(2000000000)),
+							UsageCoreNanoSeconds: new(uint64(2000000000)),
 						},
 						Fs: &stats.FsStats{
 							Time:          metav1.Time{Time: start1},
-							CapacityBytes: util.Ptr(uint64(2 * util.GB)),
+							CapacityBytes: new(uint64(2 * util.GB)),
 						},
 					},
 					Pods: []stats.PodStats{
@@ -296,8 +296,8 @@ func TestStatScraper_Scrape(t *testing.T) {
 							Network: &stats.NetworkStats{
 								Time: metav1.Time{Time: start1},
 								InterfaceStats: stats.InterfaceStats{
-									RxBytes: util.Ptr(uint64(1 * util.MB)),
-									TxBytes: util.Ptr(uint64(2 * util.MB)),
+									RxBytes: new(uint64(1 * util.MB)),
+									TxBytes: new(uint64(2 * util.MB)),
 								},
 							},
 							VolumeStats: []stats.VolumeStats{
@@ -305,7 +305,7 @@ func TestStatScraper_Scrape(t *testing.T) {
 									Name: "ignoreVol1",
 									FsStats: stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 								{
@@ -316,7 +316,7 @@ func TestStatScraper_Scrape(t *testing.T) {
 									},
 									FsStats: stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 							},
@@ -325,15 +325,15 @@ func TestStatScraper_Scrape(t *testing.T) {
 									Name: "container1",
 									CPU: &stats.CPUStats{
 										Time:                 metav1.Time{Time: start1},
-										UsageCoreNanoSeconds: util.Ptr(uint64(1000000000)),
+										UsageCoreNanoSeconds: new(uint64(1000000000)),
 									},
 									Memory: &stats.MemoryStats{
 										Time:            metav1.Time{Time: start1},
-										WorkingSetBytes: util.Ptr(uint64(5 * util.MB)),
+										WorkingSetBytes: new(uint64(5 * util.MB)),
 									},
 									Rootfs: &stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 							},
@@ -443,7 +443,7 @@ func TestStatScraper_Scrape(t *testing.T) {
 									},
 									FsStats: stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 							},
@@ -463,7 +463,7 @@ func TestStatScraper_Scrape(t *testing.T) {
 									},
 									FsStats: stats.FsStats{
 										Time:      metav1.Time{Time: start1},
-										UsedBytes: util.Ptr(uint64(1 * util.GB)),
+										UsedBytes: new(uint64(1 * util.GB)),
 									},
 								},
 							},

--- a/modules/collector-source/pkg/util/helper.go
+++ b/modules/collector-source/pkg/util/helper.go
@@ -23,7 +23,7 @@ func MetricNameFor(metric string, labels []string, values []string) string {
 	var sb strings.Builder
 	sb.WriteString(metric)
 	sb.WriteRune('{')
-	for i := 0; i < len(labels); i++ {
+	for i := range labels {
 		sb.WriteRune('"')
 		sb.WriteString(labels[i])
 		sb.WriteString(`"="`)
@@ -50,6 +50,7 @@ func ToMap(labels []string, values []string) map[string]string {
 	return m
 }
 
+//go:fix inline
 func Ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }

--- a/modules/prometheus-source/pkg/prom/clustermap.go
+++ b/modules/prometheus-source/pkg/prom/clustermap.go
@@ -72,7 +72,7 @@ func (pcm *PrometheusClusterMap) loadClusters() (map[string]*clusters.ClusterInf
 	var offset string = ""
 
 	// Execute Query
-	tryQuery := func() (interface{}, error) {
+	tryQuery := func() (any, error) {
 		ctx := pcm.contextFactory.NewNamedContext(ClusterMapContextName)
 		resCh := ctx.QueryAtTime(clusterInfoQuery(offset), time.Now())
 		r, e := resCh.Await()

--- a/modules/prometheus-source/pkg/prom/prom.go
+++ b/modules/prometheus-source/pkg/prom/prom.go
@@ -191,7 +191,7 @@ func NewRateLimitedClient(
 	}
 
 	// Start concurrent request processing
-	for i := 0; i < maxConcurrency; i++ {
+	for range maxConcurrency {
 		go rlpc.worker()
 	}
 

--- a/modules/prometheus-source/pkg/prom/query.go
+++ b/modules/prometheus-source/pkg/prom/query.go
@@ -269,13 +269,13 @@ func (ctx *Context) RawQuery(query string, t time.Time) ([]byte, error) {
 	return body, err
 }
 
-func (ctx *Context) query(query string, t time.Time) (interface{}, v1.Warnings, error) {
+func (ctx *Context) query(query string, t time.Time) (any, v1.Warnings, error) {
 	body, err := ctx.RawQuery(query, t)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var toReturn interface{}
+	var toReturn any
 	err = json.Unmarshal(body, &toReturn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("query '%s' caused unmarshal error: %s", query, err)
@@ -419,14 +419,14 @@ func (ctx *Context) RawQueryRange(query string, start, end time.Time, step time.
 	return body, err
 }
 
-func (ctx *Context) queryRange(query string, start, end time.Time, step time.Duration) (interface{}, v1.Warnings, error) {
+func (ctx *Context) queryRange(query string, start, end time.Time, step time.Duration) (any, v1.Warnings, error) {
 	body, err := ctx.RawQueryRange(query, start, end, step)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var toReturn interface{}
+	var toReturn any
 	err = json.Unmarshal(body, &toReturn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("query '%s' caused unmarshal error: %s", query, err)
@@ -458,10 +458,10 @@ func (ctx *Context) alignWindow(start time.Time, end time.Time, step time.Durati
 }
 
 // Extracts the warnings from the resulting json if they exist (part of the prometheus response api).
-func warningsFrom(result interface{}) v1.Warnings {
+func warningsFrom(result any) v1.Warnings {
 	var warnings v1.Warnings
 
-	if resultMap, ok := result.(map[string]interface{}); ok {
+	if resultMap, ok := result.(map[string]any); ok {
 		if warningProp, ok := resultMap["warnings"]; ok {
 			if w, ok := warningProp.([]string); ok {
 				warnings = w

--- a/modules/prometheus-source/pkg/prom/query_test.go
+++ b/modules/prometheus-source/pkg/prom/query_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWarningsFrom(t *testing.T) {
-	var results any = map[string]interface{}{
+	var results any = map[string]any{
 		"status": "success",
 		"warnings": []string{
 			"Warning #1",

--- a/modules/prometheus-source/pkg/prom/ratelimitedclient_test.go
+++ b/modules/prometheus-source/pkg/prom/ratelimitedclient_test.go
@@ -319,7 +319,7 @@ func TestExponentialBackOff(t *testing.T) {
 
 	w := 100 * time.Millisecond
 
-	for retry := 0; retry < 5; retry++ {
+	for retry := range 5 {
 		AssertDurationEqual(t, ExpectedResults[retry], httputil.ExponentialBackoffWaitFor(w, retry))
 	}
 }
@@ -360,7 +360,7 @@ func TestConcurrentRateLimiting(t *testing.T) {
 
 	errs := make(chan error, TotalRequests)
 
-	for i := 0; i < TotalRequests; i++ {
+	for range TotalRequests {
 		go func() {
 			req, err := http.NewRequest(http.MethodPost, "", nil)
 			if err != nil {
@@ -375,7 +375,7 @@ func TestConcurrentRateLimiting(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < TotalRequests; i++ {
+	for range TotalRequests {
 		err := <-errs
 		if err == nil {
 			t.Fatal("Expected a RateLimitedResponseError. Err was nil.")

--- a/modules/prometheus-source/pkg/prom/result.go
+++ b/modules/prometheus-source/pkg/prom/result.go
@@ -17,19 +17,19 @@ var (
 	NaNWarning warning = newWarning("Found NaN value parsing vector data point for metric")
 )
 
-func DataFieldFormatErr(query string, promResponse interface{}) error {
+func DataFieldFormatErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'data' field improperly formatted. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
-func DataPointFormatErr(query string, promResponse interface{}) error {
+func DataPointFormatErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: improperly formatted datapoint. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
-func MetricFieldDoesNotExistErr(query string, promResponse interface{}) error {
+func MetricFieldDoesNotExistErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'metric' field does not exist in data result vector. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
-func MetricFieldFormatErr(query string, promResponse interface{}) error {
+func MetricFieldFormatErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'metric' field improperly formatted. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
@@ -37,7 +37,7 @@ func NoDataErr(query string) error {
 	return source.NewNoDataError(query)
 }
 
-func PromUnexpectedResponseErr(query string, promResponse interface{}) error {
+func PromUnexpectedResponseErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: unexpected response. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
@@ -45,19 +45,19 @@ func QueryResultNilErr(query string) error {
 	return source.NewCommError(query)
 }
 
-func ResultFieldDoesNotExistErr(query string, promResponse interface{}) error {
+func ResultFieldDoesNotExistErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'result' field does not exist. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
-func ResultFieldFormatErr(query string, promResponse interface{}) error {
+func ResultFieldFormatErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'result' field improperly formatted. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
-func ResultFormatErr(query string, promResponse interface{}) error {
+func ResultFormatErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'result' field improperly formatted. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
-func ValueFieldDoesNotExistErr(query string, promResponse interface{}) error {
+func ValueFieldDoesNotExistErr(query string, promResponse any) error {
 	return fmt.Errorf("Error parsing Prometheus response: 'value' field does not exist in data result vector. Query: '%s'. Response: '%+v'", query, promResponse)
 }
 
@@ -70,7 +70,7 @@ func NewQueryResultError(query string, err error) *source.QueryResults {
 
 // NewQueryResults accepts the raw prometheus query result and returns an array of
 // QueryResult objects
-func NewQueryResults(query string, queryResult interface{}, resultKeys *source.ResultKeys) *source.QueryResults {
+func NewQueryResults(query string, queryResult any, resultKeys *source.ResultKeys) *source.QueryResults {
 	qrs := source.NewQueryResults(query)
 
 	if queryResult == nil {
@@ -78,7 +78,7 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 		return qrs
 	}
 
-	data, ok := queryResult.(map[string]interface{})["data"]
+	data, ok := queryResult.(map[string]any)["data"]
 	if !ok {
 		e, err := wrapPrometheusError(query, queryResult)
 		if err != nil {
@@ -90,7 +90,7 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 	}
 
 	// Deep Check for proper formatting
-	d, ok := data.(map[string]interface{})
+	d, ok := data.(map[string]any)
 	if !ok {
 		qrs.Error = DataFieldFormatErr(query, data)
 		return qrs
@@ -100,7 +100,7 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 		qrs.Error = ResultFieldDoesNotExistErr(query, d)
 		return qrs
 	}
-	resultsData, ok := resultData.([]interface{})
+	resultsData, ok := resultData.([]any)
 	if !ok {
 		qrs.Error = ResultFieldFormatErr(query, resultData)
 		return qrs
@@ -111,7 +111,7 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 
 	// Parse raw results and into QueryResults
 	for _, val := range resultsData {
-		resultInterface, ok := val.(map[string]interface{})
+		resultInterface, ok := val.(map[string]any)
 		if !ok {
 			qrs.Error = ResultFormatErr(query, val)
 			return qrs
@@ -122,7 +122,7 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 			qrs.Error = MetricFieldDoesNotExistErr(query, resultInterface)
 			return qrs
 		}
-		metricMap, ok := metricInterface.(map[string]interface{})
+		metricMap, ok := metricInterface.(map[string]any)
 		if !ok {
 			qrs.Error = MetricFieldFormatErr(query, metricInterface)
 			return qrs
@@ -155,7 +155,7 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 
 			vectors = append(vectors, v)
 		} else {
-			values, ok := resultInterface["values"].([]interface{})
+			values, ok := resultInterface["values"].([]any)
 			if !ok {
 				qrs.Error = fmt.Errorf("Values field is improperly formatted")
 				return qrs
@@ -188,10 +188,10 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 
 // parseDataPoint parses a data point from raw prometheus query results and returns
 // a new Vector instance containing the parsed data along with any warnings or errors.
-func parseDataPoint(query string, dataPoint interface{}) (*util.Vector, warning, error) {
+func parseDataPoint(query string, dataPoint any) (*util.Vector, warning, error) {
 	var w warning = nil
 
-	value, ok := dataPoint.([]interface{})
+	value, ok := dataPoint.([]any)
 	if !ok || len(value) != 2 {
 		return nil, w, DataPointFormatErr(query, dataPoint)
 	}
@@ -217,7 +217,7 @@ func parseDataPoint(query string, dataPoint interface{}) (*util.Vector, warning,
 	}, w, nil
 }
 
-func labelsForMetric(metricMap map[string]interface{}) string {
+func labelsForMetric(metricMap map[string]any) string {
 	var pairs []string
 	for k, v := range metricMap {
 		pairs = append(pairs, fmt.Sprintf("%s: %+v", k, v))
@@ -226,8 +226,8 @@ func labelsForMetric(metricMap map[string]interface{}) string {
 	return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
 }
 
-func wrapPrometheusError(query string, qr interface{}) (string, error) {
-	e, ok := qr.(map[string]interface{})["error"]
+func wrapPrometheusError(query string, qr any) (string, error) {
+	e, ok := qr.(map[string]any)["error"]
 	if !ok {
 		return "", PromUnexpectedResponseErr(query, qr)
 	}

--- a/pkg/cloud/alibaba/authorizer_test.go
+++ b/pkg/cloud/alibaba/authorizer_test.go
@@ -65,14 +65,14 @@ func TestSelectAuthorizerByType(t *testing.T) {
 func TestAccessKey_MarshalJSON(t *testing.T) {
 	testCases := map[string]struct {
 		accessKey      AccessKey
-		expectedFields map[string]interface{}
+		expectedFields map[string]any
 	}{
 		"complete AccessKey": {
 			accessKey: AccessKey{
 				AccessKeyID:     "test-id",
 				AccessKeySecret: "test-secret",
 			},
-			expectedFields: map[string]interface{}{
+			expectedFields: map[string]any{
 				cloud.AuthorizerTypeProperty: AccessKeyAuthorizerType,
 				"accessKeyID":                "test-id",
 				"accessKeySecret":            "test-secret",
@@ -80,7 +80,7 @@ func TestAccessKey_MarshalJSON(t *testing.T) {
 		},
 		"empty AccessKey": {
 			accessKey: AccessKey{},
-			expectedFields: map[string]interface{}{
+			expectedFields: map[string]any{
 				cloud.AuthorizerTypeProperty: AccessKeyAuthorizerType,
 				"accessKeyID":                "",
 				"accessKeySecret":            "",
@@ -95,7 +95,7 @@ func TestAccessKey_MarshalJSON(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			var result map[string]interface{}
+			var result map[string]any
 			err = json.Unmarshal(data, &result)
 			if err != nil {
 				t.Errorf("failed to unmarshal JSON: %v", err)

--- a/pkg/cloud/alibaba/boaconfiguration.go
+++ b/pkg/cloud/alibaba/boaconfiguration.go
@@ -83,13 +83,13 @@ func (bc *BOAConfiguration) Provider() string {
 }
 
 func (bc *BOAConfiguration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	account, err := cloud.GetInterfaceValue[string](fmap, "account")
 	if err != nil {

--- a/pkg/cloud/alibaba/provider.go
+++ b/pkg/cloud/alibaba/provider.go
@@ -493,7 +493,7 @@ func (alibaba *Alibaba) DownloadPricingData() error {
 }
 
 // AllNodePricing returns all the pricing data for all nodes and pvs
-func (alibaba *Alibaba) AllNodePricing() (interface{}, error) {
+func (alibaba *Alibaba) AllNodePricing() (any, error) {
 	alibaba.DownloadPricingDataLock.RLock()
 	defer alibaba.DownloadPricingDataLock.RUnlock()
 	return alibaba.Pricing, nil
@@ -720,7 +720,7 @@ func (alibaba *Alibaba) UpdateConfig(r io.Reader, updateType string) (*models.Cu
 			return fmt.Errorf("UpdateConfig for Alibaba Provider doesn't support updateType %s at this time", updateType)
 
 		} else {
-			a := make(map[string]interface{})
+			a := make(map[string]any)
 			err := json.NewDecoder(r).Decode(&a)
 			if err != nil {
 				return err
@@ -958,7 +958,7 @@ func (alibabaPVKey *AlibabaPVKey) GetStorageClass() string {
 // When supporting different new type of instances like Compute Optimized, Memory Optimized etc make sure you add the instance type
 // in unit test and check if it works or not to create the ack request and processDescribePriceAndCreateAlibabaPricing function
 // else more parameters need to be pulled from kubernetes node response or gather information from elsewhere and function modified.
-func createDescribePriceACSRequest(i interface{}) (*requests.CommonRequest, error) {
+func createDescribePriceACSRequest(i any) (*requests.CommonRequest, error) {
 	request := requests.NewCommonRequest()
 	request.Method = requests.GET
 	request.Product = ALIBABA_ECS_PRODUCT_CODE
@@ -1029,7 +1029,7 @@ func createDescribeDisksACSRequest(instanceID, regionID, diskType string) (*requ
 
 // determineKeyForPricing generate a unique key from SlimK8sNode object that is constructed from v1.Node object and
 // SlimK8sDisk that is constructed from v1.PersistentVolume.
-func determineKeyForPricing(i interface{}) (string, error) {
+func determineKeyForPricing(i any) (string, error) {
 	if i == nil {
 		return "", fmt.Errorf("nil component passed to determine key")
 	}
@@ -1077,7 +1077,7 @@ type DescribePriceResponse struct {
 }
 
 // processDescribePriceAndCreateAlibabaPricing processes the DescribePrice API and generates the pricing information for alibaba node resource and alibaba pv resource that's backed by cloud disk.
-func processDescribePriceAndCreateAlibabaPricing(client *sdk.Client, i interface{}, signer *signers.AccessKeySigner, custom *models.CustomPricing) (pricing *AlibabaPricing, err error) {
+func processDescribePriceAndCreateAlibabaPricing(client *sdk.Client, i any, signer *signers.AccessKeySigner, custom *models.CustomPricing) (pricing *AlibabaPricing, err error) {
 	pricing = &AlibabaPricing{}
 	var response DescribePriceResponse
 
@@ -1463,6 +1463,6 @@ func determinePVRegion(pv *clustercache.PersistentVolume) string {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not
 // everything that was _available_ in the pricing source.
-func (a *Alibaba) PricingSourceSummary() interface{} {
+func (a *Alibaba) PricingSourceSummary() any {
 	return a.Pricing
 }

--- a/pkg/cloud/alibaba/provider_test.go
+++ b/pkg/cloud/alibaba/provider_test.go
@@ -2,6 +2,7 @@ package alibaba
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestCreateDescribePriceACSRequest(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		testStruct    interface{}
+		testStruct    any
 		expectedError error
 	}{
 		{
@@ -84,7 +85,7 @@ func TestProcessDescribePriceAndCreateAlibabaPricing(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		teststruct    interface{}
+		teststruct    any
 		expectedError error
 	}{
 		{
@@ -501,7 +502,7 @@ func TestDetermineKeyForPricing(t *testing.T) {
 	}
 	cases := []struct {
 		name          string
-		testVar       interface{}
+		testVar       any
 		expectedKey   string
 		expectedError error
 	}{
@@ -977,7 +978,7 @@ func TestCreateDescribeNodePriceACSRequest(t *testing.T) {
 
 	cases := []struct {
 		name                 string
-		testStruct           interface{}
+		testStruct           any
 		expectedError        error
 		expectedDiskCategory string
 	}{
@@ -1726,13 +1727,7 @@ func TestRegions_WithCustomRegions(t *testing.T) {
 	}
 
 	// Check if custom region is included
-	found := false
-	for _, region := range regions {
-		if region == "custom-region" {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(regions, "custom-region")
 	if !found {
 		t.Logf("Custom region not found in regions list, but that's okay")
 	}
@@ -2107,7 +2102,7 @@ func TestPricingSourceSummary_WithValidPricing(t *testing.T) {
 	}
 
 	// Check if summary contains expected data
-	summaryMap, ok := summary.(map[string]interface{})
+	summaryMap, ok := summary.(map[string]any)
 	if ok {
 		if len(summaryMap) == 0 {
 			t.Fatalf("PricingSourceSummary should return non-empty summary")

--- a/pkg/cloud/authorizer.go
+++ b/pkg/cloud/authorizer.go
@@ -25,7 +25,7 @@ func AuthorizerFromInterface[T Authorizer](f any, authSelectFn AuthorizerSelecto
 	if f == nil {
 		return emptyAuth, nil
 	}
-	fmap, ok := f.(map[string]interface{})
+	fmap, ok := f.(map[string]any)
 	if !ok {
 		return emptyAuth, fmt.Errorf("AuthorizerFromInterface: could not cast interface as map")
 	}

--- a/pkg/cloud/aws/athenaconfiguration.go
+++ b/pkg/cloud/aws/athenaconfiguration.go
@@ -128,13 +128,13 @@ func (ac *AthenaConfiguration) Provider() string {
 }
 
 func (ac *AthenaConfiguration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	bucket, err := cloud.GetInterfaceValue[string](fmap, "bucket")
 	if err != nil {

--- a/pkg/cloud/aws/athenaquerier_mock.go
+++ b/pkg/cloud/aws/athenaquerier_mock.go
@@ -251,6 +251,8 @@ func (maq *MockAthenaQuerier) waitForQueryToComplete(ctx context.Context, client
 }
 
 // Helper function to create string pointers
+//
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/pkg/cloud/aws/athenaquerier_test.go
+++ b/pkg/cloud/aws/athenaquerier_test.go
@@ -803,7 +803,7 @@ func TestGetAthenaRowValue(t *testing.T) {
 	// Test with valid data
 	row := types.Row{
 		Data: []types.Datum{
-			{VarCharValue: stringPtr("test-value")},
+			{VarCharValue: new("test-value")},
 		},
 	}
 
@@ -839,7 +839,7 @@ func TestGetAthenaRowValueFloat(t *testing.T) {
 	// Test with valid data
 	row := types.Row{
 		Data: []types.Datum{
-			{VarCharValue: stringPtr("3.14159")},
+			{VarCharValue: new("3.14159")},
 		},
 	}
 
@@ -877,7 +877,7 @@ func TestGetAthenaRowValueFloat(t *testing.T) {
 	// Test with invalid float
 	rowWithInvalid := types.Row{
 		Data: []types.Datum{
-			{VarCharValue: stringPtr("not-a-number")},
+			{VarCharValue: new("not-a-number")},
 		},
 	}
 

--- a/pkg/cloud/aws/authorizer.go
+++ b/pkg/cloud/aws/authorizer.go
@@ -164,13 +164,13 @@ func (ara *AssumeRole) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is required for AssumeRole because it needs to unmarshal an Authorizer interface
 func (ara *AssumeRole) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	roleARN, err := cloud.GetInterfaceValue[string](fmap, "roleARN")
 	if err != nil {
@@ -278,13 +278,13 @@ func (wea *WebIdentity) MarshalJSON() ([]byte, error) {
 }
 
 func (wea *WebIdentity) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	roleARN, err := cloud.GetInterfaceValue[string](fmap, "roleARN")
 	if err != nil {
@@ -298,9 +298,9 @@ func (wea *WebIdentity) UnmarshalJSON(b []byte) error {
 	}
 	wea.IdentityProvider = idp
 
-	var tr interface{}
+	var tr any
 
-	tr, err = cloud.GetInterfaceValue[interface{}](fmap, "tokenRetriever")
+	tr, err = cloud.GetInterfaceValue[any](fmap, "tokenRetriever")
 	if err != nil {
 		return fmt.Errorf("WebIdentity: UnmarshalJSON: %s", err.Error())
 	}

--- a/pkg/cloud/aws/authorizer_test.go
+++ b/pkg/cloud/aws/authorizer_test.go
@@ -130,7 +130,7 @@ func TestAuthorizerJSON_Encode(t *testing.T) {
 				t.Errorf("Failed to Marshal Authorizer: %s", err)
 			}
 
-			var f interface{}
+			var f any
 			err = json.Unmarshal(b, &f)
 			if err != nil {
 				t.Errorf("Failed to Unmarshal Authorizer: %s", err)

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1413,7 +1413,7 @@ func (aws *AWS) LoadBalancerPricing() (*models.LoadBalancer, error) {
 }
 
 // AllNodePricing returns all the billing data fetched.
-func (aws *AWS) AllNodePricing() (interface{}, error) {
+func (aws *AWS) AllNodePricing() (any, error) {
 	aws.DownloadPricingDataLock.RLock()
 	defer aws.DownloadPricingDataLock.RUnlock()
 	return aws.Pricing, nil
@@ -2713,7 +2713,7 @@ func (aws *AWS) Regions() []string {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not
 // everything that was _available_ in the pricing source.
-func (aws *AWS) PricingSourceSummary() interface{} {
+func (aws *AWS) PricingSourceSummary() any {
 	// encode the pricing source summary as a JSON string
 	return aws.Pricing
 }

--- a/pkg/cloud/aws/s3configuration.go
+++ b/pkg/cloud/aws/s3configuration.go
@@ -95,13 +95,13 @@ func (s3c *S3Configuration) Provider() string {
 }
 
 func (s3c *S3Configuration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	bucket, err := cloud.GetInterfaceValue[string](fmap, "bucket")
 	if err != nil {

--- a/pkg/cloud/aws/spotpricehistory_test.go
+++ b/pkg/cloud/aws/spotpricehistory_test.go
@@ -98,7 +98,7 @@ func TestSpotPriceHistoryCache_GetSpotPrice_ConcurrentSameKey(t *testing.T) {
 	const goroutines = 10
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			entry, err := cache.GetSpotPrice("us-west-2", "m5.large", "us-west-2a")

--- a/pkg/cloud/azure/pricesheetdownloader.go
+++ b/pkg/cloud/azure/pricesheetdownloader.go
@@ -6,6 +6,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"sort"
@@ -125,7 +126,7 @@ func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reade
 	// is concerned). Skip them before making the CSV reader so we
 	// still get the benefit of the row length checks after the
 	// header.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		_, err := buf.ReadBytes('\n')
 		if err != nil {
 			return nil, fmt.Errorf("skipping preamble line %d: %w", i, err)
@@ -181,9 +182,7 @@ func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reade
 			units[*meterInfo.Unit] = true
 		}
 
-		for key, pricing := range pricings {
-			results[key] = pricing
-		}
+		maps.Copy(results, pricings)
 	}
 
 	if len(results) == 0 {
@@ -221,11 +220,11 @@ func makeMeterInfo(row []string) (commerce.MeterInfo, error) {
 	}
 	newPrice, unit := normalisePrice(price, row[pricesheetUnit])
 	return commerce.MeterInfo{
-		MeterName:        ptr(row[pricesheetMeterName]),
-		MeterCategory:    ptr(row[pricesheetMeterCategory]),
-		MeterSubCategory: ptr(row[pricesheetMeterSubCategory]),
+		MeterName:        new(row[pricesheetMeterName]),
+		MeterCategory:    new(row[pricesheetMeterCategory]),
+		MeterSubCategory: new(row[pricesheetMeterSubCategory]),
 		Unit:             &unit,
-		MeterRegion:      ptr(row[pricesheetMeterRegion]),
+		MeterRegion:      new(row[pricesheetMeterRegion]),
 		MeterRates:       map[string]*float64{"0": &newPrice},
 	}, nil
 }
@@ -264,8 +263,9 @@ func currentBillingPeriod() string {
 	return time.Now().Format("200601")
 }
 
+//go:fix inline
 func ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 // conversions lists all the units seen from the price sheet for

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -168,11 +169,11 @@ var azureRegions = []string{
 type regionParts []string
 
 func (r regionParts) String() string {
-	var result string
+	var result strings.Builder
 	for _, p := range r {
-		result += p
+		result.WriteString(p)
 	}
-	return result
+	return result.String()
 }
 
 func getRegions(service string, subscriptionsClient subscriptions.Client, providersClient resources.ProvidersClient, subscriptionID string) (map[string]string, error) {
@@ -436,7 +437,7 @@ type Azure struct {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not
 // everything that was _available_ in the pricing source.
-func (az *Azure) PricingSourceSummary() interface{} {
+func (az *Azure) PricingSourceSummary() any {
 	return az.Pricing
 }
 
@@ -935,9 +936,7 @@ func (az *Azure) DownloadPricingData() error {
 			log.Warnf("converting meter to pricings: %s", err.Error())
 			continue
 		}
-		for key, pricing := range pricings {
-			allPrices[key] = pricing
-		}
+		maps.Copy(allPrices, pricings)
 	}
 	addAzureFilePricing(allPrices, regions)
 
@@ -1019,7 +1018,7 @@ func convertMeterToPricings(info commerce.MeterInfo, regions map[string]string, 
 				var priceInUsd float64
 
 				if len(info.MeterRates) < 1 {
-					return nil, fmt.Errorf("missing rate info %+v", map[string]interface{}{"MeterSubCategory": *info.MeterSubCategory, "region": region})
+					return nil, fmt.Errorf("missing rate info %+v", map[string]any{"MeterSubCategory": *info.MeterSubCategory, "region": region})
 				}
 				for _, rate := range info.MeterRates {
 					priceInUsd += *rate
@@ -1055,8 +1054,8 @@ func convertMeterToPricings(info commerce.MeterInfo, regions map[string]string, 
 
 	var instanceTypes []string
 	name := strings.TrimSuffix(meterName, " Low Priority")
-	instanceType := strings.Split(name, "/")
-	for _, it := range instanceType {
+	instanceType := strings.SplitSeq(name, "/")
+	for it := range instanceType {
 		if strings.Contains(meterSubCategory, "Promo") {
 			it = it + " Promo"
 		}
@@ -1071,7 +1070,7 @@ func convertMeterToPricings(info commerce.MeterInfo, regions map[string]string, 
 	var priceInUsd float64
 
 	if len(info.MeterRates) < 1 {
-		return nil, fmt.Errorf("missing rate info %+v", map[string]interface{}{"MeterSubCategory": *info.MeterSubCategory, "region": region})
+		return nil, fmt.Errorf("missing rate info %+v", map[string]any{"MeterSubCategory": *info.MeterSubCategory, "region": region})
 	}
 	for _, rate := range info.MeterRates {
 		priceInUsd += *rate
@@ -1143,7 +1142,7 @@ func (az *Azure) addPricing(features string, azurePricing *AzurePricing) {
 }
 
 // AllNodePricing returns the Azure pricing objects stored
-func (az *Azure) AllNodePricing() (interface{}, error) {
+func (az *Azure) AllNodePricing() (any, error) {
 	az.DownloadPricingDataLock.RLock()
 	defer az.DownloadPricingDataLock.RUnlock()
 	return az.Pricing, nil
@@ -1437,7 +1436,6 @@ func (az *Azure) getDisks() ([]*compute.Disk, error) {
 
 	for diskPage.NotDone() {
 		for _, d := range diskPage.Values() {
-			d := d
 			disks = append(disks, &d)
 		}
 		err := diskPage.NextWithContext(context.Background())
@@ -1604,7 +1602,7 @@ func (az *Azure) UpdateConfig(r io.Reader, updateType string) (*models.CustomPri
 				go az.DownloadPricingData()
 			}()
 
-			a := make(map[string]interface{})
+			a := make(map[string]any)
 			err := json.NewDecoder(r).Decode(&a)
 			if err != nil {
 				return fmt.Errorf("error decoding AzureStorageConfig: %s", err)

--- a/pkg/cloud/azure/storagebillingparser_test.go
+++ b/pkg/cloud/azure/storagebillingparser_test.go
@@ -516,7 +516,7 @@ func TestDecompressIfGzipped_LargeFile(t *testing.T) {
 	// Create a larger CSV content (1000 rows)
 	var contentBuilder strings.Builder
 	contentBuilder.WriteString("col1,col2,col3,col4\n")
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		contentBuilder.WriteString("value1,value2,value3,value4\n")
 	}
 	content := contentBuilder.String()

--- a/pkg/cloud/azure/storageconfiguration.go
+++ b/pkg/cloud/azure/storageconfiguration.go
@@ -111,13 +111,13 @@ func (sc *StorageConfiguration) Provider() string {
 }
 
 func (sc *StorageConfiguration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	subscriptionID, err := cloud.GetInterfaceValue[string](fmap, "subscriptionID")
 	if err != nil {

--- a/pkg/cloud/azure/storageconfiguration_test.go
+++ b/pkg/cloud/azure/storageconfiguration_test.go
@@ -538,11 +538,11 @@ func TestStorageConfiguration_Equals(t *testing.T) {
 
 func TestStorageConfiguration_JSON(t *testing.T) {
 	testCases := map[string]struct {
-		input          map[string]interface{}
+		input          map[string]any
 		afterUnmarshal StorageConfiguration
 	}{
 		"Nil Authorizer": {
-			input: map[string]interface{}{
+			input: map[string]any{
 				"subscriptionID": "subscriptionID",
 				"account":        "account",
 				"container":      "container",
@@ -560,13 +560,13 @@ func TestStorageConfiguration_JSON(t *testing.T) {
 			},
 		},
 		"SharedKeyCredential Authorizer": {
-			input: map[string]interface{}{
+			input: map[string]any{
 				"subscriptionID": "subscriptionID",
 				"account":        "account",
 				"container":      "container",
 				"path":           "path",
 				"cloud":          "cloud",
-				"authorizer": map[string]interface{}{
+				"authorizer": map[string]any{
 					"authorizerType": "AzureAccessKey",
 					"accessKey":      "accessKey",
 					"account":        "account",
@@ -585,13 +585,13 @@ func TestStorageConfiguration_JSON(t *testing.T) {
 			},
 		},
 		"Default AuthorizerHolder Authorizer": {
-			input: map[string]interface{}{
+			input: map[string]any{
 				"subscriptionID": "subscriptionID",
 				"account":        "account",
 				"container":      "container",
 				"path":           "path",
 				"cloud":          "cloud",
-				"authorizer": map[string]interface{}{
+				"authorizer": map[string]any{
 					"authorizerType": "AzureDefaultCredential",
 				},
 			},
@@ -607,13 +607,13 @@ func TestStorageConfiguration_JSON(t *testing.T) {
 			},
 		},
 		"ClientSecretCredential Authorizer": {
-			input: map[string]interface{}{
+			input: map[string]any{
 				"subscriptionID": "subscriptionID",
 				"account":        "account",
 				"container":      "container",
 				"path":           "path",
 				"cloud":          "cloud",
-				"authorizer": map[string]interface{}{
+				"authorizer": map[string]any{
 					"authorizerType": "AzureClientSecretCredential",
 					"tenantID":       "tenantID",
 					"clientID":       "clientID",
@@ -636,16 +636,16 @@ func TestStorageConfiguration_JSON(t *testing.T) {
 			},
 		},
 		"StorageConnectionStringCredential Authorizer": {
-			input: map[string]interface{}{
+			input: map[string]any{
 				"subscriptionID": "subscriptionID",
 				"account":        "account",
 				"container":      "container",
 				"path":           "path",
 				"cloud":          "cloud",
-				"authorizer": map[string]interface{}{
+				"authorizer": map[string]any{
 					"authorizerType":          "AzureStorageConnectionString",
 					"storageConnectionString": "storageConnectionString",
-					"httpConfig": map[string]interface{}{
+					"httpConfig": map[string]any{
 						"insecureSkipVerify": true,
 					},
 				},

--- a/pkg/cloud/config.go
+++ b/pkg/cloud/config.go
@@ -24,7 +24,7 @@ type KeyedConfigWatcher interface {
 	GetConfigs() []KeyedConfig
 }
 
-func GetInterfaceValue[T any](fmap map[string]interface{}, key string) (T, error) {
+func GetInterfaceValue[T any](fmap map[string]any, key string) (T, error) {
 	var value T
 	interfaceValue, ok := fmap[key]
 	if !ok {

--- a/pkg/cloud/config/controller.go
+++ b/pkg/cloud/config/controller.go
@@ -452,11 +452,9 @@ func (c *Controller) broadcastRemoveConfig(key string) {
 	var wg sync.WaitGroup
 	for _, obs := range c.observers {
 		observer := obs
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			observer.DeleteConfig(key)
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -466,11 +464,9 @@ func (c *Controller) broadcastAddConfig(conf cloud.KeyedConfig) {
 	var wg sync.WaitGroup
 	for _, obs := range c.observers {
 		observer := obs
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			observer.PutConfig(conf)
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/pkg/cloud/config/statuses.go
+++ b/pkg/cloud/config/statuses.go
@@ -77,13 +77,13 @@ type Status struct {
 }
 
 func (s *Status) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	sourceFloat, err := cloud.GetInterfaceValue[float64](fmap, "source")
 	if err != nil {

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -45,8 +45,8 @@ type PricingCache struct {
 // DOResponse represents the response from DigitalOcean's /v2/sizes API
 type DOResponse struct {
 	Sizes []DOSize `json:"sizes"`
-	Links DOLinks  `json:"links,omitempty"`
-	Meta  DOMeta   `json:"meta,omitempty"`
+	Links DOLinks  `json:"links"`
+	Meta  DOMeta   `json:"meta"`
 }
 
 // DOSize represents a DigitalOcean Droplet size
@@ -62,7 +62,7 @@ type DOSize struct {
 	Available    bool         `json:"available"`
 	Description  string       `json:"description"`
 	DiskInfo     []DODiskInfo `json:"disk_info,omitempty"`
-	GPUInfo      DOGPUInfo    `json:"gpu_info,omitempty"`
+	GPUInfo      DOGPUInfo    `json:"gpu_info"`
 }
 
 // DODiskInfo represents disk information for a DigitalOcean size
@@ -92,7 +92,7 @@ type DODiskSize struct {
 
 // DOLinks represents pagination links
 type DOLinks struct {
-	Pages DOPages `json:"pages,omitempty"`
+	Pages DOPages `json:"pages"`
 }
 
 // DOPages represents pagination page links
@@ -588,8 +588,8 @@ func (do *DOKS) NodePricing(key models.Key) (*models.Node, models.PricingMetadat
 }
 
 func parseArch(features string) string {
-	parts := strings.Split(features, ",")
-	for _, part := range parts {
+	parts := strings.SplitSeq(features, ",")
+	for part := range parts {
 		pair := strings.SplitN(part, "=", 2)
 		if len(pair) == 2 && (pair[0] == "kubernetes.io/arch" || pair[0] == "beta.kubernetes.io/arch") {
 			return pair[1]
@@ -867,7 +867,7 @@ func isDefaultNetworkPricing(cp *models.CustomPricing) bool {
 		cp.NatGatewayIngress == "0.045"
 }
 
-func (do *DOKS) AllNodePricing() (interface{}, error) {
+func (do *DOKS) AllNodePricing() (any, error) {
 	_, _ = do.fetchPricingData()
 	return do.Cache, nil
 }
@@ -997,7 +997,7 @@ func (do *DOKS) Regions() []string {
 	return []string{"nyc1", "sfo3", "ams3"}
 }
 
-func (do *DOKS) PricingSourceSummary() interface{} {
+func (do *DOKS) PricingSourceSummary() any {
 	return nil
 }
 

--- a/pkg/cloud/gcp/authorizer_test.go
+++ b/pkg/cloud/gcp/authorizer_test.go
@@ -58,7 +58,7 @@ func TestServiceAccountKey_MarshalJSON(t *testing.T) {
 	data, err := json.Marshal(key)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	require.NoError(t, err)
 
@@ -219,7 +219,7 @@ func TestWorkloadIdentity_MarshalJSON(t *testing.T) {
 	data, err := json.Marshal(wi)
 	require.NoError(t, err)
 
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	require.NoError(t, err)
 

--- a/pkg/cloud/gcp/bigqueryconfiguration.go
+++ b/pkg/cloud/gcp/bigqueryconfiguration.go
@@ -144,13 +144,13 @@ func (bqc *BigQueryConfiguration) GetBigQueryClient(ctx context.Context) (*bigqu
 
 // UnmarshalJSON assumes data is save as an BigQueryConfigurationDTO
 func (bqc *BigQueryConfiguration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	projectID, err := cloud.GetInterfaceValue[string](fmap, "projectID")
 	if err != nil {

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -258,7 +258,7 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*models.CustomPric
 			c.AwsServiceKeySecret = a.ServiceKeySecret
 			c.AthenaProjectID = a.AccountID
 		} else {
-			a := make(map[string]interface{})
+			a := make(map[string]any)
 			err := json.NewDecoder(r).Decode(&a)
 			if err != nil {
 				return err
@@ -1577,7 +1577,7 @@ func (gcp *gcpKey) Features() string {
 }
 
 // AllNodePricing returns the GCP pricing objects stored
-func (gcp *GCP) AllNodePricing() (interface{}, error) {
+func (gcp *GCP) AllNodePricing() (any, error) {
 	gcp.DownloadPricingDataLock.RLock()
 	defer gcp.DownloadPricingDataLock.RUnlock()
 	return gcp.Pricing, nil
@@ -1717,6 +1717,6 @@ func getUsageType(labels map[string]string) string {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not
 // everything that was _available_ in the pricing source.
-func (gcp *GCP) PricingSourceSummary() interface{} {
+func (gcp *GCP) PricingSourceSummary() any {
 	return gcp.Pricing
 }

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -283,7 +283,7 @@ type Provider interface {
 	PVPricing(PVKey) (*PV, error)
 	NetworkPricing() (*Network, error)           // TODO: add key interface arg for dynamic price fetching
 	LoadBalancerPricing() (*LoadBalancer, error) // TODO: add key interface arg for dynamic price fetching
-	AllNodePricing() (interface{}, error)
+	AllNodePricing() (any, error)
 	DownloadPricingData() error
 	GetKey(map[string]string, *clustercache.Node) Key
 	GetPVKey(*clustercache.PersistentVolume, map[string]string, string) PVKey
@@ -297,7 +297,7 @@ type Provider interface {
 	ClusterManagementPricing() (string, float64, error)
 	CombinedDiscountForNode(string, bool, float64, float64) float64
 	Regions() []string
-	PricingSourceSummary() interface{}
+	PricingSourceSummary() any
 }
 
 // ProviderConfig describes config storage common to all providers.

--- a/pkg/cloud/oracle/provider.go
+++ b/pkg/cloud/oracle/provider.go
@@ -105,7 +105,7 @@ func (o *Oracle) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	return o.RateCardStore.ForLB(o.DefaultPricing)
 }
 
-func (o *Oracle) AllNodePricing() (interface{}, error) {
+func (o *Oracle) AllNodePricing() (any, error) {
 	if err := o.ensurePricingData(); err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (o *Oracle) GetPVKey(pv *clustercache.PersistentVolume, parameters map[stri
 
 func (o *Oracle) UpdateConfig(r io.Reader, _ string) (*models.CustomPricing, error) {
 	return o.Config.Update(func(pricing *models.CustomPricing) error {
-		a := make(map[string]interface{})
+		a := make(map[string]any)
 		err := json.NewDecoder(r).Decode(&a)
 		if err != nil {
 			return err
@@ -277,7 +277,7 @@ func (o *Oracle) Regions() []string {
 	return oracleRegions()
 }
 
-func (o *Oracle) PricingSourceSummary() interface{} {
+func (o *Oracle) PricingSourceSummary() any {
 	if err := o.ensurePricingData(); err != nil {
 		return err
 	}

--- a/pkg/cloud/oracle/usageapiconfiguration.go
+++ b/pkg/cloud/oracle/usageapiconfiguration.go
@@ -97,13 +97,13 @@ func (uac *UsageApiConfiguration) GetUsageApiClient() (*usageapi.UsageapiClient,
 }
 
 func (uac *UsageApiConfiguration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap := f.(map[string]interface{})
+	fmap := f.(map[string]any)
 
 	tenancyId, err := cloud.GetInterfaceValue[string](fmap, "tenancyID")
 	if err != nil {

--- a/pkg/cloud/oracle/usageapiintegration.go
+++ b/pkg/cloud/oracle/usageapiintegration.go
@@ -29,13 +29,13 @@ func (uai *UsageApiIntegration) GetCloudCost(start time.Time, end time.Time) (*o
 		RequestSummarizedUsagesDetails: usageapi.RequestSummarizedUsagesDetails{
 			Granularity:       usageapi.RequestSummarizedUsagesDetailsGranularityDaily,
 			GroupBy:           []string{"resourceId", "service", "subscriptionId", "tenantName"},
-			IsAggregateByTime: common.Bool(false),
+			IsAggregateByTime: new(false),
 			TimeUsageStarted:  &common.SDKTime{Time: start},
 			TimeUsageEnded:    &common.SDKTime{Time: end},
 			QueryType:         usageapi.RequestSummarizedUsagesDetailsQueryTypeCost,
-			TenantId:          common.String(uai.TenancyID),
+			TenantId:          new(uai.TenancyID),
 		},
-		Limit: common.Int(500),
+		Limit: new(500),
 	}
 
 	resp, err := client.RequestSummarizedUsages(context.Background(), req)

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -433,7 +433,7 @@ func (otc *OTC) GpuPricing(nodeLabels map[string]string) (string, error) {
 }
 
 // TODO: Implement method
-func (otc *OTC) AllNodePricing() (interface{}, error) {
+func (otc *OTC) AllNodePricing() (any, error) {
 	return nil, nil
 }
 
@@ -494,7 +494,7 @@ func (otc *OTC) Regions() []string {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not what
 // was returned from the relevant API.
-func (otc *OTC) PricingSourceSummary() interface{} {
+func (otc *OTC) PricingSourceSummary() any {
 	// encode the pricing source summary as a JSON string
 	return otc.Pricing
 }

--- a/pkg/cloud/ovh/provider.go
+++ b/pkg/cloud/ovh/provider.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -349,10 +350,8 @@ func isMonthlyBilling(labels map[string]string, monthlyPools []string) bool {
 	}
 
 	if pool, ok := labels[NodepoolLabel]; ok {
-		for _, mp := range monthlyPools {
-			if pool == mp {
-				return true
-			}
+		if slices.Contains(monthlyPools, pool) {
+			return true
 		}
 	}
 
@@ -575,7 +574,7 @@ func (c *OVH) GetOrphanedResources() ([]models.OrphanedResource, error) {
 }
 
 // AllNodePricing returns all cached node pricing data.
-func (c *OVH) AllNodePricing() (interface{}, error) {
+func (c *OVH) AllNodePricing() (any, error) {
 	c.DownloadLock.RLock()
 	defer c.DownloadLock.RUnlock()
 	return c.Pricing, nil
@@ -591,7 +590,7 @@ func (c *OVH) UpdateConfig(r io.Reader, updateType string) (*models.CustomPricin
 	defer c.DownloadPricingData()
 
 	return c.Config.Update(func(cp *models.CustomPricing) error {
-		a := make(map[string]interface{})
+		a := make(map[string]any)
 		err := coreJSON.NewDecoder(r).Decode(&a)
 		if err != nil {
 			return err
@@ -680,6 +679,6 @@ func (c *OVH) PricingSourceStatus() map[string]*models.PricingSource {
 }
 
 // PricingSourceSummary returns the parsed pricing data.
-func (c *OVH) PricingSourceSummary() interface{} {
+func (c *OVH) PricingSourceSummary() any {
 	return c.Pricing
 }

--- a/pkg/cloud/provider/csvprovider.go
+++ b/pkg/cloud/provider/csvprovider.go
@@ -88,8 +88,8 @@ func (c *CSVProvider) DownloadPricingData() error {
 		bucketAndKey := strings.Split(strings.TrimPrefix(c.CSVLocation, "s3://"), "/")
 		if len(bucketAndKey) == 2 {
 			out, err := s3Client.GetObject(&s3.GetObjectInput{
-				Bucket: aws.String(bucketAndKey[0]),
-				Key:    aws.String(bucketAndKey[1]),
+				Bucket: new(bucketAndKey[0]),
+				Key:    new(bucketAndKey[1]),
 			})
 			csverr = err
 			csvr = out.Body
@@ -323,8 +323,8 @@ func NodeValueFromMapField(m string, n *clustercache.Node, useRegion bool) strin
 				return toReturn + group
 			}
 		}
-		if strings.HasPrefix(n.SpecProviderID, "azure://") {
-			vmOrScaleSet := strings.ToLower(strings.TrimPrefix(n.SpecProviderID, "azure://"))
+		if after, ok := strings.CutPrefix(n.SpecProviderID, "azure://"); ok {
+			vmOrScaleSet := strings.ToLower(after)
 			return toReturn + vmOrScaleSet
 		}
 		return toReturn + n.SpecProviderID
@@ -462,6 +462,6 @@ func (c *CSVProvider) Regions() []string {
 	return []string{}
 }
 
-func (c *CSVProvider) PricingSourceSummary() interface{} {
+func (c *CSVProvider) PricingSourceSummary() any {
 	return c.Pricing
 }

--- a/pkg/cloud/provider/customprovider.go
+++ b/pkg/cloud/provider/customprovider.go
@@ -64,7 +64,7 @@ type customPVKey struct {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not what
 // was returned from the relevant API.
-func (cp *CustomProvider) PricingSourceSummary() interface{} {
+func (cp *CustomProvider) PricingSourceSummary() any {
 	return cp.Pricing
 }
 
@@ -100,7 +100,7 @@ func (cp *CustomProvider) UpdateConfigFromConfigMap(a map[string]string) (*model
 
 func (cp *CustomProvider) UpdateConfig(r io.Reader, updateType string) (*models.CustomPricing, error) {
 	// Parse config updates from reader
-	a := make(map[string]interface{})
+	a := make(map[string]any)
 	err := json.NewDecoder(r).Decode(&a)
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func (*CustomProvider) GetOrphanedResources() ([]models.OrphanedResource, error)
 	return nil, errors.New("not implemented")
 }
 
-func (cp *CustomProvider) AllNodePricing() (interface{}, error) {
+func (cp *CustomProvider) AllNodePricing() (any, error) {
 	cp.DownloadPricingDataLock.RLock()
 	defer cp.DownloadPricingDataLock.RUnlock()
 

--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -44,7 +45,7 @@ type Scaleway struct {
 // PricingSourceSummary returns the pricing source summary for the provider.
 // The summary represents what was _parsed_ from the pricing source, not
 // everything that was _available_ in the pricing source.
-func (c *Scaleway) PricingSourceSummary() interface{} {
+func (c *Scaleway) PricingSourceSummary() any {
 	return c.Pricing
 }
 func (c *Scaleway) DownloadPricingData() error {
@@ -93,15 +94,13 @@ func (c *Scaleway) DownloadPricingData() error {
 			NodesInfos: map[string]*instance.ServerType{},
 		}
 
-		for name, infos := range resp.Servers {
-			c.Pricing[zone.String()].NodesInfos[name] = infos
-		}
+		maps.Copy(c.Pricing[zone.String()].NodesInfos, resp.Servers)
 	}
 
 	return nil
 }
 
-func (c *Scaleway) AllNodePricing() (interface{}, error) {
+func (c *Scaleway) AllNodePricing() (any, error) {
 	c.DownloadPricingDataLock.RLock()
 	defer c.DownloadPricingDataLock.RUnlock()
 	return c.Pricing, nil
@@ -319,7 +318,7 @@ func (c *Scaleway) UpdateConfig(r io.Reader, updateType string) (*models.CustomP
 	defer c.DownloadPricingData()
 
 	return c.Config.Update(func(c *models.CustomPricing) error {
-		a := make(map[string]interface{})
+		a := make(map[string]any)
 		err := json.NewDecoder(r).Decode(&a)
 		if err != nil {
 			return err

--- a/pkg/cloud/stackit/costconfiguration.go
+++ b/pkg/cloud/stackit/costconfiguration.go
@@ -59,13 +59,13 @@ func (c *CostConfiguration) Provider() string {
 }
 
 func (c *CostConfiguration) UnmarshalJSON(b []byte) error {
-	var f interface{}
+	var f any
 	err := json.Unmarshal(b, &f)
 	if err != nil {
 		return err
 	}
 
-	fmap, ok := f.(map[string]interface{})
+	fmap, ok := f.(map[string]any)
 	if !ok {
 		return fmt.Errorf("CostConfiguration: UnmarshalJSON: expected object")
 	}

--- a/pkg/cloud/stackit/pim.go
+++ b/pkg/cloud/stackit/pim.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -95,7 +96,7 @@ func fetchAllPIMSKUs(req pimSearchRequest) ([]pimSKU, error) {
 	var allSKUs []pimSKU
 	cursor := ""
 
-	for page := 0; page < pimMaxPages; page++ {
+	for range pimMaxPages {
 		reqURL := fmt.Sprintf("%s/v2/skus/search?pageSize=%d", pimBaseURL, pimMaxPage)
 		if cursor != "" {
 			reqURL += "&cursor=" + url.QueryEscape(cursor)
@@ -297,9 +298,7 @@ func downloadPIMPricing() (map[string]*pimFlavorPricing, map[string]*pimStorageP
 		log.Warnf("STACKIT: failed to fetch GPU pricing from PIM API: %v", err)
 	} else {
 		gpuFlavors := parsePIMVMFlavors(gpuSKUs)
-		for k, v := range gpuFlavors {
-			flavors[k] = v
-		}
+		maps.Copy(flavors, gpuFlavors)
 		log.Infof("STACKIT: fetched %d GPU flavor prices from PIM API", len(gpuFlavors))
 	}
 

--- a/pkg/cloud/stackit/provider.go
+++ b/pkg/cloud/stackit/provider.go
@@ -37,7 +37,7 @@ type STACKIT struct {
 	pimStorage map[string]*pimStoragePricing
 }
 
-func (s *STACKIT) PricingSourceSummary() interface{} {
+func (s *STACKIT) PricingSourceSummary() any {
 	s.DownloadPricingDataLock.RLock()
 	defer s.DownloadPricingDataLock.RUnlock()
 	return s.pimFlavors
@@ -61,7 +61,7 @@ func (s *STACKIT) DownloadPricingData() error {
 	return nil
 }
 
-func (s *STACKIT) AllNodePricing() (interface{}, error) {
+func (s *STACKIT) AllNodePricing() (any, error) {
 	s.DownloadPricingDataLock.RLock()
 	defer s.DownloadPricingDataLock.RUnlock()
 	return s.pimFlavors, nil
@@ -311,7 +311,7 @@ func (s *STACKIT) UpdateConfigFromConfigMap(a map[string]string) (*models.Custom
 
 func (s *STACKIT) UpdateConfig(r io.Reader, updateType string) (*models.CustomPricing, error) {
 	cp, err := s.Config.Update(func(c *models.CustomPricing) error {
-		a := make(map[string]interface{})
+		a := make(map[string]any)
 		err := json.NewDecoder(r).Decode(&a)
 		if err != nil {
 			return err

--- a/pkg/cloudcost/ingestionmanager.go
+++ b/pkg/cloudcost/ingestionmanager.go
@@ -2,6 +2,7 @@ package cloudcost
 
 import (
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -127,9 +128,7 @@ func (im *IngestionManager) GetIngestors() map[string]*ingestor {
 
 	// Return a copy to avoid race conditions
 	copy := make(map[string]*ingestor)
-	for k, v := range im.ingestors {
-		copy[k] = v
-	}
+	maps.Copy(copy, im.ingestors)
 	return copy
 }
 

--- a/pkg/cloudcost/ingestor.go
+++ b/pkg/cloudcost/ingestor.go
@@ -163,19 +163,15 @@ func (ing *ingestor) Stop() {
 	var wg sync.WaitGroup
 
 	if ing.exitBuildCh != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ing.exitBuildCh <- msg
-		}()
+		})
 	}
 
 	if ing.exitRunCh != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ing.exitRunCh <- msg
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/cloudcost/ingestor_test.go
+++ b/pkg/cloudcost/ingestor_test.go
@@ -33,13 +33,13 @@ func TestIngestor_Status_ConcurrentWithCoverageWrite(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 2000; i++ {
+		for range 2000 {
 			ing.expandCoverage(window)
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 2000; i++ {
+		for range 2000 {
 			_ = ing.Status()
 		}
 	}()

--- a/pkg/cloudcost/repositoryquerier.go
+++ b/pkg/cloudcost/repositoryquerier.go
@@ -119,8 +119,8 @@ func cloudCostAutocompleteValues(cc *opencost.CloudCost, field string) []string 
 		}
 		return keys
 	}
-	if strings.HasPrefix(field, "label:") {
-		labelName := strings.TrimPrefix(field, "label:")
+	if after, ok := strings.CutPrefix(field, "label:"); ok {
+		labelName := after
 		if value, ok := cloudCostLabelValueFold(cc.Properties.Labels, labelName); ok {
 			return []string{value}
 		}

--- a/pkg/cloudcost/view.go
+++ b/pkg/cloudcost/view.go
@@ -21,7 +21,7 @@ func (vtrs ViewTableRows) Equal(that ViewTableRows) bool {
 		return false
 	}
 
-	for i := 0; i < len(vtrs); i++ {
+	for i := range vtrs {
 		if !vtrs[i].Equal(that[i]) {
 			return false
 		}
@@ -76,7 +76,7 @@ func (vgd ViewGraphData) Equal(that ViewGraphData) bool {
 		return false
 	}
 
-	for i := 0; i < len(vgd); i++ {
+	for i := range vgd {
 		if !vgd[i].Equal(that[i]) {
 			return false
 		}

--- a/pkg/clustercache/store.go
+++ b/pkg/clustercache/store.go
@@ -116,16 +116,16 @@ func (s *GenericStore[Input, Output]) Replace(list []any, _ string) error {
 }
 
 // Stubs to satisfy the cache.Store interface
-func (s *GenericStore[Input, Output]) List() []interface{} {
+func (s *GenericStore[Input, Output]) List() []any {
 	return nil
 }
 func (s *GenericStore[Input, Output]) ListKeys() []string {
 	return nil
 }
-func (s *GenericStore[Input, Output]) Get(_ interface{}) (item interface{}, exists bool, err error) {
+func (s *GenericStore[Input, Output]) Get(_ any) (item any, exists bool, err error) {
 	return nil, false, nil
 }
-func (s *GenericStore[Input, Output]) GetByKey(_ string) (item interface{}, exists bool, err error) {
+func (s *GenericStore[Input, Output]) GetByKey(_ string) (item any, exists bool, err error) {
 	return nil, false, nil
 }
 func (s *GenericStore[Input, Output]) Resync() error {

--- a/pkg/clustercache/watchcontroller.go
+++ b/pkg/clustercache/watchcontroller.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Type alias for a receiver func
-type WatchHandler = func(interface{})
+type WatchHandler = func(any)
 
 // WatchController defines a contract for an object which watches a specific resource set for
 // add, updates, and removals
@@ -29,7 +29,7 @@ type WatchController interface {
 	Run(int, chan struct{})
 
 	// GetAll returns all of the resources
-	GetAll() []interface{}
+	GetAll() []any
 
 	// SetUpdateHandler sets a specific handler for adding/updating individual resources
 	SetUpdateHandler(WatchHandler) WatchController
@@ -56,19 +56,19 @@ func NewCachingWatcher(restClient rest.Interface, resource string, resourceType 
 	resourceCache := cache.NewListWatchFromClient(restClient, resource, namespace, fieldSelector)
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	indexer, informer := cache.NewTransformingIndexerInformer(resourceCache, resourceType, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
-		UpdateFunc: func(old interface{}, new interface{}) {
+		UpdateFunc: func(old any, new any) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			// IndexerInformer uses a delta queue, therefore for deletes we have to use this
 			// key function.
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
@@ -87,13 +87,13 @@ func NewCachingWatcher(restClient rest.Interface, resource string, resourceType 
 	}
 }
 
-func (c *CachingWatchController) GetAll() []interface{} {
+func (c *CachingWatchController) GetAll() []any {
 	list := c.indexer.List()
 
 	// since the indexer returns the as-is pointer to the resource,
 	// we deep copy the resources such that callers don't corrupt the
 	// index
-	cloneList := make([]interface{}, 0, len(list))
+	cloneList := make([]any, 0, len(list))
 	for _, v := range list {
 		if deepCopyable, ok := v.(rt.Object); ok {
 			cloneList = append(cloneList, deepCopyable.DeepCopyObject())
@@ -152,7 +152,7 @@ func (c *CachingWatchController) handle(key string) error {
 }
 
 // handleErr checks if an error happened and makes sure we will retry later.
-func (c *CachingWatchController) handleErr(err error, key interface{}) {
+func (c *CachingWatchController) handleErr(err error, key any) {
 	if err == nil {
 		// Forget about the #AddRateLimited history of the key on every successful synchronization.
 		// This ensures that future processing of updates for this key is not delayed because of
@@ -194,7 +194,7 @@ func (c *CachingWatchController) Run(threadiness int, stopCh chan struct{}) {
 	defer c.queue.ShutDown()
 	log.Infof("Starting %s controller", c.resourceType)
 
-	for i := 0; i < threadiness; i++ {
+	for range threadiness {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}
 
@@ -209,7 +209,7 @@ func (c *CachingWatchController) runWorker() {
 
 // trimUnwantedFields removes unwanted fields from the object
 // - managedFields as this metadata can be quite large
-func trimUnwantedFields(obj interface{}) (interface{}, error) {
+func trimUnwantedFields(obj any) (any, error) {
 	if accessor, err := meta.Accessor(obj); err == nil {
 		accessor.SetManagedFields(nil)
 	}

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -191,7 +191,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 	}, nil)
 
 	// Define tool handlers
-	handleAllocationCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args AllocationArgs) (*mcp_sdk.CallToolResult, interface{}, error) {
+	handleAllocationCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args AllocationArgs) (*mcp_sdk.CallToolResult, any, error) {
 		var step time.Duration
 		if args.Step != "" {
 			var err error
@@ -233,7 +233,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 		return nil, mcpResp, nil
 	}
 
-	handleAssetCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args AssetArgs) (*mcp_sdk.CallToolResult, interface{}, error) {
+	handleAssetCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args AssetArgs) (*mcp_sdk.CallToolResult, any, error) {
 		queryRequest := &opencost_mcp.OpenCostQueryRequest{
 			QueryType:   opencost_mcp.AssetQueryType,
 			Window:      args.Window,
@@ -252,7 +252,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 		return nil, mcpResp, nil
 	}
 
-	handleCloudCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args CloudCostArgs) (*mcp_sdk.CallToolResult, interface{}, error) {
+	handleCloudCosts := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args CloudCostArgs) (*mcp_sdk.CallToolResult, any, error) {
 		queryRequest := &opencost_mcp.OpenCostQueryRequest{
 			QueryType: opencost_mcp.CloudCostQueryType,
 			Window:    args.Window,
@@ -280,7 +280,7 @@ func StartMCPServer(ctx context.Context, accesses *costmodel.Accesses, cloudCost
 		return nil, mcpResp, nil
 	}
 
-	handleEfficiency := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args EfficiencyArgs) (*mcp_sdk.CallToolResult, interface{}, error) {
+	handleEfficiency := func(ctx context.Context, req *mcp_sdk.CallToolRequest, args EfficiencyArgs) (*mcp_sdk.CallToolResult, any, error) {
 		var step time.Duration
 		if args.Step != "" {
 			var err error

--- a/pkg/cmd/costmodel/costmodel_test.go
+++ b/pkg/cmd/costmodel/costmodel_test.go
@@ -25,7 +25,7 @@ func TestMCPServerGracefulShutdown(t *testing.T) {
 
 	// Wait for server to be ready
 	serverUp := false
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		time.Sleep(100 * time.Millisecond)
 		client := &http.Client{Timeout: 1 * time.Second}
 		resp, err := client.Get(fmt.Sprintf("http://localhost:%d/", port))

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -2,6 +2,7 @@ package costmodel
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/opencost"
@@ -52,10 +53,7 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 		// By default, query for the full remaining duration. But do not let
 		// any individual query duration exceed the configured max Prometheus
 		// query duration.
-		duration := end.Sub(e)
-		if duration > cm.BatchDuration {
-			duration = cm.BatchDuration
-		}
+		duration := min(end.Sub(e), cm.BatchDuration)
 
 		// Set start and end parameters (s, e) for next individual computation.
 		e = s.Add(duration)
@@ -91,18 +89,14 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time) (*opencost.Allocati
 				if _, ok := allocationAnnotations[k]; !ok {
 					allocationAnnotations[k] = map[string]string{}
 				}
-				for name, val := range a.Properties.Annotations {
-					allocationAnnotations[k][name] = val
-				}
+				maps.Copy(allocationAnnotations[k], a.Properties.Annotations)
 			}
 
 			if len(a.Properties.Labels) > 0 {
 				if _, ok := allocationLabels[k]; !ok {
 					allocationLabels[k] = map[string]string{}
 				}
-				for name, val := range a.Properties.Labels {
-					allocationLabels[k][name] = val
-				}
+				maps.Copy(allocationLabels[k], a.Properties.Labels)
 			}
 
 			if len(a.Properties.Services) > 0 {

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -2,6 +2,7 @@ package costmodel
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"strconv"
 	"strings"
@@ -1090,9 +1091,7 @@ func resToNodeLabels(resNodeLabels []*source.NodeLabelsResult) map[nodeKey]map[s
 		labels := res.Labels
 		// labels are retrieved from prometheus here so it will be in prometheus sanitized state
 		// e.g. topology.kubernetes.io/zone => topology_kubernetes_io_zone
-		for labelKey, labelValue := range labels {
-			nodeLabels[nodeKey][labelKey] = labelValue
-		}
+		maps.Copy(nodeLabels[nodeKey], labels)
 	}
 
 	return nodeLabels
@@ -1111,9 +1110,7 @@ func resToNamespaceLabels(resNamespaceLabels []*source.NamespaceLabelsResult) ma
 			namespaceLabels[nsKey] = map[string]string{}
 		}
 
-		for k, l := range res.Labels {
-			namespaceLabels[nsKey][k] = l
-		}
+		maps.Copy(namespaceLabels[nsKey], res.Labels)
 	}
 
 	return namespaceLabels
@@ -1145,9 +1142,7 @@ func resToPodLabels(resPodLabels []*source.PodLabelsResult, podUIDKeyMap map[pod
 				podLabels[key] = map[string]string{}
 			}
 
-			for k, l := range res.Labels {
-				podLabels[key][k] = l
-			}
+			maps.Copy(podLabels[key], res.Labels)
 		}
 	}
 
@@ -1167,9 +1162,7 @@ func resToNamespaceAnnotations(resNamespaceAnnotations []*source.NamespaceAnnota
 			namespaceAnnotations[namespace] = map[string]string{}
 		}
 
-		for k, l := range res.Annotations {
-			namespaceAnnotations[namespace][k] = l
-		}
+		maps.Copy(namespaceAnnotations[namespace], res.Annotations)
 	}
 
 	return namespaceAnnotations
@@ -1199,9 +1192,7 @@ func resToPodAnnotations(resPodAnnotations []*source.PodAnnotationsResult, podUI
 				podAnnotations[key] = map[string]string{}
 			}
 
-			for k, l := range res.Annotations {
-				podAnnotations[key][k] = l
-			}
+			maps.Copy(podAnnotations[key], res.Annotations)
 		}
 	}
 
@@ -1228,9 +1219,7 @@ func applyLabels(podMap map[podKey]*pod, nodeLabels map[nodeKey]map[string]strin
 			if nodeLabels != nil {
 				nodeKey := newNodeKey(pod.Key.Cluster, pod.Node)
 				if labels, ok := nodeLabels[nodeKey]; ok {
-					for k, v := range labels {
-						allocLabels[k] = v
-					}
+					maps.Copy(allocLabels, labels)
 				}
 			}
 
@@ -1243,9 +1232,7 @@ func applyLabels(podMap map[podKey]*pod, nodeLabels map[nodeKey]map[string]strin
 			}
 
 			if labels, ok := podLabels[podKey]; ok {
-				for k, v := range labels {
-					allocLabels[k] = v
-				}
+				maps.Copy(allocLabels, labels)
 			}
 
 			alloc.Properties.Labels = allocLabels
@@ -1277,9 +1264,7 @@ func applyAnnotations(podMap map[podKey]*pod, namespaceAnnotations map[string]ma
 				}
 			}
 			if labels, ok := podAnnotations[key]; ok {
-				for k, v := range labels {
-					allocAnnotations[k] = v
-				}
+				maps.Copy(allocAnnotations, labels)
 			}
 
 			alloc.Properties.Annotations = allocAnnotations
@@ -1301,9 +1286,7 @@ func resToDeploymentLabels(resDeploymentLabels []*source.DeploymentLabelsResult)
 			deploymentLabels[controllerKey] = map[string]string{}
 		}
 
-		for k, l := range res.Labels {
-			deploymentLabels[controllerKey][k] = l
-		}
+		maps.Copy(deploymentLabels[controllerKey], res.Labels)
 	}
 
 	// Prune duplicate deployments. That is, if the same deployment exists with
@@ -1334,9 +1317,7 @@ func resToStatefulSetLabels(resStatefulSetLabels []*source.StatefulSetLabelsResu
 			statefulSetLabels[controllerKey] = map[string]string{}
 		}
 
-		for k, l := range res.Labels {
-			statefulSetLabels[controllerKey][k] = l
-		}
+		maps.Copy(statefulSetLabels[controllerKey], res.Labels)
 	}
 
 	// Prune duplicate stateful sets. That is, if the same stateful set exists
@@ -1562,9 +1543,7 @@ func getServiceLabels(resServiceLabels []*source.ServiceLabelsResult) map[servic
 			serviceLabels[serviceKey] = map[string]string{}
 		}
 
-		for k, l := range res.Labels {
-			serviceLabels[serviceKey][k] = l
-		}
+		maps.Copy(serviceLabels[serviceKey], res.Labels)
 	}
 
 	// Prune duplicate services. That is, if the same service exists with

--- a/pkg/costmodel/allocation_helpers_test.go
+++ b/pkg/costmodel/allocation_helpers_test.go
@@ -222,7 +222,7 @@ func TestBuildPVMap(t *testing.T) {
 			resolution: time.Hour * 6,
 			resultsPVCostPerGiBHour: []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id": "cluster1",
 						"volumename": "pv1",
 					},
@@ -234,7 +234,7 @@ func TestBuildPVMap(t *testing.T) {
 					source.DefaultResultKeys(),
 				),
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id": "cluster1",
 						"volumename": "pv2",
 					},
@@ -246,7 +246,7 @@ func TestBuildPVMap(t *testing.T) {
 					source.DefaultResultKeys(),
 				),
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id": "cluster2",
 						"volumename": "pv3",
 					},
@@ -258,7 +258,7 @@ func TestBuildPVMap(t *testing.T) {
 					source.DefaultResultKeys(),
 				),
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id": "cluster2",
 						"volumename": "pv4",
 					},
@@ -272,7 +272,7 @@ func TestBuildPVMap(t *testing.T) {
 			},
 			resultsActiveMinutes: []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":       "cluster1",
 						"persistentvolume": "pv1",
 					},
@@ -293,7 +293,7 @@ func TestBuildPVMap(t *testing.T) {
 					source.DefaultResultKeys(),
 				),
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":       "cluster1",
 						"persistentvolume": "pv2",
 					},
@@ -317,7 +317,7 @@ func TestBuildPVMap(t *testing.T) {
 					source.DefaultResultKeys(),
 				),
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":       "cluster2",
 						"persistentvolume": "pv3",
 					},
@@ -335,7 +335,7 @@ func TestBuildPVMap(t *testing.T) {
 					source.DefaultResultKeys(),
 				),
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":       "cluster2",
 						"persistentvolume": "pv4",
 					},

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -2,6 +2,7 @@ package costmodel
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"strconv"
 	"time"
@@ -21,14 +22,10 @@ import (
 // the first map.
 func mergeTypeMaps(clusterAndNameToType1, clusterAndNameToType2 map[nodeIdentifierNoProviderID]string) map[nodeIdentifierNoProviderID]string {
 	merged := map[nodeIdentifierNoProviderID]string{}
-	for k, v := range clusterAndNameToType2 {
-		merged[k] = v
-	}
+	maps.Copy(merged, clusterAndNameToType2)
 
 	// This ordering ensures the mappings in the first arg are preferred.
-	for k, v := range clusterAndNameToType1 {
-		merged[k] = v
-	}
+	maps.Copy(merged, clusterAndNameToType1)
 
 	return merged
 }
@@ -768,9 +765,7 @@ func buildLabelsMap(
 		if _, ok := m[key]; !ok {
 			m[key] = map[string]string{}
 		}
-		for k, l := range result.Labels {
-			m[key][k] = l
-		}
+		maps.Copy(m[key], result.Labels)
 	}
 	return m
 }

--- a/pkg/costmodel/cluster_helpers_test.go
+++ b/pkg/costmodel/cluster_helpers_test.go
@@ -738,7 +738,7 @@ func TestBuildGPUCostMap(t *testing.T) {
 			name: "All Zeros",
 			promResult: []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":    "cluster1",
 						"node":          "node1",
 						"instance_type": "type1",
@@ -772,7 +772,7 @@ func TestBuildGPUCostMap(t *testing.T) {
 			name: "Zero Node Count",
 			promResult: []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":    "cluster1",
 						"node":          "node1",
 						"instance_type": "type1",
@@ -806,7 +806,7 @@ func TestBuildGPUCostMap(t *testing.T) {
 			name: "Missing Node Count",
 			promResult: []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":    "cluster1",
 						"node":          "node1",
 						"instance_type": "type1",
@@ -846,7 +846,7 @@ func TestBuildGPUCostMap(t *testing.T) {
 			name: "All values present",
 			promResult: []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":    "cluster1",
 						"node":          "node1",
 						"instance_type": "type1",
@@ -903,7 +903,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 	pvCostPromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":       "cluster1",
 				"persistentvolume": "pvc1",
 				"provider_id":      "provider1",
@@ -920,7 +920,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 	pvSizePromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":       "cluster1",
 				"persistentvolume": "pvc1",
 				"provider_id":      "provider1",
@@ -937,7 +937,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 	pvMinsPromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":       "cluster1",
 				"persistentvolume": "pvc1",
 				"provider_id":      "provider1",
@@ -958,7 +958,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 	pvAvgUsagePromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":            "cluster1",
 				"persistentvolumeclaim": "pv-claim1",
 				"namespace":             "ns1",
@@ -979,7 +979,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 	pvMaxUsagePromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":            "cluster1",
 				"persistentvolumeclaim": "pv-claim1",
 				"namespace":             "ns1",
@@ -1000,7 +1000,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 	pvInfoPromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":            "cluster1",
 				"persistentvolumeclaim": "pv-claim1",
 				"volumename":            "pvc1",
@@ -1099,7 +1099,7 @@ func TestAssetCustompricing(t *testing.T) {
 
 			zeroCollectorPromResult := []*source.QueryResult{
 				source.NewQueryResult(
-					map[string]interface{}{
+					map[string]any{
 						"cluster_id":    "cluster1",
 						"node":          "node1",
 						"instance_type": "type1",
@@ -1171,7 +1171,7 @@ func TestBuildLabelsMap(t *testing.T) {
 
 	nodePromResult := []*source.QueryResult{
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":             "cluster1",
 				"node":                   "node1",
 				"instance_type":          "type1",
@@ -1188,7 +1188,7 @@ func TestBuildLabelsMap(t *testing.T) {
 			source.DefaultResultKeys(),
 		),
 		source.NewQueryResult(
-			map[string]interface{}{
+			map[string]any{
 				"cluster_id":             "cluster1",
 				"node":                   "node2",
 				"instance_type":          "type1",

--- a/pkg/costmodel/clusterinfo_test.go
+++ b/pkg/costmodel/clusterinfo_test.go
@@ -12,7 +12,7 @@ func TestClusterInfoLabels(t *testing.T) {
 	expected := map[string]bool{"clusterprofile": true, "errorreporting": true, "id": true, "logcollection": true, "name": true, "productanalytics": true, "provider": true, "provisioner": true, "remotereadenabled": true, "thanosenabled": true, "valuesreporting": true, "version": true}
 	clusterInfo := `{"clusterProfile":"production","errorReporting":"true","id":"cluster-one","logCollection":"true","name":"bolt-3","productAnalytics":"true","provider":"GCP","provisioner":"GKE","remoteReadEnabled":"false","thanosEnabled":"false","valuesReporting":"true","version":"1.14+"}`
 
-	var m map[string]interface{}
+	var m map[string]any
 	err := json.Unmarshal([]byte(clusterInfo), &m)
 	if err != nil {
 		t.Errorf("Error: %s", err)

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -677,9 +677,7 @@ func findDeletedPodInfo(dataSource source.OpenCostDataSource, missingContainers 
 			if !ok {
 				labels = make(map[string]string)
 			}
-			for k, v := range costData.NamespaceLabels {
-				labels[k] = v
-			}
+			maps.Copy(labels, costData.NamespaceLabels)
 			costData.Labels = labels
 		}
 	}

--- a/pkg/costmodel/costmodel_test.go
+++ b/pkg/costmodel/costmodel_test.go
@@ -3,6 +3,7 @@ package costmodel
 import (
 	"math"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,14 +39,14 @@ func TestIsValidNodeName(t *testing.T) {
 	}
 
 	chars := "abcdefghijklmnopqrstuvwxyz"
-	longName := ""
+	var longName strings.Builder
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < 255; i++ {
-		longName += string(chars[r.Intn(len(chars))])
+	for range 255 {
+		longName.WriteString(string(chars[r.Intn(len(chars))]))
 	}
 
 	fails := []string{
-		longName,
+		longName.String(),
 		"192.168.1.1:80",
 		"10.0.0.1:443",
 		"127.0.0.1:8080",

--- a/pkg/costmodel/csv_export.go
+++ b/pkg/costmodel/csv_export.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
@@ -520,12 +521,7 @@ func mergeHeaders(headers [][]string) []string {
 }
 
 func contains(slice []string, item string) bool {
-	for _, element := range slice {
-		if element == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, item)
 }
 
 func indexOf(slice []string, element string) int {

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -99,16 +99,13 @@ func (cim ClusterInfoMetric) Write(m *dto.Metric) error {
 	var labels []*dto.LabelPair
 	for k, v := range cim.labels {
 		labels = append(labels, &dto.LabelPair{
-			Name:  toStringPtr(k),
-			Value: toStringPtr(v),
+			Name:  new(k),
+			Value: new(v),
 		})
 	}
 	m.Label = labels
 	return nil
 }
-
-// returns a pointer to the string provided
-func toStringPtr(s string) *string { return &s }
 
 //--------------------------------------------------------------------------
 //  Cost Model Metrics Initialization

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -163,7 +163,7 @@ func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider) (
 	ngilen := len(usage.NetworkNatGatewayIngress)
 
 	l := max(zlen, rlen, ilen, ngelen, ngilen)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		var cost float64 = 0
 		var timestamp float64
 

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -36,7 +36,7 @@ func (m *mockProvider) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	return nil, nil
 }
 
-func (m *mockProvider) AllNodePricing() (interface{}, error) {
+func (m *mockProvider) AllNodePricing() (any, error) {
 	return nil, nil
 }
 
@@ -107,7 +107,7 @@ func (m *mockProvider) Regions() []string {
 	return nil
 }
 
-func (m *mockProvider) PricingSourceSummary() interface{} {
+func (m *mockProvider) PricingSourceSummary() any {
 	return nil
 }
 

--- a/pkg/costmodel/networkinsight.go
+++ b/pkg/costmodel/networkinsight.go
@@ -28,10 +28,7 @@ func (cm *CostModel) ComputeNetworkInsights(start, end time.Time) (*opencost.Net
 	totalNis := opencost.NewNetworkInsightSet(start, end)
 
 	for e.Before(end) {
-		duration := end.Sub(e)
-		if duration > cm.BatchDuration {
-			duration = cm.BatchDuration
-		}
+		duration := min(end.Sub(e), cm.BatchDuration)
 		e = s.Add(duration)
 		nis, err := cm.GetNetworkInsightSet(start, end)
 		if err != nil {

--- a/pkg/costmodel/resultparsers.go
+++ b/pkg/costmodel/resultparsers.go
@@ -3,6 +3,7 @@ package costmodel
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/clustercache"
@@ -177,9 +178,8 @@ func GetNamespaceLabelsMetrics(qrs []*source.QueryResult, defaultClusterID strin
 
 		nsKey := ns + "," + clusterID
 		if nsLabels, ok := toReturn[nsKey]; ok {
-			for k, v := range val.GetLabels() {
-				nsLabels[k] = v // override with more recently assigned if we changed labels within the window.
-			}
+			// override with more recently assigned if we changed labels within the window.
+			maps.Copy(nsLabels, val.GetLabels())
 		} else {
 			toReturn[nsKey] = val.GetLabels()
 		}
@@ -210,9 +210,7 @@ func GetPodLabelsMetrics(qrs []*source.QueryResult, defaultClusterID string) (ma
 		nsKey := ns + "," + pod + "," + clusterID
 		if labels, ok := toReturn[nsKey]; ok {
 			newlabels := val.GetLabels()
-			for k, v := range newlabels {
-				labels[k] = v
-			}
+			maps.Copy(labels, newlabels)
 		} else {
 			toReturn[nsKey] = val.GetLabels()
 		}
@@ -238,9 +236,8 @@ func GetNamespaceAnnotationsMetrics(qrs []*source.QueryResult, defaultClusterID 
 
 		nsKey := ns + "," + clusterID
 		if nsAnnotations, ok := toReturn[nsKey]; ok {
-			for k, v := range val.GetAnnotations() {
-				nsAnnotations[k] = v // override with more recently assigned if we changed labels within the window.
-			}
+			// override with more recently assigned if we changed labels within the window.
+			maps.Copy(nsAnnotations, val.GetAnnotations())
 		} else {
 			toReturn[nsKey] = val.GetAnnotations()
 		}
@@ -271,9 +268,7 @@ func GetPodAnnotationsMetrics(qrs []*source.QueryResult, defaultClusterID string
 
 		nsKey := ns + "," + pod + "," + clusterID
 		if labels, ok := toReturn[nsKey]; ok {
-			for k, v := range val.GetAnnotations() {
-				labels[k] = v
-			}
+			maps.Copy(labels, val.GetAnnotations())
 		} else {
 			toReturn[nsKey] = val.GetAnnotations()
 		}

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -91,12 +91,12 @@ func filterFields(fields string, data map[string]*CostData) map[string]CostData 
 	}
 	filteredData := make(map[string]CostData)
 	for cname, costdata := range data {
-		s := reflect.TypeOf(*costdata)
+		s := reflect.TypeFor[CostData]()
 		val := reflect.ValueOf(*costdata)
 		costdata2 := CostData{}
 		cd2 := reflect.New(reflect.Indirect(reflect.ValueOf(costdata2)).Type()).Elem()
 		n := s.NumField()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			field := s.Field(i)
 			value := val.Field(i)
 			value2 := cd2.Field(i)
@@ -154,7 +154,7 @@ func adminAuthMiddleware(next httprouter.Handle) httprouter.Handle {
 	}
 }
 
-func WriteData(w http.ResponseWriter, data interface{}, err error) {
+func WriteData(w http.ResponseWriter, data any, err error) {
 	if err != nil {
 		proto.WriteError(w, proto.InternalServerError(err.Error()))
 		return

--- a/pkg/customcost/ingestor.go
+++ b/pkg/customcost/ingestor.go
@@ -272,19 +272,15 @@ func (ing *CustomCostIngestor) Stop() {
 	var wg sync.WaitGroup
 
 	if ing.exitBuildCh != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ing.exitBuildCh <- msg
-		}()
+		})
 	}
 
 	if ing.exitRunCh != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ing.exitRunCh <- msg
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/customcost/ingestor_test.go
+++ b/pkg/customcost/ingestor_test.go
@@ -93,12 +93,10 @@ func TestIngestor_Stop_ConcurrentCalls(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			ingestor.Stop()
-		}()
+		})
 	}
 
 	done := make(chan struct{})
@@ -194,11 +192,11 @@ func TestIngestor_BuildWindow_WithPlugin(t *testing.T) {
 
 // mockClientProtocol implements plugin.ClientProtocol for testing.
 type mockClientProtocol struct {
-	dispenseResult interface{}
+	dispenseResult any
 	dispenseErr    error
 }
 
-func (m *mockClientProtocol) Dispense(string) (interface{}, error) {
+func (m *mockClientProtocol) Dispense(string) (any, error) {
 	return m.dispenseResult, m.dispenseErr
 }
 func (m *mockClientProtocol) Ping() error  { return nil }

--- a/pkg/customcost/querier.go
+++ b/pkg/customcost/querier.go
@@ -3,6 +3,7 @@ package customcost
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/opencost"
@@ -76,21 +77,9 @@ var allSteppedAccumulateOptions = []opencost.AccumulateOption{
 }
 
 func hasHourly(opts []opencost.AccumulateOption) bool {
-	for _, opt := range opts {
-		if opt == opencost.AccumulateOptionHour {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(opts, opencost.AccumulateOptionHour)
 }
 
 func hasDaily(opts []opencost.AccumulateOption) bool {
-	for _, opt := range opts {
-		if opt == opencost.AccumulateOptionDay {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(opts, opencost.AccumulateOptionDay)
 }

--- a/pkg/customcost/status.go
+++ b/pkg/customcost/status.go
@@ -15,11 +15,11 @@ type Status struct {
 	Provider          string                     `json:"provider,omitempty"`
 	Active            bool                       `json:"active,omitempty"`
 	Valid             bool                       `json:"valid,omitempty"`
-	LastRun           time.Time                  `json:"lastRun,omitempty"`
-	NextRun           time.Time                  `json:"nextRun,omitempty"`
+	LastRun           time.Time                  `json:"lastRun"`
+	NextRun           time.Time                  `json:"nextRun"`
 	RefreshRateDaily  string                     `json:"RefreshRateDaily,omitempty"`
 	RefreshRateHourly string                     `json:"RefreshRateHourly,omitempty"`
-	Created           time.Time                  `json:"created,omitempty"`
+	Created           time.Time                  `json:"created"`
 	Runs              int                        `json:"runs,omitempty"`
 	CoverageHourly    map[string]opencost.Window `json:"coverageHourly,omitempty"`
 	CoverageDaily     map[string]opencost.Window `json:"coverageDaily,omitempty"`

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -432,7 +432,7 @@ func GetOVHMonthlyNodepools() []string {
 		return nil
 	}
 	var pools []string
-	for _, p := range strings.Split(val, ",") {
+	for p := range strings.SplitSeq(val, ",") {
 		p = strings.TrimSpace(p)
 		if p != "" {
 			pools = append(pools, p)

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -47,7 +47,7 @@ type MCPRequest struct {
 
 // MCPResponse is the response from the OpenCost MCP server for a single turn.
 type MCPResponse struct {
-	Data      interface{}   `json:"data"`
+	Data      any           `json:"data"`
 	QueryInfo QueryMetadata `json:"queryInfo"`
 }
 
@@ -387,7 +387,7 @@ func (s *MCPServer) ProcessMCPRequest(ctx context.Context, request *MCPRequest) 
 	}
 
 	// 2. Query Dispatching
-	var data interface{}
+	var data any
 	var err error
 
 	queryStart := time.Now()

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -689,7 +689,7 @@ func TestNewMCPServer(t *testing.T) {
 type mockProvider struct{}
 
 func (mp *mockProvider) GetConfig() (*models.CustomPricing, error)                { return nil, nil }
-func (mp *mockProvider) AllNodePricing() (interface{}, error)                     { return nil, nil }
+func (mp *mockProvider) AllNodePricing() (any, error)                             { return nil, nil }
 func (mp *mockProvider) ClusterInfo() (map[string]string, error)                  { return nil, nil }
 func (mp *mockProvider) GetAddresses() ([]byte, error)                            { return nil, nil }
 func (mp *mockProvider) GetDisks() ([]byte, error)                                { return nil, nil }
@@ -719,7 +719,7 @@ func (mp *mockProvider) PricingSourceStatus() map[string]*models.PricingSource  
 func (mp *mockProvider) ClusterManagementPricing() (string, float64, error)             { return "", 0, nil }
 func (mp *mockProvider) CombinedDiscountForNode(string, bool, float64, float64) float64 { return 0 }
 func (mp *mockProvider) Regions() []string                                              { return nil }
-func (mp *mockProvider) PricingSourceSummary() interface{}                              { return nil }
+func (mp *mockProvider) PricingSourceSummary() any                                      { return nil }
 
 func TestGenerateQueryID(t *testing.T) {
 	// Test that generateQueryID returns a non-empty string

--- a/pkg/metrics/deploymentmetrics.go
+++ b/pkg/metrics/deploymentmetrics.go
@@ -106,15 +106,15 @@ func (dmlm DeploymentMatchLabelsMetric) Write(m *dto.Metric) error {
 		})
 	}
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("namespace"),
+		Name:  new("namespace"),
 		Value: &dmlm.namespace,
 	})
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("deployment"),
+		Name:  new("deployment"),
 		Value: &dmlm.deploymentName,
 	})
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("uid"),
+		Name:  new("uid"),
 		Value: &dmlm.uid,
 	})
 	m.Label = labels
@@ -223,15 +223,15 @@ func (kdr KubeDeploymentReplicasMetric) Write(m *dto.Metric) error {
 	}
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kdr.namespace,
 		},
 		{
-			Name:  toStringPtr("deployment"),
+			Name:  new("deployment"),
 			Value: &kdr.deployment,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kdr.uid,
 		},
 	}
@@ -284,15 +284,15 @@ func (kdr KubeDeploymentStatusAvailableReplicasMetric) Write(m *dto.Metric) erro
 	}
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kdr.namespace,
 		},
 		{
-			Name:  toStringPtr("deployment"),
+			Name:  new("deployment"),
 			Value: &kdr.deployment,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kdr.uid,
 		},
 	}

--- a/pkg/metrics/jobmetrics.go
+++ b/pkg/metrics/jobmetrics.go
@@ -116,19 +116,19 @@ func (kjsf KubeJobStatusFailedMetric) Write(m *dto.Metric) error {
 	}
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("job_name"),
+			Name:  new("job_name"),
 			Value: &kjsf.job,
 		},
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kjsf.namespace,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kjsf.uid,
 		},
 		{
-			Name:  toStringPtr("reason"),
+			Name:  new("reason"),
 			Value: &kjsf.reason,
 		},
 	}

--- a/pkg/metrics/kubemetrics.go
+++ b/pkg/metrics/kubemetrics.go
@@ -264,6 +264,3 @@ func boolFloat64(b bool) float64 {
 	}
 	return 0
 }
-
-// toStringPtr is used to create a new string pointer from iteration vars
-func toStringPtr(s string) *string { return &s }

--- a/pkg/metrics/namespacemetrics.go
+++ b/pkg/metrics/namespacemetrics.go
@@ -104,11 +104,11 @@ func (nam NamespaceAnnotationsMetric) Write(m *dto.Metric) error {
 	}
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &nam.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &nam.uid,
 		})
 	m.Label = labels
@@ -209,11 +209,11 @@ func (nam KubeNamespaceLabelsMetric) Write(m *dto.Metric) error {
 	}
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &nam.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &nam.uid,
 		})
 	m.Label = labels

--- a/pkg/metrics/nodemetrics.go
+++ b/pkg/metrics/nodemetrics.go
@@ -187,19 +187,19 @@ func (kpcrr KubeNodeStatusCapacityMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 		{
-			Name:  toStringPtr("resource"),
+			Name:  new("resource"),
 			Value: &kpcrr.resource,
 		},
 		{
-			Name:  toStringPtr("unit"),
+			Name:  new("unit"),
 			Value: &kpcrr.unit,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 	}
@@ -247,11 +247,11 @@ func (nam KubeNodeStatusCapacityMemoryBytesMetric) Write(m *dto.Metric) error {
 	}
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &nam.node,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &nam.uid,
 		},
 	}
@@ -299,11 +299,11 @@ func (nam KubeNodeStatusCapacityCPUCoresMetric) Write(m *dto.Metric) error {
 	}
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &nam.node,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &nam.uid,
 		},
 	}
@@ -420,19 +420,19 @@ func (nam KubeNodeStatusConditionMetric) Write(m *dto.Metric) error {
 	}
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &nam.node,
 		},
 		{
-			Name:  toStringPtr("condition"),
+			Name:  new("condition"),
 			Value: &nam.condition,
 		},
 		{
-			Name:  toStringPtr("status"),
+			Name:  new("status"),
 			Value: &nam.status,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &nam.uid,
 		},
 	}
@@ -507,19 +507,19 @@ func (kpcrr KubeNodeStatusAllocatableMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 		{
-			Name:  toStringPtr("resource"),
+			Name:  new("resource"),
 			Value: &kpcrr.resource,
 		},
 		{
-			Name:  toStringPtr("unit"),
+			Name:  new("unit"),
 			Value: &kpcrr.unit,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 	}
@@ -570,11 +570,11 @@ func (kpcrr KubeNodeStatusAllocatableCPUCoresMetric) Write(m *dto.Metric) error 
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 	}
@@ -625,11 +625,11 @@ func (kpcrr KubeNodeStatusAllocatableMemoryBytesMetric) Write(m *dto.Metric) err
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 	}

--- a/pkg/metrics/podlabelmetrics.go
+++ b/pkg/metrics/podlabelmetrics.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"maps"
+
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/core/pkg/util/promutil"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,9 +21,7 @@ type KubePodLabelsCollector struct {
 
 func (kpmc *KubePodLabelsCollector) SetLabelsWhiteList() {
 	kpmc.labelsWhitelist = make(map[string]bool)
-	for k, v := range kpmc.metricsConfig.LabelsWhitelist {
-		kpmc.labelsWhitelist[k] = v
-	}
+	maps.Copy(kpmc.labelsWhitelist, kpmc.metricsConfig.LabelsWhitelist)
 }
 
 // Describe sends the super-set of all possible descriptors of pod labels only

--- a/pkg/metrics/podmetrics.go
+++ b/pkg/metrics/podmetrics.go
@@ -305,15 +305,15 @@ func (pam PodAnnotationsMetric) Write(m *dto.Metric) error {
 	}
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &pam.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &pam.pod,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &pam.uid,
 		})
 	m.Label = labels
@@ -379,15 +379,15 @@ func (nam KubePodLabelsMetric) Write(m *dto.Metric) error {
 
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &nam.pod,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &nam.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &nam.uid,
 		},
 	)
@@ -444,19 +444,19 @@ func (kpcs KubePodContainerStatusRestartsTotalMetric) Write(m *dto.Metric) error
 	var labels []*dto.LabelPair
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcs.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcs.pod,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcs.container,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcs.uid,
 		},
 	)
@@ -515,23 +515,23 @@ func (kpcs KubePodContainerStatusTerminatedReasonMetric) Write(m *dto.Metric) er
 	var labels []*dto.LabelPair
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcs.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcs.pod,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcs.container,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcs.uid,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("reason"),
+			Name:  new("reason"),
 			Value: &kpcs.reason,
 		},
 	)
@@ -588,19 +588,19 @@ func (kpcs KubePodStatusPhaseMetric) Write(m *dto.Metric) error {
 	var labels []*dto.LabelPair
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcs.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcs.pod,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcs.uid,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("phase"),
+			Name:  new("phase"),
 			Value: &kpcs.phase,
 		},
 	)
@@ -659,19 +659,19 @@ func (kpcs KubePodContainerStatusRunningMetric) Write(m *dto.Metric) error {
 	var labels []*dto.LabelPair
 	labels = append(labels,
 		&dto.LabelPair{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcs.namespace,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcs.pod,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcs.container,
 		},
 		&dto.LabelPair{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcs.uid,
 		},
 	)
@@ -737,31 +737,31 @@ func (kpcrr KubePodContainerResourceRequestsMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcrr.namespace,
 		},
 		{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcrr.pod,
 		},
 		{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcrr.container,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 		{
-			Name:  toStringPtr("resource"),
+			Name:  new("resource"),
 			Value: &kpcrr.resource,
 		},
 		{
-			Name:  toStringPtr("unit"),
+			Name:  new("unit"),
 			Value: &kpcrr.unit,
 		},
 	}
@@ -826,31 +826,31 @@ func (kpcrr KubePodContainerResourceLimitsMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcrr.namespace,
 		},
 		{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcrr.pod,
 		},
 		{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcrr.container,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 		{
-			Name:  toStringPtr("resource"),
+			Name:  new("resource"),
 			Value: &kpcrr.resource,
 		},
 		{
-			Name:  toStringPtr("unit"),
+			Name:  new("unit"),
 			Value: &kpcrr.unit,
 		},
 	}
@@ -909,23 +909,23 @@ func (kpcrr KubePodContainerResourceLimitsCPUCoresMetric) Write(m *dto.Metric) e
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcrr.namespace,
 		},
 		{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcrr.pod,
 		},
 		{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcrr.container,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 	}
@@ -984,23 +984,23 @@ func (kpcrr KubePodContainerResourceLimitsMemoryBytesMetric) Write(m *dto.Metric
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpcrr.namespace,
 		},
 		{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpcrr.pod,
 		},
 		{
-			Name:  toStringPtr("container"),
+			Name:  new("container"),
 			Value: &kpcrr.container,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 		{
-			Name:  toStringPtr("node"),
+			Name:  new("node"),
 			Value: &kpcrr.node,
 		},
 	}
@@ -1061,28 +1061,28 @@ func (kpo KubePodOwnerMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpo.namespace,
 		},
 		{
-			Name:  toStringPtr("pod"),
+			Name:  new("pod"),
 			Value: &kpo.pod,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpo.uid,
 		},
 		{
-			Name:  toStringPtr("owner_name"),
+			Name:  new("owner_name"),
 			Value: &kpo.ownerName,
 		},
 		{
-			Name:  toStringPtr("owner_kind"),
+			Name:  new("owner_kind"),
 			Value: &kpo.ownerKind,
 		},
 		{
-			Name:  toStringPtr("owner_is_controller"),
-			Value: toStringPtr(fmt.Sprintf("%t", kpo.ownerIsController)),
+			Name:  new("owner_is_controller"),
+			Value: new(fmt.Sprintf("%t", kpo.ownerIsController)),
 		},
 	}
 	return nil

--- a/pkg/metrics/pvcmetrics.go
+++ b/pkg/metrics/pvcmetrics.go
@@ -97,15 +97,15 @@ func (kpvcrr KubePVCResourceRequestsStorageBytesMetric) Write(m *dto.Metric) err
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("persistentvolumeclaim"),
+			Name:  new("persistentvolumeclaim"),
 			Value: &kpvcrr.pvc,
 		},
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpvcrr.namespace,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpvcrr.uid,
 		},
 	}
@@ -163,23 +163,23 @@ func (kpvci KubePVCInfoMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("namespace"),
+			Name:  new("namespace"),
 			Value: &kpvci.namespace,
 		},
 		{
-			Name:  toStringPtr("persistentvolumeclaim"),
+			Name:  new("persistentvolumeclaim"),
 			Value: &kpvci.pvc,
 		},
 		{
-			Name:  toStringPtr("storageclass"),
+			Name:  new("storageclass"),
 			Value: &kpvci.storageclass,
 		},
 		{
-			Name:  toStringPtr("volumename"),
+			Name:  new("volumename"),
 			Value: &kpvci.volume,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpvci.uid,
 		},
 	}

--- a/pkg/metrics/pvmetrics.go
+++ b/pkg/metrics/pvmetrics.go
@@ -123,11 +123,11 @@ func (kpcrr KubePVCapacityBytesMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("persistentvolume"),
+			Name:  new("persistentvolume"),
 			Value: &kpcrr.pv,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 	}
@@ -180,15 +180,15 @@ func (kpcrr KubePVStatusPhaseMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("persistentvolume"),
+			Name:  new("persistentvolume"),
 			Value: &kpcrr.pv,
 		},
 		{
-			Name:  toStringPtr("phase"),
+			Name:  new("phase"),
 			Value: &kpcrr.phase,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpcrr.uid,
 		},
 	}
@@ -245,19 +245,19 @@ func (kpvim KubecostPVInfoMetric) Write(m *dto.Metric) error {
 
 	m.Label = []*dto.LabelPair{
 		{
-			Name:  toStringPtr("persistentvolume"),
+			Name:  new("persistentvolume"),
 			Value: &kpvim.pv,
 		},
 		{
-			Name:  toStringPtr("storageclass"),
+			Name:  new("storageclass"),
 			Value: &kpvim.storageClass,
 		},
 		{
-			Name:  toStringPtr("provider_id"),
+			Name:  new("provider_id"),
 			Value: &kpvim.providerId,
 		},
 		{
-			Name:  toStringPtr("uid"),
+			Name:  new("uid"),
 			Value: &kpvim.uid,
 		},
 	}

--- a/pkg/metrics/servicemetrics.go
+++ b/pkg/metrics/servicemetrics.go
@@ -106,15 +106,15 @@ func (s ServiceSelectorLabelsMetric) Write(m *dto.Metric) error {
 		})
 	}
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("namespace"),
+		Name:  new("namespace"),
 		Value: &s.namespace,
 	})
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("service"),
+		Name:  new("service"),
 		Value: &s.serviceName,
 	})
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("uid"),
+		Name:  new("uid"),
 		Value: &s.uid,
 	})
 	m.Label = labels

--- a/pkg/metrics/statefulsetmetrics.go
+++ b/pkg/metrics/statefulsetmetrics.go
@@ -107,15 +107,15 @@ func (s StatefulsetMatchLabelsMetric) Write(m *dto.Metric) error {
 		})
 	}
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("namespace"),
+		Name:  new("namespace"),
 		Value: &s.namespace,
 	})
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("statefulSet"),
+		Name:  new("statefulSet"),
 		Value: &s.statefulsetName,
 	})
 	labels = append(labels, &dto.LabelPair{
-		Name:  toStringPtr("uid"),
+		Name:  new("uid"),
 		Value: &s.uid,
 	})
 	m.Label = labels


### PR DESCRIPTION
## What

Adds Makefile-runnable lint/fix gates and wires them into CI, mirroring the enforcement pattern used in the ibm-finops-agent repo.

### New Makefile targets
- **`ci-lint`** — installs the latest `golangci-lint` and runs it against every module (`.`, `./core`, `./modules/prometheus-source`, `./modules/collector-source`) in **only-new-issues** mode (`--new-from-merge-base=origin/develop`). The large pre-existing lint backlog (~137 findings) does **not** block PRs, but every newly written/changed line is gated. Override the baseline locally with `make ci-lint LINT_BASE=HEAD~1`.
- **`go-fix-check`** — runs `go fix -diff ./...` per module. The `-diff` flag prints a unified diff instead of rewriting and exits non-zero when the diff is non-empty, failing CI on deprecated/outdated API usage.

### CI
- `.github/workflows/golangci-lint.yaml` now runs on `pull_request` / `merge_group` (was `workflow_dispatch` only), invokes `make ci-lint`, and adds a `go-fix` job calling `make go-fix-check`. Lint job checks out full history (`fetch-depth: 0`) so the merge base can be computed.

### Config
- `.golangci.yml` excludes bingen-generated `*_codecs.go` files. Their ASCII-art "DO NOT MODIFY" header isn't recognized by golangci-lint's generated-file detection.

## Why the large diff

To make the new `go-fix-check` pass, the modernizations it reports must actually be applied. The **exact command run, once per module**, is:

```sh
go fix ./...          # in . , ./core , ./modules/prometheus-source , ./modules/collector-source
```

`go fix` in modern Go runs the same modernizer analyzers as `gopls`/`staticcheck` and rewrites old idioms to current equivalents. CI then enforces the result via `go fix -diff ./...` (non-zero exit on any remaining diff). The changes are mechanical and semantically identical.

### Before / after examples

`interface{}` → `any`:
```diff
-func WriteData(w http.ResponseWriter, data interface{}, err error) {
+func WriteData(w http.ResponseWriter, data any, err error) {
```

C-style index loop → `range` over an int, plus `reflect.TypeOf` → `reflect.TypeFor`:
```diff
-		s := reflect.TypeOf(*costdata)
+		s := reflect.TypeFor[CostData]()
 		val := reflect.ValueOf(*costdata)
 		...
-		for i := 0; i < n; i++ {
+		for i := range n {
```

String concatenation in a loop → `strings.Builder`:
```diff
-		errStr := fmt.Sprintf("%d errors:", len(errs))
+		var errStr strings.Builder
+		fmt.Fprintf(&errStr, "%d errors:", len(errs))
 		for _, e := range errs {
-			errStr += fmt.Sprintf(" [%s]", e)
+			fmt.Fprintf(&errStr, " [%s]", e)
 		}
-		return errors.New(errStr)
+		return errors.New(errStr.String())
```

Taking the address of a local → Go 1.26 `new(value)` builtin:
```diff
-			Name:  toStringPtr(k),
+			Name:  new(k),
```

Other categories: `maps.Collect`, `slices` helpers. Two now-unused `toStringPtr` helpers were removed after `go fix` inlined their call sites. The `WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(...)` rewrites resolve staticcheck QF1012 on the lines `go fix` touched.

## Verification
- `make go-fix-check` — PASS (all modules)
- `make ci-lint` — PASS, 0 new issues (all modules)
- All modules build; `gofmt` clean

> Note: `ci-lint` installs golangci-lint `@latest` (per review preference) rather than a pinned version. Trade-off: zero version maintenance, but a future golangci-lint release that adds/tightens a linter can fail an unrelated PR's new code on a day nothing in this repo changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)