### PR TITLE
feat(cloud): dynamic AWS & GCP load balancer pricing lookup

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -68,6 +68,8 @@ type Service struct {
 	Type         v1.ServiceType
 	Status       v1.ServiceStatus
 	ClusterIP    string
+	Labels       map[string]string
+	Annotations  map[string]string
 }
 
 type DaemonSet struct {
@@ -310,6 +312,8 @@ func TransformService(input *v1.Service) *Service {
 		Type:         input.Spec.Type,
 		Status:       input.Status,
 		ClusterIP:    input.Spec.ClusterIP,
+		Labels:       input.Labels,
+		Annotations:  input.Annotations,
 	}
 }
 

--- a/core/pkg/external/configmapsource_test.go
+++ b/core/pkg/external/configmapsource_test.go
@@ -333,11 +333,11 @@ labels:
 
 func TestFilterValidLabels_AllValid_ReturnedUnchanged(t *testing.T) {
 	in := map[string]string{
-		"env":                     "prod",
-		"region":                  "us-east-1",
-		"app.kubernetes.io/name":  "opencost",
-		"my-key":                  "my-value",
-		"a":                       "b",
+		"env":                    "prod",
+		"region":                 "us-east-1",
+		"app.kubernetes.io/name": "opencost",
+		"my-key":                 "my-value",
+		"a":                      "b",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -396,8 +396,8 @@ func TestFilterValidLabels_KeyTooLong_EntryDropped(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 	in := map[string]string{
-		"app.kubernetes.io/name":      "opencost",
-		"example.com/env":             "staging",
+		"app.kubernetes.io/name": "opencost",
+		"example.com/env":        "staging",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -405,7 +405,7 @@ func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) {
 	in := map[string]string{
-		"valid":          "kept",
+		"valid":         "kept",
 		"-bad.prefix/k": "dropped",
 	}
 	out := filterValidLabels(in)
@@ -414,10 +414,10 @@ func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) 
 
 func TestFilterValidLabels_MixedValidAndInvalid_OnlyValidReturned(t *testing.T) {
 	in := map[string]string{
-		"cluster":    "prod",
-		"":           "no-key",
-		"bad-value":  "-oops",
-		"region":     "eu-west-1",
+		"cluster":   "prod",
+		"":          "no-key",
+		"bad-value": "-oops",
+		"region":    "eu-west-1",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, map[string]string{"cluster": "prod", "region": "eu-west-1"}, out)

--- a/pkg/cloud/alibaba/provider.go
+++ b/pkg/cloud/alibaba/provider.go
@@ -554,7 +554,7 @@ func (alibaba *Alibaba) PVPricing(pvk models.PVKey) (*models.PV, error) {
 
 // Inter zone and Inter region network cost are defaulted based on https://www.alibabacloud.com/help/en/cloud-data-transmission/latest/cross-region-data-transfers
 // Internet cost is default based on https://www.alibabacloud.com/help/en/elastic-compute-service/latest/public-bandwidth to $0.123
-func (alibaba *Alibaba) NetworkPricing() (*models.Network, error) {
+func (alibaba *Alibaba) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := alibaba.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -591,7 +591,7 @@ func (alibaba *Alibaba) NetworkPricing() (*models.Network, error) {
 
 // Alibaba loadbalancer has three different types https://www.alibabacloud.com/product/server-load-balancer,
 // defaulted price to classic load balancer https://www.alibabacloud.com/help/en/server-load-balancer/latest/pay-as-you-go.
-func (alibaba *Alibaba) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (alibaba *Alibaba) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	cpricing, err := alibaba.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/alibaba/provider_test.go
+++ b/pkg/cloud/alibaba/provider_test.go
@@ -1225,7 +1225,7 @@ func TestPVPricing_Error(t *testing.T) {
 
 func TestNetworkPricing_Error(t *testing.T) {
 	a := &Alibaba{Config: &fakeProviderConfig{}}
-	_, err := a.NetworkPricing()
+	_, err := a.NetworkPricing(nil)
 	if err == nil {
 		t.Fatalf("NetworkPricing should return error for missing config")
 	}
@@ -1233,7 +1233,7 @@ func TestNetworkPricing_Error(t *testing.T) {
 
 func TestLoadBalancerPricing_Error(t *testing.T) {
 	a := &Alibaba{Config: &fakeProviderConfig{}}
-	_, err := a.LoadBalancerPricing()
+	_, err := a.LoadBalancerPricing(nil)
 	if err == nil {
 		t.Fatalf("LoadBalancerPricing should return error for missing config")
 	}
@@ -1614,7 +1614,7 @@ func TestNetworkPricing_WithValidConfig(t *testing.T) {
 		},
 	}
 
-	network, err := a.NetworkPricing()
+	network, err := a.NetworkPricing(nil)
 	if err != nil {
 		t.Logf("NetworkPricing failed as expected: %v", err)
 	} else {
@@ -1634,7 +1634,7 @@ func TestLoadBalancerPricing_WithValidConfig(t *testing.T) {
 		},
 	}
 
-	lb, err := a.LoadBalancerPricing()
+	lb, err := a.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Logf("LoadBalancerPricing failed as expected: %v", err)
 	} else {

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1198,25 +1198,27 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 						Sku:          product.Sku,
 						LoadBalancer: &models.LoadBalancer{},
 					}
-					key := product.Attributes.RegionCode + ",LoadBalancerUsage"
-					aws.Pricing[key] = productTerms
-					skuToPricingKeyMap[product.Sku] = key
-					aws.ValidPricingKeys[key] = true
-
-					var specKey string
+					genericKey := product.Attributes.RegionCode + ",LoadBalancerUsage"
+					pricingKey := genericKey
 					switch product.Attributes.Operation {
 					case "LoadBalancing:Network":
-						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Network"
+						pricingKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Network"
 					case "LoadBalancing:Application":
-						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Application"
+						pricingKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Application"
 					case "LoadBalancing":
-						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Classic"
+						pricingKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Classic"
 					}
+					aws.Pricing[pricingKey] = productTerms
+					skuToPricingKeyMap[product.Sku] = pricingKey
+					aws.ValidPricingKeys[pricingKey] = true
 
-					if specKey != "" {
-						aws.Pricing[specKey] = productTerms
-						skuToPricingKeyMap[product.Sku] = specKey
-						aws.ValidPricingKeys[specKey] = true
+					// Preserve a stable generic fallback key (prefer Network when available).
+					if pricingKey == genericKey || product.Attributes.Operation == "LoadBalancing:Network" {
+						aws.Pricing[genericKey] = productTerms
+						aws.ValidPricingKeys[genericKey] = true
+					} else if _, exists := aws.Pricing[genericKey]; !exists {
+						aws.Pricing[genericKey] = productTerms
+						aws.ValidPricingKeys[genericKey] = true
 					}
 				}
 			}
@@ -1478,6 +1480,7 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
+	// RLock is acquired to prevent data races with concurrent pricing downloads updating the aws.Pricing map.
 	aws.DownloadPricingDataLock.RLock()
 	defer aws.DownloadPricingDataLock.RUnlock()
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1399,8 +1399,7 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
-	// TODO: determine key based on function arguments
-	// this is something that should be changed in the Provider interface
+	// TODO: use lbKey to select a more specific pricing entry when available.
 
 	key := aws.ClusterRegion + ",LoadBalancerUsage"
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1147,10 +1147,8 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 					skusToKeys[product.Sku] = key
 					aws.ValidPricingKeys[key] = true
 					aws.ValidPricingKeys[spotKey] = true
-				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") && product.Attributes.Operation == "LoadBalancing:Network" {
-					// since the costmodel is only using services of type LoadBalancer
-					// (and not ingresses controlled by AWS load balancer controller)
-					// we can safely filter for Network load balancers only
+				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") {
+					// Parse different types of load balancers when available.
 					productTerms := &AWSProductTerms{
 						Sku:          product.Sku,
 						LoadBalancer: &models.LoadBalancer{},
@@ -1160,6 +1158,22 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 					aws.Pricing[key] = productTerms
 					skusToKeys[product.Sku] = key
 					aws.ValidPricingKeys[key] = true
+
+					var specKey string
+					switch product.Attributes.Operation {
+					case "LoadBalancing:Network":
+						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Network"
+					case "LoadBalancing:Application":
+						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Application"
+					case "LoadBalancing":
+						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Classic"
+					}
+
+					if specKey != "" {
+						aws.Pricing[specKey] = productTerms
+						skusToKeys[product.Sku] = specKey
+						aws.ValidPricingKeys[specKey] = true
+					}
 				}
 			}
 		}
@@ -1399,13 +1413,36 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
-	// TODO: use lbKey to select a more specific pricing entry when available.
+	hourlyCost := 0.025 // set default price
 
+	if lbKey != nil {
+		features := strings.ToLower(lbKey.Features())
+		id := strings.ToLower(lbKey.ID())
+
+		var specKey string
+		if strings.Contains(features, "nlb") || strings.Contains(features, "network") ||
+			strings.Contains(id, "nlb") || strings.Contains(id, "network") {
+			specKey = aws.ClusterRegion + ",LoadBalancerUsage:Network"
+		} else if strings.Contains(features, "alb") || strings.Contains(features, "application") ||
+			strings.Contains(id, "alb") || strings.Contains(id, "application") {
+			specKey = aws.ClusterRegion + ",LoadBalancerUsage:Application"
+		} else if strings.Contains(features, "clb") || strings.Contains(features, "classic") ||
+			strings.Contains(id, "clb") || strings.Contains(id, "classic") {
+			specKey = aws.ClusterRegion + ",LoadBalancerUsage:Classic"
+		}
+
+		if specKey != "" {
+			if terms, ok := aws.Pricing[specKey]; ok {
+				hourlyCost = terms.LoadBalancer.Cost
+				return &models.LoadBalancer{
+					Cost: hourlyCost,
+				}, nil
+			}
+		}
+	}
+
+	// Fallback to standard generic LoadBalancerUsage key
 	key := aws.ClusterRegion + ",LoadBalancerUsage"
-
-	// set default price
-	hourlyCost := 0.025
-	// use price index when available
 	if terms, ok := aws.Pricing[key]; ok {
 		hourlyCost = terms.LoadBalancer.Cost
 	}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1363,7 +1363,7 @@ func (aws *AWS) spotPricingFromHistory(k models.Key) (*SpotPriceHistoryEntry, bo
 }
 
 // Stubbed NetworkPricing for AWS. Pull directly from aws.json for now
-func (aws *AWS) NetworkPricing() (*models.Network, error) {
+func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error) {
 	cpricing, err := aws.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1398,7 +1398,7 @@ func (aws *AWS) NetworkPricing() (*models.Network, error) {
 	}, nil
 }
 
-func (aws *AWS) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
 	// TODO: determine key based on function arguments
 	// this is something that should be changed in the Provider interface
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1194,10 +1194,6 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 					aws.ValidPricingKeys[spotKey] = true
 				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") {
 					// Parse different types of load balancers when available.
-				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") && product.Attributes.Operation == "LoadBalancing:Network" {
-					// Parse Network Load Balancer pricing
-					// Note: Only NLBs are tracked since costmodel uses LoadBalancer services,
-					// not ingresses controlled by AWS load balancer controller
 					productTerms := &AWSProductTerms{
 						Sku:          product.Sku,
 						LoadBalancer: &models.LoadBalancer{},
@@ -1219,7 +1215,7 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 
 					if specKey != "" {
 						aws.Pricing[specKey] = productTerms
-						skusToKeys[product.Sku] = specKey
+						skuToPricingKeyMap[product.Sku] = specKey
 						aws.ValidPricingKeys[specKey] = true
 					}
 				}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1413,6 +1413,9 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
+	aws.DownloadPricingDataLock.RLock()
+	defer aws.DownloadPricingDataLock.RUnlock()
+
 	hourlyCost := 0.025 // set default price
 
 	if lbKey != nil {

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -298,6 +298,7 @@ func Test_populate_pricing(t *testing.T) {
 		"us-east-2,m5.large,linux":                  expectedProdTermsInstanceOndemand,
 		"us-east-2,m5.large,linux,preemptible":      expectedProdTermsInstanceSpot,
 		"us-east-2,LoadBalancerUsage":               expectedProdTermsLoadbalancer,
+		"us-east-2,LoadBalancerUsage:Network":       expectedProdTermsLoadbalancer,
 	}
 
 	if !reflect.DeepEqual(expectedPricing, awsTest.Pricing) {
@@ -1294,4 +1295,76 @@ func TestAWS_PricingSourceStatus_spotPriceHistory(t *testing.T) {
 			t.Error("Expected Available=true when cache initialized")
 		}
 	})
+}
+
+func TestAWS_LoadBalancerPricing(t *testing.T) {
+	aws := &AWS{
+		ClusterRegion: "us-east-2",
+		Pricing: map[string]*AWSProductTerms{
+			"us-east-2,LoadBalancerUsage": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0225},
+			},
+			"us-east-2,LoadBalancerUsage:Network": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0225},
+			},
+			"us-east-2,LoadBalancerUsage:Application": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0252},
+			},
+			"us-east-2,LoadBalancerUsage:Classic": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0280},
+			},
+		},
+	}
+
+	cases := []struct {
+		name         string
+		key          models.LBKey
+		expectedCost float64
+	}{
+		{
+			name:         "Nil key defaults to LoadBalancerUsage fallback",
+			key:          nil,
+			expectedCost: 0.0225,
+		},
+		{
+			name: "NLB by feature name",
+			key: &models.CustomLBKey{
+				LBFeatures: "nlb-service",
+			},
+			expectedCost: 0.0225,
+		},
+		{
+			name: "ALB by ID",
+			key: &models.CustomLBKey{
+				LBID: "aws-loadbalancer-alb-1234",
+			},
+			expectedCost: 0.0252,
+		},
+		{
+			name: "Classic LB by features",
+			key: &models.CustomLBKey{
+				LBFeatures: "classic-lb",
+			},
+			expectedCost: 0.0280,
+		},
+		{
+			name: "Unknown key defaults to generic LoadBalancerUsage",
+			key: &models.CustomLBKey{
+				LBFeatures: "some-unknown-type",
+			},
+			expectedCost: 0.0225,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lb, err := aws.LoadBalancerPricing(tc.key)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if lb.Cost != tc.expectedCost {
+				t.Errorf("expected cost %f, got %f", tc.expectedCost, lb.Cost)
+			}
+		})
+	}
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -304,7 +304,7 @@ func Test_populate_pricing(t *testing.T) {
 		t.Fatalf("expected parsed pricing did not match actual parsed result (us-east-2)")
 	}
 
