### PR TITLE
deactivate endpoints unless admin token set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,16 @@ just validate-protobuf
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ADMIN_TOKEN` | (unset) | Bearer token for admin endpoints (`POST /serviceKey`, cloud config mutate/export, `/helmValues`). If unset, those endpoints return HTTP 501. |
+| `ADMIN_TOKEN` | (unset) | Bearer token for admin endpoints. If unset, those endpoints return HTTP 503. |
+
+Admin-protected endpoints:
+
+- `POST /serviceKey`
+- `GET /helmValues`
+- `GET /cloudCost/rebuild`, `GET /cloudCost/repair`
+- `GET /cloud/config/export`, `GET /cloud/config/enable`, `GET /cloud/config/disable`, `GET /cloud/config/delete`
+
+**Breaking change:** deployments without `ADMIN_TOKEN` can no longer call these endpoints. Set `ADMIN_TOKEN` (for example via [opencost-helm-chart](https://github.com/opencost/opencost-helm-chart) `opencost.exporter.adminToken`) before using admin APIs.
 
 ### Cloud Providers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,12 @@ just validate-protobuf
 | `MCP_SERVER_ENABLED` | `false` | Enable MCP server |
 | `MCP_HTTP_PORT` | `8081` | MCP server HTTP port |
 
+### Admin Auth
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ADMIN_TOKEN` | (unset) | Bearer token for admin endpoints (`POST /serviceKey`, cloud config mutate/export, `/helmValues`). If unset, those endpoints return HTTP 501. |
+
 ### Cloud Providers
 
 | Variable | Description |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6219/badge)](https://www.bestpractices.dev/projects/6219)
-[![Known Vulnerabilities](https://snyk.io/test/github/opencost/opencost/badge.svg)](https://snyk.io/test/github/opencost/opencost)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OpenCost%20Guru-006BFF)](https://gurubase.io/g/opencost)
 
 ![](./opencost-header.png)
@@ -12,8 +11,6 @@ These models provide cost transparency in Kubernetes environments that support m
 It also provides visibility into the cloud costs across multiple providers.
 
 OpenCost was originally developed and open sourced by [Kubecost](https://kubecost.com). This project combines a [specification](/spec/) as well as a Golang implementation of these detailed requirements. The web UI is available in the [opencost/opencost-ui](http://github.com/opencost/opencost-ui) repository.
-
-OpenCost participates in the [Snyk Secure Developer Program](https://snyk.io/?utm_source=open-source&utm_medium=pg-ptr&utm_campaign=ref-2501-osp&utm_content=pg-cta), which provides open source projects with access to Snyk's vulnerability scanning and monitoring tools to help keep our dependencies and supply chain secure.
 
 [![OpenCost UI Walkthrough](./ui/src/thumbnail.png)](https://youtu.be/lCP4Ci9Kcdg)
 *OpenCost UI Walkthrough*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6219/badge)](https://www.bestpractices.dev/projects/6219)
+[![Known Vulnerabilities](https://snyk.io/test/github/opencost/opencost/badge.svg)](https://snyk.io/test/github/opencost/opencost)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20OpenCost%20Guru-006BFF)](https://gurubase.io/g/opencost)
 
 ![](./opencost-header.png)
@@ -11,6 +12,8 @@ These models provide cost transparency in Kubernetes environments that support m
 It also provides visibility into the cloud costs across multiple providers.
 
 OpenCost was originally developed and open sourced by [Kubecost](https://kubecost.com). This project combines a [specification](/spec/) as well as a Golang implementation of these detailed requirements. The web UI is available in the [opencost/opencost-ui](http://github.com/opencost/opencost-ui) repository.
+
+OpenCost participates in the [Snyk Secure Developer Program](https://snyk.io/?utm_source=open-source&utm_medium=pg-ptr&utm_campaign=ref-2501-osp&utm_content=pg-cta), which provides open source projects with access to Snyk's vulnerability scanning and monitoring tools to help keep our dependencies and supply chain secure.
 
 [![OpenCost UI Walkthrough](./ui/src/thumbnail.png)](https://youtu.be/lCP4Ci9Kcdg)
 *OpenCost UI Walkthrough*

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -132,13 +132,15 @@ func ParsePercentString(percentStr string) (float64, error) {
 }
 
 // adminAuthMiddleware wraps a handler and requires a Bearer token matching ADMIN_TOKEN.
-// When ADMIN_TOKEN is not set, returns 501 — the endpoint is disabled until configured.
-// When ADMIN_TOKEN is set, returns 401 if the Bearer token is missing or 403 if it does not match.
+// When ADMIN_TOKEN is not set, returns 503 with Cache-Control: no-store — the endpoint is
+// disabled until configured. When ADMIN_TOKEN is set, returns 401 if the Bearer token is
+// missing or 403 if it does not match.
 func adminAuthMiddleware(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		adminToken := env.GetAdminToken()
 		if adminToken == "" {
-			http.Error(w, "Admin token is required to activate this endpoint; set the ADMIN_TOKEN environment variable", http.StatusNotImplemented)
+			w.Header().Set("Cache-Control", "no-store")
+			http.Error(w, "Admin token is required to activate this endpoint; set the ADMIN_TOKEN environment variable", http.StatusServiceUnavailable)
 			return
 		}
 		authHeader := r.Header.Get("Authorization")

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -131,15 +131,14 @@ func ParsePercentString(percentStr string) (float64, error) {
 	return discount, nil
 }
 
-// adminAuthMiddleware wraps a handler and requires a Bearer token matching ADMIN_TOKEN env var when set.
-// When ADMIN_TOKEN is not set, logs a deduped warning and allows the request through.
+// adminAuthMiddleware wraps a handler and requires a Bearer token matching ADMIN_TOKEN.
+// When ADMIN_TOKEN is not set, returns 501 — the endpoint is disabled until configured.
 // When ADMIN_TOKEN is set, returns 401 if the Bearer token is missing or 403 if it does not match.
 func adminAuthMiddleware(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		adminToken := env.GetAdminToken()
 		if adminToken == "" {
-			log.DedupedWarningf(5, "Admin token (ADMIN_TOKEN) not configured; write operations are unauthenticated")
-			next(w, r, ps)
+			http.Error(w, "Admin token is required to activate this endpoint; set the ADMIN_TOKEN environment variable", http.StatusNotImplemented)
 			return
 		}
 		authHeader := r.Header.Get("Authorization")
@@ -591,7 +590,7 @@ func Initialize(router *httprouter.Router, additionalConfigWatchers ...*watcher.
 	router.GET("/installNamespace", a.GetInstallNamespace)
 	router.GET("/installInfo", a.GetInstallInfo)
 	router.POST("/serviceKey", adminAuthMiddleware(a.AddServiceKey))
-	router.GET("/helmValues", a.GetHelmValues)
+	router.GET("/helmValues", adminAuthMiddleware(a.GetHelmValues))
 
 	return a
 }

--- a/pkg/costmodel/router_test.go
+++ b/pkg/costmodel/router_test.go
@@ -3,7 +3,6 @@ package costmodel
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -21,28 +20,31 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		setToken       string
-		authHeader     string
-		wantStatus     int
-		wantNextCalled bool
-		wantBodySubstr string
+		name              string
+		setToken          string
+		authHeader        string
+		wantStatus        int
+		wantNextCalled    bool
+		wantBodySubstr    string
+		wantCacheControl  string
 	}{
 		{
-			name:           "no admin token configured - returns 501",
-			setToken:       "",
-			authHeader:     "",
-			wantStatus:     http.StatusNotImplemented,
-			wantNextCalled: false,
-			wantBodySubstr: "Admin token is required to activate this endpoint",
+			name:             "no admin token configured - returns 503",
+			setToken:         "",
+			authHeader:       "",
+			wantStatus:       http.StatusServiceUnavailable,
+			wantNextCalled:   false,
+			wantBodySubstr:   "Admin token is required to activate this endpoint",
+			wantCacheControl: "no-store",
 		},
 		{
-			name:           "no admin token configured - bearer ignored, still 501",
-			setToken:       "",
-			authHeader:     "Bearer anything",
-			wantStatus:     http.StatusNotImplemented,
-			wantNextCalled: false,
-			wantBodySubstr: "Admin token is required to activate this endpoint",
+			name:             "no admin token configured - bearer ignored, still 503",
+			setToken:         "",
+			authHeader:       "Bearer anything",
+			wantStatus:       http.StatusServiceUnavailable,
+			wantNextCalled:   false,
+			wantBodySubstr:   "Admin token is required to activate this endpoint",
+			wantCacheControl: "no-store",
 		},
 		{
 			name:           "missing authorization header",
@@ -82,18 +84,10 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prevToken := os.Getenv(env.AdminTokenEnvVar)
-			defer func() {
-				if prevToken == "" {
-					os.Unsetenv(env.AdminTokenEnvVar)
-				} else {
-					os.Setenv(env.AdminTokenEnvVar, prevToken)
-				}
-			}()
 			if tt.setToken != "" {
-				os.Setenv(env.AdminTokenEnvVar, tt.setToken)
+				t.Setenv(env.AdminTokenEnvVar, tt.setToken)
 			} else {
-				os.Unsetenv(env.AdminTokenEnvVar)
+				t.Setenv(env.AdminTokenEnvVar, "")
 			}
 
 			nextCalled = false
@@ -114,6 +108,9 @@ func TestAdminAuthMiddleware(t *testing.T) {
 			}
 			if tt.wantBodySubstr != "" && !strings.Contains(rec.Body.String(), tt.wantBodySubstr) {
 				t.Errorf("body = %q, want substring %q", rec.Body.String(), tt.wantBodySubstr)
+			}
+			if tt.wantCacheControl != "" && rec.Header().Get("Cache-Control") != tt.wantCacheControl {
+				t.Errorf("Cache-Control = %q, want %q", rec.Header().Get("Cache-Control"), tt.wantCacheControl)
 			}
 		})
 	}

--- a/pkg/costmodel/router_test.go
+++ b/pkg/costmodel/router_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
@@ -25,13 +26,23 @@ func TestAdminAuthMiddleware(t *testing.T) {
 		authHeader     string
 		wantStatus     int
 		wantNextCalled bool
+		wantBodySubstr string
 	}{
 		{
-			name:           "no admin token configured - request allowed with deduped warning",
+			name:           "no admin token configured - returns 501",
 			setToken:       "",
 			authHeader:     "",
-			wantStatus:     http.StatusOK,
-			wantNextCalled: true,
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+			wantBodySubstr: "Admin token is required to activate this endpoint",
+		},
+		{
+			name:           "no admin token configured - bearer ignored, still 501",
+			setToken:       "",
+			authHeader:     "Bearer anything",
+			wantStatus:     http.StatusNotImplemented,
+			wantNextCalled: false,
+			wantBodySubstr: "Admin token is required to activate this endpoint",
 		},
 		{
 			name:           "missing authorization header",
@@ -71,12 +82,12 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prev := os.Getenv(env.AdminTokenEnvVar)
+			prevToken := os.Getenv(env.AdminTokenEnvVar)
 			defer func() {
-				if prev == "" {
+				if prevToken == "" {
 					os.Unsetenv(env.AdminTokenEnvVar)
 				} else {
-					os.Setenv(env.AdminTokenEnvVar, prev)
+					os.Setenv(env.AdminTokenEnvVar, prevToken)
 				}
 			}()
 			if tt.setToken != "" {
@@ -100,6 +111,9 @@ func TestAdminAuthMiddleware(t *testing.T) {
 			}
 			if nextCalled != tt.wantNextCalled {
 				t.Errorf("nextCalled = %v, want %v", nextCalled, tt.wantNextCalled)
+			}
+			if tt.wantBodySubstr != "" && !strings.Contains(rec.Body.String(), tt.wantBodySubstr) {
+				t.Errorf("body = %q, want substring %q", rec.Body.String(), tt.wantBodySubstr)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Fixes CVE-2026-44300 by failing closed on admin-protected HTTP endpoints when `ADMIN_TOKEN` is unset.

- `adminAuthMiddleware` now returns HTTP 503 (with `Cache-Control: no-store`) when `ADMIN_TOKEN` is not configured, instead of warn-and-allow.
- `GET /helmValues` is now protected by `adminAuthMiddleware` (it returns decoded `HELM_VALUES`, which may contain secrets).

## Related Issues

Fixes CVE-2026-44300

## User Impact

**Breaking change.** Deployments without `ADMIN_TOKEN` lose access to:

- `POST /serviceKey`
- `GET /helmValues`
- `GET /cloudCost/rebuild`, `GET /cloudCost/repair`
- `GET /cloud/config/export`, `GET /cloud/config/enable`, `GET /cloud/config/disable`, `GET /cloud/config/delete`

Set `ADMIN_TOKEN` before using these endpoints. The [opencost-helm-chart](https://github.com/opencost/opencost-helm-chart) supports this via `opencost.exporter.adminToken` (currently opt-in / disabled by default).

If opencost-ui calls `/helmValues`, default installs without `ADMIN_TOKEN` will see an error until the token is configured.

## Testing

- `go test ./pkg/costmodel/ -run TestAdminAuth`
- Verified middleware returns 503 + `Cache-Control: no-store` when `ADMIN_TOKEN` is unset
- Verified 401/403 behavior unchanged when `ADMIN_TOKEN` is set