### PR TITLE
feat(aws): add Athena query result reuse configuration

### DIFF
--- a/pkg/cloud/aws/athenaconfiguration.go
+++ b/pkg/cloud/aws/athenaconfiguration.go
@@ -18,6 +18,10 @@ type AthenaConfiguration struct {
 	Workgroup  string     `json:"workgroup"`
 	Account    string     `json:"account"`
 	Authorizer Authorizer `json:"authorizer"`
+	// ResultReuseMaxAgeMinutes enables Athena query result reuse for this many minutes (0 = disabled).
+	// When set, identical queries within the TTL window return cached results instead of re-scanning,
+	// reducing cost for multi-cluster deployments where many clusters run the same CUR query.
+	ResultReuseMaxAgeMinutes int32 `json:"resultReuseMaxAgeMinutes,omitempty"`
 }
 
 func (ac *AthenaConfiguration) Validate() error {
@@ -103,19 +107,24 @@ func (ac *AthenaConfiguration) Equals(config cloud.Config) bool {
 		return false
 	}
 
+	if ac.ResultReuseMaxAgeMinutes != thatConfig.ResultReuseMaxAgeMinutes {
+		return false
+	}
+
 	return true
 }
 
 func (ac *AthenaConfiguration) Sanitize() cloud.Config {
 	return &AthenaConfiguration{
-		Bucket:     ac.Bucket,
-		Region:     ac.Region,
-		Database:   ac.Database,
-		Catalog:    ac.Catalog,
-		Table:      ac.Table,
-		Workgroup:  ac.Workgroup,
-		Account:    ac.Account,
-		Authorizer: ac.Authorizer.Sanitize().(Authorizer),
+		Bucket:                   ac.Bucket,
+		Region:                   ac.Region,
+		Database:                 ac.Database,
+		Catalog:                  ac.Catalog,
+		Table:                    ac.Table,
+		Workgroup:                ac.Workgroup,
+		Account:                  ac.Account,
+		Authorizer:               ac.Authorizer.Sanitize().(Authorizer),
+		ResultReuseMaxAgeMinutes: ac.ResultReuseMaxAgeMinutes,
 	}
 }
 
@@ -189,6 +198,14 @@ func (ac *AthenaConfiguration) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("AthenaConfiguration: UnmarshalJSON: %w", err)
 	}
 	ac.Authorizer = authorizer
+
+	if _, ok := fmap["resultReuseMaxAgeMinutes"]; ok {
+		resultReuseMaxAgeMinutes, err := cloud.GetInterfaceValue[float64](fmap, "resultReuseMaxAgeMinutes")
+		if err != nil {
+			return fmt.Errorf("AthenaConfiguration: UnmarshalJSON: %w", err)
+		}
+		ac.ResultReuseMaxAgeMinutes = int32(resultReuseMaxAgeMinutes)
+	}
 
 	return nil
 }

--- a/pkg/cloud/aws/athenaconfiguration_test.go
+++ b/pkg/cloud/aws/athenaconfiguration_test.go
@@ -515,6 +515,37 @@ func TestAthenaConfiguration_Equals(t *testing.T) {
 			},
 			expected: false,
 		},
