### PR TITLE
fix(gcp): close response body in parsePages

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1020,6 +1020,7 @@ func (gcp *GCP) parsePages(inputKeys map[string]models.Key, pvKeys map[string]mo
 			return err
 		}
 		page, token, err := gcp.parsePage(resp.Body, inputKeys, pvKeys)
+		resp.Body.Close()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Close the HTTP response body returned by `httpClient.Get()` in the GCP pricing downloader after it has been consumed by `parsePage()`.

This ensures the response body is properly closed once it is no longer needed, following Go's `net/http` ownership contract.

## Related Issues

Fixes #3921

## User Impact

No user-facing changes.

This fixes an internal resource management issue by ensuring HTTP response bodies are properly closed after use. There are no API or behavioral changes.

## Testing

- Ran `go test ./pkg/cloud/gcp/...`
- Ran `go test ./...`