### PR TITLE
Fix handler early returns on invalid window parameter

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -78,6 +78,12 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request — missing or invalid parameters (e.g. `window`, `aggregate`, `step`, `accumulate`)"
+          },
+          "500": {
+            "description": "Internal server error — the allocation query failed"
           }
         }
       }
@@ -106,6 +112,12 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request — missing or invalid `window` parameter"
+          },
+          "500": {
+            "description": "Internal server error — computing or filtering assets failed"
           }
         }
       }
@@ -134,6 +146,15 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request — missing or invalid parameters"
+          },
+          "500": {
+            "description": "Internal server error — the cloud cost query failed"
+          },
+          "501": {
+            "description": "Cloud cost query service is not available. Note: when `CLOUD_COST_ENABLED` is not set to `true` this route is not registered at all and requests return 404."
           }
         }
       }
@@ -214,6 +235,9 @@
           },
           "400": {
             "description": "Bad request — missing or invalid parameters"
+          },
+          "500": {
+            "description": "Internal server error — the inference cost query failed"
           },
           "501": {
             "description": "Inference cost tracking is not enabled (`INFERENCE_COST_ENABLED` is not set to `true`)"
@@ -296,6 +320,9 @@
           "400": {
             "description": "Bad request — missing or invalid parameters (including missing `accumulate`)"
           },
+          "500": {
+            "description": "Internal server error — the inference cost query failed"
+          },
           "501": {
             "description": "Inference cost tracking is not enabled (`INFERENCE_COST_ENABLED` is not set to `true`)"
           }
@@ -362,17 +389,7 @@
             "type": "number"
           },
           "window": {
-            "type": "object",
-            "properties": {
-              "start": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "end": {
-                "type": "string",
-                "format": "date-time"
-              }
-            }
+            "$ref": "#/components/schemas/Window"
           },
           "properties": {
             "type": "object",
@@ -418,17 +435,7 @@
             "type": "string"
           },
           "window": {
-            "type": "object",
-            "properties": {
-              "start": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "end": {
-                "type": "string",
-                "format": "date-time"
-              }
-            }
+            "$ref": "#/components/schemas/Window"
           }
         }
       },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -80,7 +80,7 @@
             }
           },
           "400": {
-            "description": "Bad request — missing or invalid parameters (e.g. `window`, `aggregate`, `step`, `accumulate`)"
+            "description": "Bad request — missing or invalid parameters (e.g. `window`, `step`, `accumulateBy`)"
           },
           "500": {
             "description": "Internal server error — the allocation query failed"
@@ -125,7 +125,7 @@
     "/cloudCost": {
       "get": {
         "summary": "query for cloud provider billing data",
-        "description": "Retrieves non-K8s cloud provider costs via cloud integration.",
+        "description": "Retrieves non-K8s cloud provider costs via cloud integration. Requires `CLOUD_COST_ENABLED=true`; when disabled this route is not registered and requests return 404.",
         "parameters": [
           {
             "name": "window",
@@ -152,9 +152,6 @@
           },
           "500": {
             "description": "Internal server error — the cloud cost query failed"
-          },
-          "501": {
-            "description": "Cloud cost query service is not available. Note: when `CLOUD_COST_ENABLED` is not set to `true` this route is not registered at all and requests return 404."
           }
         }
       }

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -212,6 +212,7 @@ func (a *Accesses) ComputeAllocationHandlerSummary(w http.ResponseWriter, r *htt
 	window, err := opencost.ParseWindowWithOffset(qp.Get("window", ""), env.GetParsedUTCOffset())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid 'window' parameter: %s", err), http.StatusBadRequest)
+		return
 	}
 
 	// Step is an optional parameter that defines the duration per-set, i.e.
@@ -225,6 +226,7 @@ func (a *Accesses) ComputeAllocationHandlerSummary(w http.ResponseWriter, r *htt
 	aggregateBy, err := ParseAggregationProperties(aggregations)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid 'aggregate' parameter: %s", err), http.StatusBadRequest)
+		return
 	}
 
 	// Accumulate is an optional parameter that accepts bool-style values (e.g.
@@ -337,6 +339,7 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	window, err := opencost.ParseWindowWithOffset(qp.Get("window", ""), env.GetParsedUTCOffset())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid 'window' parameter: %s", err), http.StatusBadRequest)
+		return
 	}
 
 	// Step is an optional parameter that defines the duration per-set, i.e.
@@ -350,6 +353,7 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	aggregateBy, err := ParseAggregationProperties(aggregations)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid 'aggregate' parameter: %s", err), http.StatusBadRequest)
+		return
 	}
 
 	// IncludeIdle, if true, uses Asset data to incorporate Idle Allocation

