### PR TITLE
core: fix potential error overwrite in InsertExternalAllocations loop

### DIFF
--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -1636,6 +1636,11 @@ func (sasr *SummaryAllocationSetRange) InsertExternalAllocations(that *Allocatio
 		return fmt.Errorf("cannot insert range into nil AllocationSetRange")
 	}
 
+	// Providing an empty or nil set range is a no-op
+	if that == nil {
+		return nil
+	}
+
 	// keys maps window to index in range
 	keys := map[string]int{}
 	for i, as := range sasr.SummaryAllocationSets {
@@ -1666,7 +1671,7 @@ func (sasr *SummaryAllocationSetRange) InsertExternalAllocations(that *Allocatio
 		for _, alloc := range thatAS.Allocations {
 			externalSA := NewSummaryAllocation(alloc, true, true)
 			if err := sas.Insert(externalSA); err != nil {
-				return err
+				return fmt.Errorf("InsertExternalAllocations: failed inserting into window %s: %w", thatAS.Window.String(), err)
 			}
 		}
 	}

--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -1650,34 +1650,28 @@ func (sasr *SummaryAllocationSetRange) InsertExternalAllocations(that *Allocatio
 		return nil
 	}
 
-	var err error
 	for _, thatAS := range that.Allocations {
-		if thatAS == nil || err != nil {
+		if thatAS == nil {
 			continue
 		}
 
 		// Find matching AllocationSet in asr
 		i, ok := keys[thatAS.Window.String()]
 		if !ok {
-			err = fmt.Errorf("cannot merge AllocationSet into window that does not exist: %s", thatAS.Window.String())
-			continue
+			return fmt.Errorf("cannot merge AllocationSet into window that does not exist: %s", thatAS.Window.String())
 		}
 		sas := sasr.SummaryAllocationSets[i]
 
 		// Insert each Allocation from the given set
 		for _, alloc := range thatAS.Allocations {
 			externalSA := NewSummaryAllocation(alloc, true, true)
-			// This error will be returned below
-			// TODO:CLEANUP should Each have early-error-return functionality?
-			err = sas.Insert(externalSA)
-			if err != nil {
+			if err := sas.Insert(externalSA); err != nil {
 				return err
 			}
 		}
 	}
 
-	// err might be nil
-	return err
+	return nil
 }
 
 func (sasr *SummaryAllocationSetRange) TotalCost() float64 {

--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -1670,6 +1670,9 @@ func (sasr *SummaryAllocationSetRange) InsertExternalAllocations(that *Allocatio
 			// This error will be returned below
 			// TODO:CLEANUP should Each have early-error-return functionality?
 			err = sas.Insert(externalSA)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/core/pkg/opencost/summaryallocation_test.go
+++ b/core/pkg/opencost/summaryallocation_test.go
@@ -1194,9 +1194,9 @@ func TestSummaryAllocationSetRange_InsertExternalAllocations_ErrorOverwrite(t *t
 	}
 
 	as1 := NewAllocationSet(start, end)
-	// "aaa-nil" sorts before "zzz-valid" alphabetically. Go map iteration is
-	// random, but regardless of order the nil entry always causes Insert to
-	// fail, so the test must see a non-nil error.
+	// Go map iteration order is random and not influenced by key names.
+	// Regardless of which entry is visited first, the nil entry always causes
+	// sas.Insert to fail, so the function must return a non-nil error.
 	as1.Allocations["aaa-nil"] = nil
 	as1.Allocations["zzz-valid"] = validAlloc
 

--- a/core/pkg/opencost/summaryallocation_test.go
+++ b/core/pkg/opencost/summaryallocation_test.go
@@ -1154,3 +1154,58 @@ func TestSummaryAllocationSetRange_InsertExternalAllocations(t *testing.T) {
 		t.Fatalf("expected error from InsertExternalAllocations, got nil")
 	}
 }
+
+// TestSummaryAllocationSetRange_InsertExternalAllocations_ErrorOverwrite
+// verifies that when the first sas.Insert() call fails and a subsequent call
+// succeeds, the error from the first failure is preserved and returned — not
+// silently overwritten by the later success.
+//
+// Background: a naive loop of the form
+//
+//	var err error
+//	for _, alloc := range allocations {
+//	    err = sas.Insert(...)   // second iteration overwrites err with nil
+//	}
+//	return err
+//
+// would drop the first error if any later iteration succeeds. The fix is to
+// return immediately on the first error.
+func TestSummaryAllocationSetRange_InsertExternalAllocations_ErrorOverwrite(t *testing.T) {
+	start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2021, time.January, 2, 0, 0, 0, 0, time.UTC)
+	day := 24 * time.Hour
+
+	sas1 := NewMockUnitSummaryAllocationSet(start, day)
+	sasr := NewSummaryAllocationSetRange(sas1)
+
+	// Passing a nil *Allocation to NewSummaryAllocation returns a nil
+	// *SummaryAllocation, and sas.Insert(nil) returns an error — this is the
+	// "first failure" in the inner loop.
+	//
+	// The second entry is a valid Allocation whose Insert() succeeds. In the
+	// buggy implementation (accumulating err in a variable and returning only
+	// at the end of the loop) the second success overwrites err to nil, so the
+	// caller would see no error. The fixed implementation returns on the first
+	// error, so the caller still receives a non-nil error.
+	validAlloc := &Allocation{
+		Name:  "container2",
+		Start: start,
+		End:   end,
+	}
+
+	as1 := NewAllocationSet(start, end)
+	// "aaa-nil" sorts before "zzz-valid" alphabetically. Go map iteration is
+	// random, but regardless of order the nil entry always causes Insert to
+	// fail, so the test must see a non-nil error.
+	as1.Allocations["aaa-nil"] = nil
+	as1.Allocations["zzz-valid"] = validAlloc
+
+	asr := NewAllocationSetRange(as1)
+
+	err := sasr.InsertExternalAllocations(asr)
+	if err == nil {
+		t.Fatalf("InsertExternalAllocations: expected error when a nil allocation " +
+			"is present in the inner loop, but got nil — the Insert error may " +
+			"have been overwritten by a later successful Insert")
+	}
+}

--- a/core/pkg/opencost/summaryallocation_test.go
+++ b/core/pkg/opencost/summaryallocation_test.go
@@ -1126,3 +1126,31 @@ func TestSummaryAllocationSetRange_AccumulateBy_Month(t *testing.T) {
 		}
 	}
 }
