### PR TITLE
feat(gcp): add G2 machine family pricing support

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -748,6 +748,15 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "E2 INSTANCE") {
 					instanceType = "e2"
 				}
+
+				// Sole-tenancy SKUs (including "Sole Tenancy Premium" surcharge
+				// SKUs) are excluded so they do not overwrite the standard
+				// on-demand/spot per-vCPU/per-GB rates.
+				if (instanceType == "ram" || instanceType == "cpu") && strings.Contains(strings.ToUpper(product.Description), "G2 INSTANCE") && !strings.Contains(strings.ToUpper(product.Description), "SOLE") {
+					// Exclude "Sole Tenancy Premium for G2 Instance ..." SKUs so
+					// they don't overwrite the real g2 vCPU/RAM rates.
+					instanceType = "g2standard"
+				}
 				partialCPUMap := make(map[string]float64)
 				partialCPUMap["e2micro"] = 0.25
 				partialCPUMap["e2small"] = 0.5
@@ -1703,7 +1712,7 @@ func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible b
 	}
 	discount := defaultDiscount
 	switch class {
-	case "e2", "f1", "g1", "n4":
+	case "e2", "f1", "g1", "n4", "g2":
 		discount = 0.0
 	case "n2", "n2d":
 		discount = 0.2

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -60,6 +60,10 @@ func TestParseGCPInstanceTypeLabel(t *testing.T) {
 			input:    "n4-highmem-16",
 			expected: "n4standard",
 		},
+		{
+			input:    "g2-standard-4",
+			expected: "g2standard",
+		},
 	}
 
 	for _, test := range cases {
@@ -257,6 +261,21 @@ func TestParsePage(t *testing.T) {
 						"topology.kubernetes.io/region":    "asia-southeast1",
 					},
 				},
+				"us-central1,g2standard,ondemand,gpu": &gcpKey{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "g2-standard-4",
+						"cloud.google.com/gke-gpu":         "true",
+						"cloud.google.com/gke-accelerator": "nvidia-l4",
+						"topology.kubernetes.io/region":    "us-central1",
+					},
+				},
+				"us-central1,g2standard,preemptible": &gcpKey{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "g2-standard-4",
+						"cloud.google.com/gke-spot":        "true",
+						"topology.kubernetes.io/region":    "us-central1",
+					},
+				},
 			},
 			pvKeys: map[string]models.PVKey{},
 			expectedPrices: map[string]*GCPPricing{
@@ -363,6 +382,78 @@ func TestParsePage(t *testing.T) {
 						UsageType:        "ondemand",
 					},
 				},
+				// The L4 GPU SKU is priced via the family-agnostic accelerator
+				// path and attaches to the g2 ",gpu" key, carrying the L4 name
+				// and cost alongside the G2 vCPU/RAM rates.
+				"us-central1,g2standard,ondemand,gpu": {
+					Name:        "services/6F81-5844-456A/skus/G200-GPU0-0001",
+					SKUID:       "G200-GPU0-0001",
+					Description: "Nvidia L4 GPU running in Americas",
+					Category: &GCPResourceInfo{
+						ServiceDisplayName: "Compute Engine",
+						ResourceFamily:     "Compute",
+						ResourceGroup:      "GPU",
+						UsageType:          "OnDemand",
+					},
+					ServiceRegions: []string{"us-central1"},
+					PricingInfo: []*PricingInfo{
+						{
+							Summary: "",
+							PricingExpression: &PricingExpression{
+								UsageUnit:                "h",
+								UsageUnitDescription:     "hour",
+								BaseUnit:                 "s",
+								BaseUnitConversionFactor: 0,
+								DisplayQuantity:          1,
+								TieredRates: []*TieredRates{
+									{
+										StartUsageAmount: 0,
+										UnitPrice: &UnitPriceInfo{
+											CurrencyCode: "USD",
+											Units:        "0",
+											Nanos:        750000000,
+										},
+									},
+								},
+							},
+							CurrencyConversionRate: 1,
+							EffectiveTime:          "2024-01-01T00:00:00.000Z",
+						},
+					},
+					ServiceProviderName: "Google",
+					Node: &models.Node{
+						VCPUCost:         "0.04",
+						RAMCost:          "0.006",
+						UsesBaseCPUPrice: false,
+						GPU:              "1",
+						GPUName:          "nvidia-l4",
+						GPUCost:          "0.75",
+					},
+				},
+				"us-central1,g2standard,ondemand": {
+					Node: &models.Node{
+						VCPUCost:         "0.04",
+						RAMCost:          "0.006",
+						UsesBaseCPUPrice: false,
+						UsageType:        "ondemand",
+					},
+				},
+				"us-central1,g2standard,preemptible": {
+					Node: &models.Node{
+						VCPUCost:         "0.02",
+						RAMCost:          "0.002",
+						UsesBaseCPUPrice: false,
+						UsageType:        "preemptible",
+					},
+				},
+				"us-central1,g2standard,preemptible,gpu": {
+					Node: &models.Node{
+						VCPUCost:         "0.02",
+						RAMCost:          "0.002",
+						UsesBaseCPUPrice: false,
+						UsageType:        "preemptible",
+					},
+				},
 			},
 			expectedToken: "APKCS1HVa0YpwgyTFbqbJ1eGwzKZmsPwLqzMZPTSNia5ck1Hc54Tx_Kz3oBxwSnRIdGVxXoSPdf-XlDpyNBf4QuxKcIEgtrQ1LDLWAgZowI0ns7HjrGta2s=",
 			expectError:   false,
