### PR TITLE
fix(azure): close response body and validate HTTP status codes

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -317,8 +317,9 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch retail price with URL \"%s\": %w", pricingURL, err)
 	}
+	defer resp.Body.Close()
 
-	if resp.StatusCode < 200 && resp.StatusCode > 299 {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return "", fmt.Errorf("retail price responded with error status code %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
## Summary

Fixes #3918

This PR fixes two issues in the Azure retail price lookup implementation.

### Changes

* Close the HTTP response body after the request completes to avoid leaking HTTP connections.
* Fix the HTTP status code validation logic so non-2xx responses are handled correctly before attempting to parse the response.

### Why

The response body was never closed, which could lead to unnecessary resource usage and leaks over time.

The existing status code check could never evaluate to true because it used `&&` instead of `||`. As a result, HTTP error responses were not handled correctly and could lead to parsing errors.

### Testing

* Verified the changes build successfully.
* Confirmed the response body is closed after each request.
* Confirmed non-2xx HTTP responses are now detected and returned as errors.
