### PR TITLE
fix(prom): handle nil responses during rate-limit retries

### DIFF
--- a/core/pkg/util/httputil/httputil.go
+++ b/core/pkg/util/httputil/httputil.go
@@ -189,6 +189,9 @@ func ExponentialBackoffWaitFor(defaultWait time.Duration, retry int) time.Durati
 
 // IsRateLimitedResponse returns true if the status code is a 429 (TooManyRequests)
 func IsRateLimitedResponse(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
 	return resp.StatusCode == http.StatusTooManyRequests
 }
 
@@ -196,6 +199,9 @@ func IsRateLimitedResponse(resp *http.Response) bool {
 // has occurred. This function is a result of some API providers (AWS) returning
 // a 400 status code instead of 429 for rate limit exceptions.
 func IsRateLimitedBody(resp *http.Response, body []byte) bool {
+	if resp == nil {
+		return false
+	}
 	// ignore non-400 status
 	if resp.StatusCode < http.StatusBadRequest || resp.StatusCode >= http.StatusInternalServerError {
 		return false

--- a/modules/prometheus-source/pkg/prom/ratelimitedclient_test.go
+++ b/modules/prometheus-source/pkg/prom/ratelimitedclient_test.go
@@ -18,6 +18,8 @@ import (
 	prometheus "github.com/prometheus/client_golang/api"
 )
 
+var errTransportFailed = errors.New("dial tcp: connection refused")
+
 // ResponseAndBody is just a test objet used to hold predefined responses
 // and response bodies
 type ResponseAndBody struct {
@@ -401,7 +403,7 @@ func TestRateLimitedRetryTransportError(t *testing.T) {
 		{
 			Response: nil,
 			Body:     nil,
-			Error:    errors.New("dial tcp: connection refused"),
+			Error:    errTransportFailed,
 		},
 	})
 
@@ -425,7 +427,7 @@ func TestRateLimitedRetryTransportError(t *testing.T) {
 	}
 
 	_, _, err = client.Do(context.Background(), req)
-	if err == nil {
-		t.Fatal("expected a transport error, got nil")
+	if !errors.Is(err, errTransportFailed) {
+		t.Fatalf("Expected %v, got %v", errTransportFailed, err)
 	}
 }

--- a/modules/prometheus-source/pkg/prom/ratelimitedclient_test.go
+++ b/modules/prometheus-source/pkg/prom/ratelimitedclient_test.go
@@ -3,6 +3,7 @@ package prom
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"math"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 type ResponseAndBody struct {
 	Response *http.Response
 	Body     []byte
+	Error    error
 }
 
 // MockPromClient accepts a slice of responses and bodies to return on requests made.
@@ -51,7 +53,7 @@ func (mpc *MockPromClient) Do(context.Context, *http.Request) (*http.Response, [
 		mpc.current = 0
 	}
 
-	return rnb.Response, rnb.Body, nil
+	return rnb.Response, rnb.Body, rnb.Error
 }
 
 // Creates a new mock prometheus client
@@ -387,5 +389,43 @@ func TestConcurrentRateLimiting(t *testing.T) {
 		}
 
 		t.Logf("%s\n", rateLimitErr.Error())
+	}
+}
+
+// Test transport errors during rate-limit retries.
+func TestRateLimitedRetryTransportError(t *testing.T) {
+	t.Parallel()
+
+	promClient := newMockPromClientWith([]*ResponseAndBody{
+		newNormalRateLimitedResponse("0"),
+		{
+			Response: nil,
+			Body:     nil,
+			Error:    errors.New("dial tcp: connection refused"),
+		},
+	})
+
+	client, err := NewRateLimitedClient(
+		"TestClient",
+		promClient,
+		1,
+		nil,
+		nil,
+		newTestRetryOpts(),
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = client.Do(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected a transport error, got nil")
 	}
 }

--- a/pkg/costmodel/router_test.go
+++ b/pkg/costmodel/router_test.go
@@ -20,13 +20,13 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		setToken          string
-		authHeader        string
-		wantStatus        int
-		wantNextCalled    bool
-		wantBodySubstr    string
-		wantCacheControl  string
+		name             string
+		setToken         string
+		authHeader       string
+		wantStatus       int
+		wantNextCalled   bool
+		wantBodySubstr   string
+		wantCacheControl string
 	}{
 		{
 			name:             "no admin token configured - returns 503",


### PR DESCRIPTION
## Description

Fix a nil pointer dereference in `RateLimitedPrometheusClient` when a transport error occurs during a rate-limit retry.

If an initial request receives an HTTP `429 Too Many Requests` response and a subsequent retry fails at the transport layer, the upstream Prometheus client returns `(nil, nil, err)`. The retry path may then evaluate the rate-limit helpers with a nil response, resulting in a panic.

This change adds nil guards to the shared rate-limit helper functions and adds a regression test covering this retry path.

## Related Issues

Fixes #3926

## User Impact

Prevents a nil pointer dereference during a transport failure on a rate-limit retry. Transport errors are now returned to the caller instead of causing a panic.

This is not a breaking change and is fully backward compatible.

## Testing

- Added a regression test covering a transport error during a rate-limit retry.
- Verified the new regression test passes.
- Ran:
  - `go test ./pkg/prom/...`
  - `go test ./pkg/util/httputil/...`