-	lbPricing, _ := awsTest.LoadBalancerPricing()
+	lbPricing, _ := awsTest.LoadBalancerPricing(nil)
 	if lbPricing.Cost != 0.0225 {
 		t.Fatalf("expected loadbalancer pricing of 0.0225 but got %f (us-east-2)", lbPricing.Cost)
 	}

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -1369,6 +1369,8 @@ func TestAWS_LoadBalancerPricing(t *testing.T) {
 			}
 		})
 	}
+}
+
 func TestAWS_findCostForDisk(t *testing.T) {
 	aws := &AWS{
 		ClusterRegion: "us-east-1",

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1453,7 +1453,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 }
 
 // Stubbed NetworkPricing for Azure. Pull directly from azure.json for now
-func (az *Azure) NetworkPricing() (*models.Network, error) {
+func (az *Azure) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := az.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1492,7 +1492,7 @@ func (az *Azure) NetworkPricing() (*models.Network, error) {
 // services will be that of a standard static public IP https://azure.microsoft.com/en-us/pricing/details/ip-addresses/.
 // Azure still has load balancers which follow the standard pricing scheme based on rules
 // https://azure.microsoft.com/en-us/pricing/details/load-balancer/, they are created on a per-cluster basis.
-func (azr *Azure) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (azr *Azure) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.005,
 	}, nil

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -788,14 +788,13 @@ func fallbackPV(key models.PVKey) (*models.PV, error) {
 // - Public Network Load Balancer:       ~$0.02232/hr
 // - Statically sized Load Balancers:    $0.01786–$0.10714/hr
 //
-// However, the current OpenCost provider interface does not pass information about
-// individual Load Balancer characteristics (like annotations or network mode).
+// The provider interface has been updated to accept models.LBKey.
 //
-// As a result, this implementation uses a fixed average hourly rate of $0.02,
-// which is representative of the most common DO LBs.
+// However, the current implementation still uses a fixed average hourly rate of $0.02,
+// which is representative of the most common DO LBs, because the key is not yet used for
+// pricing selection.
 //
-// TODO Once the provider interface supports more granular Load Balancer metadata,
-// this method should be updated to assign costs more precisely.
+// TODO: Update this method to use the key for assigning costs more precisely when dynamic lookup is supported.
 func (do *DOKS) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	hourlyCost := 0.02
 	return &models.LoadBalancer{

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -796,14 +796,14 @@ func fallbackPV(key models.PVKey) (*models.PV, error) {
 //
 // TODO Once the provider interface supports more granular Load Balancer metadata,
 // this method should be updated to assign costs more precisely.
-func (do *DOKS) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (do *DOKS) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	hourlyCost := 0.02
 	return &models.LoadBalancer{
 		Cost: hourlyCost,
 	}, nil
 }
 
-func (do *DOKS) NetworkPricing() (*models.Network, error) {
+func (do *DOKS) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	// fallback
 	const (
 		defaultZoneEgress        = 0.00

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1165,7 +1165,7 @@ func (gcp *GCP) PVPricing(pvk models.PVKey) (*models.PV, error) {
 }
 
 // Stubbed NetworkPricing for GCP. Pull directly from gcp.json for now
-func (gcp *GCP) NetworkPricing() (*models.Network, error) {
+func (gcp *GCP) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := gcp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1200,7 +1200,7 @@ func (gcp *GCP) NetworkPricing() (*models.Network, error) {
 	}, nil
 }
 
-func (gcp *GCP) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (gcp *GCP) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	fffrc := 0.025
 	afrc := 0.010
 	lbidc := 0.008

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -630,6 +630,28 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 					return nil, "", err
 				}
 
+				// Check if this is a load balancer forwarding rule
+				if strings.Contains(product.Description, "Forwarding Rule") || product.Category.ResourceGroup == "ForwardingRule" {
+					var lbType string
+					descLower := strings.ToLower(product.Description)
+					if strings.Contains(descLower, "external http") || strings.Contains(descLower, "global forwarding rule") {
+						lbType = "external-http"
+					} else if strings.Contains(descLower, "internal http") {
+						lbType = "internal-http"
+					} else if strings.Contains(descLower, "regional forwarding rule") || strings.Contains(descLower, "network") || strings.Contains(descLower, "tcp") {
+						lbType = "network-tcp"
+					} else if strings.Contains(descLower, "ssl proxy") || strings.Contains(descLower, "ssl") || strings.Contains(descLower, "proxy") {
+						lbType = "ssl-proxy"
+					}
+
+					if lbType != "" {
+						for _, region := range product.ServiceRegions {
+							candidateKey := region + ",ForwardingRule:" + lbType
+							gcpPricingList[candidateKey] = product
+						}
+					}
+				}
+
 				usageType := strings.ToLower(product.Category.UsageType)
 				instanceType := strings.ToLower(product.Category.ResourceGroup)
 
@@ -1200,7 +1222,72 @@ func (gcp *GCP) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	}, nil
 }
 
+func getGCPPricingRate(product *GCPPricing) (float64, error) {
+	if len(product.PricingInfo) == 0 || product.PricingInfo[0].PricingExpression == nil {
+		return 0.0, fmt.Errorf("no pricing expression")
+	}
+	pe := product.PricingInfo[0].PricingExpression
+	lastRateIndex := len(pe.TieredRates) - 1
+	if lastRateIndex < 0 {
+		return 0.0, fmt.Errorf("no rates found")
+	}
+	rate := pe.TieredRates[lastRateIndex]
+	nanos := float64(rate.UnitPrice.Nanos)
+	units, err := strconv.ParseFloat(rate.UnitPrice.Units, 64)
+	if err != nil {
+		units = 0
+	}
+	price := units + nanos*math.Pow10(-9)
+	// If the unit is month or similar, convert it to hourly rate
+	if strings.Contains(strings.ToLower(pe.UsageUnit), "month") || strings.Contains(strings.ToLower(pe.UsageUnitDescription), "month") {
+		price = price / 730.0
+	}
+	return price, nil
+}
+
 func (gcp *GCP) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
+	if key != nil {
+		features := strings.ToLower(key.Features())
+		id := strings.ToLower(key.ID())
+
+		var lbType string
+		if strings.Contains(features, "external-http") || strings.Contains(features, "external") || (strings.Contains(features, "http") && !strings.Contains(features, "internal")) ||
+			strings.Contains(id, "external-http") || strings.Contains(id, "external") || (strings.Contains(id, "http") && !strings.Contains(id, "internal")) {
+			lbType = "external-http"
+		} else if strings.Contains(features, "internal-http") || (strings.Contains(features, "internal") && strings.Contains(features, "http")) ||
+			strings.Contains(id, "internal-http") || (strings.Contains(id, "internal") && strings.Contains(id, "http")) {
+			lbType = "internal-http"
+		} else if strings.Contains(features, "network") || strings.Contains(features, "tcp") ||
+			strings.Contains(id, "network") || strings.Contains(id, "tcp") {
+			lbType = "network-tcp"
+		} else if strings.Contains(features, "ssl") || strings.Contains(features, "proxy") ||
+			strings.Contains(id, "ssl") || strings.Contains(id, "proxy") {
+			lbType = "ssl-proxy"
+		}
+
+		if lbType != "" {
+			region := gcp.ClusterRegion
+			if region == "" {
+				region = "us-central1"
+			}
+			cacheKey := region + ",ForwardingRule:" + lbType
+
+			gcp.DownloadPricingDataLock.RLock()
+			product, ok := gcp.Pricing[cacheKey]
+			gcp.DownloadPricingDataLock.RUnlock()
+
+			if ok {
+				price, err := getGCPPricingRate(product)
+				if err == nil {
+					return &models.LoadBalancer{
+						Cost: price,
+					}, nil
+				}
+			}
+		}
+	}
+
+	// Fallback to standard defaults
 	fffrc := 0.025
 	afrc := 0.010
 	lbidc := 0.008

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1227,15 +1227,33 @@ func getGCPPricingRate(product *GCPPricing) (float64, error) {
 		return 0.0, fmt.Errorf("no pricing expression")
 	}
 	pe := product.PricingInfo[0].PricingExpression
-	lastRateIndex := len(pe.TieredRates) - 1
-	if lastRateIndex < 0 {
-		return 0.0, fmt.Errorf("no rates found")
+
+	var rate *TieredRates
+	for _, r := range pe.TieredRates {
+		if r != nil && r.StartUsageAmount == 0 {
+			rate = r
+			break
+		}
 	}
-	rate := pe.TieredRates[lastRateIndex]
+	if rate == nil {
+		for _, r := range pe.TieredRates {
+			if r != nil {
+				rate = r
+				break
+			}
+		}
+	}
+	if rate == nil {
+		return 0.0, fmt.Errorf("no non-nil tiered rates found")
+	}
+	if rate.UnitPrice == nil {
+		return 0.0, fmt.Errorf("tiered rate unit price is nil")
+	}
+
 	nanos := float64(rate.UnitPrice.Nanos)
 	units, err := strconv.ParseFloat(rate.UnitPrice.Units, 64)
 	if err != nil {
-		units = 0
+		return 0.0, fmt.Errorf("failed to parse rate unit price units %q: %w", rate.UnitPrice.Units, err)
 	}
 	price := units + nanos*math.Pow10(-9)
 	// If the unit is month or similar, convert it to hourly rate

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -634,7 +634,7 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 				if strings.Contains(product.Description, "Forwarding Rule") || product.Category.ResourceGroup == "ForwardingRule" {
 					var lbType string
 					descLower := strings.ToLower(product.Description)
-					if strings.Contains(descLower, "external http") || strings.Contains(descLower, "global forwarding rule") {
+					if strings.Contains(descLower, "external http") || (strings.Contains(descLower, "global forwarding rule") && strings.Contains(descLower, "http")) {
 						lbType = "external-http"
 					} else if strings.Contains(descLower, "internal http") {
 						lbType = "internal-http"

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -809,7 +809,7 @@ func TestGCP_NetworkPricing(t *testing.T) {
 		Config: &mockConfig{},
 	}
 
-	result, err := gcp.NetworkPricing()
+	result, err := gcp.NetworkPricing(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -817,7 +817,7 @@ func TestGCP_NetworkPricing(t *testing.T) {
 func TestGCP_LoadBalancerPricing(t *testing.T) {
 	gcp := &GCP{}
 
-	result, err := gcp.LoadBalancerPricing()
+	result, err := gcp.LoadBalancerPricing(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -815,11 +815,139 @@ func TestGCP_NetworkPricing(t *testing.T) {
 }
 
 func TestGCP_LoadBalancerPricing(t *testing.T) {
-	gcp := &GCP{}
+	gcp := &GCP{
+		ClusterRegion: "us-central1",
+		Pricing: map[string]*GCPPricing{
+			"us-central1,ForwardingRule:external-http": {
+				Description: "External HTTP(S) Load Balancer Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 25000000, // 0.025
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"us-central1,ForwardingRule:internal-http": {
+				Description: "Internal HTTP(S) Load Balancer Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 18000000, // 0.018
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"us-central1,ForwardingRule:network-tcp": {
+				Description: "Regional Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 20000000, // 0.020
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"us-central1,ForwardingRule:ssl-proxy": {
+				Description: "SSL Proxy Load Balancer Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 35000000, // 0.035
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 
-	result, err := gcp.LoadBalancerPricing(nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
+	cases := []struct {
+		name         string
+		key          models.LBKey
+		expectedCost float64
+	}{
+		{
+			name:         "Nil key defaults to fallback rule cost (fffrc * 1 = 0.025)",
+			key:          nil,
+			expectedCost: 0.025,
+		},
+		{
+			name: "External HTTP(S) LB by feature name",
+			key: &models.CustomLBKey{
+				LBFeatures: "external-http",
+			},
+			expectedCost: 0.025,
+		},
+		{
+			name: "Internal HTTP(S) LB by ID",
+			key: &models.CustomLBKey{
+				LBID: "gcp-lb-internal-http",
+			},
+			expectedCost: 0.018,
+		},
+		{
+			name: "Network/TCP LB by features",
+			key: &models.CustomLBKey{
+				LBFeatures: "network-tcp-lb",
+			},
+			expectedCost: 0.020,
+		},
+		{
+			name: "SSL Proxy LB by features",
+			key: &models.CustomLBKey{
+				LBFeatures: "ssl-proxy",
+			},
+			expectedCost: 0.035,
+		},
+		{
+			name: "Unknown key defaults to fallback rule cost (0.025)",
+			key: &models.CustomLBKey{
+				LBFeatures: "unknown-lb-type",
+			},
+			expectedCost: 0.025,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := gcp.LoadBalancerPricing(tc.key)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.InDelta(t, tc.expectedCost, result.Cost, 0.0001)
+		})
+	}
 }
 
 func TestGCP_GetPVKey(t *testing.T) {

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -281,8 +281,8 @@ type Provider interface {
 	NodePricing(Key) (*Node, PricingMetadata, error)
 	GpuPricing(map[string]string) (string, error)
 	PVPricing(PVKey) (*PV, error)
-	NetworkPricing() (*Network, error)           // TODO: add key interface arg for dynamic price fetching
-	LoadBalancerPricing() (*LoadBalancer, error) // TODO: add key interface arg for dynamic price fetching
+	NetworkPricing(NetworkKey) (*Network, error)
+	LoadBalancerPricing(LBKey) (*LoadBalancer, error)
 	AllNodePricing() (interface{}, error)
 	DownloadPricingData() error
 	GetKey(map[string]string, *clustercache.Node) Key

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -1,9 +1,34 @@
 package models
 
-// TODO: used for dynamic cloud provider price fetching.
-// determine what identifies a load balancer in the json returned from the cloud provider pricing API call
-// type LBKey interface {
-// }
+// LBKey represents metadata identifying a load balancer for pricing
+type LBKey interface {
+	ID() string
+	Features() string
+}
+
+// CustomLBKey is a default implementation of LBKey
+type CustomLBKey struct {
+	LBID       string
+	LBFeatures string
+}
+
+func (k *CustomLBKey) ID() string       { return k.LBID }
+func (k *CustomLBKey) Features() string { return k.LBFeatures }
+
+// NetworkKey represents metadata identifying a network resource for pricing
+type NetworkKey interface {
+	ID() string
+	Features() string
+}
+
+// CustomNetworkKey is a default implementation of NetworkKey
+type CustomNetworkKey struct {
+	NetworkID       string
+	NetworkFeatures string
+}
+
+func (k *CustomNetworkKey) ID() string       { return k.NetworkID }
+func (k *CustomNetworkKey) Features() string { return k.NetworkFeatures }
 
 // Network is the interface by which the provider and cost model communicate network egress prices.
 // The provider will best-effort try to fill out this struct.

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -4,6 +4,7 @@ package models
 type LBKey interface {
 	ID() string
 	Features() string
+	IsLBKey() bool
 }
 
 // CustomLBKey is a default implementation of LBKey
@@ -14,11 +15,13 @@ type CustomLBKey struct {
 
 func (k *CustomLBKey) ID() string       { return k.LBID }
 func (k *CustomLBKey) Features() string { return k.LBFeatures }
+func (k *CustomLBKey) IsLBKey() bool    { return true }
 
 // NetworkKey represents metadata identifying a network resource for pricing
 type NetworkKey interface {
 	ID() string
 	Features() string
+	IsNetworkKey() bool
 }
 
 // CustomNetworkKey is a default implementation of NetworkKey
@@ -27,8 +30,9 @@ type CustomNetworkKey struct {
 	NetworkFeatures string
 }
 
-func (k *CustomNetworkKey) ID() string       { return k.NetworkID }
-func (k *CustomNetworkKey) Features() string { return k.NetworkFeatures }
+func (k *CustomNetworkKey) ID() string         { return k.NetworkID }
+func (k *CustomNetworkKey) Features() string   { return k.NetworkFeatures }
+func (k *CustomNetworkKey) IsNetworkKey() bool { return true }
 
 // Network is the interface by which the provider and cost model communicate network egress prices.
 // The provider will best-effort try to fill out this struct.

--- a/pkg/cloud/oracle/provider.go
+++ b/pkg/cloud/oracle/provider.go
@@ -87,7 +87,7 @@ func (o *Oracle) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	return o.RateCardStore.ForPVK(pvk, o.DefaultPricing)
 }
 
-func (o *Oracle) NetworkPricing() (*models.Network, error) {
+func (o *Oracle) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	if err := o.ensurePricingData(); err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (o *Oracle) NetworkPricing() (*models.Network, error) {
 	return o.RateCardStore.ForEgressRegion(o.ClusterRegion, o.DefaultPricing)
 }
 
-func (o *Oracle) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (o *Oracle) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	if err := o.ensurePricingData(); err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -226,7 +226,7 @@ func (otc *OTC) DownloadPricingData() error {
 	return nil
 }
 
-func (otc *OTC) NetworkPricing() (*models.Network, error) {
+func (otc *OTC) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := otc.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -342,7 +342,7 @@ func (otc *OTC) GetConfig() (*models.CustomPricing, error) {
 
 // load balancer cost
 // taken straight up from aws
-func (otc *OTC) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (otc *OTC) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.05,
 	}, nil

--- a/pkg/cloud/ovh/provider.go
+++ b/pkg/cloud/ovh/provider.go
@@ -481,7 +481,7 @@ func (c *OVH) PVPricing(pvk models.PVKey) (*models.PV, error) {
 }
 
 // NetworkPricing returns static network pricing for OVH.
-func (c *OVH) NetworkPricing() (*models.Network, error) {
+func (c *OVH) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	return &models.Network{
 		ZoneNetworkEgressCost:     0,
 		RegionNetworkEgressCost:   0,
@@ -492,7 +492,7 @@ func (c *OVH) NetworkPricing() (*models.Network, error) {
 }
 
 // LoadBalancerPricing returns static load balancer pricing for OVH.
-func (c *OVH) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (c *OVH) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.012,
 	}, nil

--- a/pkg/cloud/ovh/provider_test.go
+++ b/pkg/cloud/ovh/provider_test.go
@@ -387,7 +387,7 @@ func TestPVPricing(t *testing.T) {
 func TestNetworkPricing(t *testing.T) {
 	provider := &OVH{}
 
-	net, err := provider.NetworkPricing()
+	net, err := provider.NetworkPricing(nil)
 	if err != nil {
 		t.Fatalf("NetworkPricing failed: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestNetworkPricing(t *testing.T) {
 func TestLoadBalancerPricing(t *testing.T) {
 	provider := &OVH{}
 
-	lb, err := provider.LoadBalancerPricing()
+	lb, err := provider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing failed: %v", err)
 	}

--- a/pkg/cloud/provider/customprovider.go
+++ b/pkg/cloud/provider/customprovider.go
@@ -301,7 +301,7 @@ func (cp *CustomProvider) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	}, nil
 }
 
-func (cp *CustomProvider) NetworkPricing() (*models.Network, error) {
+func (cp *CustomProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := cp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -347,7 +347,7 @@ func parsePriceOrZero(field, value string) (float64, error) {
 	return price, nil
 }
 
-func (cp *CustomProvider) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (cp *CustomProvider) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	cpricing, err := cp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/provider/provider_test.go
+++ b/pkg/cloud/provider/provider_test.go
@@ -228,7 +228,7 @@ func TestCustomProviderClusterInfoUsesStaticDefaultName(t *testing.T) {
 func TestCustomProviderLoadBalancerPricingEmptyConfig(t *testing.T) {
 	customProvider := newTestCustomProvider(t, nil)
 
-	lb, err := customProvider.LoadBalancerPricing()
+	lb, err := customProvider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing returned error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestCustomProviderLoadBalancerPricingUsesDefaultLBPriceFallback(t *testing.
 		"defaultLBPrice": "0.025",
 	})
 
-	lb, err := customProvider.LoadBalancerPricing()
+	lb, err := customProvider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing returned error: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestCustomProviderLoadBalancerPricingUsesForwardingRulePrice(t *testing.T) 
 		"defaultLBPrice":               "0.025",
 	})
 
-	lb, err := customProvider.LoadBalancerPricing()
+	lb, err := customProvider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing returned error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestCustomProviderLoadBalancerPricingInvalidValue(t *testing.T) {
 		"firstFiveForwardingRulesCost": "not-a-price",
 	})
 
-	_, err := customProvider.LoadBalancerPricing()
+	_, err := customProvider.LoadBalancerPricing(nil)
 	if err == nil {
 		t.Fatal("LoadBalancerPricing returned nil error, want invalid pricing error")
 	}

--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -162,7 +162,7 @@ func (c *Scaleway) NodePricing(key models.Key) (*models.Node, models.PricingMeta
 	return nil, meta, fmt.Errorf("Unable to find node pricing matching thes features `%s`", key.Features())
 }
 
-func (c *Scaleway) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (c *Scaleway) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	// Different LB types, lets take the cheaper for now, we can't get the type
 	// without a service specifying the type in the annotations
 	return &models.LoadBalancer{
@@ -170,7 +170,7 @@ func (c *Scaleway) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (c *Scaleway) NetworkPricing() (*models.Network, error) {
+func (c *Scaleway) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	// it's free baby!
 	return &models.Network{
 		ZoneNetworkEgressCost:     0,

--- a/pkg/cloud/stackit/provider.go
+++ b/pkg/cloud/stackit/provider.go
@@ -122,7 +122,7 @@ func (s *STACKIT) NodePricing(key models.Key) (*models.Node, models.PricingMetad
 	}, meta, nil
 }
 
-func (s *STACKIT) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (s *STACKIT) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	config, err := s.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config: %w", err)
@@ -138,7 +138,7 @@ func (s *STACKIT) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (s *STACKIT) NetworkPricing() (*models.Network, error) {
+func (s *STACKIT) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	config, err := s.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config: %w", err)

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1374,7 +1374,7 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 
 		if service.Type == "LoadBalancer" {
 			lbKey := &costAnalyzerCloud.CustomLBKey{
-				LBID: service.Name,
+				LBID: fmt.Sprintf("%s/%s/%s", coreenv.GetClusterID(), service.Namespace, service.Name),
 			}
 			loadBalancer, err := cp.LoadBalancerPricing(lbKey)
 			if err != nil {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1352,6 +1352,35 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 	return nodes, nil
 }
 
+func getLBFeatures(service *clustercache.Service, providerType string) string {
+	var hints []string
+
+	if service.Annotations != nil {
+		// AWS load balancer annotations
+		if class, ok := service.Annotations["service.beta.kubernetes.io/aws-load-balancer-class"]; ok {
+			hints = append(hints, strings.ToLower(class))
+		}
+		if lbType, ok := service.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"]; ok {
+			hints = append(hints, strings.ToLower(lbType))
+		}
+
+		// GCP load balancer annotations
+		if lbType, ok := service.Annotations["cloud.google.com/load-balancer-type"]; ok {
+			hints = append(hints, strings.ToLower(lbType))
+		}
+		if lbType, ok := service.Annotations["networking.gke.io/load-balancer-type"]; ok {
+			hints = append(hints, strings.ToLower(lbType))
+		}
+	}
+
+	// Add provider-specific defaults
+	if providerType == opencost.GCPProvider {
+		hints = append(hints, "network", "tcp")
+	}
+
+	return strings.Join(hints, ",")
+}
+
 // TODO: drop some logs
 func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer, error) {
 	// for fetching prices from cloud provider
@@ -1363,6 +1392,11 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 	servicesList := cm.Cache.GetAllServices()
 	loadBalancerMap := make(map[serviceKey]*costAnalyzerCloud.LoadBalancer)
 
+	var providerType string
+	if info, err := cp.ClusterInfo(); err == nil && info != nil {
+		providerType = info["provider"]
+	}
+
 	for _, service := range servicesList {
 		namespace := service.Namespace
 		name := service.Name
@@ -1373,8 +1407,10 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 		}
 
 		if service.Type == "LoadBalancer" {
+			lbFeatures := getLBFeatures(service, providerType)
 			lbKey := &costAnalyzerCloud.CustomLBKey{
-				LBID: fmt.Sprintf("%s/%s/%s", coreenv.GetClusterID(), service.Namespace, service.Name),
+				LBID:       fmt.Sprintf("%s/%s/%s", coreenv.GetClusterID(), service.Namespace, service.Name),
+				LBFeatures: lbFeatures,
 			}
 			loadBalancer, err := cp.LoadBalancerPricing(lbKey)
 			if err != nil {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1373,7 +1373,10 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 		}
 
 		if service.Type == "LoadBalancer" {
-			loadBalancer, err := cp.LoadBalancerPricing()
+			lbKey := &costAnalyzerCloud.CustomLBKey{
+				LBID: service.Name,
+			}
+			loadBalancer, err := cp.LoadBalancerPricing(lbKey)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1373,11 +1373,9 @@ func getLBFeatures(service *clustercache.Service, providerType string) string {
 		}
 	}
 
-	// Add provider-specific defaults
-	if providerType == opencost.GCPProvider {
-		hints = append(hints, "network", "tcp")
-	}
-
+	// Intentionally avoid provider-specific defaults here. Leaving hints empty (when no annotations
+	// are present) allows cloud providers to fall back to their standard default pricing.
+	// (If we later add reliable GCP LB type detection, it should be derived from Service metadata.)
 	return strings.Join(hints, ",")
 }
 

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -490,7 +490,7 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 			cmme.ClusterManagementCostRecorder.WithLabelValues(provisioner).Set(clusterManagementCost)
 
 			// Record network pricing at global scope
-			networkCosts, err := cmme.CloudProvider.NetworkPricing()
+			networkCosts, err := cmme.CloudProvider.NetworkPricing(nil)
 			if err != nil {
 				log.Debugf("Failed to retrieve network costs: %s", err.Error())
 			} else {

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -146,7 +146,13 @@ func GetNetworkUsageData(
 func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider) ([]*util.Vector, error) {
 	var results []*util.Vector
 
-	pricing, err := cloud.NetworkPricing()
+	var netKey costAnalyzerCloud.NetworkKey
+	if usage != nil {
+		netKey = &costAnalyzerCloud.CustomNetworkKey{
+			NetworkID: usage.PodName,
+		}
+	}
+	pricing, err := cloud.NetworkPricing(netKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -144,13 +144,14 @@ func GetNetworkUsageData(
 
 // GetNetworkCost computes the actual cost for NetworkUsageData based on data provided by the Provider.
 func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider) ([]*util.Vector, error) {
+	if usage == nil {
+		return nil, fmt.Errorf("network usage is nil")
+	}
+
 	var results []*util.Vector
 
-	var netKey costAnalyzerCloud.NetworkKey
-	if usage != nil {
-		netKey = &costAnalyzerCloud.CustomNetworkKey{
-			NetworkID: usage.PodName,
-		}
+	netKey := &costAnalyzerCloud.CustomNetworkKey{
+		NetworkID: fmt.Sprintf("%s/%s/%s", usage.ClusterID, usage.Namespace, usage.PodName),
 	}
 	pricing, err := cloud.NetworkPricing(netKey)
 	if err != nil {

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -616,3 +616,11 @@ func TestGetNetworkCost_NATGatewayMisalignedVectors(t *testing.T) {
 		t.Errorf("expected third vector cost %f, got %f", expectedThird, result[2].Value)
 	}
 }
+
+func TestGetNetworkCost_NilUsage(t *testing.T) {
+	provider := &mockProvider{}
+	_, err := GetNetworkCost(nil, provider)
+	if err == nil {
+		t.Fatal("expected error when usage is nil, got nil")
+	}
+}

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -16,7 +16,7 @@ type mockProvider struct {
 	err     error
 }
 
-func (m *mockProvider) NetworkPricing() (*models.Network, error) {
+func (m *mockProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	return m.network, m.err
 }
 
@@ -32,7 +32,7 @@ func (m *mockProvider) NodePricing(models.Key) (*models.Node, models.PricingMeta
 	return nil, models.PricingMetadata{}, nil
 }
 
-func (m *mockProvider) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (m *mockProvider) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return nil, nil
 }
 

--- a/pkg/costmodel/router_test.go
+++ b/pkg/costmodel/router_test.go
@@ -20,13 +20,13 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		setToken          string
-		authHeader        string
-		wantStatus        int
-		wantNextCalled    bool
-		wantBodySubstr    string
-		wantCacheControl  string
+		name             string
+		setToken         string
+		authHeader       string
+		wantStatus       int
+		wantNextCalled   bool
+		wantBodySubstr   string
+		wantCacheControl string
 	}{
 		{
 			name:             "no admin token configured - returns 503",

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -697,10 +697,12 @@ func (mp *mockProvider) GetOrphanedResources() ([]models.OrphanedResource, error
 func (mp *mockProvider) NodePricing(models.Key) (*models.Node, models.PricingMetadata, error) {
 	return nil, models.PricingMetadata{}, nil
 }
-func (mp *mockProvider) GpuPricing(map[string]string) (string, error)            { return "", nil }
-func (mp *mockProvider) PVPricing(models.PVKey) (*models.PV, error)              { return nil, nil }
-func (mp *mockProvider) NetworkPricing() (*models.Network, error)                { return nil, nil }
-func (mp *mockProvider) LoadBalancerPricing() (*models.LoadBalancer, error)      { return nil, nil }
+func (mp *mockProvider) GpuPricing(map[string]string) (string, error)              { return "", nil }
+func (mp *mockProvider) PVPricing(models.PVKey) (*models.PV, error)                { return nil, nil }
+func (mp *mockProvider) NetworkPricing(models.NetworkKey) (*models.Network, error) { return nil, nil }
+func (mp *mockProvider) LoadBalancerPricing(models.LBKey) (*models.LoadBalancer, error) {
+	return nil, nil
+}
 func (mp *mockProvider) DownloadPricingData() error                              { return nil }
 func (mp *mockProvider) GetKey(map[string]string, *clustercache.Node) models.Key { return nil }
 func (mp *mockProvider) GetPVKey(*clustercache.PersistentVolume, map[string]string, string) models.PVKey {


### PR DESCRIPTION
Fixes #3935

### Description
This PR upgrades the AWS and GCP provider implementations of `LoadBalancerPricing` to dynamically parse the `models.LBKey` features and ID and select specific hourly costs based on the load balancer configuration.

### Changes
- **AWS**:
  - Modified `populatePricing` to check and register specific load balancer usage types (Network, Application, Classic) in the pricing cache.
  - Upgraded `LoadBalancerPricing` to parse the features/ID of `lbKey` and query the cache for specific SKUs matching these types, falling back to the standard generic regional pricing if no match is found.
- **GCP**:
  - Modified `parsePage` to check if a product is a load balancer forwarding rule, classify it (External HTTP(S), Internal HTTP(S), Network/TCP, SSL Proxy), and store it in the pricing cache under region-specific keys.
  - Implemented `getGCPPricingRate` helper to calculate hourly prices from GCPPricing tiered rates.
  - Upgraded `LoadBalancerPricing` to inspect `lbKey` features/ID and query the specific cached forwarding rule rate, falling back to the standard default calculation if there is no exact match.

### Verification
- Added table-driven unit tests for both AWS and GCP packages verifying that various `LBKey` feature sets resolve to their distinct mock hourly rates.
- Verified all unit tests pass locally:
  - `go test ./pkg/cloud/aws/...`
  - `go test ./pkg/cloud/gcp/...`