### PR TITLE
feat(mcp): support federated multi-cluster pricing reconciliation

### DIFF
--- a/core/pkg/external/configmapsource_test.go
+++ b/core/pkg/external/configmapsource_test.go
@@ -333,11 +333,11 @@ labels:
 
 func TestFilterValidLabels_AllValid_ReturnedUnchanged(t *testing.T) {
 	in := map[string]string{
-		"env":                     "prod",
-		"region":                  "us-east-1",
-		"app.kubernetes.io/name":  "opencost",
-		"my-key":                  "my-value",
-		"a":                       "b",
+		"env":                    "prod",
+		"region":                 "us-east-1",
+		"app.kubernetes.io/name": "opencost",
+		"my-key":                 "my-value",
+		"a":                      "b",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -396,8 +396,8 @@ func TestFilterValidLabels_KeyTooLong_EntryDropped(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 	in := map[string]string{
-		"app.kubernetes.io/name":      "opencost",
-		"example.com/env":             "staging",
+		"app.kubernetes.io/name": "opencost",
+		"example.com/env":        "staging",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -405,7 +405,7 @@ func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) {
 	in := map[string]string{
-		"valid":          "kept",
+		"valid":         "kept",
 		"-bad.prefix/k": "dropped",
 	}
 	out := filterValidLabels(in)
@@ -414,10 +414,10 @@ func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) 
 
 func TestFilterValidLabels_MixedValidAndInvalid_OnlyValidReturned(t *testing.T) {
 	in := map[string]string{
-		"cluster":    "prod",
-		"":           "no-key",
-		"bad-value":  "-oops",
-		"region":     "eu-west-1",
+		"cluster":   "prod",
+		"":          "no-key",
+		"bad-value": "-oops",
+		"region":    "eu-west-1",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, map[string]string{"cluster": "prod", "region": "eu-west-1"}, out)

--- a/pkg/cloud/alibaba/provider.go
+++ b/pkg/cloud/alibaba/provider.go
@@ -557,7 +557,7 @@ func (alibaba *Alibaba) PVPricing(pvk models.PVKey) (*models.PV, error) {
 
 // Inter zone and Inter region network cost are defaulted based on https://www.alibabacloud.com/help/en/cloud-data-transmission/latest/cross-region-data-transfers
 // Internet cost is default based on https://www.alibabacloud.com/help/en/elastic-compute-service/latest/public-bandwidth to $0.123
-func (alibaba *Alibaba) NetworkPricing() (*models.Network, error) {
+func (alibaba *Alibaba) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := alibaba.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -594,6 +594,10 @@ func (alibaba *Alibaba) NetworkPricing() (*models.Network, error) {
 
 // Alibaba loadbalancer has three different types https://www.alibabacloud.com/product/server-load-balancer,
 // defaulted price to classic load balancer https://www.alibabacloud.com/help/en/server-load-balancer/latest/pay-as-you-go.
+func (alibaba *Alibaba) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
+}
+
 func (alibaba *Alibaba) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	cpricing, err := alibaba.Config.GetCustomPricingData()
 	if err != nil {

--- a/pkg/cloud/alibaba/provider_test.go
+++ b/pkg/cloud/alibaba/provider_test.go
@@ -1225,7 +1225,7 @@ func TestPVPricing_Error(t *testing.T) {
 
 func TestNetworkPricing_Error(t *testing.T) {
 	a := &Alibaba{Config: &fakeProviderConfig{}}
-	_, err := a.NetworkPricing()
+	_, err := a.NetworkPricing(nil)
 	if err == nil {
 		t.Fatalf("NetworkPricing should return error for missing config")
 	}
@@ -1614,7 +1614,7 @@ func TestNetworkPricing_WithValidConfig(t *testing.T) {
 		},
 	}
 
-	network, err := a.NetworkPricing()
+	network, err := a.NetworkPricing(nil)
 	if err != nil {
 		t.Logf("NetworkPricing failed as expected: %v", err)
 	} else {

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1427,8 +1427,7 @@ func (aws *AWS) spotPricingFromHistory(k models.Key) (*SpotPriceHistoryEntry, bo
 	return price, true
 }
 
-// Stubbed NetworkPricing for AWS. Pull directly from aws.json for now
-func (aws *AWS) NetworkPricing() (*models.Network, error) {
+func (aws *AWS) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := aws.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1461,6 +1460,10 @@ func (aws *AWS) NetworkPricing() (*models.Network, error) {
 		NatGatewayEgressCost:      nge,
 		NatGatewayIngressCost:     ngi,
 	}, nil
+}
+
+func (aws *AWS) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (aws *AWS) LoadBalancerPricing() (*models.LoadBalancer, error) {

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1452,8 +1452,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 	}, meta, nil
 }
 
-// Stubbed NetworkPricing for Azure. Pull directly from azure.json for now
-func (az *Azure) NetworkPricing() (*models.Network, error) {
+func (az *Azure) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := az.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1492,6 +1491,10 @@ func (az *Azure) NetworkPricing() (*models.Network, error) {
 // services will be that of a standard static public IP https://azure.microsoft.com/en-us/pricing/details/ip-addresses/.
 // Azure still has load balancers which follow the standard pricing scheme based on rules
 // https://azure.microsoft.com/en-us/pricing/details/load-balancer/, they are created on a per-cluster basis.
+func (az *Azure) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
+}
+
 func (azr *Azure) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.005,

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -803,7 +803,7 @@ func (do *DOKS) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (do *DOKS) NetworkPricing() (*models.Network, error) {
+func (do *DOKS) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	// fallback
 	const (
 		defaultZoneEgress        = 0.00
@@ -843,6 +843,10 @@ func (do *DOKS) NetworkPricing() (*models.Network, error) {
 		NatGatewayEgressCost:      nge,
 		NatGatewayIngressCost:     ngi,
 	}, nil
+}
+
+func (do *DOKS) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func parseWithDefault(val string, fallback float64, label string) float64 {

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1175,8 +1175,7 @@ func (gcp *GCP) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	return pricing.PV, nil
 }
 
-// Stubbed NetworkPricing for GCP. Pull directly from gcp.json for now
-func (gcp *GCP) NetworkPricing() (*models.Network, error) {
+func (gcp *GCP) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := gcp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1209,6 +1208,10 @@ func (gcp *GCP) NetworkPricing() (*models.Network, error) {
 		NatGatewayEgressCost:      nge,
 		NatGatewayIngressCost:     ngi,
 	}, nil
+}
+
+func (gcp *GCP) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (gcp *GCP) LoadBalancerPricing() (*models.LoadBalancer, error) {

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -811,7 +811,7 @@ func TestGCP_NetworkPricing(t *testing.T) {
 		Config: &mockConfig{},
 	}
 
-	result, err := gcp.NetworkPricing()
+	result, err := gcp.NetworkPricing(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -281,12 +281,13 @@ type Provider interface {
 	NodePricing(Key) (*Node, PricingMetadata, error)
 	GpuPricing(map[string]string) (string, error)
 	PVPricing(PVKey) (*PV, error)
-	NetworkPricing() (*Network, error)           // TODO: add key interface arg for dynamic price fetching
+	NetworkPricing(NetworkKey) (*Network, error)
 	LoadBalancerPricing() (*LoadBalancer, error) // TODO: add key interface arg for dynamic price fetching
 	AllNodePricing() (interface{}, error)
 	DownloadPricingData() error
 	GetKey(map[string]string, *clustercache.Node) Key
 	GetPVKey(*clustercache.PersistentVolume, map[string]string, string) PVKey
+	GetNetworkKey(labels map[string]string, clusterID string) NetworkKey
 	UpdateConfig(r io.Reader, updateType string) (*CustomPricing, error)
 	UpdateConfigFromConfigMap(map[string]string) (*CustomPricing, error)
 	GetConfig() (*CustomPricing, error)

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -281,6 +281,8 @@ type Provider interface {
 	NodePricing(Key) (*Node, PricingMetadata, error)
 	GpuPricing(map[string]string) (string, error)
 	PVPricing(PVKey) (*PV, error)
+	// NetworkPricing retrieves network egress/ingress prices for the given NetworkKey topology.
+	// Passing a nil NetworkKey resolves prices using global/default provider configurations.
 	NetworkPricing(NetworkKey) (*Network, error)
 	LoadBalancerPricing() (*LoadBalancer, error) // TODO: add key interface arg for dynamic price fetching
 	AllNodePricing() (interface{}, error)

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -1,9 +1,85 @@
 package models
 
+import (
+	"github.com/opencost/opencost/core/pkg/util"
+)
+
 // TODO: used for dynamic cloud provider price fetching.
 // determine what identifies a load balancer in the json returned from the cloud provider pricing API call
 // type LBKey interface {
 // }
+
+// NetworkKey represents metadata identifying a network resource and its topology (e.g. region, zone, cluster)
+// for multi-dimensional network pricing resolution.
+//
+// Semantics of the NetworkKey interface methods:
+//   - ID(): Primary identifier for exact matching and caching (zone if present, otherwise region).
+//   - Features(): Comma-separated string encoding available topology dimensions
+//     (e.g. "us-east-1,us-east-1a", "us-east-1", or "us-east-1a").
+//   - GetZone(): Returns the availability zone string (empty string when unspecified).
+//   - GetRegion(): Returns the cloud region string (empty string when unspecified).
+type NetworkKey interface {
+	ID() string
+	Features() string
+	GetZone() string
+	GetRegion() string
+}
+
+// DefaultNetworkKey is the standard implementation of NetworkKey derived from
+// Kubernetes node labels and the cluster identifier.
+type DefaultNetworkKey struct {
+	Zone      string
+	Region    string
+	Labels    map[string]string
+	ClusterID string
+}
+
+// NewNetworkKey constructs a NetworkKey by extracting zone and region from the
+// provided node labels map, falling back to empty strings when labels are absent.
+func NewNetworkKey(labels map[string]string, clusterID string) NetworkKey {
+	zone, _ := util.GetZone(labels)
+	region, _ := util.GetRegion(labels)
+	return &DefaultNetworkKey{
+		Zone:      zone,
+		Region:    region,
+		Labels:    labels,
+		ClusterID: clusterID,
+	}
+}
+
+// ID returns the primary network topology identifier.
+// It returns Zone when non-empty, otherwise Region.
+func (n *DefaultNetworkKey) ID() string {
+	if n.Zone != "" {
+		return n.Zone
+	}
+	return n.Region
+}
+
+// Features returns a comma-separated string encoding available topology dimensions.
+//   - Both Region and Zone set → "Region,Zone"
+//   - Only Zone set            → "Zone"
+//   - Only Region set          → "Region"
+//   - Neither set              → ""
+func (n *DefaultNetworkKey) Features() string {
+	if n.Region != "" && n.Zone != "" {
+		return n.Region + "," + n.Zone
+	}
+	if n.Zone != "" {
+		return n.Zone
+	}
+	return n.Region
+}
+
+// GetZone returns the availability zone, or an empty string when unspecified.
+func (n *DefaultNetworkKey) GetZone() string {
+	return n.Zone
+}
+
+// GetRegion returns the cloud region, or an empty string when unspecified.
+func (n *DefaultNetworkKey) GetRegion() string {
+	return n.Region
+}
 
 // Network is the interface by which the provider and cost model communicate network egress prices.
 // The provider will best-effort try to fill out this struct.

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -40,7 +40,7 @@ type DefaultNetworkKey struct {
 
 // NewNetworkKey constructs a NetworkKey by extracting zone and region from the
 // provided node labels map, falling back to empty strings when labels are absent.
-// The provided labels map is defensively cloned to prevent data races and unwanted mutations.
+// The provided labels map is defensively cloned so future mutations of the input map don't affect the key.
 func NewNetworkKey(labels map[string]string, clusterID string) NetworkKey {
 	var cloned map[string]string
 	if labels != nil {

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -18,11 +18,15 @@ import (
 //     (e.g. "us-east-1,us-east-1a", "us-east-1", or "us-east-1a").
 //   - GetZone(): Returns the availability zone string (empty string when unspecified).
 //   - GetRegion(): Returns the cloud region string (empty string when unspecified).
+//   - GetClusterID(): Returns the cluster identifier string (empty string when unspecified).
+//   - GetLabels(): Returns a copy of the node labels map.
 type NetworkKey interface {
 	ID() string
 	Features() string
 	GetZone() string
 	GetRegion() string
+	GetClusterID() string
+	GetLabels() map[string]string
 }
 
 // DefaultNetworkKey is the standard implementation of NetworkKey derived from
@@ -36,13 +40,24 @@ type DefaultNetworkKey struct {
 
 // NewNetworkKey constructs a NetworkKey by extracting zone and region from the
 // provided node labels map, falling back to empty strings when labels are absent.
+// The provided labels map is defensively cloned to prevent data races and unwanted mutations.
 func NewNetworkKey(labels map[string]string, clusterID string) NetworkKey {
-	zone, _ := util.GetZone(labels)
-	region, _ := util.GetRegion(labels)
+	var cloned map[string]string
+	if labels != nil {
+		cloned = make(map[string]string, len(labels))
+		for k, v := range labels {
+			cloned[k] = v
+		}
+	} else {
+		cloned = make(map[string]string)
+	}
+
+	zone, _ := util.GetZone(cloned)
+	region, _ := util.GetRegion(cloned)
 	return &DefaultNetworkKey{
 		Zone:      zone,
 		Region:    region,
-		Labels:    labels,
+		Labels:    cloned,
 		ClusterID: clusterID,
 	}
 }
@@ -50,6 +65,9 @@ func NewNetworkKey(labels map[string]string, clusterID string) NetworkKey {
 // ID returns the primary network topology identifier.
 // It returns Zone when non-empty, otherwise Region.
 func (n *DefaultNetworkKey) ID() string {
+	if n == nil {
+		return ""
+	}
 	if n.Zone != "" {
 		return n.Zone
 	}
@@ -62,6 +80,9 @@ func (n *DefaultNetworkKey) ID() string {
 //   - Only Region set          → "Region"
 //   - Neither set              → ""
 func (n *DefaultNetworkKey) Features() string {
+	if n == nil {
+		return ""
+	}
 	if n.Region != "" && n.Zone != "" {
 		return n.Region + "," + n.Zone
 	}
@@ -73,12 +94,38 @@ func (n *DefaultNetworkKey) Features() string {
 
 // GetZone returns the availability zone, or an empty string when unspecified.
 func (n *DefaultNetworkKey) GetZone() string {
+	if n == nil {
+		return ""
+	}
 	return n.Zone
 }
 
 // GetRegion returns the cloud region, or an empty string when unspecified.
 func (n *DefaultNetworkKey) GetRegion() string {
+	if n == nil {
+		return ""
+	}
 	return n.Region
+}
+
+// GetClusterID returns the cluster identifier, or an empty string when unspecified.
+func (n *DefaultNetworkKey) GetClusterID() string {
+	if n == nil {
+		return ""
+	}
+	return n.ClusterID
+}
+
+// GetLabels returns a defensive copy of the node labels map.
+func (n *DefaultNetworkKey) GetLabels() map[string]string {
+	if n == nil || n.Labels == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(n.Labels))
+	for k, v := range n.Labels {
+		cloned[k] = v
+	}
+	return cloned
 }
 
 // Network is the interface by which the provider and cost model communicate network egress prices.

--- a/pkg/cloud/models/network_test.go
+++ b/pkg/cloud/models/network_test.go
@@ -1,0 +1,210 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewNetworkKey(t *testing.T) {
+	t.Run("extracts topology labels correctly", func(t *testing.T) {
+		labels := map[string]string{
+			"topology.kubernetes.io/region": "us-west-2",
+			"topology.kubernetes.io/zone":   "us-west-2a",
+		}
+		key := NewNetworkKey(labels, "cluster-prod")
+
+		if key.GetRegion() != "us-west-2" {
+			t.Errorf("expected region 'us-west-2', got '%s'", key.GetRegion())
+		}
+		if key.GetZone() != "us-west-2a" {
+			t.Errorf("expected zone 'us-west-2a', got '%s'", key.GetZone())
+		}
+		if key.GetClusterID() != "cluster-prod" {
+			t.Errorf("expected clusterID 'cluster-prod', got '%s'", key.GetClusterID())
+		}
+	})
+
+	t.Run("handles nil labels gracefully", func(t *testing.T) {
+		key := NewNetworkKey(nil, "cluster-1")
+
+		if key.GetRegion() != "" {
+			t.Errorf("expected empty region, got '%s'", key.GetRegion())
+		}
+		if key.GetZone() != "" {
+			t.Errorf("expected empty zone, got '%s'", key.GetZone())
+		}
+		if key.GetClusterID() != "cluster-1" {
+			t.Errorf("expected clusterID 'cluster-1', got '%s'", key.GetClusterID())
+		}
+		if key.GetLabels() == nil {
+			t.Errorf("expected non-nil empty map from GetLabels()")
+		}
+	})
+
+	t.Run("clones input labels map defensively", func(t *testing.T) {
+		labels := map[string]string{
+			"topology.kubernetes.io/region": "us-east-1",
+			"topology.kubernetes.io/zone":   "us-east-1b",
+		}
+		key := NewNetworkKey(labels, "cluster-dev")
+
+		// Mutate original map after creation
+		labels["topology.kubernetes.io/region"] = "mutated-region"
+		labels["extra"] = "value"
+
+		if key.GetRegion() != "us-east-1" {
+			t.Errorf("expected region to remain 'us-east-1', got '%s'", key.GetRegion())
+		}
+
+		keyLabels := key.GetLabels()
+		if keyLabels["extra"] == "value" {
+			t.Errorf("key labels map was affected by original map mutation")
+		}
+
+		// Mutate map returned by GetLabels()
+		keyLabels["mutated"] = "true"
+		if key.GetLabels()["mutated"] == "true" {
+			t.Errorf("GetLabels() did not return a defensive copy")
+		}
+	})
+}
+
+func TestDefaultNetworkKey_ID(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      *DefaultNetworkKey
+		expected string
+	}{
+		{
+			name:     "nil receiver",
+			key:      nil,
+			expected: "",
+		},
+		{
+			name: "zone present preferred over region",
+			key: &DefaultNetworkKey{
+				Zone:   "us-east-1a",
+				Region: "us-east-1",
+			},
+			expected: "us-east-1a",
+		},
+		{
+			name: "zone only",
+			key: &DefaultNetworkKey{
+				Zone: "us-east-1a",
+			},
+			expected: "us-east-1a",
+		},
+		{
+			name: "region only",
+			key: &DefaultNetworkKey{
+				Region: "us-east-1",
+			},
+			expected: "us-east-1",
+		},
+		{
+			name:     "both empty",
+			key:      &DefaultNetworkKey{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.key.ID(); got != tt.expected {
+				t.Errorf("ID() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultNetworkKey_Features(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      *DefaultNetworkKey
+		expected string
+	}{
+		{
+			name:     "nil receiver",
+			key:      nil,
+			expected: "",
+		},
+		{
+			name: "both region and zone present",
+			key: &DefaultNetworkKey{
+				Region: "eu-west-1",
+				Zone:   "eu-west-1a",
+			},
+			expected: "eu-west-1,eu-west-1a",
+		},
+		{
+			name: "zone only present",
+			key: &DefaultNetworkKey{
+				Zone: "eu-west-1a",
+			},
+			expected: "eu-west-1a",
+		},
+		{
+			name: "region only present",
+			key: &DefaultNetworkKey{
+				Region: "eu-west-1",
+			},
+			expected: "eu-west-1",
+		},
+		{
+			name:     "neither region nor zone present",
+			key:      &DefaultNetworkKey{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.key.Features(); got != tt.expected {
+				t.Errorf("Features() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultNetworkKey_AccessorsAndNilSafety(t *testing.T) {
+	t.Run("nil receiver handles all accessors safely", func(t *testing.T) {
+		var nilKey *DefaultNetworkKey
+
+		if got := nilKey.GetZone(); got != "" {
+			t.Errorf("GetZone() on nil = %v, want empty string", got)
+		}
+		if got := nilKey.GetRegion(); got != "" {
+			t.Errorf("GetRegion() on nil = %v, want empty string", got)
+		}
+		if got := nilKey.GetClusterID(); got != "" {
+			t.Errorf("GetClusterID() on nil = %v, want empty string", got)
+		}
+		if got := nilKey.GetLabels(); got != nil {
+			t.Errorf("GetLabels() on nil = %v, want nil", got)
+		}
+	})
+
+	t.Run("valid receiver returns correct values", func(t *testing.T) {
+		labels := map[string]string{"env": "prod"}
+		key := &DefaultNetworkKey{
+			Zone:      "us-central1-a",
+			Region:    "us-central1",
+			ClusterID: "gcp-cluster",
+			Labels:    labels,
+		}
+
+		if key.GetZone() != "us-central1-a" {
+			t.Errorf("GetZone() = %v, want us-central1-a", key.GetZone())
+		}
+		if key.GetRegion() != "us-central1" {
+			t.Errorf("GetRegion() = %v, want us-central1", key.GetRegion())
+		}
+		if key.GetClusterID() != "gcp-cluster" {
+			t.Errorf("GetClusterID() = %v, want gcp-cluster", key.GetClusterID())
+		}
+		if !reflect.DeepEqual(key.GetLabels(), labels) {
+			t.Errorf("GetLabels() = %v, want %v", key.GetLabels(), labels)
+		}
+	})
+}

--- a/pkg/cloud/oracle/provider.go
+++ b/pkg/cloud/oracle/provider.go
@@ -87,13 +87,21 @@ func (o *Oracle) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	return o.RateCardStore.ForPVK(pvk, o.DefaultPricing)
 }
 
-func (o *Oracle) NetworkPricing() (*models.Network, error) {
+func (o *Oracle) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	if err := o.ensurePricingData(); err != nil {
 		return nil, err
 	}
 	o.DownloadPricingDataLock.RLock()
 	defer o.DownloadPricingDataLock.RUnlock()
-	return o.RateCardStore.ForEgressRegion(o.ClusterRegion, o.DefaultPricing)
+	region := o.ClusterRegion
+	if key != nil && key.GetRegion() != "" {
+		region = key.GetRegion()
+	}
+	return o.RateCardStore.ForEgressRegion(region, o.DefaultPricing)
+}
+
+func (o *Oracle) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (o *Oracle) LoadBalancerPricing() (*models.LoadBalancer, error) {

--- a/pkg/cloud/oracle/provider_test.go
+++ b/pkg/cloud/oracle/provider_test.go
@@ -173,3 +173,95 @@ func testNode(gpus int) *clustercache.Node {
 		},
 	}
 }
+
+// TestOracleNetworkPricing verifies that NetworkPricing returns a non-nil Network
+// using pre-populated pricing data and that a NetworkKey with an explicit region
+// overrides the provider's ClusterRegion for egress resolution.
+func TestOracleNetworkPricing(t *testing.T) {
+	const egressPrice = 0.0085
+
+	newOracle := func(clusterRegion string) *Oracle {
+		return &Oracle{
+			ClusterRegion: clusterRegion,
+			RateCardStore: &RateCardStore{
+				prices: map[string]Price{
+					egress1PartNumber: {UnitPrice: egressPrice},
+				},
+			},
+			DefaultPricing: DefaultPricing{},
+		}
+	}
+
+	t.Run("uses ClusterRegion when key region is empty", func(t *testing.T) {
+		o := newOracle("us-ashburn-1")
+		key := &oracleNetworkKey{region: ""}
+		network, err := o.NetworkPricing(key)
+		assert.NoError(t, err)
+		assert.NotNil(t, network)
+		assert.Equal(t, egressPrice, network.RegionNetworkEgressCost)
+		assert.Equal(t, egressPrice, network.InternetNetworkEgressCost)
+	})
+
+	t.Run("overrides region from NetworkKey when non-empty", func(t *testing.T) {
+		// ClusterRegion is ap-sydney-1 (egress2), but key specifies a us-* region (egress1)
+		o := newOracle("ap-sydney-1")
+		key := &oracleNetworkKey{region: "us-phoenix-1"}
+		network, err := o.NetworkPricing(key)
+		assert.NoError(t, err)
+		assert.NotNil(t, network)
+		assert.Equal(t, egressPrice, network.RegionNetworkEgressCost,
+			"should use key region (us-phoenix-1 → egress1), not ClusterRegion (ap-sydney-1 → egress2)")
+	})
+
+	t.Run("nil key falls back to ClusterRegion", func(t *testing.T) {
+		o := newOracle("us-ashburn-1")
+		network, err := o.NetworkPricing(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, network)
+		assert.Equal(t, egressPrice, network.RegionNetworkEgressCost)
+	})
+
+	t.Run("unknown region returns zero egress cost", func(t *testing.T) {
+		o := newOracle("unknown-region-1")
+		network, err := o.NetworkPricing(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, network)
+		assert.Equal(t, 0.0, network.RegionNetworkEgressCost)
+		assert.Equal(t, 0.0, network.ZoneNetworkEgressCost)
+	})
+}
+
+// TestOracleGetNetworkKey verifies that GetNetworkKey extracts zone and region
+// from Kubernetes node labels and returns a valid NetworkKey.
+func TestOracleGetNetworkKey(t *testing.T) {
+	o := &Oracle{}
+
+	t.Run("extracts region from topology label", func(t *testing.T) {
+		labels := map[string]string{
+			"topology.kubernetes.io/region": "us-ashburn-1",
+			"topology.kubernetes.io/zone":   "AD-1",
+		}
+		key := o.GetNetworkKey(labels, "cluster-1")
+		assert.Equal(t, "AD-1", key.GetZone())
+		assert.Equal(t, "us-ashburn-1", key.GetRegion())
+		assert.NotEmpty(t, key.ID())
+		assert.Contains(t, key.Features(), "us-ashburn-1")
+		assert.Contains(t, key.Features(), "AD-1")
+	})
+
+	t.Run("handles empty labels gracefully", func(t *testing.T) {
+		key := o.GetNetworkKey(map[string]string{}, "cluster-2")
+		assert.Empty(t, key.GetZone())
+		assert.Empty(t, key.GetRegion())
+		assert.Empty(t, key.ID())
+		assert.Empty(t, key.Features())
+	})
+}
+
+// oracleNetworkKey is a minimal NetworkKey stub for unit testing.
+type oracleNetworkKey struct{ region string }
+
+func (k *oracleNetworkKey) ID() string        { return k.region }
+func (k *oracleNetworkKey) Features() string  { return k.region }
+func (k *oracleNetworkKey) GetZone() string   { return "" }
+func (k *oracleNetworkKey) GetRegion() string { return k.region }

--- a/pkg/cloud/oracle/provider_test.go
+++ b/pkg/cloud/oracle/provider_test.go
@@ -261,7 +261,9 @@ func TestOracleGetNetworkKey(t *testing.T) {
 // oracleNetworkKey is a minimal NetworkKey stub for unit testing.
 type oracleNetworkKey struct{ region string }
 
-func (k *oracleNetworkKey) ID() string        { return k.region }
-func (k *oracleNetworkKey) Features() string  { return k.region }
-func (k *oracleNetworkKey) GetZone() string   { return "" }
-func (k *oracleNetworkKey) GetRegion() string { return k.region }
+func (k *oracleNetworkKey) ID() string                   { return k.region }
+func (k *oracleNetworkKey) Features() string             { return k.region }
+func (k *oracleNetworkKey) GetZone() string              { return "" }
+func (k *oracleNetworkKey) GetRegion() string            { return k.region }
+func (k *oracleNetworkKey) GetClusterID() string         { return "" }
+func (k *oracleNetworkKey) GetLabels() map[string]string { return nil }

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -226,7 +226,7 @@ func (otc *OTC) DownloadPricingData() error {
 	return nil
 }
 
-func (otc *OTC) NetworkPricing() (*models.Network, error) {
+func (otc *OTC) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := otc.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -342,6 +342,10 @@ func (otc *OTC) GetConfig() (*models.CustomPricing, error) {
 
 // load balancer cost
 // taken straight up from aws
+func (otc *OTC) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
+}
+
 func (otc *OTC) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.05,

--- a/pkg/cloud/ovh/provider.go
+++ b/pkg/cloud/ovh/provider.go
@@ -481,7 +481,7 @@ func (c *OVH) PVPricing(pvk models.PVKey) (*models.PV, error) {
 }
 
 // NetworkPricing returns static network pricing for OVH.
-func (c *OVH) NetworkPricing() (*models.Network, error) {
+func (c *OVH) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	return &models.Network{
 		ZoneNetworkEgressCost:     0,
 		RegionNetworkEgressCost:   0,
@@ -492,6 +492,10 @@ func (c *OVH) NetworkPricing() (*models.Network, error) {
 }
 
 // LoadBalancerPricing returns static load balancer pricing for OVH.
+func (c *OVH) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
+}
+
 func (c *OVH) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.012,

--- a/pkg/cloud/ovh/provider_test.go
+++ b/pkg/cloud/ovh/provider_test.go
@@ -387,7 +387,7 @@ func TestPVPricing(t *testing.T) {
 func TestNetworkPricing(t *testing.T) {
 	provider := &OVH{}
 
-	net, err := provider.NetworkPricing()
+	net, err := provider.NetworkPricing(nil)
 	if err != nil {
 		t.Fatalf("NetworkPricing failed: %v", err)
 	}

--- a/pkg/cloud/provider/customprovider.go
+++ b/pkg/cloud/provider/customprovider.go
@@ -301,7 +301,7 @@ func (cp *CustomProvider) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	}, nil
 }
 
-func (cp *CustomProvider) NetworkPricing() (*models.Network, error) {
+func (cp *CustomProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := cp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -345,6 +345,10 @@ func parsePriceOrZero(field, value string) (float64, error) {
 		return 0, fmt.Errorf("invalid custom pricing value %q for %s: %w", value, field, err)
 	}
 	return price, nil
+}
+
+func (cp *CustomProvider) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (cp *CustomProvider) LoadBalancerPricing() (*models.LoadBalancer, error) {

--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -170,7 +170,7 @@ func (c *Scaleway) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (c *Scaleway) NetworkPricing() (*models.Network, error) {
+func (c *Scaleway) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	// it's free baby!
 	return &models.Network{
 		ZoneNetworkEgressCost:     0,
@@ -179,6 +179,10 @@ func (c *Scaleway) NetworkPricing() (*models.Network, error) {
 		NatGatewayEgressCost:      0,
 		NatGatewayIngressCost:     0,
 	}, nil
+}
+
+func (c *Scaleway) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (c *Scaleway) GetKey(l map[string]string, n *clustercache.Node) models.Key {

--- a/pkg/cloud/stackit/provider.go
+++ b/pkg/cloud/stackit/provider.go
@@ -138,7 +138,7 @@ func (s *STACKIT) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (s *STACKIT) NetworkPricing() (*models.Network, error) {
+func (s *STACKIT) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	config, err := s.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config: %w", err)
@@ -157,6 +157,10 @@ func (s *STACKIT) NetworkPricing() (*models.Network, error) {
 		NatGatewayEgressCost:      natEgress,
 		NatGatewayIngressCost:     natIngress,
 	}, nil
+}
+
+func (s *STACKIT) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (s *STACKIT) GetKey(l map[string]string, n *clustercache.Node) models.Key {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -208,6 +208,11 @@ func (cm *CostModel) ComputeCostData(start, end time.Time) (map[string]*CostData
 		return nil, err
 	}
 
+	nodeLabelsMap := make(map[string]map[string]string)
+	for _, n := range cm.Cache.GetAllNodes() {
+		nodeLabelsMap[n.Name] = n.Labels
+	}
+
 	// Unmounted PVs represent the PVs that are not mounted or tied to a volume on a container
 	unmountedPVs := make(map[string][]*PersistentVolumeClaimData)
 	pvClaimMapping, err := GetPVInfoLocal(cm.Cache, clusterID)
@@ -335,7 +340,9 @@ func (cm *CostModel) ComputeCostData(start, end time.Time) (map[string]*CostData
 
 			var podNetCosts []*util.Vector
 			if usage, ok := networkUsageMap[ns+","+podName+","+clusterID]; ok {
-				netCosts, err := GetNetworkCost(usage, cp)
+				nodeLabels := nodeLabelsMap[pod.Spec.NodeName]
+				netKey := cp.GetNetworkKey(nodeLabels, clusterID)
+				netCosts, err := GetNetworkCost(usage, cp, netKey)
 				if err != nil {
 					log.Debugf("Error pulling network costs: %s", err.Error())
 				} else {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -341,6 +341,9 @@ func (cm *CostModel) ComputeCostData(start, end time.Time) (map[string]*CostData
 			var podNetCosts []*util.Vector
 			if usage, ok := networkUsageMap[ns+","+podName+","+clusterID]; ok {
 				nodeLabels := nodeLabelsMap[pod.Spec.NodeName]
+				if nodeLabels == nil {
+					nodeLabels = map[string]string{}
+				}
 				netKey := cp.GetNetworkKey(nodeLabels, clusterID)
 				netCosts, err := GetNetworkCost(usage, cp, netKey)
 				if err != nil {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -341,9 +341,6 @@ func (cm *CostModel) ComputeCostData(start, end time.Time) (map[string]*CostData
 			var podNetCosts []*util.Vector
 			if usage, ok := networkUsageMap[ns+","+podName+","+clusterID]; ok {
 				nodeLabels := nodeLabelsMap[pod.Spec.NodeName]
-				if nodeLabels == nil {
-					nodeLabels = map[string]string{}
-				}
 				netKey := cp.GetNetworkKey(nodeLabels, clusterID)
 				netCosts, err := GetNetworkCost(usage, cp, netKey)
 				if err != nil {

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -490,7 +490,7 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 			cmme.ClusterManagementCostRecorder.WithLabelValues(provisioner).Set(clusterManagementCost)
 
 			// Record network pricing at global scope
-			networkCosts, err := cmme.CloudProvider.NetworkPricing()
+			networkCosts, err := cmme.CloudProvider.NetworkPricing(nil)
 			if err != nil {
 				log.Debugf("Failed to retrieve network costs: %s", err.Error())
 			} else {

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -143,10 +143,10 @@ func GetNetworkUsageData(
 }
 
 // GetNetworkCost computes the actual cost for NetworkUsageData based on data provided by the Provider.
-func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider) ([]*util.Vector, error) {
+func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider, key costAnalyzerCloud.NetworkKey) ([]*util.Vector, error) {
 	var results []*util.Vector
 
-	pricing, err := cloud.NetworkPricing()
+	pricing, err := cloud.NetworkPricing(key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -12,11 +12,13 @@ import (
 
 // mockProvider is a mock implementation of the Provider interface for testing
 type mockProvider struct {
-	network *models.Network
-	err     error
+	network        *models.Network
+	err            error
+	lastNetworkKey models.NetworkKey
 }
 
 func (m *mockProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
+	m.lastNetworkKey = key
 	return m.network, m.err
 }
 
@@ -618,5 +620,47 @@ func TestGetNetworkCost_NATGatewayMisalignedVectors(t *testing.T) {
 	expectedThird := 20.0 * 0.05
 	if diff := result[2].Value - expectedThird; diff > 0.001 || diff < -0.001 {
 		t.Errorf("expected third vector cost %f, got %f", expectedThird, result[2].Value)
+	}
+}
+
+func TestGetNetworkCost_NetworkKeyPropagation(t *testing.T) {
+	nodeLabels := map[string]string{
+		"topology.kubernetes.io/region": "us-east-1",
+		"topology.kubernetes.io/zone":   "us-east-1a",
+	}
+
+	provider := &mockProvider{
+		network: &models.Network{
+			ZoneNetworkEgressCost: 0.01,
+		},
+	}
+
+	netKey := provider.GetNetworkKey(nodeLabels, "cluster-test")
+
+	usage := &NetworkUsageData{
+		PodName:   "pod1",
+		Namespace: "ns1",
+		NetworkZoneEgress: []*util.Vector{
+			{Value: 100.0, Timestamp: 1000},
+		},
+	}
+
+	_, err := GetNetworkCost(usage, provider, netKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if provider.lastNetworkKey == nil {
+		t.Fatal("expected NetworkKey to be passed to NetworkPricing, but got nil")
+	}
+
+	if provider.lastNetworkKey.GetRegion() != "us-east-1" {
+		t.Errorf("expected region 'us-east-1', got '%s'", provider.lastNetworkKey.GetRegion())
+	}
+	if provider.lastNetworkKey.GetZone() != "us-east-1a" {
+		t.Errorf("expected zone 'us-east-1a', got '%s'", provider.lastNetworkKey.GetZone())
+	}
+	if provider.lastNetworkKey.GetClusterID() != "cluster-test" {
+		t.Errorf("expected clusterID 'cluster-test', got '%s'", provider.lastNetworkKey.GetClusterID())
 	}
 }

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -16,8 +16,12 @@ type mockProvider struct {
 	err     error
 }
 
-func (m *mockProvider) NetworkPricing() (*models.Network, error) {
+func (m *mockProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	return m.network, m.err
+}
+
+func (m *mockProvider) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
 }
 
 func (m *mockProvider) GetKey(map[string]string, *clustercache.Node) models.Key {
@@ -531,7 +535,7 @@ func TestGetNetworkCost(t *testing.T) {
 				network: tc.pricing,
 			}
 
-			result, err := GetNetworkCost(tc.usage, provider)
+			result, err := GetNetworkCost(tc.usage, provider, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -586,7 +590,7 @@ func TestGetNetworkCost_NATGatewayMisalignedVectors(t *testing.T) {
 		network: pricing,
 	}
 
-	result, err := GetNetworkCost(usage, provider)
+	result, err := GetNetworkCost(usage, provider, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -84,6 +84,8 @@ type AllocationQuery struct {
 	IncludeAggregatedMetadata             bool          `json:"includeAggregatedMetadata,omitempty"`
 	ShareLB                               bool          `json:"sharelb,omitempty"`
 	Filter                                string        `json:"filter,omitempty"` // Filter expression for allocations (e.g., "cluster:production", "namespace:kube-system")
+	Reconcile                             bool          `json:"reconcile,omitempty"`
+	ReconcileNetwork                      bool          `json:"reconcileNetwork,omitempty"`
 }
 
 // AssetQuery contains the parameters for an asset query.
@@ -113,6 +115,8 @@ type EfficiencyQuery struct {
 	Aggregate                  string        `json:"aggregate,omitempty"`                  // Aggregation properties (e.g., "pod", "namespace", "controller")
 	Filter                     string        `json:"filter,omitempty"`                     // Filter expression for allocations (same as AllocationQuery)
 	EfficiencyBufferMultiplier *float64      `json:"efficiencyBufferMultiplier,omitempty"` // Buffer multiplier for recommendations (default: 1.2 for 20% headroom)
+	Reconcile                  bool          `json:"reconcile,omitempty"`
+	ReconcileNetwork           bool          `json:"reconcileNetwork,omitempty"`
 }
 
 // AllocationResponse represents the allocation data returned to the AI agent.
@@ -138,10 +142,27 @@ func (as *AllocationSet) TotalCost() float64 {
 	return total
 }
 
-// Allocation represents a single allocation data point.
+// AllocationProperties describes a set of Kubernetes objects.
+type AllocationProperties struct {
+	Cluster              string            `json:"cluster,omitempty"`
+	Node                 string            `json:"node,omitempty"`
+	Container            string            `json:"container,omitempty"`
+	Controller           string            `json:"controller,omitempty"`
+	ControllerKind       string            `json:"controllerKind,omitempty"`
+	Namespace            string            `json:"namespace,omitempty"`
+	Pod                  string            `json:"pod,omitempty"`
+	Services             []string          `json:"services,omitempty"`
+	ProviderID           string            `json:"providerID,omitempty"`
+	Labels               map[string]string `json:"labels,omitempty"`
+	Annotations          map[string]string `json:"annotations,omitempty"`
+	NamespaceLabels      map[string]string `json:"namespaceLabels,omitempty"`
+	NamespaceAnnotations map[string]string `json:"namespaceAnnotations,omitempty"`
+}
 
+// Allocation represents a single allocation data point.
 type Allocation struct {
-	Name string `json:"name"` // Allocation key (namespace, cluster, etc.)
+	Name       string                `json:"name"` // Allocation key (namespace, cluster, etc.)
+	Properties *AllocationProperties `json:"properties,omitempty"`
 
 	CPUCost      float64 `json:"cpuCost"`      // Cost of CPU usage
 	GPUCost      float64 `json:"gpuCost"`      // Cost of GPU usage
@@ -519,6 +540,7 @@ func (s *MCPServer) QueryAllocations(query *OpenCostQueryRequest) (*AllocationRe
 	var includeIdle, idleByNode, includeProportionalAssetResourceCosts, includeAggregatedMetadata, sharedLoadBalancer, shareIdle bool
 	var accumulateBy opencost.AccumulateOption
 	var filterString string
+	var reconcile, reconcileNetwork bool
 
 	// 3. Parse allocation parameters if provided
 	if query.AllocationParams != nil {
@@ -541,6 +563,8 @@ func (s *MCPServer) QueryAllocations(query *OpenCostQueryRequest) (*AllocationRe
 		includeAggregatedMetadata = query.AllocationParams.IncludeAggregatedMetadata
 		sharedLoadBalancer = query.AllocationParams.ShareLB
 		shareIdle = query.AllocationParams.ShareIdle
+		reconcile = query.AllocationParams.Reconcile
+		reconcileNetwork = query.AllocationParams.ReconcileNetwork
 
 		// Set filter string
 		filterString = query.AllocationParams.Filter
@@ -596,11 +620,11 @@ func (s *MCPServer) QueryAllocations(query *OpenCostQueryRequest) (*AllocationRe
 	// If we have multiple sets, we'll combine them or return the first one
 	// For now, let's return the first allocation set
 	firstSet := asr.Allocations[0]
-	return transformAllocationSet(firstSet), nil
+	return transformAllocationSet(firstSet, reconcile, reconcileNetwork), nil
 }
 
 // transformAllocationSet converts an opencost.AllocationSet into the MCP's AllocationResponse format.
-func transformAllocationSet(allocSet *opencost.AllocationSet) *AllocationResponse {
+func transformAllocationSet(allocSet *opencost.AllocationSet, reconcile bool, reconcileNetwork bool) *AllocationResponse {
 	if allocSet == nil {
 		return &AllocationResponse{Allocations: make(map[string]*AllocationSet)}
 	}
@@ -619,16 +643,83 @@ func transformAllocationSet(allocSet *opencost.AllocationSet) *AllocationRespons
 			continue
 		}
 
+		var cpuCost, gpuCost, ramCost, pvCost, networkCost, lbCost float64
+		if reconcile {
+			cpuCost = alloc.CPUCost + alloc.CPUCostAdjustment
+			gpuCost = alloc.GPUCost + alloc.GPUCostAdjustment
+			ramCost = alloc.RAMCost + alloc.RAMCostAdjustment
+			pvCost = alloc.PVCost() + alloc.PVCostAdjustment
+			lbCost = alloc.LoadBalancerCost + alloc.LoadBalancerCostAdjustment
+			if reconcileNetwork {
+				networkCost = alloc.NetworkCost + alloc.NetworkCostAdjustment
+			} else {
+				networkCost = alloc.NetworkCost
+			}
+		} else {
+			cpuCost = alloc.CPUCost
+			gpuCost = alloc.GPUCost
+			ramCost = alloc.RAMCost
+			pvCost = alloc.PVCost()
+			lbCost = alloc.LoadBalancerCost
+			if reconcileNetwork {
+				networkCost = alloc.NetworkCost + alloc.NetworkCostAdjustment
+			} else {
+				networkCost = alloc.NetworkCost
+			}
+		}
+
+		totalCost := cpuCost + gpuCost + ramCost + pvCost + networkCost + lbCost + alloc.SharedCost + alloc.ExternalCost
+
+		var props *AllocationProperties
+		if alloc.Properties != nil {
+			props = &AllocationProperties{
+				Cluster:        alloc.Properties.Cluster,
+				Node:           alloc.Properties.Node,
+				Container:      alloc.Properties.Container,
+				Controller:     alloc.Properties.Controller,
+				ControllerKind: alloc.Properties.ControllerKind,
+				Namespace:      alloc.Properties.Namespace,
+				Pod:            alloc.Properties.Pod,
+				Services:       alloc.Properties.Services,
+				ProviderID:     alloc.Properties.ProviderID,
+			}
+			if alloc.Properties.Labels != nil {
+				props.Labels = make(map[string]string, len(alloc.Properties.Labels))
+				for k, v := range alloc.Properties.Labels {
+					props.Labels[k] = v
+				}
+			}
+			if alloc.Properties.Annotations != nil {
+				props.Annotations = make(map[string]string, len(alloc.Properties.Annotations))
+				for k, v := range alloc.Properties.Annotations {
+					props.Annotations[k] = v
+				}
+			}
+			if alloc.Properties.NamespaceLabels != nil {
+				props.NamespaceLabels = make(map[string]string, len(alloc.Properties.NamespaceLabels))
+				for k, v := range alloc.Properties.NamespaceLabels {
+					props.NamespaceLabels[k] = v
+				}
+			}
+			if alloc.Properties.NamespaceAnnotations != nil {
+				props.NamespaceAnnotations = make(map[string]string, len(alloc.Properties.NamespaceAnnotations))
+				for k, v := range alloc.Properties.NamespaceAnnotations {
+					props.NamespaceAnnotations[k] = v
+				}
+			}
+		}
+
 		mcpAlloc := &Allocation{
 			Name:         alloc.Name,
-			CPUCost:      alloc.CPUCost,
-			GPUCost:      alloc.GPUCost,
-			RAMCost:      alloc.RAMCost,
-			PVCost:       alloc.PVCost(), // Call the method
-			NetworkCost:  alloc.NetworkCost,
+			Properties:   props,
+			CPUCost:      cpuCost,
+			GPUCost:      gpuCost,
+			RAMCost:      ramCost,
+			PVCost:       pvCost,
+			NetworkCost:  networkCost,
 			SharedCost:   alloc.SharedCost,
 			ExternalCost: alloc.ExternalCost,
-			TotalCost:    alloc.TotalCost(),
+			TotalCost:    totalCost,
 			CPUCoreHours: alloc.CPUCoreHours,
 			RAMByteHours: alloc.RAMByteHours,
 			GPUHours:     alloc.GPUHours,
@@ -1116,6 +1207,7 @@ func (s *MCPServer) QueryEfficiency(query *OpenCostQueryRequest) (*EfficiencyRes
 	var aggregateBy []string
 	var filterString string
 	var bufferMultiplier float64 = efficiencyBufferMultiplier // Default to 1.2 (20% headroom)
+	var reconcile, reconcileNetwork bool
 
 	// 3. Parse efficiency parameters if provided
 	if query.EfficiencyParams != nil {
@@ -1142,6 +1234,9 @@ func (s *MCPServer) QueryEfficiency(query *OpenCostQueryRequest) (*EfficiencyRes
 		if query.EfficiencyParams.EfficiencyBufferMultiplier != nil {
 			bufferMultiplier = *query.EfficiencyParams.EfficiencyBufferMultiplier
 		}
+
+		reconcile = query.EfficiencyParams.Reconcile
+		reconcileNetwork = query.EfficiencyParams.ReconcileNetwork
 	} else {
 		// Default to pod-level aggregation
 		aggregateBy = []string{"pod"}
@@ -1218,7 +1313,7 @@ func (s *MCPServer) QueryEfficiency(query *OpenCostQueryRequest) (*EfficiencyRes
 			// Compute metrics for all allocations in this set
 			localMetrics := make([]*EfficiencyMetric, 0, len(allocSet.Allocations))
 			for _, alloc := range allocSet.Allocations {
-				if metric := computeEfficiencyMetric(alloc, bufferMultiplier); metric != nil {
+				if metric := computeEfficiencyMetric(alloc, bufferMultiplier, reconcile, reconcileNetwork); metric != nil {
 					localMetrics = append(localMetrics, metric)
 				}
 			}
@@ -1249,7 +1344,7 @@ func safeDiv(numerator, denominator float64) float64 {
 }
 
 // computeEfficiencyMetric calculates efficiency metrics for a single allocation.
-func computeEfficiencyMetric(alloc *opencost.Allocation, bufferMultiplier float64) *EfficiencyMetric {
+func computeEfficiencyMetric(alloc *opencost.Allocation, bufferMultiplier float64, reconcile, reconcileNetwork bool) *EfficiencyMetric {
 	if alloc == nil {
 		return nil
 	}
@@ -1288,19 +1383,44 @@ func computeEfficiencyMetric(alloc *opencost.Allocation, bufferMultiplier float6
 	resultingCPUEff := safeDiv(cpuCoresUsed, recommendedCPU)
 	resultingMemEff := safeDiv(ramBytesUsed, recommendedRAM)
 
+	var cpuCost, gpuCost, ramCost, pvCost, networkCost, lbCost float64
+	if reconcile {
+		cpuCost = alloc.CPUCost + alloc.CPUCostAdjustment
+		gpuCost = alloc.GPUCost + alloc.GPUCostAdjustment
+		ramCost = alloc.RAMCost + alloc.RAMCostAdjustment
+		pvCost = alloc.PVCost() + alloc.PVCostAdjustment
+		lbCost = alloc.LoadBalancerCost + alloc.LoadBalancerCostAdjustment
+		if reconcileNetwork {
+			networkCost = alloc.NetworkCost + alloc.NetworkCostAdjustment
+		} else {
+			networkCost = alloc.NetworkCost
+		}
+	} else {
+		cpuCost = alloc.CPUCost
+		gpuCost = alloc.GPUCost
+		ramCost = alloc.RAMCost
+		pvCost = alloc.PVCost()
+		lbCost = alloc.LoadBalancerCost
+		if reconcileNetwork {
+			networkCost = alloc.NetworkCost + alloc.NetworkCostAdjustment
+		} else {
+			networkCost = alloc.NetworkCost
+		}
+	}
+
 	// Calculate cost per unit based on REQUESTED amounts (not used amounts)
 	// This gives us the cost per core-hour or byte-hour that the cluster charges
-	cpuCostPerCoreHour := safeDiv(alloc.CPUCost, cpuCoresRequested*hours)
-	ramCostPerByteHour := safeDiv(alloc.RAMCost, ramBytesRequested*hours)
+	cpuCostPerCoreHour := safeDiv(cpuCost, cpuCoresRequested*hours)
+	ramCostPerByteHour := safeDiv(ramCost, ramBytesRequested*hours)
 
 	// Current total cost
-	currentTotalCost := alloc.TotalCost()
+	currentTotalCost := cpuCost + gpuCost + ramCost + pvCost + networkCost + lbCost + alloc.SharedCost + alloc.ExternalCost
 
 	// Estimate recommended cost based on recommended requests
 	recommendedCPUCost := recommendedCPU * hours * cpuCostPerCoreHour
 	recommendedRAMCost := recommendedRAM * hours * ramCostPerByteHour
-	// Keep other costs the same (PV, network, shared, external, GPU)
-	otherCosts := alloc.PVCost() + alloc.NetworkCost + alloc.SharedCost + alloc.ExternalCost + alloc.GPUCost
+	// Keep other costs the same (PV, network, shared, external, GPU, LoadBalancer)
+	otherCosts := pvCost + networkCost + alloc.SharedCost + alloc.ExternalCost + gpuCost + lbCost
 	recommendedTotalCost := recommendedCPUCost + recommendedRAMCost + otherCosts
 
 	// Clamp recommended cost to avoid rounding issues making it higher than current

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -739,7 +739,7 @@ func TestGenerateQueryID(t *testing.T) {
 }
 
 func TestTransformAllocationSet_NilInput(t *testing.T) {
-	result := transformAllocationSet(nil)
+	result := transformAllocationSet(nil, false, false)
 
 	require.NotNil(t, result)
 	assert.NotNil(t, result.Allocations)
@@ -751,11 +751,149 @@ func TestTransformAllocationSet_EmptyInput(t *testing.T) {
 		Allocations: map[string]*opencost.Allocation{},
 	}
 
-	result := transformAllocationSet(emptySet)
+	result := transformAllocationSet(emptySet, false, false)
 
 	require.NotNil(t, result)
 	assert.Contains(t, result.Allocations, "allocations")
 	assert.Len(t, result.Allocations["allocations"].Allocations, 0)
+}
+
+func TestTransformAllocationSet_ReconciliationAndProperties(t *testing.T) {
+	// Create an allocation with adjustments
+	alloc := &opencost.Allocation{
+		Name: "test-alloc",
+		Properties: &opencost.AllocationProperties{
+			Cluster:    "cluster-1",
+			Namespace:  "namespace-1",
+			Pod:        "pod-1",
+			ProviderID: "provider-id-1",
+			Labels:     opencost.AllocationLabels{"app": "test-app"},
+		},
+		CPUCost:                    10.0,
+		CPUCostAdjustment:          2.0,
+		GPUCost:                    5.0,
+		GPUCostAdjustment:          1.0,
+		RAMCost:                    8.0,
+		RAMCostAdjustment:          1.5,
+		NetworkCost:                3.0,
+		NetworkCostAdjustment:      0.5,
+		LoadBalancerCost:           2.0,
+		LoadBalancerCostAdjustment: 0.2,
+		SharedCost:                 1.0,
+		ExternalCost:               0.5,
+		CPUCoreHours:               100.0,
+		RAMByteHours:               50000.0,
+		GPUHours:                   10.0,
+		Start:                      time.Now().Add(-24 * time.Hour),
+		End:                        time.Now(),
+	}
+
+	// We also need to add some PV to test PV reconciliation
+	alloc.PVs = opencost.PVAllocations{
+		opencost.PVKey{
+			Cluster: "cluster-1",
+			Name:    "pv-1",
+		}: &opencost.PVAllocation{Cost: 4.0},
+	}
+	alloc.PVCostAdjustment = 0.8
+
+	// Create allocation set
+	allocSet := &opencost.AllocationSet{
+		Allocations: map[string]*opencost.Allocation{
+			"test-alloc": alloc,
+		},
+	}
+
+	// Test case 1: Reconcile=false, ReconcileNetwork=false
+	{
+		res := transformAllocationSet(allocSet, false, false)
+		require.NotNil(t, res)
+		mcpAlloc := res.Allocations["allocations"].Allocations[0]
+		assert.Equal(t, 10.0, mcpAlloc.CPUCost)
+		assert.Equal(t, 5.0, mcpAlloc.GPUCost)
+		assert.Equal(t, 8.0, mcpAlloc.RAMCost)
+		assert.Equal(t, 4.0, mcpAlloc.PVCost)
+		assert.Equal(t, 3.0, mcpAlloc.NetworkCost)
+		assert.Equal(t, 1.0, mcpAlloc.SharedCost)
+		assert.Equal(t, 0.5, mcpAlloc.ExternalCost)
+		// Total: 10 + 5 + 8 + 4 + 3 + 2 (LB) + 1 + 0.5 = 33.5
+		assert.Equal(t, 33.5, mcpAlloc.TotalCost)
+
+		// Verify properties mapping
+		require.NotNil(t, mcpAlloc.Properties)
+		assert.Equal(t, "cluster-1", mcpAlloc.Properties.Cluster)
+		assert.Equal(t, "namespace-1", mcpAlloc.Properties.Namespace)
+		assert.Equal(t, "pod-1", mcpAlloc.Properties.Pod)
+		assert.Equal(t, "provider-id-1", mcpAlloc.Properties.ProviderID)
+		assert.Equal(t, "test-app", mcpAlloc.Properties.Labels["app"])
+	}
+
+	// Test case 2: Reconcile=true, ReconcileNetwork=true
+	{
+		res := transformAllocationSet(allocSet, true, true)
+		require.NotNil(t, res)
+		mcpAlloc := res.Allocations["allocations"].Allocations[0]
+		assert.Equal(t, 12.0, mcpAlloc.CPUCost)
+		assert.Equal(t, 6.0, mcpAlloc.GPUCost)
+		assert.Equal(t, 9.5, mcpAlloc.RAMCost)
+		assert.Equal(t, 4.8, mcpAlloc.PVCost)
+		assert.Equal(t, 3.5, mcpAlloc.NetworkCost)
+		// Total: 12 + 6 + 9.5 + 4.8 + 3.5 + 2.2 (LB) + 1 + 0.5 = 39.5
+		assert.Equal(t, 39.5, mcpAlloc.TotalCost)
+	}
+
+	// Test case 3: Reconcile=true, ReconcileNetwork=false
+	{
+		res := transformAllocationSet(allocSet, true, false)
+		require.NotNil(t, res)
+		mcpAlloc := res.Allocations["allocations"].Allocations[0]
+		assert.Equal(t, 12.0, mcpAlloc.CPUCost)
+		assert.Equal(t, 6.0, mcpAlloc.GPUCost)
+		assert.Equal(t, 9.5, mcpAlloc.RAMCost)
+		assert.Equal(t, 4.8, mcpAlloc.PVCost)
+		assert.Equal(t, 3.0, mcpAlloc.NetworkCost) // Network is not reconciled
+		// Total: 12 + 6 + 9.5 + 4.8 + 3.0 + 2.2 (LB) + 1 + 0.5 = 39.0
+		assert.Equal(t, 39.0, mcpAlloc.TotalCost)
+	}
+}
+
+func TestComputeEfficiencyMetric_Reconciliation(t *testing.T) {
+	alloc := &opencost.Allocation{
+		Name:                       "test-alloc",
+		CPUCoreHours:               100.0,
+		CPUCoreRequestAverage:      10.0,
+		RAMByteHours:               1000.0,
+		RAMBytesRequestAverage:     100.0,
+		CPUCost:                    10.0,
+		CPUCostAdjustment:          2.0,
+		GPUCost:                    0.0,
+		RAMCost:                    8.0,
+		RAMCostAdjustment:          1.5,
+		NetworkCost:                3.0,
+		NetworkCostAdjustment:      0.5,
+		LoadBalancerCost:           2.0,
+		LoadBalancerCostAdjustment: 0.2,
+		SharedCost:                 1.0,
+		ExternalCost:               0.5,
+		Start:                      time.Now().Add(-10 * time.Hour),
+		End:                        time.Now(),
+	}
+
+	// Case 1: Reconcile=false, ReconcileNetwork=false
+	{
+		metric := computeEfficiencyMetric(alloc, 1.2, false, false)
+		require.NotNil(t, metric)
+		// Total cost: 10 + 0 + 8 + 0 (PV) + 3 + 2 (LB) + 1 + 0.5 = 24.5
+		assert.Equal(t, 24.5, metric.CurrentTotalCost)
+	}
+
+	// Case 2: Reconcile=true, ReconcileNetwork=true
+	{
+		metric := computeEfficiencyMetric(alloc, 1.2, true, true)
+		require.NotNil(t, metric)
+		// Total cost: 12 + 0 + 9.5 + 0 + 3.5 + 2.2 + 1 + 0.5 = 28.7
+		assert.Equal(t, 28.7, metric.CurrentTotalCost)
+	}
 }
 
 func TestTransformAssetSet_NilInput(t *testing.T) {
@@ -1041,7 +1179,7 @@ func TestSafeDiv(t *testing.T) {
 }
 
 func TestComputeEfficiencyMetric_NilAllocation(t *testing.T) {
-	result := computeEfficiencyMetric(nil, 1.2)
+	result := computeEfficiencyMetric(nil, 1.2, false, false)
 	assert.Nil(t, result)
 }
 
@@ -1053,7 +1191,7 @@ func TestComputeEfficiencyMetric_ZeroMinutes(t *testing.T) {
 		End:   now, // Same time, so 0 minutes
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 	assert.Nil(t, result)
 }
 
@@ -1072,7 +1210,7 @@ func TestComputeEfficiencyMetric_ValidAllocation(t *testing.T) {
 		RAMCost:                5.0,
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 	assert.Equal(t, "test-pod", result.Name)
@@ -1103,7 +1241,7 @@ func TestComputeEfficiencyMetric_CustomBufferMultiplier(t *testing.T) {
 	}
 
 	// Test with 1.4 buffer multiplier (40% headroom)
-	result := computeEfficiencyMetric(alloc, 1.4)
+	result := computeEfficiencyMetric(alloc, 1.4, false, false)
 
 	require.NotNil(t, result)
 	assert.Equal(t, 1.4, result.RecommendedCPURequest)   // 1 * 1.4 = 1.4
@@ -1132,7 +1270,7 @@ func TestComputeEfficiencyMetric_MinimumThresholds(t *testing.T) {
 		RAMCost:                0.001,
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 	// Should enforce minimum CPU (0.001 cores)
@@ -1155,7 +1293,7 @@ func TestComputeEfficiencyMetric_NoRequests(t *testing.T) {
 		RAMCost:                5.0,
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 	// Efficiency should be 0 when no requests are set
@@ -1180,7 +1318,7 @@ func TestComputeEfficiencyMetric_OverProvisioned(t *testing.T) {
 		RAMCost:                20.0,
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 	// Low efficiency due to over-provisioning
@@ -1208,7 +1346,7 @@ func TestComputeEfficiencyMetric_UnderProvisioned(t *testing.T) {
 		RAMCost:                5.0,
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 	// High efficiency (>100%) due to under-provisioning
@@ -1237,7 +1375,7 @@ func TestComputeEfficiencyMetric_CostCalculations(t *testing.T) {
 		GPUCost:                1.0,  // $1 for GPU
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 
@@ -1275,7 +1413,7 @@ func TestComputeEfficiencyMetric_OtherCostsPreserved(t *testing.T) {
 		GPUCost:                0.0,
 	}
 
-	result := computeEfficiencyMetric(alloc, 1.2)
+	result := computeEfficiencyMetric(alloc, 1.2, false, false)
 
 	require.NotNil(t, result)
 

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -697,9 +697,15 @@ func (mp *mockProvider) GetOrphanedResources() ([]models.OrphanedResource, error
 func (mp *mockProvider) NodePricing(models.Key) (*models.Node, models.PricingMetadata, error) {
 	return nil, models.PricingMetadata{}, nil
 }
-func (mp *mockProvider) GpuPricing(map[string]string) (string, error)            { return "", nil }
-func (mp *mockProvider) PVPricing(models.PVKey) (*models.PV, error)              { return nil, nil }
-func (mp *mockProvider) NetworkPricing() (*models.Network, error)                { return nil, nil }
+func (mp *mockProvider) GpuPricing(map[string]string) (string, error) { return "", nil }
+func (mp *mockProvider) PVPricing(models.PVKey) (*models.PV, error)   { return nil, nil }
+func (mp *mockProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
+	return nil, nil
+}
+func (mp *mockProvider) GetNetworkKey(labels map[string]string, clusterID string) models.NetworkKey {
+	return models.NewNetworkKey(labels, clusterID)
+}
+
 func (mp *mockProvider) LoadBalancerPricing() (*models.LoadBalancer, error)      { return nil, nil }
 func (mp *mockProvider) DownloadPricingData() error                              { return nil }
 func (mp *mockProvider) GetKey(map[string]string, *clustercache.Node) models.Key { return nil }


### PR DESCRIPTION
### Description
This pull request adds support for pricing reconciliation and multi-cluster metadata preservation in the MCP Server (`pkg/mcp`). 

Specifically, it:
1. Adds `reconcile` and `reconcileNetwork` parameters to the allocation and efficiency query parameters.
2. Exposes an `AllocationProperties` object in the allocation response, containing cluster, namespace, node, pod, controller, labels, and annotations.
3. Dynamically calculates reconciled costs (applying adjustments) for CPU, GPU, RAM, PV, Load Balancer, and Network components when reconciliation is enabled.
4. Updates efficiency recommendation algorithms to account for reconciled cost values consistently.

### Core Changes
- **`pkg/mcp/server.go`**:
  - Structs extended: `AllocationQuery`, `EfficiencyQuery`, `Allocation`.
  - Added `AllocationProperties` struct.
  - Updated `transformAllocationSet` to accept reconciliation flags, calculate adjusted costs, and populate `Properties`.
  - Updated `computeEfficiencyMetric` and `QueryEfficiency` to support reconciliation.
- **`pkg/mcp/server_test.go`**:
  - Updated existing mock calls.
  - Added `TestTransformAllocationSet_ReconciliationAndProperties` to verify cost calculations and metadata mapping.
  - Added `TestComputeEfficiencyMetric_Reconciliation` to verify recommendation cost reconciliation.

### Test Results
Run the unit test suite:
```bash
go test -v ./pkg/mcp/...
```
Output:
```
=== RUN   TestTransformAllocationSet_ReconciliationAndProperties
--- PASS: TestTransformAllocationSet_ReconciliationAndProperties (0.00s)
=== RUN   TestComputeEfficiencyMetric_Reconciliation
--- PASS: TestComputeEfficiencyMetric_Reconciliation (0.00s)
PASS
ok  	github.com/opencost/opencost/pkg/mcp	1.104s
```

All formatting (`go fmt`) and vetting (`go vet`) checks pass cleanly.
