### PR TITLE
feat(aws): make RI/SP Athena refresh interval configurable

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -966,6 +966,12 @@ func (aws *AWS) DownloadPricingData() error {
 		pvkeys[key.Features()] = key
 	}
 
+	// riSpRefreshInterval controls how often the Reserved Instance and Savings Plan
+	// watchers refresh their data from Athena. Defaults to 1h; raise it (e.g. to 24h
+	// via AWS_RI_SP_REFRESH_RATE_HOURS) to reduce Athena scan cost in multi-cluster
+	// deployments that share a single CUR export.
+	riSpRefreshInterval := time.Hour * time.Duration(env.GetAWSRISPRefreshRateHours())
+
 	// RIDataRunning establishes the existence of the goroutine. Since it's possible we
 	// run multiple downloads, we don't want to create multiple go routines if one already exists
 	//
@@ -986,8 +992,8 @@ func (aws *AWS) DownloadPricingData() error {
 				aws.RIDataRunning = true
 
 				for {
-					log.Infof("Reserved Instance watcher running... next update in 1h")
-					time.Sleep(time.Hour)
+					log.Infof("Reserved Instance watcher running... next update in %s", riSpRefreshInterval)
+					time.Sleep(riSpRefreshInterval)
 					err := aws.GetReservationDataFromAthena()
 					if err != nil {
 						log.Infof("Error updating RI data: %s", err.Error())
@@ -1009,8 +1015,8 @@ func (aws *AWS) DownloadPricingData() error {
 				defer errs.HandlePanic()
 				aws.SavingsPlanDataRunning = true
 				for {
-					log.Infof("Savings Plan watcher running... next update in 1h")
-					time.Sleep(time.Hour)
+					log.Infof("Savings Plan watcher running... next update in %s", riSpRefreshInterval)
+					time.Sleep(riSpRefreshInterval)
 					err := aws.GetSavingsPlanDataFromAthena()
 					if err != nil {
 						log.Infof("Error updating Savings Plan data: %s", err.Error())

--- a/pkg/env/costmodel.go
+++ b/pkg/env/costmodel.go
@@ -29,6 +29,10 @@ const (
 	AWSPricingURL            = "AWS_PRICING_URL"
 	AWSECSPricingURLOverride = "AWS_ECS_PRICING_URL"
 
+	// AWSRISPRefreshRateHoursEnvVar controls how often (in hours) the Reserved
+	// Instance and Savings Plan watchers refresh their data from Athena.
+	AWSRISPRefreshRateHoursEnvVar = "AWS_RI_SP_REFRESH_RATE_HOURS"
+
 	AlibabaAccessKeyIDEnvVar     = "ALIBABA_ACCESS_KEY_ID"
 	AlibabaAccessKeySecretEnvVar = "ALIBABA_SECRET_ACCESS_KEY"
 
@@ -183,6 +187,14 @@ func GetAWSPricingURL() string {
 // GetAWSECSPricingURLOverride returns an optional alternative URL to fetch AmazonECS pricing data from; for use in airgapped environments
 func GetAWSECSPricingURLOverride() string {
 	return env.Get(AWSECSPricingURLOverride, "")
+}
+
+// GetAWSRISPRefreshRateHours returns how often (in hours) the Reserved Instance
+// and Savings Plan watchers refresh their data from Athena. Defaults to 1, which
+// preserves the historical hourly behavior. For multi-cluster deployments sharing
+// a single CUR export, raising this (e.g. to 24) reduces Athena scan cost.
+func GetAWSRISPRefreshRateHours() int {
+	return env.GetInt(AWSRISPRefreshRateHoursEnvVar, 1)
 }
 
 // GetAlibabaAccessKeyID returns the environment variable value for AlibabaAccessKeyIDEnvVar which represents

--- a/pkg/env/costmodel_test.go
+++ b/pkg/env/costmodel_test.go
@@ -101,3 +101,40 @@ func TestIsMCPServerEnabled_True(t *testing.T) {
 		t.Fatalf("expected true when env var set to true, got %v", got)
 	}
 }
+
+func TestGetAWSRISPRefreshRateHours(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+		pre  func(t *testing.T)
+	}{
+		{
+			name: "defaults to 1 when unset",
+			want: 1,
+		},
+		{
+			name: "returns 24 when AWS_RI_SP_REFRESH_RATE_HOURS is set to 24",
+			want: 24,
+			pre: func(t *testing.T) {
+				t.Setenv("AWS_RI_SP_REFRESH_RATE_HOURS", "24")
+			},
+		},
+		{
+			name: "falls back to 1 when set to an invalid value",
+			want: 1,
+			pre: func(t *testing.T) {
+				t.Setenv("AWS_RI_SP_REFRESH_RATE_HOURS", "foo")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.pre != nil {
+				tt.pre(t)
+			}
+			if got := GetAWSRISPRefreshRateHours(); got != tt.want {
+				t.Errorf("GetAWSRISPRefreshRateHours() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The Reserved Instance and Savings Plan watchers in `pkg/cloud/aws/provider.go` refresh their data from Athena in background goroutines that previously slept for a **hardcoded 1 hour** between runs. There was no supported way to change this cadence — the `athenaRefreshInterval` Helm value under `customPricing.costModel` is not wired to these watchers in code.

This PR makes the interval configurable via a new environment variable, `AWS_RI_SP_REFRESH_RATE_HOURS`, **defaulting to `1`** (identical to current behavior).

**Changes**
- Add env var `AWS_RI_SP_REFRESH_RATE_HOURS` and helper `env.GetAWSRISPRefreshRateHours()` (default `1`) in `pkg/env/costmodel.go`, next to the existing `AWS_*` vars/getters.
- In `provider.go`, compute the interval once — `riSpRefreshInterval := time.Hour * time.Duration(env.GetAWSRISPRefreshRateHours())` — and use it for both the RI and SP watcher `time.Sleep` calls.
- Watcher log lines now report the configured interval (e.g. `next update in 24h0m0s`) instead of a hardcoded `1h`.

**Configuration example** (exporter deployment):
```yaml
env:
  - name: AWS_RI_SP_REFRESH_RATE_HOURS
    value: "24"
```

## Related Issues

<!-- Replace with Fixes #<number> if an issue is filed -->
N/A

## User Impact

Fully backward compatible; **not** a breaking change.

- The default of `1` means unset, empty, or invalid values all resolve to the current 1-hour interval, so existing and single-cluster deployments are unaffected.
- Multi-cluster deployments that share a single CUR export via a cross-account IAM role can raise the interval to reduce Athena scan cost, since the query cadence multiplies across clusters.

Illustrative cost (~10 clusters, RI + SP queries):

| Interval | Scans/day | Approx. monthly Athena cost |
|----------|-----------|-----------------------------|
| 1h (current default) | 480 | ~$45 |
| 24h (opt-in override) | 20 | ~$1 |

**Rollout note:** the matching Helm value (e.g. `awsRiSpRefreshRateHours` → `AWS_RI_SP_REFRESH_RATE_HOURS`) lives in the separate [opencost-helm-chart](https://github.com/opencost/opencost-helm-chart) repo and will be a follow-up PR there; this change provides the env var it maps to.

## Testing

Added `TestGetAWSRISPRefreshRateHours` in `pkg/env/costmodel_test.go` covering the default (`1`) when unset, an override (`24`), and fallback to `1` on invalid input.

Local verification:
```
$ go build ./pkg/...
$ go vet ./pkg/env/ ./pkg/cloud/aws/
$ gofmt -l pkg/env/costmodel.go pkg/env/costmodel_test.go pkg/cloud/aws/provider.go   # no output
$ go test ./pkg/env/ -run TestGetAWSRISPRefreshRateHours
ok  	github.com/opencost/opencost/pkg/env
```

No integration tests required — this only changes a background refresh cadence with a behavior-preserving default. Manual check: with `AWS_RI_SP_REFRESH_RATE_HOURS=24`, the watcher logs report `next update in 24h0m0s`; unset, they report `1h0m0s`.
