### PR TITLE
feat(gcp): add C3 machine family pricing support

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -748,6 +748,17 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "E2 INSTANCE") {
 					instanceType = "e2"
 				}
+
+				// Sole-tenancy SKUs (including "Sole Tenancy Premium" surcharge
+				// SKUs) are excluded so they do not overwrite the standard
+				// on-demand/spot per-vCPU/per-GB rates.
+				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "C3 INSTANCE") && !strings.Contains(strings.ToUpper(product.Description), "SOLE") {
+					// Matching "C3 INSTANCE" — with the space between "C3" and
+					// "INSTANCE" — excludes C3D SKUs, whose descriptions read
+					// "C3D Instance ..." ("C3D" has no space before "INSTANCE",
+					// so it fails this substring check).
+					instanceType = "c3standard"
+				}
 				partialCPUMap := make(map[string]float64)
 				partialCPUMap["e2micro"] = 0.25
 				partialCPUMap["e2small"] = 0.5
@@ -1566,6 +1577,8 @@ func parseGCPInstanceTypeLabel(it string) string {
 			instanceType = "e2standard"
 		} else if instanceType == "n2dhighmem" || instanceType == "n2dhighcpu" {
 			instanceType = "n2dstandard"
+		} else if instanceType == "c3highmem" || instanceType == "c3highcpu" {
+			instanceType = "c3standard" // C3 variants are priced the same per vCPU and RAM
 		} else if strings.HasPrefix(instanceType, "custom") {
 			instanceType = "custom" // The suffix of custom does not matter
 		}
@@ -1703,7 +1716,7 @@ func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible b
 	}
 	discount := defaultDiscount
 	switch class {
-	case "e2", "f1", "g1", "n4":
+	case "e2", "f1", "g1", "n4", "c3":
 		discount = 0.0
 	case "n2", "n2d":
 		discount = 0.2

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -60,6 +60,18 @@ func TestParseGCPInstanceTypeLabel(t *testing.T) {
 			input:    "n4-highmem-16",
 			expected: "n4standard",
 		},
+		{
+			input:    "c3-highmem-8",
+			expected: "c3standard",
+		},
+		{
+			input:    "c3-highcpu-8",
+			expected: "c3standard",
+		},
+		{
+			input:    "c3-standard-4",
+			expected: "c3standard",
+		},
 	}
 
 	for _, test := range cases {
@@ -257,6 +269,19 @@ func TestParsePage(t *testing.T) {
 						"topology.kubernetes.io/region":    "asia-southeast1",
 					},
 				},
+				"us-central1,c3standard,ondemand": &gcpKey{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "c3-standard-4",
+						"topology.kubernetes.io/region":    "us-central1",
+					},
+				},
+				"us-central1,c3standard,preemptible": &gcpKey{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "c3-standard-4",
+						"cloud.google.com/gke-spot":        "true",
+						"topology.kubernetes.io/region":    "us-central1",
+					},
+				},
 			},
 			pvKeys: map[string]models.PVKey{},
 			expectedPrices: map[string]*GCPPricing{
@@ -361,6 +386,42 @@ func TestParsePage(t *testing.T) {
 						RAMCost:          "68.204999658",
 						UsesBaseCPUPrice: false,
 						UsageType:        "ondemand",
+					},
+				},
+				// C3 must resolve to keys distinct from C3D: matching "C3 INSTANCE"
+				// (the space between "C3" and "INSTANCE") excludes C3D SKUs, whose
+				// descriptions read "C3D Instance ...". The "Sole Tenancy Premium for
+				// C3 Instance Core" SKU is excluded and creates no keys.
+				"us-central1,c3standard,ondemand": {
+					Node: &models.Node{
+						VCPUCost:         "0.034",
+						RAMCost:          "0.005",
+						UsesBaseCPUPrice: false,
+						UsageType:        "ondemand",
+					},
+				},
+				"us-central1,c3standard,ondemand,gpu": {
+					Node: &models.Node{
+						VCPUCost:         "0.034",
+						RAMCost:          "0.005",
+						UsesBaseCPUPrice: false,
+						UsageType:        "ondemand",
+					},
+				},
+				"us-central1,c3standard,preemptible": {
+					Node: &models.Node{
+						VCPUCost:         "0.0125",
+						RAMCost:          "0.0015",
+						UsesBaseCPUPrice: false,
+						UsageType:        "preemptible",
+					},
+				},
+				"us-central1,c3standard,preemptible,gpu": {
+					Node: &models.Node{
+						VCPUCost:         "0.0125",
+						RAMCost:          "0.0015",
+						UsesBaseCPUPrice: false,
+						UsageType:        "preemptible",
 					},
 				},
 			},
