### PR TITLE
core: initialize and merge GPUAllocation in Allocation.add when recei…

### DIFF
--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -1376,6 +1376,10 @@ func (a *Allocation) add(that *Allocation) {
 		a.End = that.End
 	}
 
+	if a.GPUAllocation == nil && that.GPUAllocation != nil {
+		a.GPUAllocation = that.GPUAllocation.Clone()
+	}
+
 	// Convert cumulative request and usage back into rates
 	// TODO:TEST write a unit test that fails if this is done incorrectly
 	if a.Minutes() > 0 {
@@ -1385,10 +1389,6 @@ func (a *Allocation) add(that *Allocation) {
 		a.RAMBytesRequestAverage = ramReqByteMins / a.Minutes()
 		a.RAMBytesLimitAverage = ramLimByteMins / a.Minutes()
 		a.RAMBytesUsageAverage = ramUseByteMins / a.Minutes()
-
-		if a.GPUAllocation == nil && that.GPUAllocation != nil {
-			a.GPUAllocation = that.GPUAllocation.Clone()
-		}
 
 		if a.GPUAllocation != nil {
 			if gpuReqMins != nil {
@@ -1412,10 +1412,6 @@ func (a *Allocation) add(that *Allocation) {
 		a.RAMBytesRequestAverage = 0.0
 		a.RAMBytesLimitAverage = 0.0
 		a.RAMBytesUsageAverage = 0.0
-
-		if a.GPUAllocation == nil && that.GPUAllocation != nil {
-			a.GPUAllocation = that.GPUAllocation.Clone()
-		}
 
 		if a.GPUAllocation != nil {
 			a.GPUAllocation.GPURequestAverage = nil

--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -1386,6 +1386,10 @@ func (a *Allocation) add(that *Allocation) {
 		a.RAMBytesLimitAverage = ramLimByteMins / a.Minutes()
 		a.RAMBytesUsageAverage = ramUseByteMins / a.Minutes()
 
+		if a.GPUAllocation == nil && that.GPUAllocation != nil {
+			a.GPUAllocation = that.GPUAllocation.Clone()
+		}
+
 		if a.GPUAllocation != nil {
 			if gpuReqMins != nil {
 				gpuReqMinsRes := *gpuReqMins / a.Minutes()
@@ -1408,6 +1412,10 @@ func (a *Allocation) add(that *Allocation) {
 		a.RAMBytesRequestAverage = 0.0
 		a.RAMBytesLimitAverage = 0.0
 		a.RAMBytesUsageAverage = 0.0
+
+		if a.GPUAllocation == nil && that.GPUAllocation != nil {
+			a.GPUAllocation = that.GPUAllocation.Clone()
+		}
 
 		if a.GPUAllocation != nil {
 			a.GPUAllocation.GPURequestAverage = nil

--- a/core/pkg/opencost/allocation_test.go
+++ b/core/pkg/opencost/allocation_test.go
@@ -234,6 +234,44 @@ func TestAllocation_Add(t *testing.T) {
 	if act.RawAllocationOnly != nil {
 		t.Errorf("Allocation.Add: Raw only data must be nil after an add")
 	}
+
+	// Test GPUAllocation merging edge cases:
+	// Case A: Receiver has nil GPUAllocation, incoming has non-nil GPUAllocation
+	g1 := &Allocation{
+		Start:      s1,
+		End:        e1,
+		Window:     NewWindow(&s1, &e1),
+		Properties: &AllocationProperties{},
+	}
+	gpuReqVal := 1.0
+	gpuUseVal := 0.5
+	g2 := &Allocation{
+		Start:      s2,
+		End:        e2,
+		Window:     NewWindow(&s2, &e2),
+		Properties: &AllocationProperties{},
+		GPUAllocation: &GPUAllocation{
+			GPUDevice:         "nvidia-tesla-t4",
+			GPURequestAverage: &gpuReqVal,
+			GPUUsageAverage:   &gpuUseVal,
+		},
+	}
+	actG, err := g1.Add(g2)
+	if err != nil {
+		t.Fatalf("Allocation.Add: unexpected error: %s", err)
+	}
+	if actG.GPUAllocation == nil {
+		t.Fatalf("Allocation.Add: expected non-nil GPUAllocation from merge")
+	}
+	if actG.GPUAllocation.GPUDevice != "nvidia-tesla-t4" {
+		t.Errorf("Allocation.Add: expected GPUDevice 'nvidia-tesla-t4', got %s", actG.GPUAllocation.GPUDevice)
+	}
+	if actG.GPUAllocation.GPURequestAverage == nil || !util.IsApproximately(0.75, *actG.GPUAllocation.GPURequestAverage) {
+		t.Errorf("Allocation.Add: expected GPURequestAverage 0.75, got %v", actG.GPUAllocation.GPURequestAverage)
+	}
+	if actG.GPUAllocation.GPUUsageAverage == nil || !util.IsApproximately(0.375, *actG.GPUAllocation.GPUUsageAverage) {
+		t.Errorf("Allocation.Add: expected GPUUsageAverage 0.375, got %v", actG.GPUAllocation.GPUUsageAverage)
+	}
 }
 
 func TestAllocation_Share(t *testing.T) {


### PR DESCRIPTION
## Description
This PR resolves a bug in the [add](file:///Users/rucha/LFX/OpenCost/opencost/core/pkg/opencost/allocation.go#L1253) method of `Allocation` where GPU allocation data was lost during aggregation if the receiver allocation's `GPUAllocation` field was `nil` but the incoming allocation had a non-nil `GPUAllocation`. 

We now clone and initialize the incoming `GPUAllocation` if the receiver's is `nil`, ensuring that GPU metadata (model, device, etc.) is preserved and the average usage/request rates are correctly recalculated over the expanded time window.

## Related Issues
Fixes #3912

## User Impact
Ensures that GPU allocation metrics are correctly propagated and not dropped when aggregating workloads with mismatched GPU initialization states. No breaking changes or backwards compatibility issues.

## Testing
- Added new test cases verifying `GPUAllocation` merging and rate aggregation to [TestAllocation_Add](file:///Users/rucha/LFX/OpenCost/opencost/core/pkg/opencost/allocation_test.go#L46) in [allocation_test.go](file:///Users/rucha/LFX/OpenCost/opencost/core/pkg/opencost/allocation_test.go#L46).
- All core opencost unit tests pass successfully.