### PR TITLE
feat(allocation): attribute pods to their controller for any owner kind

### DIFF
--- a/core/pkg/source/decoders.go
+++ b/core/pkg/source/decoders.go
@@ -57,12 +57,16 @@ const (
 	OwnerKindLabel       = "owner_kind"
 	OwnerUIDLabel        = "owner_uid"
 	ControllerLabel      = "controller"
-	UnitLabel            = "unit"
-	InternetLabel        = "internet"
-	SameZoneLabel        = "same_zone"
-	SameRegionLabel      = "same_region"
-	NatGatewayLabel      = "nat_gateway"
-	KubeModelVersion     = "kubemodel_version"
+	// OwnerIsControllerLabel is what kube-state-metrics emits on kube_pod_owner
+	// to mark the controlling owner reference (OpenCost's own emitter uses
+	// ControllerLabel instead).
+	OwnerIsControllerLabel = "owner_is_controller"
+	UnitLabel              = "unit"
+	InternetLabel          = "internet"
+	SameZoneLabel          = "same_zone"
+	SameRegionLabel        = "same_region"
+	NatGatewayLabel        = "nat_gateway"
+	KubeModelVersion       = "kubemodel_version"
 )
 
 const (
@@ -761,23 +765,37 @@ func DecodePodPVCVolumeResult(result *QueryResult) *PodPVCVolumeResult {
 type OwnerResult struct {
 	UID        string
 	Cluster    string
+	Namespace  string
+	Pod        string
 	OwnerUID   string
 	OwnerKind  string
+	OwnerName  string
 	Controller bool
 }
 
 func DecodeOwnerResult(result *QueryResult) *OwnerResult {
 	uid, _ := result.GetString(UIDLabel)
 	cluster, _ := result.GetCluster()
+	namespace, _ := result.GetNamespace()
+	pod, _ := result.GetPod()
 	ownerUID, _ := result.GetString(OwnerUIDLabel)
 	ownerKind, _ := result.GetString(OwnerKindLabel)
+	ownerName, _ := result.GetString(OwnerNameLabel)
+	// The controlling owner reference is marked by "controller" (OpenCost's own
+	// metric emitter) or "owner_is_controller" (kube-state-metrics).
 	controller, _ := result.GetBool(ControllerLabel)
+	if ownerIsController, _ := result.GetBool(OwnerIsControllerLabel); ownerIsController {
+		controller = true
+	}
 
 	return &OwnerResult{
 		UID:        uid,
 		Cluster:    cluster,
+		Namespace:  namespace,
+		Pod:        pod,
 		OwnerUID:   ownerUID,
 		OwnerKind:  ownerKind,
+		OwnerName:  ownerName,
 		Controller: controller,
 	}
 }

--- a/modules/prometheus-source/pkg/prom/metricsquerier.go
+++ b/modules/prometheus-source/pkg/prom/metricsquerier.go
@@ -815,7 +815,7 @@ func (pds *PrometheusMetricsQuerier) QueryPodUptime(start, end time.Time) *sourc
 
 func (pds *PrometheusMetricsQuerier) QueryPodOwners(start, end time.Time) *source.Future[source.OwnerResult] {
 	const queryName = "QueryPodOwners"
-	const queryFmtPodOwners = `avg(avg_over_time(kube_pod_owner{%s}[%s])) by (%s, uid, owner_uid, owner_kind, controller)`
+	const queryFmtPodOwners = `avg(avg_over_time(kube_pod_owner{%s}[%s])) by (%s, namespace, pod, uid, owner_uid, owner_kind, owner_name, controller, owner_is_controller)`
 
 	cfg := pds.promConfig
 

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -352,6 +352,11 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 
 	resChPodsWithJobOwner := source.WithGroup(grp, ds.QueryPodsWithJobOwner(start, end))
 
+	// Generic owner resolution: every pod's direct controller, whatever the kind.
+	// Attributes workload CRDs (PyTorchJob, RayCluster, ...) that have no dedicated
+	// query and would otherwise fall to __unallocated__.
+	resChPodOwners := source.WithGroup(grp, ds.QueryPodOwners(start, end))
+
 	resChLBCostPerHr := source.WithGroup(grp, ds.QueryLBPricePerHr(start, end))
 	resChLBActiveMins := source.WithGroup(grp, ds.QueryLBActiveMinutes(start, end))
 
@@ -416,6 +421,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 	resReplicaSetsWithoutOwners, _ := resChReplicaSetsWithoutOwners.Await()
 	resReplicaSetsWithRolloutOwner, _ := resChReplicaSetsWithRolloutOwner.Await()
 	resPodsWithJobOwner, _ := resChPodsWithJobOwner.Await()
+	resPodOwners, _ := resChPodOwners.Await()
 	resLBCostPerHr, _ := resChLBCostPerHr.Await()
 	resLBActiveMins, _ := resChLBActiveMins.Await()
 
@@ -479,6 +485,10 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 	podDaemonSetMap := resToPodDaemonSetMap(resPodsWithDaemonSetOwner, podUIDKeyMap, ingestPodUID)
 	podJobMap := resToPodJobMap(resPodsWithJobOwner, podUIDKeyMap, ingestPodUID)
 	podReplicaSetMap := resToPodReplicaSetMap(resPodsWithReplicaSetOwner, resReplicaSetsWithoutOwners, resReplicaSetsWithRolloutOwner, podUIDKeyMap, ingestPodUID)
+	// Base layer: generic owner for any kind. Applied first so the dedicated
+	// per-kind maps below override it for the kinds they handle.
+	podAnyOwnerMap := resToPodAnyOwnerMap(resPodOwners, podUIDKeyMap, ingestPodUID)
+	applyControllersToPods(podMap, podAnyOwnerMap)
 	applyControllersToPods(podMap, podDeploymentMap)
 	applyControllersToPods(podMap, podStatefulSetMap)
 	applyControllersToPods(podMap, podDaemonSetMap)

--- a/pkg/costmodel/allocation_anyowner_test.go
+++ b/pkg/costmodel/allocation_anyowner_test.go
@@ -1,0 +1,101 @@
+package costmodel
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+	"github.com/opencost/opencost/core/pkg/source"
+)
+
+// TestResToPodAnyOwnerMap covers the generic owner resolution that attributes a
+// pod to its direct controller regardless of kind, so workload CRDs (PyTorchJob,
+// RayCluster, ...) that have no dedicated query are no longer left unattributed.
+func TestResToPodAnyOwnerMap(t *testing.T) {
+	cases := map[string]struct {
+		owners   []*source.OwnerResult
+		expected map[podKey]controllerKey
+	}{
+		"attributes an unrecognized kind to its direct controller": {
+			owners: []*source.OwnerResult{
+				{Cluster: "cluster1", Namespace: "ns", Pod: "ray-head-0", OwnerKind: "RayCluster", OwnerName: "myray", Controller: true},
+			},
+			expected: map[podKey]controllerKey{
+				newPodKey("cluster1", "ns", "ray-head-0"): newControllerKey("cluster1", "ns", "raycluster", "myray"),
+			},
+		},
+		"lowercases the owner kind": {
+			owners: []*source.OwnerResult{
+				{Cluster: "cluster1", Namespace: "ns", Pod: "master-0", OwnerKind: "PyTorchJob", OwnerName: "bert", Controller: true},
+			},
+			expected: map[podKey]controllerKey{
+				newPodKey("cluster1", "ns", "master-0"): newControllerKey("cluster1", "ns", "pytorchjob", "bert"),
+			},
+		},
+		"skips non-controller owner references": {
+			owners: []*source.OwnerResult{
+				{Cluster: "cluster1", Namespace: "ns", Pod: "p", OwnerKind: "RayCluster", OwnerName: "myray", Controller: false},
+			},
+			expected: map[podKey]controllerKey{},
+		},
+		"skips rows missing owner name or kind": {
+			owners: []*source.OwnerResult{
+				{Cluster: "cluster1", Namespace: "ns", Pod: "p", OwnerKind: "", OwnerName: "x", Controller: true},
+				{Cluster: "cluster1", Namespace: "ns", Pod: "p", OwnerKind: "Job", OwnerName: "", Controller: true},
+			},
+			expected: map[podKey]controllerKey{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := resToPodAnyOwnerMap(tc.owners, map[podKey][]podKey{}, false)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %d entries, got %d (%v)", len(tc.expected), len(got), got)
+			}
+			for k, want := range tc.expected {
+				gv, ok := got[k]
+				if !ok {
+					t.Errorf("missing expected key %s", k)
+					continue
+				}
+				if gv != want {
+					t.Errorf("key %s: expected %s, got %s", k, want, gv)
+				}
+			}
+		})
+	}
+}
+
+// TestAnyOwnerPrecedence guards the design contract: the any-owner base map is
+// applied before the dedicated per-kind maps, so a pod present in both is
+// attributed to the specific kind (a Deployment's pod resolves to the
+// Deployment, not the ReplicaSet the generic map would otherwise assign).
+func TestAnyOwnerPrecedence(t *testing.T) {
+	// A Deployment's pod appears in both the generic any-owner map (as its
+	// ReplicaSet) and the dedicated deployment map; the deployment must win.
+	pk := newPodKey("cluster1", "ns", "web-abc")
+	alloc := &opencost.Allocation{Properties: &opencost.AllocationProperties{}}
+
+	// A pod with no controlling owner is in no map; it must stay unattributed
+	// (empty controller -> __unallocated__), i.e. no regression from this change.
+	barePk := newPodKey("cluster1", "ns", "bare-pod")
+	bareAlloc := &opencost.Allocation{Properties: &opencost.AllocationProperties{}}
+
+	podMap := map[podKey]*pod{
+		pk:     {Allocations: map[string]*opencost.Allocation{"web": alloc}},
+		barePk: {Allocations: map[string]*opencost.Allocation{"c": bareAlloc}},
+	}
+
+	anyOwner := map[podKey]controllerKey{pk: newControllerKey("cluster1", "ns", "replicaset", "web-rs")}
+	deployment := map[podKey]controllerKey{pk: newControllerKey("cluster1", "ns", "deployment", "web")}
+
+	applyControllersToPods(podMap, anyOwner)
+	applyControllersToPods(podMap, deployment)
+
+	if alloc.Properties.ControllerKind != "deployment" || alloc.Properties.Controller != "web" {
+		t.Fatalf("expected deployment/web to win, got %s/%s", alloc.Properties.ControllerKind, alloc.Properties.Controller)
+	}
+	if bareAlloc.Properties.ControllerKind != "" || bareAlloc.Properties.Controller != "" {
+		t.Fatalf("expected uncontrolled pod to stay unattributed, got %s/%s", bareAlloc.Properties.ControllerKind, bareAlloc.Properties.Controller)
+	}
+}

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -1458,6 +1458,46 @@ func resToPodJobMap(resJobLabels []*source.PodsWithJobOwnerResult, podUIDKeyMap 
 	return jobLabels
 }
 
+// resToPodAnyOwnerMap maps every pod to its direct controller owner, whatever
+// the owner kind, from the generic kube_pod_owner data. This is the base layer
+// of controller resolution: it attributes pods owned by kinds OpenCost has no
+// dedicated query for (PyTorchJob, RayCluster, and any other workload CRD) that
+// would otherwise fall to __unallocated__. It is applied before the dedicated
+// per-kind maps, so those still win for the kinds they handle (a Deployment's
+// pod is resolved to the Deployment, not to its ReplicaSet).
+func resToPodAnyOwnerMap(resPodOwners []*source.OwnerResult, podUIDKeyMap map[podKey][]podKey, ingestPodUID bool) map[podKey]controllerKey {
+	anyOwner := map[podKey]controllerKey{}
+
+	for _, res := range resPodOwners {
+		// Only the controlling owner reference names the workload.
+		if !res.Controller || res.OwnerName == "" || res.OwnerKind == "" {
+			continue
+		}
+
+		controllerKey, err := newResultControllerKey(res.Cluster, res.Namespace, res.OwnerName, strings.ToLower(res.OwnerKind))
+		if err != nil {
+			continue
+		}
+
+		key := newPodKey(controllerKey.Cluster, controllerKey.Namespace, res.Pod)
+
+		var keys []podKey
+		if ingestPodUID {
+			if uidKeys, ok := podUIDKeyMap[key]; ok {
+				keys = append(keys, uidKeys...)
+			}
+		} else {
+			keys = []podKey{key}
+		}
+
+		for _, key := range keys {
+			anyOwner[key] = controllerKey
+		}
+	}
+
+	return anyOwner
+}
+
 func resToPodReplicaSetMap(resPodsWithReplicaSetOwner []*source.PodsWithReplicaSetOwnerResult, resReplicaSetsWithoutOwners []*source.ReplicaSetsWithoutOwnersResult, resReplicaSetsWithRolloutOwner []*source.ReplicaSetsWithRolloutResult, podUIDKeyMap map[podKey][]podKey, ingestPodUID bool) map[podKey]controllerKey {
 	// Build out set of ReplicaSets that have no owners, themselves, such that
 	// the ReplicaSet should be used as the owner of the Pods it controls.


### PR DESCRIPTION
## Description

OpenCost's allocation read path resolves each pod's controller with a fixed set of
owner-kind queries: Deployment, StatefulSet, DaemonSet, Job, ReplicaSet (`pkg/costmodel/allocation.go`).
A pod owned by any other kind - `PyTorchJob` (Kubeflow), `RayCluster` (KubeRay), `MPIJob`,
and other workload CRDs - matches none of these, so under `aggregate=controller` /
`aggregate=controllerKind` its cost falls into `__unallocated__`. On GPU / AI clusters these
CRDs own the most expensive pods, so the spend that matters most is the least attributable.

The data is already there: `kube_pod_owner` carries the real `owner_kind` and `owner_name`
for every pod. This PR reads what is already emitted; it does not add a new metric or a new
watch.

- New `resToPodAnyOwnerMap` maps each pod to its direct controlling owner of any kind, from
  the existing `QueryPodOwners` result.
- It is applied as a base layer **before** the five dedicated per-kind maps, so those still
  win for the kinds they handle (a Deployment's pod resolves to the Deployment, not its
  ReplicaSet) and previously unattributed kinds are filled in. A pod with no controlling
  owner matches nothing and stays `__unallocated__`, so there is no regression.
- Decodes `owner_name` and `owner_is_controller` from `kube_pod_owner`. kube-state-metrics
  marks the controlling reference with `owner_is_controller`; OpenCost's own emitter uses
  `controller`. Both are honored, and empty/absent owner labels are skipped.

### Why the read/decoder path (not metric emission)

The change lives in the query + decoder path (`core/pkg/source/decoders.go`,
`modules/prometheus-source/.../metricsquerier.go`, `pkg/costmodel/`) rather than at metric
emission (`pkg/metrics`), because `kube_pod_owner` already carries `owner_kind`/`owner_name`
for every kind - nothing new needs to be emitted. Resolving at emission would not help
(the clustercache only watches native kinds, so it has no RayCluster/PyTorchJob objects),
and the existing per-kind resolution already happens here, so this stays consistent with it.

### Verified

End-to-end on a kind cluster (fake-gpu-operator + KubeRay + Kubeflow training-operator): a
`PyTorchJob` and a `RayCluster` that previously sat in `__unallocated__` now aggregate under
`pytorchjob:<name>` and `raycluster:<name>`, and the `__unallocated__` GPU cost drops to zero.

### Out of scope (follow-up)

Rolling multi-hop chains up to a higher logical root (`RayCluster` -> `RayJob`,
`Job` -> `JobSet`) is intentionally not included. It needs an intermediate-owner edge that
Prometheus does not expose generically - only `kube_replicaset_owner` exists (for
ReplicaSet -> Deployment/Rollout) - and the clustercache watches only native kinds. Pods
still attribute to their direct controller, which removes the `__unallocated__` gap; rolling
that up to the logical workload is a separate change (a CRD-aware informer or a
custom-resource-state owner metric), kept out to hold this PR to a single intent.

## Related Issues

Relates to #3902

## User Impact

Pods owned by workload CRDs are now attributed to their controller under
`aggregate=controller` / `aggregate=controllerKind` instead of `__unallocated__`. No
configuration required. Behavior for the existing native kinds is unchanged, and pods with no
controlling owner remain unallocated as before. Not a breaking change to the API.

**Release notes:** cost that previously showed as `__unallocated__` under controller
aggregation will now move under the owning workload (e.g. a `PyTorchJob` or `RayCluster`).
This is more correct but will change the numbers in existing controller-level dashboards and
alerts, so it is worth calling out to users.

## Testing

- `TestResToPodAnyOwnerMap` - the new map builder: attributes an unrecognized kind to its
  direct controller, lowercases the owner kind, skips non-controller owner references, and
  skips rows missing an owner name or kind.
- `TestAnyOwnerPrecedence` - guards the design contract that the dedicated per-kind maps
  override the generic base layer (a Deployment's pod resolves to the Deployment), and that a
  pod with no controlling owner stays unattributed (no regression).
- `go test ./pkg/costmodel/`, `go vet`, and `gofmt` clean; `core` and `prometheus-source`
  modules build.
- Manual end-to-end on kind as described above.
