### PR TITLE
feat(gcp): make n2/n2d sustained-use discount configurable

### DIFF
--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -149,6 +149,12 @@ func (gcp *GCP) GetConfig() (*models.CustomPricing, error) {
 	if c.NegotiatedDiscount == "" {
 		c.NegotiatedDiscount = "0%"
 	}
+	if c.N2SustainedUseDiscount == "" {
+		// GCP applies a ~20% sustained-use discount to the n2/n2d families (vs the 30% default
+		// used for n1 etc). Kept as a config default so it can be overridden (e.g. "0%") instead
+		// of hardcoded in the pricing logic.
+		c.N2SustainedUseDiscount = "0.2"
+	}
 	if c.CurrencyCode == "" {
 		c.CurrencyCode = "USD"
 	}
@@ -1682,7 +1688,15 @@ func (gcp *GCP) PricingSourceStatus() map[string]*models.PricingSource {
 
 func (gcp *GCP) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	class := strings.Split(instanceType, "-")[0]
-	return 1.0 - ((1.0 - sustainedUseDiscount(class, defaultDiscount, isPreemptible)) * (1.0 - negotiatedDiscount))
+	// n2/n2d sustained-use discount is config-driven (GetConfig defaults it to 0.20). Fall back to
+	// 0.20 if config is unreadable, preserving the historical built-in value.
+	n2Discount := 0.2
+	if c, err := gcp.GetConfig(); err == nil {
+		if v := parseN2SustainedUseDiscount(c.N2SustainedUseDiscount); v != nil {
+			n2Discount = *v
+		}
+	}
+	return 1.0 - ((1.0 - sustainedUseDiscount(class, defaultDiscount, n2Discount, isPreemptible)) * (1.0 - negotiatedDiscount))
 }
 
 func (gcp *GCP) Regions() []string {
@@ -1697,7 +1711,28 @@ func (gcp *GCP) Regions() []string {
 	return gcpRegions
 }
 
-func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible bool) float64 {
+// parseN2SustainedUseDiscount parses the optional N2SustainedUseDiscount override for the
+// n2/n2d families. Accepts "0.2" or "20%". Returns nil for empty or unparseable input, in
+// which case the caller keeps the built-in 0.20 default (backwards-compatible).
+func parseN2SustainedUseDiscount(s string) *float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if strings.HasSuffix(s, "%") {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64); err == nil {
+			d := v / 100.0
+			return &d
+		}
+		return nil
+	}
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		return &v
+	}
+	return nil
+}
+
+func sustainedUseDiscount(class string, defaultDiscount, n2Discount float64, isPreemptible bool) float64 {
 	if isPreemptible {
 		return 0.0
 	}
@@ -1706,7 +1741,7 @@ func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible b
 	case "e2", "f1", "g1", "n4":
 		discount = 0.0
 	case "n2", "n2d":
-		discount = 0.2
+		discount = n2Discount
 	}
 	return discount
 }

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1688,12 +1688,18 @@ func (gcp *GCP) PricingSourceStatus() map[string]*models.PricingSource {
 
 func (gcp *GCP) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	class := strings.Split(instanceType, "-")[0]
-	// n2/n2d sustained-use discount is config-driven (GetConfig defaults it to 0.20). Fall back to
-	// 0.20 if config is unreadable, preserving the historical built-in value.
+	// n2/n2d sustained-use discount is config-driven; default 0.20. Only resolve config for those
+	// classes — every other class ignores n2Discount, so skip the lookup entirely. Read the raw
+	// pricing data rather than GetConfig, which mutates the shared CustomPricing to apply defaults
+	// (avoidable per-node writes / races on the hot path). Fall back to 0.20 if absent/unreadable.
 	n2Discount := 0.2
-	if c, err := gcp.GetConfig(); err == nil {
-		if v := parseN2SustainedUseDiscount(c.N2SustainedUseDiscount); v != nil {
-			n2Discount = *v
+	if class == "n2" || class == "n2d" {
+		if gcp.Config != nil {
+			if c, err := gcp.Config.GetCustomPricingData(); err == nil && c != nil {
+				if v := parseN2SustainedUseDiscount(c.N2SustainedUseDiscount); v != nil {
+					n2Discount = *v
+				}
+			}
 		}
 	}
 	return 1.0 - ((1.0 - sustainedUseDiscount(class, defaultDiscount, n2Discount, isPreemptible)) * (1.0 - negotiatedDiscount))
@@ -1712,24 +1718,29 @@ func (gcp *GCP) Regions() []string {
 }
 
 // parseN2SustainedUseDiscount parses the optional N2SustainedUseDiscount override for the
-// n2/n2d families. Accepts "0.2" or "20%". Returns nil for empty or unparseable input, in
-// which case the caller keeps the built-in 0.20 default (backwards-compatible).
+// n2/n2d families. Accepts "0.2" or "20%". Returns nil for empty, unparseable, non-finite, or
+// out-of-[0,1] input, in which case the caller keeps the built-in 0.20 default. Rejecting
+// out-of-range values prevents a bad override from producing a combined discount > 1 (which
+// would yield negative effective prices).
 func parseN2SustainedUseDiscount(s string) *float64 {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return nil
 	}
+	var v float64
+	var err error
 	if strings.HasSuffix(s, "%") {
-		if v, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64); err == nil {
-			d := v / 100.0
-			return &d
+		if v, err = strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64); err != nil {
+			return nil
 		}
+		v /= 100.0
+	} else if v, err = strconv.ParseFloat(s, 64); err != nil {
 		return nil
 	}
-	if v, err := strconv.ParseFloat(s, 64); err == nil {
-		return &v
+	if math.IsNaN(v) || math.IsInf(v, 0) || v < 0.0 || v > 1.0 {
+		return nil
 	}
-	return nil
+	return &v
 }
 
 func sustainedUseDiscount(class string, defaultDiscount, n2Discount float64, isPreemptible bool) float64 {

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -939,7 +939,7 @@ func TestGCP_PricingSourceStatus(t *testing.T) {
 }
 
 func TestGCP_CombinedDiscountForNode(t *testing.T) {
-	gcp := &GCP{}
+	gcp := &GCP{Config: &mockConfig{}}
 
 	tests := []struct {
 		name               string
@@ -973,6 +973,14 @@ func TestGCP_CombinedDiscountForNode(t *testing.T) {
 			negotiatedDiscount: 0.20,
 			expectedDiscount:   0.20, // E2 has no sustained use discount
 		},
+		{
+			name:               "N2 instance (default 0.2 SUD from config)",
+			instanceType:       "n2-standard-4",
+			isPreemptible:      false,
+			defaultDiscount:    0.30,
+			negotiatedDiscount: 0.20,
+			expectedDiscount:   0.36, // 1 - (1-0.2)*(1-0.2); n2 uses its 0.2 SUD, not defaultDiscount
+		},
 	}
 
 	for _, tt := range tests {
@@ -981,6 +989,18 @@ func TestGCP_CombinedDiscountForNode(t *testing.T) {
 			assert.InDelta(t, tt.expectedDiscount, result, 0.01)
 		})
 	}
+}
+
+func TestGCP_CombinedDiscountForNode_N2Override(t *testing.T) {
+	// n2/n2d SUD overridden to 0 via the N2SustainedUseDiscount config -> only the negotiated
+	// discount remains for n2/n2d, while n1 (defaultDiscount) is unaffected by the override.
+	gcp := &GCP{Config: &mockConfig{n2: "0%"}}
+
+	gotN2D := gcp.CombinedDiscountForNode("n2d-highmem-8", false, 0.30, 0.20)
+	assert.InDelta(t, 0.20, gotN2D, 0.01) // 1 - (1-0)*(1-0.2)
+
+	gotN1 := gcp.CombinedDiscountForNode("n1-standard-2", false, 0.30, 0.20)
+	assert.InDelta(t, 0.44, gotN1, 0.01) // 1 - (1-0.3)*(1-0.2), unchanged
 }
 
 func TestGCP_Regions(t *testing.T) {
@@ -1035,6 +1055,13 @@ func TestParseN2SustainedUseDiscount(t *testing.T) {
 	}
 	if got := parseN2SustainedUseDiscount("not-a-number"); got != nil {
 		t.Errorf("unparseable: expected nil, got %v", *got)
+	}
+	// Non-finite and out-of-[0,1] overrides must be rejected (nil) so the caller keeps the
+	// 0.20 default instead of producing a combined discount > 1 (negative effective prices).
+	for _, bad := range []string{"2", "1.5", "200%", "-0.1", "-5%", "NaN", "Inf", "+Inf", "-Inf"} {
+		if got := parseN2SustainedUseDiscount(bad); got != nil {
+			t.Errorf("%q: expected nil (out-of-range/non-finite), got %v", bad, *got)
+		}
 	}
 	for _, tc := range []struct {
 		in   string
@@ -1349,18 +1376,21 @@ func TestGCP_loadGCPAuthSecret(t *testing.T) {
 }
 
 // Mock implementations for testing
-type mockConfig struct{}
+type mockConfig struct {
+	n2 string // optional N2SustainedUseDiscount value for tests
+}
 
 func (m *mockConfig) GetCustomPricingData() (*models.CustomPricing, error) {
 	return &models.CustomPricing{
-		Discount:              "30%",
-		NegotiatedDiscount:    "0%",
-		CurrencyCode:          "USD",
-		ZoneNetworkEgress:     "0.12",
-		RegionNetworkEgress:   "0.08",
-		InternetNetworkEgress: "0.15",
-		NatGatewayEgress:      "0.45",
-		NatGatewayIngress:     "0.45",
+		Discount:               "30%",
+		NegotiatedDiscount:     "0%",
+		CurrencyCode:           "USD",
+		ZoneNetworkEgress:      "0.12",
+		RegionNetworkEgress:    "0.08",
+		InternetNetworkEgress:  "0.15",
+		NatGatewayEgress:       "0.45",
+		NatGatewayIngress:      "0.45",
+		N2SustainedUseDiscount: m.n2,
 	}, nil
 }
 

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -1006,44 +1006,52 @@ func TestSustainedUseDiscount(t *testing.T) {
 		name            string
 		class           string
 		defaultDiscount float64
+		n2Discount      float64
 		isPreemptible   bool
 		expected        float64
 	}{
-		{
-			name:            "Preemptible instance",
-			class:           "n1",
-			defaultDiscount: 0.30,
-			isPreemptible:   true,
-			expected:        0.0,
-		},
-		{
-			name:            "E2 instance",
-			class:           "e2",
-			defaultDiscount: 0.30,
-			isPreemptible:   false,
-			expected:        0.0,
-		},
-		{
-			name:            "N2 instance",
-			class:           "n2",
-			defaultDiscount: 0.30,
-			isPreemptible:   false,
-			expected:        0.2,
-		},
-		{
-			name:            "N1 instance",
-			class:           "n1",
-			defaultDiscount: 0.30,
-			isPreemptible:   false,
-			expected:        0.30,
-		},
+		{name: "Preemptible instance", class: "n1", defaultDiscount: 0.30, n2Discount: 0.2, isPreemptible: true, expected: 0.0},
+		{name: "E2 instance", class: "e2", defaultDiscount: 0.30, n2Discount: 0.2, expected: 0.0},
+		{name: "N2 default (0.2)", class: "n2", defaultDiscount: 0.30, n2Discount: 0.2, expected: 0.2},
+		{name: "N2D default (0.2)", class: "n2d", defaultDiscount: 0.30, n2Discount: 0.2, expected: 0.2},
+		{name: "N2 zeroed", class: "n2", defaultDiscount: 0.30, n2Discount: 0.0, expected: 0.0},
+		{name: "N2D zeroed", class: "n2d", defaultDiscount: 0.30, n2Discount: 0.0, expected: 0.0},
+		{name: "N1 uses defaultDiscount", class: "n1", defaultDiscount: 0.30, n2Discount: 0.2, expected: 0.30},
+		{name: "N1 ignores n2Discount", class: "n1", defaultDiscount: 0.30, n2Discount: 0.0, expected: 0.30},
+		{name: "E2 ignores n2Discount", class: "e2", defaultDiscount: 0.30, n2Discount: 0.0, expected: 0.0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sustainedUseDiscount(tt.class, tt.defaultDiscount, tt.isPreemptible)
+			result := sustainedUseDiscount(tt.class, tt.defaultDiscount, tt.n2Discount, tt.isPreemptible)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestParseN2SustainedUseDiscount(t *testing.T) {
+	if got := parseN2SustainedUseDiscount(""); got != nil {
+		t.Errorf("empty: expected nil, got %v", *got)
+	}
+	if got := parseN2SustainedUseDiscount("not-a-number"); got != nil {
+		t.Errorf("unparseable: expected nil, got %v", *got)
+	}
+	for _, tc := range []struct {
+		in   string
+		want float64
+	}{
+		{"0.2", 0.2},
+		{"20%", 0.2},
+		{"0", 0.0},
+		{"0%", 0.0},
+		{" 30% ", 0.3},
+	} {
+		got := parseN2SustainedUseDiscount(tc.in)
+		if got == nil {
+			t.Errorf("%q: expected %v, got nil", tc.in, tc.want)
+			continue
+		}
+		assert.InDelta(t, tc.want, *got, 1e-9, "input %q", tc.in)
 	}
 }
 

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -183,7 +183,10 @@ type CustomPricing struct {
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`
 	// N2SustainedUseDiscount overrides the built-in sustained-use discount for the n2 and n2d
-	// machine families (GCP). Empty = built-in default (0.20). Accepts "0.2" or "20%".
+	// machine families (GCP). Empty = built-in default (0.20). A bare number is a fraction
+	// ("0.2" = 20%); a percent string is also accepted ("20%" = 20%). Note this fraction
+	// interpretation differs from Discount/NegotiatedDiscount (ParsePercentString), which read a
+	// bare number as a percent — there "20" = 20% and "0.2" = 0.2%, not 20%.
 	N2SustainedUseDiscount string `json:"n2SustainedUseDiscount,omitempty"`
 	ClusterName            string `json:"clusterName"`
 	ClusterAccountID       string `json:"clusterAccount,omitempty"`

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -182,9 +182,12 @@ type CustomPricing struct {
 	CurrencyCode                 string `json:"currencyCode"`
 	Discount                     string `json:"discount"`
 	NegotiatedDiscount           string `json:"negotiatedDiscount"`
-	ClusterName                  string `json:"clusterName"`
-	ClusterAccountID             string `json:"clusterAccount,omitempty"`
-	DefaultLBPrice               string `json:"defaultLBPrice"`
+	// N2SustainedUseDiscount overrides the built-in sustained-use discount for the n2 and n2d
+	// machine families (GCP). Empty = built-in default (0.20). Accepts "0.2" or "20%".
+	N2SustainedUseDiscount string `json:"n2SustainedUseDiscount,omitempty"`
+	ClusterName            string `json:"clusterName"`
+	ClusterAccountID       string `json:"clusterAccount,omitempty"`
+	DefaultLBPrice         string `json:"defaultLBPrice"`
 }
 
 func sanitizeFloatString(number string, allowNaN bool) (string, error) {


### PR DESCRIPTION
## What
Make the **n2/n2d** sustained-use discount (SUD) configurable, defaulting to the current `0.20`.

## Why
`sustainedUseDiscount` hardcodes SUD per family: `e2/f1/g1/n4/c3/c3d/c4a/g2 → 0.0`, `n2/n2d → 0.2`, and everything else (n1, m1, a2, …) falls through to the `Discount` config (default 30%). So the fall-through families are already zeroable via `Discount`, and the `0.0` families are already zero — but **n2/n2d cannot be changed at all** because their `0.2` is hardcoded. Users who model GCP's committed-use/negotiated discounts separately and want OpenCost to report **undiscounted list prices** currently can't zero the n2/n2d SUD.

## What changed
- **`models.go`**: add `N2SustainedUseDiscount string` to `CustomPricing` (`json:"n2SustainedUseDiscount,omitempty"`). Accepts `"0.2"` or `"20%"`.
- **`provider.go`**:
  - `GetConfig` supplies the `0.20` default when unset — same pattern as `Discount`/`NegotiatedDiscount` — so the value is config-driven rather than hardcoded in the pricing logic.
  - `sustainedUseDiscount` now takes the resolved `n2Discount` and the `n2/n2d` switch arm simply returns it (no literal `0.2`).
  - `CombinedDiscountForNode` resolves it from config (parsing `"20%"`/`"0.2"`), falling back to `0.20` if config is unreadable — its **interface signature is unchanged**.

## Scope / compatibility
- **Backwards-compatible**: unconfigured n2/n2d stays exactly `0.20`.
- **Only n2/n2d**: no general all-family override; e2/n4/c3/… (0.0) and the fall-through families (n1, etc.) are untouched.
- GCP-only; no `CombinedDiscountForNode` signature change, no other provider touched.

## Testing
- Table-driven `sustainedUseDiscount` cases (default 0.2, zeroed, n2 vs n2d, e2/n1 unaffected, preemptible→0) + a `parseN2SustainedUseDiscount` test (`"0.2"`, `"20%"`, `"0%"`, empty/garbage→nil). `gofmt` clean.

