### PR TITLE
fix(gcp): handle AggregatedList pagination

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -328,11 +328,6 @@ func (gcp *GCP) ClusterManagementPricing() (string, float64, error) {
 }
 
 func (gcp *GCP) getAllAddresses() (*compute.AddressAggregatedList, error) {
-	projID, err := gcp.MetadataClient.ProjectID()
-	if err != nil {
-		return nil, err
-	}
-
 	client, err := google.DefaultClient(context.TODO(),
 		"https://www.googleapis.com/auth/compute.readonly")
 	if err != nil {
@@ -344,13 +339,34 @@ func (gcp *GCP) getAllAddresses() (*compute.AddressAggregatedList, error) {
 		return nil, err
 	}
 
-	res, err := svc.Addresses.AggregatedList(projID).Do()
+	return getAllAddressesWithService(gcp, svc)
+}
 
+func getAllAddressesWithService(gcp *GCP, svc *compute.Service) (*compute.AddressAggregatedList, error) {
+	projID, err := gcp.MetadataClient.ProjectID()
 	if err != nil {
 		return nil, err
 	}
 
-	return res, nil
+	merged := &compute.AddressAggregatedList{
+		Items: make(map[string]compute.AddressesScopedList),
+	}
+
+	if err := svc.Addresses.AggregatedList(projID).Pages(
+		context.TODO(),
+		func(page *compute.AddressAggregatedList) error {
+			for scope, scopedList := range page.Items {
+				existing := merged.Items[scope]
+				existing.Addresses = append(existing.Addresses, scopedList.Addresses...)
+				merged.Items[scope] = existing
+			}
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return merged, nil
 }
 
 func (gcp *GCP) GetAddresses() ([]byte, error) {
@@ -368,11 +384,6 @@ func (gcp *GCP) isAddressOrphaned(address *compute.Address) bool {
 }
 
 func (gcp *GCP) getAllDisks() (*compute.DiskAggregatedList, error) {
-	projID, err := gcp.MetadataClient.ProjectID()
-	if err != nil {
-		return nil, err
-	}
-
 	client, err := google.DefaultClient(context.TODO(),
 		"https://www.googleapis.com/auth/compute.readonly")
 	if err != nil {
@@ -384,13 +395,34 @@ func (gcp *GCP) getAllDisks() (*compute.DiskAggregatedList, error) {
 		return nil, err
 	}
 
-	res, err := svc.Disks.AggregatedList(projID).Do()
+	return getAllDisksWithService(gcp, svc)
+}
 
+func getAllDisksWithService(gcp *GCP, svc *compute.Service) (*compute.DiskAggregatedList, error) {
+	projID, err := gcp.MetadataClient.ProjectID()
 	if err != nil {
 		return nil, err
 	}
 
-	return res, nil
+	merged := &compute.DiskAggregatedList{
+		Items: make(map[string]compute.DisksScopedList),
+	}
+
+	if err := svc.Disks.AggregatedList(projID).Pages(
+		context.TODO(),
+		func(page *compute.DiskAggregatedList) error {
+			for zone, scopedList := range page.Items {
+				existing := merged.Items[zone]
+				existing.Disks = append(existing.Disks, scopedList.Disks...)
+				merged.Items[zone] = existing
+			}
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return merged, nil
 }
 
 // GetDisks returns the GCP disks backing PVs. Useful because sometimes k8s will not clean up PVs correctly. Requires a json config in /var/configs with key region.

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"reflect"
@@ -11,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
 	"github.com/google/martian/log"
 	"github.com/opencost/opencost/core/pkg/clustercache"
 	"github.com/opencost/opencost/pkg/cloud/httputil"
@@ -18,6 +21,7 @@ import (
 	"github.com/opencost/opencost/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -590,6 +594,111 @@ func TestGCP_GetDisks(t *testing.T) {
 	// This line should not be reached due to panic, but if it is, we expect an error
 	if err == nil {
 		t.Error("Expected error due to nil metadata client")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newFakeMetadataServer(projectID string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Metadata-Flavor", "Google")
+		_, _ = w.Write([]byte(projectID))
+	}))
+}
+
+func newFakeComputeService(t *testing.T, handler http.HandlerFunc) (*compute.Service, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	svc, err := compute.NewService(t.Context(), option.WithoutAuthentication(), option.WithEndpoint(srv.URL+"/"))
+	if err != nil {
+		srv.Close()
+		t.Fatalf("compute.NewService: %v", err)
+	}
+	return svc, srv
+}
+
+func fakeMetadataClient(srv *httptest.Server) *metadata.Client {
+	return metadata.NewClient(&http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r2 := r.Clone(r.Context())
+			r2.URL.Host = srv.Listener.Addr().String()
+			r2.URL.Scheme = "http"
+			return http.DefaultTransport.RoundTrip(r2)
+		}),
+	})
+}
+
+func TestGetAllDisks_Pagination(t *testing.T) {
+	page1 := &compute.DiskAggregatedList{
+		Items:         map[string]compute.DisksScopedList{"zones/us-central1-a": {Disks: []*compute.Disk{{Name: "disk-1"}}}},
+		NextPageToken: "tok",
+	}
+	page2 := &compute.DiskAggregatedList{
+		Items: map[string]compute.DisksScopedList{"zones/us-central1-a": {Disks: []*compute.Disk{{Name: "disk-2"}}}},
+	}
+
+	svc, computeSrv := newFakeComputeService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("pageToken") == "tok" {
+			_ = json.NewEncoder(w).Encode(page2)
+		} else {
+			_ = json.NewEncoder(w).Encode(page1)
+		}
+	})
+	defer computeSrv.Close()
+
+	metaSrv := newFakeMetadataServer("test-project")
+	defer metaSrv.Close()
+
+	got, err := getAllDisksWithService(&GCP{MetadataClient: fakeMetadataClient(metaSrv)}, svc)
+	if err != nil {
+		t.Fatalf("getAllDisksWithService: %v", err)
+	}
+
+	total := 0
+	for _, sl := range got.Items {
+		total += len(sl.Disks)
+	}
+	if total != 2 {
+		t.Errorf("expected 2 disks across all pages, got %d", total)
+	}
+}
+
+func TestGetAllAddresses_Pagination(t *testing.T) {
+	page1 := &compute.AddressAggregatedList{
+		Items:         map[string]compute.AddressesScopedList{"regions/us-central1": {Addresses: []*compute.Address{{Name: "addr-1"}}}},
+		NextPageToken: "tok",
+	}
+	page2 := &compute.AddressAggregatedList{
+		Items: map[string]compute.AddressesScopedList{"regions/us-central1": {Addresses: []*compute.Address{{Name: "addr-2"}}}},
+	}
+
+	svc, computeSrv := newFakeComputeService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("pageToken") == "tok" {
+			_ = json.NewEncoder(w).Encode(page2)
+		} else {
+			_ = json.NewEncoder(w).Encode(page1)
+		}
+	})
+	defer computeSrv.Close()
+
+	metaSrv := newFakeMetadataServer("test-project")
+	defer metaSrv.Close()
+
+	got, err := getAllAddressesWithService(&GCP{MetadataClient: fakeMetadataClient(metaSrv)}, svc)
+	if err != nil {
+		t.Fatalf("getAllAddressesWithService: %v", err)
+	}
+
+	total := 0
+	for _, sl := range got.Items {
+		total += len(sl.Addresses)
+	}
+	if total != 2 {
+		t.Errorf("expected 2 addresses across all pages, got %d", total)
 	}
 }
 