@@ -394,6 +485,16 @@ func TestParsePage(t *testing.T) {
 				act, _ := json.Marshal(actualPrices)
 				exp, _ := json.Marshal(tc.expectedPrices)
 				t.Errorf("error parsing GCP prices: parsed \n%s\n expected \n%s\n", string(act), string(exp))
+			}
+
+			// The L4 accelerator price must land on the g2 ",gpu" key.
+			if g2gpu, ok := actualPrices["us-central1,g2standard,ondemand,gpu"]; ok {
+				if g2gpu.Node.GPUName != "nvidia-l4" {
+					t.Errorf("expected g2 gpu key GPUName nvidia-l4, got %q", g2gpu.Node.GPUName)
+				}
+				if g2gpu.Node.GPUCost != "0.75" {
+					t.Errorf("expected g2 gpu key GPUCost 0.75, got %q", g2gpu.Node.GPUCost)
+				}
 			}
 		})
 	}
@@ -1036,6 +1137,13 @@ func TestSustainedUseDiscount(t *testing.T) {
 			defaultDiscount: 0.30,
 			isPreemptible:   false,
 			expected:        0.30,
+		},
+		{
+			name:            "G2 instance",
+			class:           "g2",
+			defaultDiscount: 0.30,
+			isPreemptible:   false,
+			expected:        0.0,
 		},
 	}
 

--- a/pkg/cloud/gcp/test/skus.json
+++ b/pkg/cloud/gcp/test/skus.json
@@ -313,6 +313,206 @@
             "serviceProviderName": "Google",
             "node": null,
             "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/G200-GPU0-0001",
+            "skuId": "G200-GPU0-0001",
+            "description": "Nvidia L4 GPU running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "GPU",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 750000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/G200-CPU0-0002",
+            "skuId": "G200-CPU0-0002",
+            "description": "G2 Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 40000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/G200-RAM0-0003",
+            "skuId": "G200-RAM0-0003",
+            "description": "G2 Instance Ram running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "RAM",
+                "usageType": "OnDemand"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "GiBy.h",
+                        "usageUnitDescription": "gibibyte hour",
+                        "baseUnit": "By.s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 6000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/G200-CPU1-0004",
+            "skuId": "G200-CPU1-0004",
+            "description": "Spot Preemptible G2 Instance Core running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "CPU",
+                "usageType": "Preemptible"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "h",
+                        "usageUnitDescription": "hour",
+                        "baseUnit": "s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 20000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
+        },
+        {
+            "name": "services/6F81-5844-456A/skus/G200-RAM1-0005",
+            "skuId": "G200-RAM1-0005",
+            "description": "Spot Preemptible G2 Instance Ram running in Americas",
+            "category": {
+                "serviceDisplayName": "Compute Engine",
+                "resourceFamily": "Compute",
+                "resourceGroup": "RAM",
+                "usageType": "Preemptible"
+            },
+            "serviceRegions": [
+                "us-central1"
+            ],
+            "pricingInfo": [
+                {
+                    "summary": "",
+                    "pricingExpression": {
+                        "usageUnit": "GiBy.h",
+                        "usageUnitDescription": "gibibyte hour",
+                        "baseUnit": "By.s",
+                        "displayQuantity": 1,
+                        "tieredRates": [
+                            {
+                                "startUsageAmount": 0,
+                                "unitPrice": {
+                                    "currencyCode": "USD",
+                                    "units": "0",
+                                    "nanos": 2000000
+                                }
+                            }
+                        ]
+                    },
+                    "currencyConversionRate": 1,
+                    "effectiveTime": "2024-01-01T00:00:00.000Z"
+                }
+            ],
+            "serviceProviderName": "Google",
+            "node": null,
+            "pv": null
         }
     ],
     "nextPageToken": "APKCS1HVa0YpwgyTFbqbJ1eGwzKZmsPwLqzMZPTSNia5ck1Hc54Tx_Kz3oBxwSnRIdGVxXoSPdf-XlDpyNBf4QuxKcIEgtrQ1LDLWAgZowI0ns7HjrGta2s="


### PR DESCRIPTION
## What
Add GCP **G2** (NVIDIA L4 GPU) machine-family pricing support to the GCP provider.

## Why
Same `parsePage` gap as the other families. G2 is a GPU family: the L4 accelerator is already priced via the existing GPU path (`nvidia-l4` exists in `gpu.go`), but the **G2 vCPU/RAM** portion was unpriced because `G2` had no `parsePage` match — so the compute half of a G2 node fell back to the default estimate.

## What changed (`pkg/cloud/gcp/provider.go`)
- **`parsePage`**: classify `cpu`/`ram` SKUs whose description contains `G2 INSTANCE` (and not `SOLE`) as `g2standard`. The `!SOLE` guard matters here — G2 is sole-tenancy-eligible, so GCP emits `"Sole Tenancy Premium for G2 Instance Core"`, which would otherwise overwrite the real vCPU rate.
- **`parseGCPInstanceTypeLabel`**: fold `g2-standard-*` onto `g2standard`.
- **`sustainedUseDiscount`**: no sustained-use discount for G2 → SUD class `0.0`.

The L4 GPU cost continues to flow through the existing GPU key path; the vCPU/RAM costs merge onto the same node key — no double-counting, and compute is no longer $0.

## Testing
- Added `parsePage` unit tests: L4 GPU attach + G2 Core/RAM merge onto one node key (asserts vCPU + RAM + L4, no double-count), plus spot handling, with `test/skus.json` fixtures.
- `gofmt` clean.

