### PR TITLE
Handle immutable releases in SBOM creation

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -176,6 +176,9 @@ jobs:
             opencost-container-sbom.spdx.json
             opencost-container-sbom.cyclonedx.json
           fail_on_unmatched_files: false
+          # Immutable releases forbid deleting/replacing published assets.
+          # Skip assets that already exist instead of delete-and-replace.
+          overwrite_files: false
 
       # Create a summary of the SBOM generation
       - name: Generate Summary


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Fixes a bug where the Generate SBOM workflow fails now that releases are immutable. This prevents the job from attempting to overwrite existing assets. 

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->
N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->
N/A

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->