--- a/pkg/costmodel/router_test.go
+++ b/pkg/costmodel/router_test.go
@@ -20,13 +20,13 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		setToken          string
-		authHeader        string
-		wantStatus        int
-		wantNextCalled    bool
-		wantBodySubstr    string
-		wantCacheControl  string
+		name             string
+		setToken         string
+		authHeader       string
+		wantStatus       int
+		wantNextCalled   bool
+		wantBodySubstr   string
+		wantCacheControl string
 	}{
 		{
 			name:             "no admin token configured - returns 503",


### PR DESCRIPTION
## Description

Fix GCP `AggregatedList` pagination when retrieving persistent disks and static IP addresses.

`getAllDisks()` and `getAllAddresses()` previously used the Google Compute Engine SDK's `AggregatedList(...).Do()` method, which only retrieves a single page of results. For projects with more than the default page size (500 resources), any remaining disks or addresses were silently omitted.

This change switches to the SDK's `Pages()` iterator so all pages are retrieved and merged before returning the result. The pagination logic is extracted into package-private helpers to enable deterministic regression testing.

## Related Issues

Fixes #3931

## User Impact

This fixes incomplete orphaned resource detection for larger GCP projects.

Previously, only the first page of disks and static IP addresses was processed, so orphaned resources beyond the first page could be missed.

There are no breaking changes or API changes. Behavior for projects with 500 or fewer resources is unchanged.

## Testing

- Added regression tests for:
  - `getAllDisks()`
  - `getAllAddresses()`
- Verified multi-page `AggregatedList` responses are retrieved and merged correctly using a mocked Compute Engine API.
- Ran:
  ```bash
  go fmt ./pkg/cloud/gcp/...
  go vet ./pkg/cloud/gcp/...
  go test -race ./pkg/cloud/gcp/...
  go test ./pkg/cloud/gcp/...
  ```
- Verified all existing GCP provider tests continue to pass.