### PR TITLE
gcp: query dynamic persistent disk pricing in findCostForDisk

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -517,7 +517,42 @@ func (gcp *GCP) GetOrphanedResources() ([]models.OrphanedResource, error) {
 }
 
 func (gcp *GCP) findCostForDisk(disk *compute.Disk) (*float64, error) {
-	//todo: use GCP pricing struct
+	var region string
+	if disk.Region != "" {
+		region = path.Base(disk.Region)
+	} else if disk.Zone != "" {
+		zone := path.Base(disk.Zone)
+		if idx := strings.LastIndex(zone, "-"); idx != -1 {
+			region = zone[:idx]
+		} else {
+			region = zone
+		}
+	}
+	if region == "" || region == "." {
+		region = gcp.ClusterRegion
+	}
+
+	diskType := "pdstandard"
+	if strings.Contains(disk.Type, "ssd") {
+		diskType = "ssd"
+	}
+
+	key := region + "," + diskType
+
+	gcp.DownloadPricingDataLock.RLock()
+	pricing, ok := gcp.Pricing[key]
+	gcp.DownloadPricingDataLock.RUnlock()
+
+	if ok && pricing != nil && pricing.PV != nil {
+		priceStr := pricing.PV.Cost
+		price, err := strconv.ParseFloat(priceStr, 64)
+		if err == nil {
+			cost := price * timeutil.HoursPerMonth * float64(disk.SizeGb)
+			return &cost, nil
+		}
+	}
+
+	// Fallback to static constants
 	price := GCPMonthlyBasicDiskCost
 	if strings.Contains(disk.Type, "ssd") {
 		price = GCPMonthlySSDDiskCost
@@ -526,20 +561,6 @@ func (gcp *GCP) findCostForDisk(disk *compute.Disk) (*float64, error) {
 		price = GCPMonthlyGP2DiskCost
 	}
 	cost := price * float64(disk.SizeGb)
-
-	// This isn't much use but I (Nick) think its could be going down the
-	// right path. Disk region isnt returning anything (and if it did its
-	// a url, same with type). Currently the only region stored in the
-	// Pricing struct is uscentral-1, so that would need to be fixed
-	// key := disk.Region + "," + disk.Type
-
-	// priceStr := gcp.Pricing[key].PV.Cost
-	// price, err := strconv.ParseFloat(priceStr, 64)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// cost := price * timeutil.HoursPerMonth * float64(disk.SizeGb)
 	return &cost, nil
 }
 

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -669,6 +669,7 @@ func TestGCP_findCostForDisk(t *testing.T) {
 	tests := []struct {
 		name     string
 		disk     *compute.Disk
+		pricing  map[string]*GCPPricing
 		expected float64
 	}{
 		{
@@ -695,15 +696,49 @@ func TestGCP_findCostForDisk(t *testing.T) {
 			},
 			expected: GCPMonthlyGP2DiskCost * 200,
 		},
+		{
+			name: "Dynamic SSD disk from zone",
+			disk: &compute.Disk{
+				Type:   "pd-ssd",
+				SizeGb: 100,
+				Zone:   "us-central1-a",
+			},
+			pricing: map[string]*GCPPricing{
+				"us-central1,ssd": {
+					PV: &models.PV{
+						Cost: "0.000228",
+					},
+				},
+			},
+			expected: 0.000228 * 730.0 * 100,
+		},
+		{
+			name: "Dynamic Standard disk from region URL",
+			disk: &compute.Disk{
+				Type:   "pd-standard",
+				SizeGb: 50,
+				Region: "https://www.googleapis.com/compute/v1/projects/my-project/regions/europe-west1",
+			},
+			pricing: map[string]*GCPPricing{
+				"europe-west1,pdstandard": {
+					PV: &models.PV{
+						Cost: "0.000055",
+					},
+				},
+			},
+			expected: 0.000055 * 730.0 * 50,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gcp := &GCP{}
+			gcp := &GCP{
+				Pricing: tt.pricing,
+			}
 			cost, err := gcp.findCostForDisk(tt.disk)
 			assert.NoError(t, err)
 			assert.NotNil(t, cost)
-			assert.Equal(t, tt.expected, *cost)
+			assert.InDelta(t, tt.expected, *cost, 1e-9)
 		})
 	}
 }


### PR DESCRIPTION
## Description
This PR updates the GCP provider's [findCostForDisk](file:///Users/rucha/LFX/OpenCost/opencost/pkg/cloud/gcp/provider.go#L519) function to perform dynamic pricing lookup. Instead of immediately using hardcoded fallback constants, the method now parses the region and disk type from the `compute.Disk` attributes and queries `gcp.Pricing`. If pricing data is available, it computes the cost using the dynamic billing API prices. It falls back to static constants only when dynamic lookup is unavailable.

## Related Issues
Fixes  #3896

## User Impact
Improves GCP disk pricing accuracy for orphaned resource metrics by utilizing dynamic Google Cloud Billing API prices. No breaking changes or backwards compatibility concerns.

## Testing
- Extended the existing unit test [TestGCP_findCostForDisk](file:///Users/rucha/LFX/OpenCost/opencost/pkg/cloud/gcp/provider_test.go#L668) in [provider_test.go](file:///Users/rucha/LFX/OpenCost/opencost/pkg/cloud/gcp/provider_test.go#L668) to test both dynamic pricing lookups (with region/zone parsing) and the fallback mechanisms.
- Verified all GCP provider tests pass successfully.