+
+func TestSummaryAllocationSetRange_InsertExternalAllocations(t *testing.T) {
+	start := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2021, time.January, 2, 0, 0, 0, 0, time.UTC)
+	day := 24 * time.Hour
+
+	sas1 := NewMockUnitSummaryAllocationSet(start, day)
+	sasr := NewSummaryAllocationSetRange(sas1)
+
+	// Create a valid Allocation
+	a1 := &Allocation{
+		Name:  "container1",
+		Start: start,
+		End:   end,
+	}
+
+	// Create AllocationSetRange with one valid and one nil allocation
+	as1 := NewAllocationSet(start, end)
+	as1.Allocations["valid"] = a1
+	as1.Allocations["invalid"] = nil
+
+	asr := NewAllocationSetRange(as1)
+
+	err := sasr.InsertExternalAllocations(asr)
+	if err == nil {
+		t.Fatalf("expected error from InsertExternalAllocations, got nil")
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes a bug in [InsertExternalAllocations](file:///Users/rucha/LFX/OpenCost/opencost/core/pkg/opencost/summaryallocation.go#L1634) where errors returned from `sas.Insert(...)` inside the inner loop could be overwritten by subsequent successful insertions. The inner loop now checks the returned error and returns it early to prevent error suppression.

## Related Issues
Fixes #3878 

## User Impact
No user-facing changes or breaking API changes. Improves safety and error reporting correctness for integrations using external allocations.

## Testing
- Added a new unit test [TestSummaryAllocationSetRange_InsertExternalAllocations](file:///Users/rucha/LFX/OpenCost/opencost/core/pkg/opencost/summaryallocation_test.go#L1130) to [summaryallocation_test.go](file:///Users/rucha/LFX/OpenCost/opencost/core/pkg/opencost/summaryallocation_test.go#L1130).
- Ran all tests successfully in the core module.