### PR TITLE
aws: parse disk region dynamically from AvailabilityZone in findCostF…

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -2177,9 +2177,8 @@ func (aws *AWS) GetOrphanedResources() ([]models.OrphanedResource, error) {
 }
 
 func (aws *AWS) findCostForDisk(disk *ec2Types.Volume) (*float64, error) {
-	// todo: use AWS pricing from all regions
 	if disk.AvailabilityZone == nil {
-		return nil, fmt.Errorf("nil region")
+		return nil, fmt.Errorf("nil AvailabilityZone")
 	}
 	if disk.Size == nil {
 		return nil, fmt.Errorf("nil disk size")
@@ -2187,7 +2186,12 @@ func (aws *AWS) findCostForDisk(disk *ec2Types.Volume) (*float64, error) {
 
 	class := volTypes[string(disk.VolumeType)]
 
-	key := aws.ClusterRegion + "," + class
+	region := regionRx.FindString(*disk.AvailabilityZone)
+	if region == "" {
+		region = aws.ClusterRegion
+	}
+
+	key := region + "," + class
 
 	pricing, ok := aws.Pricing[key]
 	if !ok {

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go"
-	"github.com/opencost/opencost/pkg/cloud/httputil"
 	"github.com/opencost/opencost/pkg/cloud/models"
 	"github.com/opencost/opencost/pkg/cloud/utils"
 
@@ -859,10 +858,7 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 	}
 
 	log.Infof("starting download of \"%s\", which is quite large ...", pricingURL)
-	// This file is large and can take a while to stream, so the streaming client
-	// bounds connect/TLS/response-header time but not the total body read - enough
-	// to bail on a hung endpoint without truncating a legitimate slow download.
-	resp, err := httputil.StreamingGet(context.Background(), pricingURL)
+	resp, err := http.Get(pricingURL)
 	if err != nil {
 		log.Errorf("Bogus fetch of \"%s\": %v", pricingURL, err)
 		return nil, pricingURL, err
@@ -1356,7 +1352,7 @@ func (aws *AWS) spotPricingFromHistory(k models.Key) (*SpotPriceHistoryEntry, bo
 
 	price, err := aws.SpotPriceHistoryCache.GetSpotPrice(region, instanceType, availabilityZone)
 	if err != nil {
-		log.Debugf("Failed to get spot price history for instance %s: %s", k.ID(), err.Error())
+		log.DedupedWarningf(10, "Failed to get spot price history for instance %s: %s", k.ID(), err.Error())
 		return nil, false
 	}
 	return price, true
@@ -1487,7 +1483,7 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 			UsageType:    PreemptibleType,
 		}, meta, nil
 	} else if aws.isPreemptible(key) { // Preemptible but we don't have any data in the pricing report.
-		log.Debugf("Node %s marked preemptible but no spot feed data available; falling back to other pricing sources", k.ID())
+		log.DedupedWarningf(5, "Node %s marked preemptible but no spot feed data available; falling back to other pricing sources", k.ID())
 
 		// Try to get spot pricing from DescribeSpotPriceHistory API
 		if historyEntry, ok := aws.spotPricingFromHistory(k); ok {
@@ -1509,7 +1505,7 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 
 		if publicPricingFound {
 			// return public price if found
-			log.Debugf("No spot price history available for %s, falling back to on-demand pricing", k.ID())
+			log.DedupedWarningf(5, "No spot price history available for %s, falling back to on-demand pricing", k.ID())
 			return &models.Node{
 				Cost:         cost,
 				VCPU:         terms.VCpu,
@@ -2119,7 +2115,7 @@ func (aws *AWS) GetOrphanedResources() ([]models.OrphanedResource, error) {
 				zone = *volume.AvailabilityZone
 			}
 			var region, url string
-			region = regionRx.FindString(zone)
+			region = parseRegionFromAZ(zone)
 			if region != "" {
 				url = "https://console.aws.amazon.com/ec2/home?region=" + region + "#Volumes:sort=desc:createTime"
 			} else {
@@ -2186,14 +2182,28 @@ func (aws *AWS) findCostForDisk(disk *ec2Types.Volume) (*float64, error) {
 
 	class := volTypes[string(disk.VolumeType)]
 
-	region := regionRx.FindString(*disk.AvailabilityZone)
-	if region == "" {
-		region = aws.ClusterRegion
+	region := parseRegionFromAZ(*disk.AvailabilityZone)
+
+	var pricing *AWSProductTerms
+	var ok bool
+	var key string
+
+	if region != "" {
+		key = region + "," + class
+		pricing, ok = aws.Pricing[key]
+		if ok && pricing != nil && pricing.PV != nil {
+			priceStr := pricing.PV.Cost
+			price, err := strconv.ParseFloat(priceStr, 64)
+			if err == nil {
+				cost := price * timeutil.HoursPerMonth * float64(*disk.Size)
+				return &cost, nil
+			}
+		}
 	}
 
-	key := region + "," + class
-
-	pricing, ok := aws.Pricing[key]
+	// Fallback to ClusterRegion
+	key = aws.ClusterRegion + "," + class
+	pricing, ok = aws.Pricing[key]
 	if !ok {
 		return nil, fmt.Errorf("no pricing data for key '%s'", key)
 	}
@@ -2724,4 +2734,17 @@ func (aws *AWS) Regions() []string {
 func (aws *AWS) PricingSourceSummary() interface{} {
 	// encode the pricing source summary as a JSON string
 	return aws.Pricing
+}
+
+func parseRegionFromAZ(zone string) string {
+	region := ""
+	for _, r := range awsRegions {
+		if strings.HasPrefix(zone, r) && len(r) > len(region) {
+			region = r
+		}
+	}
+	if region == "" {
+		region = regionRx.FindString(zone)
+	}
+	return region
 }

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go"
+	"github.com/opencost/opencost/pkg/cloud/httputil"
 	"github.com/opencost/opencost/pkg/cloud/models"
 	"github.com/opencost/opencost/pkg/cloud/utils"
 
@@ -858,7 +859,10 @@ func (aws *AWS) getRegionPricing(nodeList []*clustercache.Node) (*http.Response,
 	}
 
 	log.Infof("starting download of \"%s\", which is quite large ...", pricingURL)
-	resp, err := http.Get(pricingURL)
+	// This file is large and can take a while to stream, so the streaming client
+	// bounds connect/TLS/response-header time but not the total body read - enough
+	// to bail on a hung endpoint without truncating a legitimate slow download.
+	resp, err := httputil.StreamingGet(context.Background(), pricingURL)
 	if err != nil {
 		log.Errorf("Bogus fetch of \"%s\": %v", pricingURL, err)
 		return nil, pricingURL, err
@@ -1352,7 +1356,7 @@ func (aws *AWS) spotPricingFromHistory(k models.Key) (*SpotPriceHistoryEntry, bo
 
 	price, err := aws.SpotPriceHistoryCache.GetSpotPrice(region, instanceType, availabilityZone)
 	if err != nil {
-		log.DedupedWarningf(10, "Failed to get spot price history for instance %s: %s", k.ID(), err.Error())
+		log.Debugf("Failed to get spot price history for instance %s: %s", k.ID(), err.Error())
 		return nil, false
 	}
 	return price, true
@@ -1483,7 +1487,7 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 			UsageType:    PreemptibleType,
 		}, meta, nil
 	} else if aws.isPreemptible(key) { // Preemptible but we don't have any data in the pricing report.
-		log.DedupedWarningf(5, "Node %s marked preemptible but no spot feed data available; falling back to other pricing sources", k.ID())
+		log.Debugf("Node %s marked preemptible but no spot feed data available; falling back to other pricing sources", k.ID())
 
 		// Try to get spot pricing from DescribeSpotPriceHistory API
 		if historyEntry, ok := aws.spotPricingFromHistory(k); ok {
@@ -1505,7 +1509,7 @@ func (aws *AWS) createNode(terms *AWSProductTerms, usageType string, k models.Ke
 
 		if publicPricingFound {
 			// return public price if found
-			log.DedupedWarningf(5, "No spot price history available for %s, falling back to on-demand pricing", k.ID())
+			log.Debugf("No spot price history available for %s, falling back to on-demand pricing", k.ID())
 			return &models.Node{
 				Cost:         cost,
 				VCPU:         terms.VCpu,
@@ -2184,26 +2188,14 @@ func (aws *AWS) findCostForDisk(disk *ec2Types.Volume) (*float64, error) {
 
 	region := parseRegionFromAZ(*disk.AvailabilityZone)
 
-	var pricing *AWSProductTerms
-	var ok bool
-	var key string
-
-	if region != "" {
-		key = region + "," + class
-		pricing, ok = aws.Pricing[key]
-		if ok && pricing != nil && pricing.PV != nil {
-			priceStr := pricing.PV.Cost
-			price, err := strconv.ParseFloat(priceStr, 64)
-			if err == nil {
-				cost := price * timeutil.HoursPerMonth * float64(*disk.Size)
-				return &cost, nil
-			}
-		}
+	key := region + "," + class
+	_, ok := aws.Pricing[key]
+	if region == "" || !ok {
+		// Fallback to ClusterRegion
+		key = aws.ClusterRegion + "," + class
 	}
 
-	// Fallback to ClusterRegion
-	key = aws.ClusterRegion + "," + class
-	pricing, ok = aws.Pricing[key]
+	pricing, ok := aws.Pricing[key]
 	if !ok {
 		return nil, fmt.Errorf("no pricing data for key '%s'", key)
 	}

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1394,5 +1395,100 @@ func TestAWS_findCostForDisk(t *testing.T) {
 			Size:             &size1,
 		}
 		checkCost(t, diskNoPrice, expectedCost1)
+	})
+
+	// Case 6: Region-specific pricing key is present but value is nil.
+	// It should return an error, NOT fall back.
+	t.Run("Region pricing key present but value is nil", func(t *testing.T) {
+		awsCustom := &AWS{
+			ClusterRegion: "us-east-1",
+			Pricing: map[string]*AWSProductTerms{
+				"us-east-1,EBS:VolumeUsage.gp2": {
+					PV: &models.PV{
+						Cost: "0.10",
+					},
+				},
+				"us-west-2,EBS:VolumeUsage.gp2": nil,
+			},
+		}
+		zone := "us-west-2b"
+		disk := &ec2Types.Volume{
+			AvailabilityZone: &zone,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		_, err := awsCustom.findCostForDisk(disk)
+		if err == nil {
+			t.Fatal("expected error because us-west-2 pricing is nil, but got nil error")
+		}
+		expectedErr := "nil pricing data for key 'us-west-2,EBS:VolumeUsage.gp2'"
+		if err.Error() != expectedErr {
+			t.Fatalf("expected error message %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	// Case 7: Region-specific pricing key is present but pricing.PV is nil.
+	// It should return an error, NOT fall back.
+	t.Run("Region pricing key present but PV is nil", func(t *testing.T) {
+		awsCustom := &AWS{
+			ClusterRegion: "us-east-1",
+			Pricing: map[string]*AWSProductTerms{
+				"us-east-1,EBS:VolumeUsage.gp2": {
+					PV: &models.PV{
+						Cost: "0.10",
+					},
+				},
+				"us-west-2,EBS:VolumeUsage.gp2": {
+					PV: nil,
+				},
+			},
+		}
+		zone := "us-west-2b"
+		disk := &ec2Types.Volume{
+			AvailabilityZone: &zone,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		_, err := awsCustom.findCostForDisk(disk)
+		if err == nil {
+			t.Fatal("expected error because us-west-2 pricing PV is nil, but got nil error")
+		}
+		expectedErr := "pricing for key 'us-west-2,EBS:VolumeUsage.gp2' has nil PV"
+		if err.Error() != expectedErr {
+			t.Fatalf("expected error message %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	// Case 8: Region-specific pricing key is present but pricing.PV.Cost is unparsable.
+	// It should return an error, NOT fall back.
+	t.Run("Region pricing key present but Cost is unparsable", func(t *testing.T) {
+		awsCustom := &AWS{
+			ClusterRegion: "us-east-1",
+			Pricing: map[string]*AWSProductTerms{
+				"us-east-1,EBS:VolumeUsage.gp2": {
+					PV: &models.PV{
+						Cost: "0.10",
+					},
+				},
+				"us-west-2,EBS:VolumeUsage.gp2": {
+					PV: &models.PV{
+						Cost: "not-a-float",
+					},
+				},
+			},
+		}
+		zone := "us-west-2b"
+		disk := &ec2Types.Volume{
+			AvailabilityZone: &zone,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		_, err := awsCustom.findCostForDisk(disk)
+		if err == nil {
+			t.Fatal("expected error because us-west-2 pricing cost is unparsable, but got nil error")
+		}
+		if !strings.Contains(err.Error(), "parsing \"not-a-float\"") {
+			t.Fatalf("expected parsing float error, got %q", err.Error())
+		}
 	})
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -1311,48 +1311,88 @@ func TestAWS_findCostForDisk(t *testing.T) {
 					Cost: "0.12",
 				},
 			},
+			"us-gov-west-1,EBS:VolumeUsage.gp2": {
+				PV: &models.PV{
+					Cost: "0.15",
+				},
+			},
 		},
 	}
 
-	// Case 1: Disk has AvailabilityZone matching ClusterRegion (e.g. us-east-1a)
-	zone1 := "us-east-1a"
 	size1 := int32(100)
-	disk1 := &ec2Types.Volume{
-		AvailabilityZone: &zone1,
-		VolumeType:       ec2Types.VolumeTypeGp2,
-		Size:             &size1,
+	expectedCost1 := 0.10 * 730.0 * 100.0
+	expectedCost2 := 0.12 * 730.0 * 100.0
+	expectedCostGov := 0.15 * 730.0 * 100.0
+
+	checkCost := func(t *testing.T, disk *ec2Types.Volume, expectedCost float64) {
+		cost, err := aws.findCostForDisk(disk)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cost == nil {
+			t.Fatalf("expected cost %v, got nil", expectedCost)
+		}
+		diff := *cost - expectedCost
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 1e-9 {
+			t.Fatalf("expected cost %f, got %f", expectedCost, *cost)
+		}
 	}
 
-	cost1, err := aws.findCostForDisk(disk1)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	expectedCost1 := 0.10 * 730.0 * 100.0
-	if cost1 == nil || *cost1 != expectedCost1 {
-		t.Fatalf("expected cost %v, got %v", expectedCost1, cost1)
-	}
+	// Case 1: Disk has AvailabilityZone matching ClusterRegion (e.g. us-east-1a)
+	t.Run("AZ matching ClusterRegion", func(t *testing.T) {
+		zone1 := "us-east-1a"
+		disk1 := &ec2Types.Volume{
+			AvailabilityZone: &zone1,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		checkCost(t, disk1, expectedCost1)
+	})
 
 	// Case 2: Disk has AvailabilityZone from a different region (e.g. us-west-2b)
-	zone2 := "us-west-2b"
-	disk2 := &ec2Types.Volume{
-		AvailabilityZone: &zone2,
-		VolumeType:       ec2Types.VolumeTypeGp2,
-		Size:             &size1,
-	}
+	t.Run("AZ from different region", func(t *testing.T) {
+		zone2 := "us-west-2b"
+		disk2 := &ec2Types.Volume{
+			AvailabilityZone: &zone2,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		checkCost(t, disk2, expectedCost2)
+	})
 
-	cost2, err := aws.findCostForDisk(disk2)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	expectedCost2 := 0.12 * 730.0 * 100.0
-	if cost2 == nil {
-		t.Fatalf("expected cost %v, got %v", expectedCost2, cost2)
-	}
-	diff2 := *cost2 - expectedCost2
-	if diff2 < 0 {
-		diff2 = -diff2
-	}
-	if diff2 > 1e-9 {
-		t.Fatalf("expected cost %v, got %v", expectedCost2, cost2)
-	}
+	// Case 3: GovCloud region prefix match (e.g. us-gov-west-1a)
+	t.Run("GovCloud region prefix match", func(t *testing.T) {
+		zoneGov := "us-gov-west-1a"
+		diskGov := &ec2Types.Volume{
+			AvailabilityZone: &zoneGov,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		checkCost(t, diskGov, expectedCostGov)
+	})
+
+	// Case 4: Invalid/unknown region format, should fall back to ClusterRegion
+	t.Run("Invalid AZ fallback", func(t *testing.T) {
+		zoneUnknown := "unknown-zone"
+		diskUnknown := &ec2Types.Volume{
+			AvailabilityZone: &zoneUnknown,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		checkCost(t, diskUnknown, expectedCost1)
+	})
+
+	// Case 5: Valid region but pricing not loaded, should fall back to ClusterRegion
+	t.Run("No pricing loaded fallback", func(t *testing.T) {
+		zoneNoPrice := "eu-west-1b"
+		diskNoPrice := &ec2Types.Volume{
+			AvailabilityZone: &zoneNoPrice,
+			VolumeType:       ec2Types.VolumeTypeGp2,
+			Size:             &size1,
+		}
+		checkCost(t, diskNoPrice, expectedCost1)
+	})
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -1345,7 +1345,14 @@ func TestAWS_findCostForDisk(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	expectedCost2 := 0.12 * 730.0 * 100.0
-	if cost2 == nil || *cost2 != expectedCost2 {
+	if cost2 == nil {
+		t.Fatalf("expected cost %v, got %v", expectedCost2, cost2)
+	}
+	diff2 := *cost2 - expectedCost2
+	if diff2 < 0 {
+		diff2 = -diff2
+	}
+	if diff2 > 1e-9 {
 		t.Fatalf("expected cost %v, got %v", expectedCost2, cost2)
 	}
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/pkg/cloud/models"
 	"github.com/opencost/opencost/pkg/config"
@@ -1294,4 +1295,57 @@ func TestAWS_PricingSourceStatus_spotPriceHistory(t *testing.T) {
 			t.Error("Expected Available=true when cache initialized")
 		}
 	})
+}
+
+func TestAWS_findCostForDisk(t *testing.T) {
+	aws := &AWS{
+		ClusterRegion: "us-east-1",
+		Pricing: map[string]*AWSProductTerms{
+			"us-east-1,EBS:VolumeUsage.gp2": {
+				PV: &models.PV{
+					Cost: "0.10",
+				},
+			},
+			"us-west-2,EBS:VolumeUsage.gp2": {
+				PV: &models.PV{
+					Cost: "0.12",
+				},
+			},
+		},
+	}
+
+	// Case 1: Disk has AvailabilityZone matching ClusterRegion (e.g. us-east-1a)
+	zone1 := "us-east-1a"
+	size1 := int32(100)
+	disk1 := &ec2Types.Volume{
+		AvailabilityZone: &zone1,
+		VolumeType:       ec2Types.VolumeTypeGp2,
+		Size:             &size1,
+	}
+
+	cost1, err := aws.findCostForDisk(disk1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedCost1 := 0.10 * 730.0 * 100.0
+	if cost1 == nil || *cost1 != expectedCost1 {
+		t.Fatalf("expected cost %v, got %v", expectedCost1, cost1)
+	}
+
+	// Case 2: Disk has AvailabilityZone from a different region (e.g. us-west-2b)
+	zone2 := "us-west-2b"
+	disk2 := &ec2Types.Volume{
+		AvailabilityZone: &zone2,
+		VolumeType:       ec2Types.VolumeTypeGp2,
+		Size:             &size1,
+	}
+
+	cost2, err := aws.findCostForDisk(disk2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedCost2 := 0.12 * 730.0 * 100.0
+	if cost2 == nil || *cost2 != expectedCost2 {
+		t.Fatalf("expected cost %v, got %v", expectedCost2, cost2)
+	}
 }


### PR DESCRIPTION
## Description
This PR resolves a limitation in the AWS provider's [findCostForDisk](file:///Users/rucha/LFX/OpenCost/opencost/pkg/cloud/aws/provider.go#L2175) function, which previously relied on the global `aws.ClusterRegion` for disk pricing lookups. We now parse the region dynamically from the disk's `AvailabilityZone` using `regionRx` and fall back to `aws.ClusterRegion` if parsing fails.

## Related Issues
Fixes #3885

## User Impact
Improves AWS disk pricing lookup accuracy for clusters utilizing multi-region persistent disks. No breaking changes or backwards compatibility issues.

## Testing
- Added a new unit test [TestAWS_findCostForDisk](file:///Users/rucha/LFX/OpenCost/opencost/pkg/cloud/aws/provider_test.go#L1368) to [provider_test.go](file:///Users/rucha/LFX/OpenCost/opencost/pkg/cloud/aws/provider_test.go#L1368).
- Verified that all AWS provider tests pass locally.