+		"different resultReuseMaxAgeMinutes": {
+			left: AthenaConfiguration{
+				Bucket:                   "bucket",
+				Region:                   "region",
+				Database:                 "database",
+				Catalog:                  "catalog",
+				Table:                    "table",
+				Workgroup:                "workgroup",
+				Account:                  "account",
+				ResultReuseMaxAgeMinutes: 60,
+				Authorizer: &AccessKey{
+					ID:     "id",
+					Secret: "secret",
+				},
+			},
+			right: &AthenaConfiguration{
+				Bucket:                   "bucket",
+				Region:                   "region",
+				Database:                 "database",
+				Catalog:                  "catalog",
+				Table:                    "table",
+				Workgroup:                "workgroup",
+				Account:                  "account",
+				ResultReuseMaxAgeMinutes: 120,
+				Authorizer: &AccessKey{
+					ID:     "id",
+					Secret: "secret",
+				},
+			},
+			expected: false,
+		},
 		"different config": {
 			left: AthenaConfiguration{
 				Bucket:    "bucket",
@@ -579,6 +610,22 @@ func TestAthenaConfiguration_JSON(t *testing.T) {
 				Workgroup:  "workgroup",
 				Account:    "account",
 				Authorizer: &ServiceAccount{},
+			},
+		},
+		"ResultReuseMaxAgeMinutes": {
+			config: AthenaConfiguration{
+				Bucket:                   "bucket",
+				Region:                   "region",
+				Database:                 "database",
+				Catalog:                  "catalog",
+				Table:                    "table",
+				Workgroup:                "workgroup",
+				Account:                  "account",
+				ResultReuseMaxAgeMinutes: 60,
+				Authorizer: &AccessKey{
+					ID:     "id",
+					Secret: "secret",
+				},
 			},
 		},
 		"AssumeRole with AccessKey": {

--- a/pkg/cloud/aws/athenaquerier.go
+++ b/pkg/cloud/aws/athenaquerier.go
@@ -113,6 +113,15 @@ func (aq *AthenaQuerier) queryAthenaPaginated(ctx context.Context, query string,
 		startQueryExecutionInput.WorkGroup = aws.String(aq.Workgroup)
 	}
 
+	if aq.ResultReuseMaxAgeMinutes > 0 {
+		startQueryExecutionInput.ResultReuseConfiguration = &types.ResultReuseConfiguration{
+			ResultReuseByAgeConfiguration: &types.ResultReuseByAgeConfiguration{
+				Enabled:         true,
+				MaxAgeInMinutes: aws.Int32(aq.ResultReuseMaxAgeMinutes),
+			},
+		}
+	}
+
 	// Create Athena Client
 	cli, err := aq.GetAthenaClient()
 	if err != nil {


### PR DESCRIPTION
Add ResultReuseMaxAgeMinutes to AthenaConfiguration to enable Athena's per-query result reuse feature. When set to a non-zero value, identical queries within the TTL window return cached results instead of re-scanning S3, reducing cost for multi-cluster deployments sharing a single CUR workgroup.

Defaults to 0 (disabled), preserving existing behavior. Optional in cloud-integration.json; wired through Equals, Sanitize, and UnmarshalJSON.

## Description

Adds an optional `resultReuseMaxAgeMinutes` field to the AWS Athena cloud integration config (`AthenaConfiguration`). When set to a non-zero value, OpenCost enables [Athena query result reuse](https://docs.aws.amazon.com/athena/latest/ug/reusing-query-results.html) on every `StartQueryExecution` call, so identical CUR queries issued within the TTL window return cached results instead of re-scanning S3.

Changes:
- New field `ResultReuseMaxAgeMinutes int32` on `AthenaConfiguration` (JSON: `resultReuseMaxAgeMinutes`, `omitempty`).
- In `queryAthenaPaginated`, when the value is `> 0`, set `ResultReuseConfiguration.ResultReuseByAgeConfiguration` with `Enabled: true` and `MaxAgeInMinutes` = the configured value.
- Field wired through `Equals`, `Sanitize`, and `UnmarshalJSON` for parity with existing configuration fields.

Example `cloud-integration.json` (AWS block):

```json
{
  "athenaBucketName": "...",
  "athenaRegion": "...",
  "athenaDatabase": "...",
  "athenaTable": "...",
  "resultReuseMaxAgeMinutes": 60
}
```

**Motivation:** OpenCost issues the same CUR queries against Athena on a recurring schedule. In multi-cluster deployments pointing at a shared Athena workgroup/CUR table, these queries are frequently identical within a short window, and each re-scan is billed by bytes scanned. Result reuse lets AWS serve cached results, reducing Athena scan cost and query latency with no change to returned data.

## Related Issues

N/A

## User Impact

Fully backward compatible; not a breaking change.

- The field defaults to `0`, which means "disabled." When unset, `StartQueryExecutionInput.ResultReuseConfiguration` is left `nil` — identical to prior behavior. No config migration required.
- Users who want the cost/latency benefit opt in by setting `resultReuseMaxAgeMinutes` to a positive number of minutes.

Limitations:
- Athena result reuse requires query **engine v3**; on v2 workgroups the setting has no effect.
- AWS caps `MaxAgeInMinutes` at 10080 (7 days).

## Testing

Added unit tests in `pkg/cloud/aws/athenaconfiguration_test.go`:
- `TestAthenaConfiguration_Equals` — new case asserting configs differing only by `resultReuseMaxAgeMinutes` are not equal.
- `TestAthenaConfiguration_JSON` — new case covering the marshal/unmarshal round-trip of the field.

All pass, and the package is clean under `gofmt` and `go vet`:

```
$ go test ./pkg/cloud/aws/ -run TestAthenaConfiguration
ok  	github.com/opencost/opencost/pkg/cloud/aws	0.589s

$ go vet ./pkg/cloud/aws/
$ gofmt -l pkg/cloud/aws/
```
