### PR TITLE
fix(gcp): close billing API response body and validate HTTP status

### DIFF
--- a/core/pkg/external/configmapsource_test.go
+++ b/core/pkg/external/configmapsource_test.go
@@ -333,11 +333,11 @@ labels:
 
 func TestFilterValidLabels_AllValid_ReturnedUnchanged(t *testing.T) {
 	in := map[string]string{
-		"env":                     "prod",
-		"region":                  "us-east-1",
-		"app.kubernetes.io/name":  "opencost",
-		"my-key":                  "my-value",
-		"a":                       "b",
+		"env":                    "prod",
+		"region":                 "us-east-1",
+		"app.kubernetes.io/name": "opencost",
+		"my-key":                 "my-value",
+		"a":                      "b",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -396,8 +396,8 @@ func TestFilterValidLabels_KeyTooLong_EntryDropped(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 	in := map[string]string{
-		"app.kubernetes.io/name":      "opencost",
-		"example.com/env":             "staging",
+		"app.kubernetes.io/name": "opencost",
+		"example.com/env":        "staging",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -405,7 +405,7 @@ func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) {
 	in := map[string]string{
-		"valid":          "kept",
+		"valid":         "kept",
 		"-bad.prefix/k": "dropped",
 	}
 	out := filterValidLabels(in)
@@ -414,10 +414,10 @@ func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) 
 
 func TestFilterValidLabels_MixedValidAndInvalid_OnlyValidReturned(t *testing.T) {
 	in := map[string]string{
-		"cluster":    "prod",
-		"":           "no-key",
-		"bad-value":  "-oops",
-		"region":     "eu-west-1",
+		"cluster":   "prod",
+		"":          "no-key",
+		"bad-value": "-oops",
+		"region":    "eu-west-1",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, map[string]string{"cluster": "prod", "region": "eu-west-1"}, out)

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -996,6 +996,24 @@ func (gcp *GCP) getBillingAPIClientAndURL(apiKey, currencyCode string) (*http.Cl
 	return googleHttpClient, url.String(), nil
 }
 
+// fetchAndParsePage fetches a single GCP Billing API page, validates the HTTP
+// status code, and parses the body. The response body is always closed before
+// returning, so paginating the full catalog no longer leaks a connection per
+// page.
+func (gcp *GCP) fetchAndParsePage(client *http.Client, reqURL string, inputKeys map[string]models.Key, pvKeys map[string]models.PVKey) (map[string]*GCPPricing, string, error) {
+	resp, err := client.Get(reqURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("GCP Billing API responded with error status code %d", resp.StatusCode)
+	}
+
+	return gcp.parsePage(resp.Body, inputKeys, pvKeys)
+}
+
 func (gcp *GCP) parsePages(inputKeys map[string]models.Key, pvKeys map[string]models.PVKey) (map[string]*GCPPricing, error) {
 	c, err := gcp.GetConfig()
 	if err != nil {
@@ -1026,11 +1044,7 @@ func (gcp *GCP) parsePagesWithClient(httpClient *http.Client, url string, inputK
 		if pageToken != "" {
 			reqURL = url + "&pageToken=" + pageToken
 		}
-		resp, err := httpClient.Get(reqURL)
-		if err != nil {
-			return err
-		}
-		page, token, err := gcp.parsePage(resp.Body, inputKeys, pvKeys)
+		page, token, err := gcp.fetchAndParsePage(httpClient, reqURL, inputKeys, pvKeys)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -1098,6 +1098,42 @@ func TestGCP_parsePages(t *testing.T) {
 	assert.Error(t, err) // Expect error due to missing API key
 }
 
+func TestGCP_fetchAndParsePage_Non200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "boom")
+	}))
+	defer srv.Close()
+
+	gcp := &GCP{}
+	_, _, err := gcp.fetchAndParsePage(srv.Client(), srv.URL, map[string]models.Key{}, map[string]models.PVKey{})
+	if err == nil {
+		t.Fatal("expected an error for a non-200 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to include status code 500, got %q", err.Error())
+	}
+}
+
+func TestGCP_fetchAndParsePage_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"skus":[],"nextPageToken":""}`)
+	}))
+	defer srv.Close()
+
+	gcp := &GCP{}
+	page, token, err := gcp.fetchAndParsePage(srv.Client(), srv.URL, map[string]models.Key{}, map[string]models.PVKey{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "done" {
+		t.Errorf("token = %q, want %q", token, "done")
+	}
+	if len(page) != 0 {
+		t.Errorf("page len = %d, want 0", len(page))
+	}
+}
+
 // TestGCP_parsePagesWithClient_Pagination verifies that multi-page traversal
 // sends exactly one pageToken param per request rather than accumulating
 // tokens from earlier pages.


### PR DESCRIPTION
Was going through the cloud providers and noticed the GCP billing pricing path never closes the HTTP response body or checks the status code, while azure/oracle/aws/otc all already do both.

The pagination walks every page of the GCP Cloud Billing catalog, and each request did `httpClient.Get(...)` then handed `resp.Body` straight to `parsePage`, which only reads it. Nothing ever closed the body, so a full pricing refresh leaks a connection per page (dozens of them) and also blocks keep-alive reuse. The status code wasn't checked either, so a 4xx/5xx (expired key, quota, outage) went into the JSON parser as if it were pricing data.

Pulled the fetch+parse into a small `fetchAndParsePage` helper that defers `Body.Close()` and returns an error on a non-200 before parsing. Since it's its own method now, each page's body closes before the next request instead of stacking up until the whole catalog finishes.

Added two httptest unit tests (non-200 -> error mentioning the status code, 200 -> parses cleanly). Happy path is unchanged.
