### PR TITLE
Memory Optimizations

### DIFF
--- a/pkg/cloudcost/querier.go
+++ b/pkg/cloudcost/querier.go
@@ -43,7 +43,7 @@ type ViewQueryRequest struct {
 	Limit            int
 	SortDirection    SortDirection
 	SortColumn       SortField
-	SkipCount bool
+	SkipCount        bool
 }
 
 // SortDirection a string type that acts as an enumeration of possible request options

--- a/pkg/cloudcost/querier.go
+++ b/pkg/cloudcost/querier.go
@@ -43,6 +43,7 @@ type ViewQueryRequest struct {
 	Limit            int
 	SortDirection    SortDirection
 	SortColumn       SortField
+	SkipCount bool
 }
 
 // SortDirection a string type that acts as an enumeration of possible request options

--- a/pkg/cloudcost/queryservice_helper.go
+++ b/pkg/cloudcost/queryservice_helper.go
@@ -96,6 +96,11 @@ func ParseCloudCostViewRequest(qp httputil.QueryParams) (*ViewQueryRequest, erro
 		return nil, fmt.Errorf("error parsing 'sortBy': %w", err)
 	}
 
+	// includeCount controls whether the (potentially very expensive) NumResults
+	// count is computed alongside the combined cost. Defaults to true; callers
+	// pass includeCount=false to skip it.
+	includeCount := qp.GetBool("includeCount", true)
+
 	return &ViewQueryRequest{
 		QueryRequest:     *qr,
 		CostMetricName:   costMetricName,
@@ -104,6 +109,7 @@ func ParseCloudCostViewRequest(qp httputil.QueryParams) (*ViewQueryRequest, erro
 		Offset:           offset,
 		SortDirection:    order,
 		SortColumn:       sortColumn,
+		SkipCount:        !includeCount,
 	}, nil
 }
 


### PR DESCRIPTION
## Description
* Adds an `includeCount` parameter to `ViewQueryRequest`, allowing for callers to disable item counts in the request. This parameter defaults to true.

## Related Issues
* N/A.

## User Impact
* Users are unaffected, but this will allow for improved query times in aggregator

## Testing
* To be tested in the aggregator PR.
