### PR TITLE
fix(mcp): use raw cAdvisor usage for efficiency, not max(usage, request)

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1190,9 +1190,11 @@ func computeEfficiencyMetric(alloc *opencost.Allocation, bufferMultiplier float6
 		return nil
 	}
 
-	// Get current usage (average over the period)
-	cpuCoresUsed := alloc.CPUCoreHours / hours
-	ramBytesUsed := alloc.RAMByteHours / hours
+	// Get current usage — use raw cAdvisor averages, not CPUCoreHours/RAMByteHours
+	// which are max(usage, request) and would floor efficiency at 1.0, hiding
+	// over-provisioned workloads from right-sizing recommendations.
+	cpuCoresUsed := alloc.CPUCoreUsageAverage
+	ramBytesUsed := alloc.RAMBytesUsageAverage
 
 	// Get requested amounts
 	cpuCoresRequested := alloc.CPUCoreRequestAverage


### PR DESCRIPTION
## Problem

The MCP `get_efficiency` endpoint reports `cpuCoresUsed` and `ramBytesUsed` as exactly equal to the resource request for any pod where actual usage is below the request. This makes `cpuEfficiency` / `memoryEfficiency` always ≥ 1.0, hiding over-provisioned workloads — exactly the workloads the efficiency API is meant to surface for right-sizing.

## Root cause

`computeEfficiencyMetric` in `pkg/mcp/server.go` derives "used" from the allocation's `CPUCoreHours` / `RAMByteHours`:

```go
cpuCoresUsed := alloc.CPUCoreHours / hours
ramBytesUsed := alloc.RAMByteHours / hours
```

`CPUCoreHours` and `RAMByteHours` are **allocation** hours, which use `max(actual_usage, request)` — you're billed for the request regardless of consumption. So when `actual_usage < request`:

- `CPUCoreHours = request × hours`
- `cpuCoresUsed = CPUCoreHours / hours = request`
- `cpuEfficiency = request / request = 1.0`

When `actual_usage > request`, `CPUCoreHours = usage × hours`, so real usage shows through and efficiency > 1.0. This is why the API can show under-provisioning but never over-provisioning.

## Fix

Use `alloc.CPUCoreUsageAverage` and `alloc.RAMBytesUsageAverage` instead. These fields hold the **raw cAdvisor usage averages** (populated by `applyCPUCoresUsedAvg` and the memory equivalent) without the `max(usage, request)` floor. `Allocation.CPUEfficiency()` already uses `CPUCoreUsageAverage / CPUCoreRequestAverage` — the MCP efficiency endpoint was inconsistent with the rest of the codebase.

## Verification

Before the fix (1h window, `kubectl top` = 3m CPU / 129 MiB):

```json
{
  "name": "concourse-worker-0",
  "cpuCoresRequested": 1.0,
  "cpuCoresUsed": 1.0,        // ← request, not real usage
  "cpuEfficiency": 1.0,
  "ramBytesRequested": 1572864000,
  "ramBytesUsed": 1572864000,  // ← request, not real usage
  "memoryEfficiency": 1.0,
  "recommendedCpuRequest": 1.2, // ← request × 1.2, useless
  "recommendedRamRequest": 1887436800
}
```

After the fix (expected):

```json
{
  "name": "concourse-worker-0",
  "cpuCoresRequested": 1.0,
  "cpuCoresUsed": 0.003,       // ← real cAdvisor usage (3m)
  "cpuEfficiency": 0.003,      // ← now shows over-provisioning
  "ramBytesRequested": 1572864000,
  "ramBytesUsed": 135266304,    // ← real usage (129 MiB)
  "memoryEfficiency": 0.086,
  "recommendedCpuRequest": 0.0036, // ← usage × 1.2, actionable
  "recommendedRamRequest": 162319565
}
```

## Impact

This affects every deployment using the MCP efficiency endpoint for right-sizing. Workloads that are over-provisioned (usage < request) appear perfectly efficient (1.0), leading to incorrect "no action needed" conclusions and missed cost-saving opportunities.
