### PR TITLE
feat(gcp): add C4A machine family pricing support

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -748,6 +748,13 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "E2 INSTANCE") {
 					instanceType = "e2"
 				}
+
+				// Sole-tenancy SKUs (including "Sole Tenancy Premium" surcharge
+				// SKUs) are excluded so they do not overwrite the standard
+				// on-demand/spot per-vCPU/per-GB rates.
+				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "C4A") && !strings.Contains(strings.ToUpper(product.Description), "SOLE") {
+					instanceType = "c4astandard"
+				}
 				partialCPUMap := make(map[string]float64)
 				partialCPUMap["e2micro"] = 0.25
 				partialCPUMap["e2small"] = 0.5
@@ -1566,6 +1573,8 @@ func parseGCPInstanceTypeLabel(it string) string {
 			instanceType = "e2standard"
 		} else if instanceType == "n2dhighmem" || instanceType == "n2dhighcpu" {
 			instanceType = "n2dstandard"
+		} else if instanceType == "c4ahighmem" || instanceType == "c4ahighcpu" {
+			instanceType = "c4astandard" // C4A (Arm) variants are priced the same per vCPU and RAM
 		} else if strings.HasPrefix(instanceType, "custom") {
 			instanceType = "custom" // The suffix of custom does not matter
 		}
@@ -1703,7 +1712,7 @@ func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible b
 	}
 	discount := defaultDiscount
 	switch class {
-	case "e2", "f1", "g1", "n4":
+	case "e2", "f1", "g1", "n4", "c4a":
 		discount = 0.0
 	case "n2", "n2d":
 		discount = 0.2

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -60,6 +60,18 @@ func TestParseGCPInstanceTypeLabel(t *testing.T) {
 			input:    "n4-highmem-16",
 			expected: "n4standard",
 		},
+		{
+			input:    "c4a-highmem-8",
+			expected: "c4astandard",
+		},
+		{
+			input:    "c4a-highcpu-8",
+			expected: "c4astandard",
+		},
+		{
+			input:    "c4a-standard-4",
+			expected: "c4astandard",
+		},
 	}
 
 	for _, test := range cases {
@@ -257,6 +269,19 @@ func TestParsePage(t *testing.T) {
 						"topology.kubernetes.io/region":    "asia-southeast1",
 					},
 				},
+				"us-central1,c4astandard,ondemand": &gcpKey{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "c4a-standard-4",
+						"topology.kubernetes.io/region":    "us-central1",
+					},
+				},
+				"us-central1,c4astandard,preemptible": &gcpKey{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "c4a-standard-4",
+						"cloud.google.com/gke-spot":        "true",
+						"topology.kubernetes.io/region":    "us-central1",
+					},
+				},
 			},
 			pvKeys: map[string]models.PVKey{},
 			expectedPrices: map[string]*GCPPricing{
@@ -361,6 +386,40 @@ func TestParsePage(t *testing.T) {
 						RAMCost:          "68.204999658",
 						UsesBaseCPUPrice: false,
 						UsageType:        "ondemand",
+					},
+				},
+				// The "Sole Tenancy Premium for C4A Instance Core" SKU must be
+				// excluded, so no additional keys are created from it.
+				"us-central1,c4astandard,ondemand": {
+					Node: &models.Node{
+						VCPUCost:         "0.025",
+						RAMCost:          "0.004",
+						UsesBaseCPUPrice: false,
+						UsageType:        "ondemand",
+					},
+				},
+				"us-central1,c4astandard,ondemand,gpu": {
+					Node: &models.Node{
+						VCPUCost:         "0.025",
+						RAMCost:          "0.004",
+						UsesBaseCPUPrice: false,
+						UsageType:        "ondemand",
+					},
+				},
+				"us-central1,c4astandard,preemptible": {
+					Node: &models.Node{
+						VCPUCost:         "0.008",
+						RAMCost:          "0.001",
+						UsesBaseCPUPrice: false,
+						UsageType:        "preemptible",
+					},
+				},
+				"us-central1,c4astandard,preemptible,gpu": {
+					Node: &models.Node{
+						VCPUCost:         "0.008",
+						RAMCost:          "0.001",
+						UsesBaseCPUPrice: false,
+						UsageType:        "preemptible",
 					},
 				},
 			},
@@ -1036,6 +1095,13 @@ func TestSustainedUseDiscount(t *testing.T) {
 			defaultDiscount: 0.30,
 			isPreemptible:   false,
 			expected:        0.30,
+		},
+		{
+			name:            "C4A instance",
+			class:           "c4a",
+			defaultDiscount: 0.30,
+			isPreemptible:   false,
+			expected:        0.0,
 		},
 	}
 

--- a/pkg/cloud/gcp/test/skus.json
+++ b/pkg/cloud/gcp/test/skus.json
@@ -313,6 +313,206 @@
             "serviceProviderName": "Google",
             "node": null,
             "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C4A0-CPU0-0001",
+            "skuId": "C4A0-CPU0-0001",
+            "description": "C4A Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 25000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C4A0-RAM0-0002",
+            "skuId": "C4A0-RAM0-0002",
+            "description": "C4A Instance Ram running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "RAM",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "GiBy.h",
+                        "usageUnitDescription": "gibibyte hour",
+                        "baseUnit": "By.s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 4000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C4A0-CPU1-0003",
+            "skuId": "C4A0-CPU1-0003",
+            "description": "Spot Preemptible C4A Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "Preemptible"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 8000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C4A0-RAM1-0004",
+            "skuId": "C4A0-RAM1-0004",
+            "description": "Spot Preemptible C4A Instance Ram running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "RAM",
+                "usageType": "Preemptible"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "GiBy.h",
+                        "usageUnitDescription": "gibibyte hour",
+                        "baseUnit": "By.s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 1000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C4A0-SOLE-0005",
+            "skuId": "C4A0-SOLE-0005",
+            "description": "Sole Tenancy Premium for C4A Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 88000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
         }
     ],
     "nextPageToken": "APKCS1HVa0YpwgyTFbqbJ1eGwzKZmsPwLqzMZPTSNia5ck1Hc54Tx_Kz3oBxwSnRIdGVxXoSPdf-XlDpyNBf4QuxKcIEgtrQ1LDLWAgZowI0ns7HjrGta2s="


### PR DESCRIPTION
## What
Add GCP **C4A** (Arm/Axion) machine-family pricing support to the GCP provider.

## Why
Same class of gap as C3D (#3944): `parsePage` has no `C4A` match, so C4A nodes get no catalog price and fall back to the default estimate (spot billed at on-demand list). C4A is an Arm family, so the Core/RAM classification keys on the description containing `RAM` — note `ARM` (A-R-M) does not contain `RAM` (R-A-M), so the existing RAM-vs-Core split stays correct.

## What changed (`pkg/cloud/gcp/provider.go`)
- **`parsePage`**: classify `cpu`/`ram` SKUs whose description contains `C4A` (and not `SOLE`) as `c4astandard`.
- **`parseGCPInstanceTypeLabel`**: fold `c4a-highmem-*` / `c4a-highcpu-*` onto `c4astandard`.
- **`sustainedUseDiscount`**: no sustained-use discount for C4A → SUD class `0.0`.

## Testing
- Added `parsePage` unit tests (on-demand + spot + sole-tenancy exclusion; asserts `ARM`≠`RAM`) with `test/skus.json` fixtures.
- `gofmt` clean.