--- a/pkg/costmodel/aggregation_test.go
+++ b/pkg/costmodel/aggregation_test.go
@@ -1,10 +1,14 @@
 package costmodel
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/julienschmidt/httprouter"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/util/httputil"
 )
@@ -443,5 +447,67 @@ func TestTrimAllocationSetRangeToRequestWindow(t *testing.T) {
 	}
 	if trimmed.FromStore != asr.FromStore {
 		t.Fatalf("expected FromStore to be preserved")
+	}
+}
+
+// invalidWindowRequest builds a GET request to the given path with an
+// unparseable window parameter.
+func invalidWindowRequest(path string) *http.Request {
+	r, _ := http.NewRequest(http.MethodGet, path+"?window=notawindow", nil)
+	return r
+}
+
+// The handlers must return immediately after writing the 400 for an invalid
+// window. Before the fix, execution continued with a zero-value Window: the
+// nil Model here would have caused a panic instead of a clean 400.
+func TestComputeAllocationHandler_InvalidWindow_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	w := httptest.NewRecorder()
+	a.ComputeAllocationHandler(w, invalidWindowRequest("/allocation"), httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid 'window' parameter") {
+		t.Fatalf("expected invalid window error in body, got: %q", w.Body.String())
+	}
+}
+
+func TestComputeAllocationHandler_MissingWindow_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	r, _ := http.NewRequest(http.MethodGet, "/allocation", nil)
+	w := httptest.NewRecorder()
+	a.ComputeAllocationHandler(w, r, httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestComputeAllocationHandlerSummary_InvalidWindow_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	w := httptest.NewRecorder()
+	a.ComputeAllocationHandlerSummary(w, invalidWindowRequest("/allocation/summary"), httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid 'window' parameter") {
+		t.Fatalf("expected invalid window error in body, got: %q", w.Body.String())
+	}
+}
+
+func TestComputeAllocationHandlerSummary_MissingWindow_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	r, _ := http.NewRequest(http.MethodGet, "/allocation/summary", nil)
+	w := httptest.NewRecorder()
+	a.ComputeAllocationHandlerSummary(w, r, httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes a bug where HTTP handlers (`ComputeAllocationHandler` and `ComputeAllocationHandlerSummary`) would continue executing after writing a 400 Bad Request response for invalid or missing `window` parameters. The handlers now properly return immediately after writing the error response, preventing potential panics or undefined behavior from executing with zero-value state.

Additionally, the Swagger/OpenAPI documentation has been updated to reflect proper error responses (400, 500, 501) across all allocation and cost query endpoints.

## Changes
- **pkg/costmodel/aggregation.go**: Added `return` statements after `http.Error()` calls in `ComputeAllocationHandler` and `ComputeAllocationHandlerSummary` to prevent continued execution after error responses
- **pkg/costmodel/aggregation_test.go**: Added comprehensive test coverage for invalid and missing window parameters in both handlers
- **docs/swagger.json**: Updated API documentation to include 400, 500, and 501 error responses for allocation, asset, cloud cost, and inference cost endpoints; refactored window schema to use `$ref` for consistency

## Related Issues
Fixes #3923

Also fixes a potential panic when handlers receive invalid window parameters and continue execution with nil/zero-value state.

## User Impact
- **Bug Fix**: Handlers now properly reject invalid requests without risk of panic
- **API Documentation**: Swagger documentation now accurately reflects all possible HTTP status codes returned by the endpoints
- **No Breaking Changes**: This is a bug fix that makes error handling more robust

## Testing
Added 4 new unit tests covering:
- `TestComputeAllocationHandler_InvalidWindow_Returns400`: Verifies 400 response with error message for invalid window
- `TestComputeAllocationHandler_MissingWindow_Returns400`: Verifies 400 response for missing window parameter
- `TestComputeAllocationHandlerSummary_InvalidWindow_Returns400`: Verifies 400 response with error message for invalid window in summary endpoint
- `TestComputeAllocationHandlerSummary_MissingWindow_Returns400`: Verifies 400 response for missing window parameter in summary endpoint

All tests verify that handlers return immediately with appropriate HTTP status codes and error messages.