@@ -1036,6 +1097,13 @@ func TestSustainedUseDiscount(t *testing.T) {
 			defaultDiscount: 0.30,
 			isPreemptible:   false,
 			expected:        0.30,
+		},
+		{
+			name:            "C3 instance",
+			class:           "c3",
+			defaultDiscount: 0.30,
+			isPreemptible:   false,
+			expected:        0.0,
 		},
 	}
 

--- a/pkg/cloud/gcp/test/skus.json
+++ b/pkg/cloud/gcp/test/skus.json
@@ -313,6 +313,206 @@
             "serviceProviderName": "Google",
             "node": null,
             "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C300-CPU0-0001",
+            "skuId": "C300-CPU0-0001",
+            "description": "C3 Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 34000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C300-RAM0-0002",
+            "skuId": "C300-RAM0-0002",
+            "description": "C3 Instance Ram running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "RAM",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "GiBy.h",
+                        "usageUnitDescription": "gibibyte hour",
+                        "baseUnit": "By.s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 5000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C300-CPU1-0003",
+            "skuId": "C300-CPU1-0003",
+            "description": "Spot Preemptible C3 Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "Preemptible"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 12500000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C300-RAM1-0004",
+            "skuId": "C300-RAM1-0004",
+            "description": "Spot Preemptible C3 Instance Ram running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "RAM",
+                "usageType": "Preemptible"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "GiBy.h",
+                        "usageUnitDescription": "gibibyte hour",
+                        "baseUnit": "By.s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 1500000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/C300-SOLE-0005",
+            "skuId": "C300-SOLE-0005",
+            "description": "Sole Tenancy Premium for C3 Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 77000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
         }
     ],
     "nextPageToken": "APKCS1HVa0YpwgyTFbqbJ1eGwzKZmsPwLqzMZPTSNia5ck1Hc54Tx_Kz3oBxwSnRIdGVxXoSPdf-XlDpyNBf4QuxKcIEgtrQ1LDLWAgZowI0ns7HjrGta2s="


### PR DESCRIPTION
## What
Add GCP **C3** (Intel) machine-family pricing support to the GCP provider.

## Why
Same gap as C3D (#3944) / C4A (#3945): `parsePage` has no `C3` match. The tricky part is not matching C3D SKUs: GCP's C3 descriptions read `"... C3 Instance Core ..."` while C3D reads `"C3D Instance ..."`, so the match uses the substring `"C3 INSTANCE"` (with the trailing space) — this excludes C3D. C3D must still be checked first (it is, in #3944's arm).

## What changed (`pkg/cloud/gcp/provider.go`)
- **`parsePage`**: classify `cpu`/`ram` SKUs whose description contains `C3 INSTANCE` (trailing space guards against C3D) and not `SOLE` as `c3standard`.
- **`parseGCPInstanceTypeLabel`**: fold `c3-highmem-*` / `c3-highcpu-*` onto `c3standard`.
- **`sustainedUseDiscount`**: no sustained-use discount for C3 → SUD class `0.0`.

## Testing
- Added `parsePage` unit tests including a distinct **C3-vs-C3D** vCPU-rate assertion (regression guard for the substring boundary) plus spot + sole-tenancy exclusion, with `test/skus.json` fixtures.
- `gofmt` clean.

