### PR TITLE
feat(anomaly): implement cost anomaly detection GET /anomaly API

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -68,6 +68,8 @@ type Service struct {
 	Type         v1.ServiceType
 	Status       v1.ServiceStatus
 	ClusterIP    string
+	Labels       map[string]string
+	Annotations  map[string]string
 }
 
 type DaemonSet struct {
@@ -310,6 +312,8 @@ func TransformService(input *v1.Service) *Service {
 		Type:         input.Spec.Type,
 		Status:       input.Status,
 		ClusterIP:    input.Spec.ClusterIP,
+		Labels:       input.Labels,
+		Annotations:  input.Annotations,
 	}
 }
 

--- a/core/pkg/external/configmapsource_test.go
+++ b/core/pkg/external/configmapsource_test.go
@@ -333,11 +333,11 @@ labels:
 
 func TestFilterValidLabels_AllValid_ReturnedUnchanged(t *testing.T) {
 	in := map[string]string{
-		"env":                     "prod",
-		"region":                  "us-east-1",
-		"app.kubernetes.io/name":  "opencost",
-		"my-key":                  "my-value",
-		"a":                       "b",
+		"env":                    "prod",
+		"region":                 "us-east-1",
+		"app.kubernetes.io/name": "opencost",
+		"my-key":                 "my-value",
+		"a":                      "b",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -396,8 +396,8 @@ func TestFilterValidLabels_KeyTooLong_EntryDropped(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 	in := map[string]string{
-		"app.kubernetes.io/name":      "opencost",
-		"example.com/env":             "staging",
+		"app.kubernetes.io/name": "opencost",
+		"example.com/env":        "staging",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, in, out)
@@ -405,7 +405,7 @@ func TestFilterValidLabels_PrefixedKey_Valid(t *testing.T) {
 
 func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) {
 	in := map[string]string{
-		"valid":          "kept",
+		"valid":         "kept",
 		"-bad.prefix/k": "dropped",
 	}
 	out := filterValidLabels(in)
@@ -414,10 +414,10 @@ func TestFilterValidLabels_PrefixedKey_InvalidPrefix_EntryDropped(t *testing.T) 
 
 func TestFilterValidLabels_MixedValidAndInvalid_OnlyValidReturned(t *testing.T) {
 	in := map[string]string{
-		"cluster":    "prod",
-		"":           "no-key",
-		"bad-value":  "-oops",
-		"region":     "eu-west-1",
+		"cluster":   "prod",
+		"":          "no-key",
+		"bad-value": "-oops",
+		"region":    "eu-west-1",
 	}
 	out := filterValidLabels(in)
 	assert.Equal(t, map[string]string{"cluster": "prod", "region": "eu-west-1"}, out)

--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -87,6 +87,9 @@ type Allocation struct {
 	RAMCostIdle                float64               `json:"ramCostIdle"` //@bingen:field[ignore]
 	SharedCost                 float64               `json:"sharedCost"`
 	ExternalCost               float64               `json:"externalCost"`
+	QuotaOverheadCost          float64               `json:"quotaOverheadCost"`
+	QuotaOverheadCPUCost       float64               `json:"quotaOverheadCpuCost"`
+	QuotaOverheadRAMCost       float64               `json:"quotaOverheadRamCost"`
 	CarbonKilograms            float64               `json:"carbonKilograms"`
 	// RawAllocationOnly is a pointer so if it is not present it will be
 	// marshalled as null rather than as an object with Go default values.
@@ -789,6 +792,9 @@ func (a *Allocation) Clone() *Allocation {
 		RAMCostAdjustment:              a.RAMCostAdjustment,
 		SharedCost:                     a.SharedCost,
 		ExternalCost:                   a.ExternalCost,
+		QuotaOverheadCost:              a.QuotaOverheadCost,
+		QuotaOverheadCPUCost:           a.QuotaOverheadCPUCost,
+		QuotaOverheadRAMCost:           a.QuotaOverheadRAMCost,
 		CarbonKilograms:                a.CarbonKilograms,
 		RawAllocationOnly:              a.RawAllocationOnly.Clone(),
 		ProportionalAssetResourceCosts: a.ProportionalAssetResourceCosts.Clone(),
@@ -903,6 +909,15 @@ func (a *Allocation) Equal(that *Allocation) bool {
 	if !util.IsApproximately(a.ExternalCost, that.ExternalCost) {
 		return false
 	}
+	if !util.IsApproximately(a.QuotaOverheadCost, that.QuotaOverheadCost) {
+		return false
+	}
+	if !util.IsApproximately(a.QuotaOverheadCPUCost, that.QuotaOverheadCPUCost) {
+		return false
+	}
+	if !util.IsApproximately(a.QuotaOverheadRAMCost, that.QuotaOverheadRAMCost) {
+		return false
+	}
 	if !util.IsApproximately(a.CarbonKilograms, that.CarbonKilograms) {
 		return false
 	}
@@ -932,7 +947,7 @@ func (a *Allocation) TotalCost() float64 {
 		return 0.0
 	}
 
-	return a.CPUTotalCost() + a.GPUTotalCost() + a.RAMTotalCost() + a.PVTotalCost() + a.NetworkTotalCost() + a.LBTotalCost() + a.SharedTotalCost() + a.ExternalCost
+	return a.CPUTotalCost() + a.GPUTotalCost() + a.RAMTotalCost() + a.PVTotalCost() + a.NetworkTotalCost() + a.LBTotalCost() + a.SharedTotalCost() + a.ExternalCost + a.QuotaOverheadCost
 }
 
 // CPUTotalCost calculates total CPU cost of Allocation including adjustment
@@ -1443,6 +1458,9 @@ func (a *Allocation) add(that *Allocation) {
 	a.LoadBalancerCost += that.LoadBalancerCost
 	a.SharedCost += that.SharedCost
 	a.ExternalCost += that.ExternalCost
+	a.QuotaOverheadCost += that.QuotaOverheadCost
+	a.QuotaOverheadCPUCost += that.QuotaOverheadCPUCost
+	a.QuotaOverheadRAMCost += that.QuotaOverheadRAMCost
 	a.CarbonKilograms += that.CarbonKilograms
 	a.UnmountedPVCost += that.UnmountedPVCost
 

--- a/core/pkg/opencost/allocation.go
+++ b/core/pkg/opencost/allocation.go
@@ -87,6 +87,7 @@ type Allocation struct {
 	RAMCostIdle                float64               `json:"ramCostIdle"` //@bingen:field[ignore]
 	SharedCost                 float64               `json:"sharedCost"`
 	ExternalCost               float64               `json:"externalCost"`
+	CarbonKilograms            float64               `json:"carbonKilograms"`
 	// RawAllocationOnly is a pointer so if it is not present it will be
 	// marshalled as null rather than as an object with Go default values.
 	RawAllocationOnly *RawAllocationOnlyData `json:"rawAllocationOnly"`
@@ -788,6 +789,7 @@ func (a *Allocation) Clone() *Allocation {
 		RAMCostAdjustment:              a.RAMCostAdjustment,
 		SharedCost:                     a.SharedCost,
 		ExternalCost:                   a.ExternalCost,
+		CarbonKilograms:                a.CarbonKilograms,
 		RawAllocationOnly:              a.RawAllocationOnly.Clone(),
 		ProportionalAssetResourceCosts: a.ProportionalAssetResourceCosts.Clone(),
 		SharedCostBreakdown:            a.SharedCostBreakdown.Clone(),
@@ -899,6 +901,9 @@ func (a *Allocation) Equal(that *Allocation) bool {
 		return false
 	}
 	if !util.IsApproximately(a.ExternalCost, that.ExternalCost) {
+		return false
+	}
+	if !util.IsApproximately(a.CarbonKilograms, that.CarbonKilograms) {
 		return false
 	}
 
@@ -1438,6 +1443,7 @@ func (a *Allocation) add(that *Allocation) {
 	a.LoadBalancerCost += that.LoadBalancerCost
 	a.SharedCost += that.SharedCost
 	a.ExternalCost += that.ExternalCost
+	a.CarbonKilograms += that.CarbonKilograms
 	a.UnmountedPVCost += that.UnmountedPVCost
 
 	// Sum PVAllocations
@@ -2851,6 +2857,10 @@ func (a *Allocation) SanitizeNaN() {
 	if math.IsNaN(a.ExternalCost) {
 		log.DedupedWarningf(5, "Allocation: Unexpected NaN found for ExternalCost name:%s, window:%s, properties:%s", a.Name, a.Window.String(), a.Properties.String())
 		a.ExternalCost = 0
+	}
+	if math.IsNaN(a.CarbonKilograms) {
+		log.DedupedWarningf(5, "Allocation: Unexpected NaN found for CarbonKilograms name:%s, window:%s, properties:%s", a.Name, a.Window.String(), a.Properties.String())
+		a.CarbonKilograms = 0
 	}
 
 	a.PVs.SanitizeNaN()

--- a/core/pkg/opencost/allocation_json.go
+++ b/core/pkg/opencost/allocation_json.go
@@ -61,6 +61,9 @@ type AllocationJSON struct {
 	RAMEfficiency                  *float64                        `json:"ramEfficiency"`
 	ExternalCost                   *float64                        `json:"externalCost"`
 	SharedCost                     *float64                        `json:"sharedCost"`
+	QuotaOverheadCost              *float64                        `json:"quotaOverheadCost"`
+	QuotaOverheadCPUCost           *float64                        `json:"quotaOverheadCpuCost"`
+	QuotaOverheadRAMCost           *float64                        `json:"quotaOverheadRamCost"`
 	TotalCost                      *float64                        `json:"totalCost"`
 	TotalEfficiency                *float64                        `json:"totalEfficiency"`
 	CarbonKilograms                *float64                        `json:"carbonKilograms"`
@@ -123,6 +126,9 @@ func (aj *AllocationJSON) BuildFromAllocation(a *Allocation) {
 	aj.RAMEfficiency = formatFloat64ForResponse(a.RAMEfficiency())
 	aj.SharedCost = formatFloat64ForResponse(a.SharedCost)
 	aj.ExternalCost = formatFloat64ForResponse(a.ExternalCost)
+	aj.QuotaOverheadCost = formatFloat64ForResponse(a.QuotaOverheadCost)
+	aj.QuotaOverheadCPUCost = formatFloat64ForResponse(a.QuotaOverheadCPUCost)
+	aj.QuotaOverheadRAMCost = formatFloat64ForResponse(a.QuotaOverheadRAMCost)
 	aj.TotalCost = formatFloat64ForResponse(a.TotalCost())
 	aj.TotalEfficiency = formatFloat64ForResponse(a.TotalEfficiency())
 	aj.CarbonKilograms = formatFloat64ForResponse(a.CarbonKilograms)

--- a/core/pkg/opencost/allocation_json.go
+++ b/core/pkg/opencost/allocation_json.go
@@ -63,6 +63,7 @@ type AllocationJSON struct {
 	SharedCost                     *float64                        `json:"sharedCost"`
 	TotalCost                      *float64                        `json:"totalCost"`
 	TotalEfficiency                *float64                        `json:"totalEfficiency"`
+	CarbonKilograms                *float64                        `json:"carbonKilograms"`
 	RawAllocationOnly              *RawAllocationOnlyData          `json:"rawAllocationOnly,omitempty"`
 	ProportionalAssetResourceCosts *ProportionalAssetResourceCosts `json:"proportionalAssetResourceCosts,omitempty"`
 	LoadBalancers                  LbAllocations                   `json:"lbAllocations"`
@@ -124,6 +125,7 @@ func (aj *AllocationJSON) BuildFromAllocation(a *Allocation) {
 	aj.ExternalCost = formatFloat64ForResponse(a.ExternalCost)
 	aj.TotalCost = formatFloat64ForResponse(a.TotalCost())
 	aj.TotalEfficiency = formatFloat64ForResponse(a.TotalEfficiency())
+	aj.CarbonKilograms = formatFloat64ForResponse(a.CarbonKilograms)
 	aj.RawAllocationOnly = a.RawAllocationOnly
 	aj.ProportionalAssetResourceCosts = &a.ProportionalAssetResourceCosts
 	aj.LoadBalancers = a.LoadBalancers

--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -48,6 +48,7 @@ type SummaryAllocation struct {
 	Share                  bool                  `json:"-"`
 	UnmountedPVCost        float64               `json:"-"`
 	Efficiency             float64               `json:"efficiency"`
+	CarbonKilograms        float64               `json:"carbonKilograms"`
 }
 
 // NewSummaryAllocation converts an Allocation to a SummaryAllocation by
@@ -90,6 +91,7 @@ func NewSummaryAllocation(alloc *Allocation, reconcile, reconcileNetwork bool) *
 		SharedCost:             alloc.SharedCost,
 		ExternalCost:           alloc.ExternalCost,
 		UnmountedPVCost:        alloc.UnmountedPVCost,
+		CarbonKilograms:        alloc.CarbonKilograms,
 	}
 
 	// Revert adjustments if reconciliation is off. If only network
@@ -229,6 +231,7 @@ func (sa *SummaryAllocation) Add(that *SummaryAllocation) error {
 	sa.PVCost += that.PVCost
 	sa.RAMCost += that.RAMCost
 	sa.SharedCost += that.SharedCost
+	sa.CarbonKilograms += that.CarbonKilograms
 
 	sa.Efficiency = sa.TotalEfficiency()
 	return nil
@@ -258,6 +261,7 @@ func (sa *SummaryAllocation) Clone() *SummaryAllocation {
 		SharedCost:             sa.SharedCost,
 		ExternalCost:           sa.ExternalCost,
 		Efficiency:             sa.Efficiency,
+		CarbonKilograms:        sa.CarbonKilograms,
 	}
 }
 
@@ -358,6 +362,10 @@ func (sa *SummaryAllocation) Equal(that *SummaryAllocation) bool {
 	}
 
 	if sa.ExternalCost != that.ExternalCost {
+		return false
+	}
+
+	if sa.CarbonKilograms != that.CarbonKilograms {
 		return false
 	}
 

--- a/core/pkg/opencost/summaryallocation.go
+++ b/core/pkg/opencost/summaryallocation.go
@@ -45,6 +45,9 @@ type SummaryAllocation struct {
 	RAMCostIdle            float64               `json:"ramCostIdle"`
 	SharedCost             float64               `json:"sharedCost"`
 	ExternalCost           float64               `json:"externalCost"`
+	QuotaOverheadCost      float64               `json:"quotaOverheadCost"`
+	QuotaOverheadCPUCost   float64               `json:"quotaOverheadCpuCost"`
+	QuotaOverheadRAMCost   float64               `json:"quotaOverheadRamCost"`
 	Share                  bool                  `json:"-"`
 	UnmountedPVCost        float64               `json:"-"`
 	Efficiency             float64               `json:"efficiency"`
@@ -90,6 +93,9 @@ func NewSummaryAllocation(alloc *Allocation, reconcile, reconcileNetwork bool) *
 		RAMCostIdle:            alloc.RAMCostIdle,
 		SharedCost:             alloc.SharedCost,
 		ExternalCost:           alloc.ExternalCost,
+		QuotaOverheadCost:      alloc.QuotaOverheadCost,
+		QuotaOverheadCPUCost:   alloc.QuotaOverheadCPUCost,
+		QuotaOverheadRAMCost:   alloc.QuotaOverheadRAMCost,
 		UnmountedPVCost:        alloc.UnmountedPVCost,
 		CarbonKilograms:        alloc.CarbonKilograms,
 	}
@@ -231,6 +237,9 @@ func (sa *SummaryAllocation) Add(that *SummaryAllocation) error {
 	sa.PVCost += that.PVCost
 	sa.RAMCost += that.RAMCost
 	sa.SharedCost += that.SharedCost
+	sa.QuotaOverheadCost += that.QuotaOverheadCost
+	sa.QuotaOverheadCPUCost += that.QuotaOverheadCPUCost
+	sa.QuotaOverheadRAMCost += that.QuotaOverheadRAMCost
 	sa.CarbonKilograms += that.CarbonKilograms
 
 	sa.Efficiency = sa.TotalEfficiency()
@@ -260,6 +269,9 @@ func (sa *SummaryAllocation) Clone() *SummaryAllocation {
 		RAMCost:                sa.RAMCost,
 		SharedCost:             sa.SharedCost,
 		ExternalCost:           sa.ExternalCost,
+		QuotaOverheadCost:      sa.QuotaOverheadCost,
+		QuotaOverheadCPUCost:   sa.QuotaOverheadCPUCost,
+		QuotaOverheadRAMCost:   sa.QuotaOverheadRAMCost,
 		Efficiency:             sa.Efficiency,
 		CarbonKilograms:        sa.CarbonKilograms,
 	}
@@ -453,7 +465,7 @@ func (sa *SummaryAllocation) TotalCost() float64 {
 		return 0.0
 	}
 
-	return sa.CPUCost + sa.GPUCost + sa.RAMCost + sa.PVCost + sa.NetworkCost + sa.LoadBalancerCost + sa.SharedCost + sa.ExternalCost
+	return sa.CPUCost + sa.GPUCost + sa.RAMCost + sa.PVCost + sa.NetworkCost + sa.LoadBalancerCost + sa.SharedCost + sa.ExternalCost + sa.QuotaOverheadCost
 }
 
 // TotalEfficiency is the cost-weighted average of CPU and RAM efficiency. If

--- a/core/pkg/opencost/summaryallocation_json.go
+++ b/core/pkg/opencost/summaryallocation_json.go
@@ -33,6 +33,7 @@ type SummaryAllocationResponse struct {
 	ExternalCost           *float64  `json:"externalCost"`
 	TotalEfficiency        *float64  `json:"totalEfficiency"`
 	TotalCost              *float64  `json:"totalCost"`
+	CarbonKilograms        *float64  `json:"carbonKilograms"`
 }
 
 // ToResponse converts a SummaryAllocation to a SummaryAllocationResponse,
@@ -77,6 +78,7 @@ func (sa *SummaryAllocation) ToResponse() *SummaryAllocationResponse {
 		ExternalCost:           formatutil.Float64ToResponse(sa.ExternalCost),
 		TotalEfficiency:        formatutil.Float64ToResponse(efficiency),
 		TotalCost:              formatutil.Float64ToResponse(sa.TotalCost()),
+		CarbonKilograms:        formatutil.Float64ToResponse(sa.CarbonKilograms),
 	}
 }
 

--- a/core/pkg/opencost/totals.go
+++ b/core/pkg/opencost/totals.go
@@ -48,6 +48,9 @@ type AllocationTotals struct {
 	RAMCost                        float64   `json:"ramCost"`
 	RAMCostAdjustment              float64   `json:"ramCostAdjustment"`
 	RAMByteHours                   float64   `json:"ramByteHours"`
+	QuotaOverheadCost              float64   `json:"quotaOverheadCost"`
+	QuotaOverheadCPUCost           float64   `json:"quotaOverheadCpuCost"`
+	QuotaOverheadRAMCost           float64   `json:"quotaOverheadRamCost"`
 	// UnmountedPVCost is used to track how much of the cost in
 	// PersistentVolumeCost is for an unmounted PV. It is not additive of that
 	// field, and need not be sent in API responses.
@@ -87,6 +90,9 @@ func (art *AllocationTotals) Clone() *AllocationTotals {
 		RAMCost:                        art.RAMCost,
 		RAMCostAdjustment:              art.RAMCostAdjustment,
 		RAMByteHours:                   art.RAMByteHours,
+		QuotaOverheadCost:              art.QuotaOverheadCost,
+		QuotaOverheadCPUCost:           art.QuotaOverheadCPUCost,
+		QuotaOverheadRAMCost:           art.QuotaOverheadRAMCost,
 	}
 }
 
@@ -123,7 +129,8 @@ func (art *AllocationTotals) TotalRAMCost() float64 {
 // TotalCost returns the sum of all costs.
 func (art *AllocationTotals) TotalCost() float64 {
 	return art.TotalCPUCost() + art.TotalGPUCost() + art.TotalLoadBalancerCost() +
-		art.TotalNetworkCost() + art.TotalPersistentVolumeCost() + art.TotalRAMCost()
+		art.TotalNetworkCost() + art.TotalPersistentVolumeCost() + art.TotalRAMCost() +
+		art.QuotaOverheadCost
 }
 
 // ComputeAllocationTotals totals the resource costs of the given AllocationSet
@@ -186,6 +193,9 @@ func ComputeAllocationTotals(as *AllocationSet, prop string) map[string]*Allocat
 		arts[key].RAMCost += alloc.RAMCost
 		arts[key].RAMCostAdjustment += alloc.RAMCostAdjustment
 		arts[key].RAMByteHours += alloc.RAMByteHours
+		arts[key].QuotaOverheadCost += alloc.QuotaOverheadCost
+		arts[key].QuotaOverheadCPUCost += alloc.QuotaOverheadCPUCost
+		arts[key].QuotaOverheadRAMCost += alloc.QuotaOverheadRAMCost
 	}
 
 	return arts

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,24 @@
+---
+name: OpenCost Feature request
+about: Suggest an idea for this project
+title: 'feat: Add cost anomaly detection API endpoint (GET /anomaly)'
+labels: 'feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+FinOps teams need to monitor sudden, unexpected spikes in daily or hourly cost data (e.g., a namespace's CPU cost suddenly doubling or cloud storage costs spiking). Currently, OpenCost has no native anomaly detection.
+
+**Describe the solution you'd like**
+Implement a cost anomaly detection API endpoint `GET /anomaly` that analyzes time-series metrics.
+We want to:
+1. Create a package `pkg/anomaly` to implement simple statistical anomaly detection algorithms on historical allocations (e.g., seasonal/rolling Z-score or rolling Median Absolute Deviation (MAD)).
+2. Add a `GET /anomaly` router handler in `router.go`.
+3. Allow query parameters to define lookback windows (e.g., 7 days or 30 days) and sensitivity thresholds.
+
+**Describe alternatives you've considered**
+External time-series anomaly detection tools, but built-in native anomaly detection in OpenCost provides faster, zero-configuration cost monitoring for FinOps teams.
+
+**Additional context**
+The endpoint will return reports detailing the cost values, expected baseline values (mean/median), deviations (stddev/MAD), and anomaly scores.

--- a/pkg/anomaly/anomaly.go
+++ b/pkg/anomaly/anomaly.go
@@ -1,0 +1,213 @@
+package anomaly
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+// AnomalyDetail contains detailed information about a single detected anomaly.
+type AnomalyDetail struct {
+	Start     time.Time `json:"start"`
+	End       time.Time `json:"end"`
+	Cost      float64   `json:"cost"`
+	Baseline  float64   `json:"baseline"`  // Mean or Median depending on algorithm
+	Deviation float64   `json:"deviation"` // StdDev or MAD depending on algorithm
+	Score     float64   `json:"score"`
+	Threshold float64   `json:"threshold"`
+}
+
+// AnomalyReport lists the anomalies detected for a specific aggregation key (e.g. namespace).
+type AnomalyReport struct {
+	Key       string          `json:"key"`
+	Anomalies []AnomalyDetail `json:"anomalies"`
+}
+
+// stats calculates the mean and sample standard deviation of a slice.
+func stats(slice []float64) (float64, float64) {
+	n := len(slice)
+	if n == 0 {
+		return 0, 0
+	}
+	var sum float64
+	for _, v := range slice {
+		sum += v
+	}
+	mean := sum / float64(n)
+	var varianceSum float64
+	for _, v := range slice {
+		varianceSum += (v - mean) * (v - mean)
+	}
+	var stdDev float64
+	if n > 1 {
+		stdDev = math.Sqrt(varianceSum / float64(n-1))
+	} else {
+		stdDev = 0
+	}
+	return mean, stdDev
+}
+
+// madStats calculates the median and median absolute deviation (MAD) of a slice.
+func madStats(slice []float64) (float64, float64) {
+	n := len(slice)
+	if n == 0 {
+		return 0, 0
+	}
+	sorted := make([]float64, n)
+	copy(sorted, slice)
+	sort.Float64s(sorted)
+
+	var median float64
+	if n%2 == 1 {
+		median = sorted[n/2]
+	} else {
+		median = (sorted[n/2-1] + sorted[n/2]) / 2.0
+	}
+
+	devs := make([]float64, n)
+	for i, v := range slice {
+		devs[i] = math.Abs(v - median)
+	}
+	sort.Float64s(devs)
+
+	var mad float64
+	if n%2 == 1 {
+		mad = devs[n/2]
+	} else {
+		mad = (devs[n/2-1] + devs[n/2]) / 2.0
+	}
+
+	return median, mad
+}
+
+// Detect processes the AllocationSetRange and identifies cost anomalies.
+func Detect(asr *opencost.AllocationSetRange, step, lookback time.Duration, algorithm string, threshold, minCost float64) ([]AnomalyReport, error) {
+	if asr == nil || len(asr.Allocations) == 0 {
+		return nil, nil
+	}
+
+	// Determine the lookback count in terms of data points.
+	// Minimum lookback is 2 points (to be able to calculate standard deviation/MAD).
+	lookbackPoints := int(lookback / step)
+	if lookbackPoints < 2 {
+		lookbackPoints = 2
+	}
+
+	// 1. Gather all unique keys across the entire time series range
+	allKeys := make(map[string]bool)
+	for _, set := range asr.Allocations {
+		if set != nil {
+			for key := range set.Allocations {
+				allKeys[key] = true
+			}
+		}
+	}
+
+	numSets := len(asr.Allocations)
+	reports := []AnomalyReport{}
+
+	// 2. Run detection for each key
+	for key := range allKeys {
+		// Construct the time series of costs
+		costs := make([]float64, numSets)
+		for i, set := range asr.Allocations {
+			if set != nil {
+				if alloc, ok := set.Allocations[key]; ok {
+					costs[i] = alloc.TotalCost()
+				} else {
+					costs[i] = 0.0
+				}
+			}
+		}
+
+		anomalies := []AnomalyDetail{}
+
+		// Scan through the time series (starting from 1, since we need at least 1 historical point)
+		for i := 0; i < numSets; i++ {
+			// Find start index of historical lookback window (excluding current point)
+			startIdx := i - lookbackPoints
+			if startIdx < 0 {
+				startIdx = 0
+			}
+
+			// We need at least 2 historical data points to compute baseline
+			historyLen := i - startIdx
+			if historyLen < 2 {
+				continue
+			}
+
+			history := costs[startIdx:i]
+			currentVal := costs[i]
+
+			// Only evaluate spikes that exceed our minimum cost threshold
+			if currentVal < minCost {
+				continue
+			}
+
+			var isAnomaly bool
+			var baseline, deviation, score float64
+
+			if algorithm == "zscore" {
+				mean, stdDev := stats(history)
+				baseline = mean
+				deviation = stdDev
+				if stdDev > 0 {
+					score = (currentVal - mean) / stdDev
+					if score > threshold {
+						isAnomaly = true
+					}
+				} else if currentVal > mean {
+					// stdDev is 0 (all history is equal), so any increase is an anomaly
+					score = math.MaxFloat64
+					isAnomaly = true
+				}
+			} else { // default to mad
+				median, mad := madStats(history)
+				baseline = median
+				deviation = mad
+				if mad > 0 {
+					// Modified Z-score using 0.6745 multiplier
+					score = 0.6745 * (currentVal - median) / mad
+					if score > threshold {
+						isAnomaly = true
+					}
+				} else if currentVal > median {
+					// mad is 0, any increase is an anomaly
+					score = math.MaxFloat64
+					isAnomaly = true
+				}
+			}
+
+			if isAnomaly {
+				var startVal, endVal time.Time
+				if asr.Allocations[i].Window.Start() != nil {
+					startVal = *asr.Allocations[i].Window.Start()
+				}
+				if asr.Allocations[i].Window.End() != nil {
+					endVal = *asr.Allocations[i].Window.End()
+				}
+
+				anomalies = append(anomalies, AnomalyDetail{
+					Start:     startVal,
+					End:       endVal,
+					Cost:      currentVal,
+					Baseline:  baseline,
+					Deviation: deviation,
+					Score:     score,
+					Threshold: threshold,
+				})
+			}
+		}
+
+		if len(anomalies) > 0 {
+			reports = append(reports, AnomalyReport{
+				Key:       key,
+				Anomalies: anomalies,
+			})
+		}
+	}
+
+	return reports, nil
+}

--- a/pkg/anomaly/anomaly_test.go
+++ b/pkg/anomaly/anomaly_test.go
@@ -1,0 +1,153 @@
+package anomaly
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/opencost"
+)
+
+func TestStats(t *testing.T) {
+	data := []float64{10.0, 12.0, 11.0, 9.0, 10.0}
+	mean, stdDev := stats(data)
+
+	expectedMean := 10.4
+	if mean != expectedMean {
+		t.Errorf("expected mean %f, got %f", expectedMean, mean)
+	}
+
+	expectedStdDev := 1.140175
+	if mathAbs(stdDev-expectedStdDev) > 1e-5 {
+		t.Errorf("expected stdDev ~%f, got %f", expectedStdDev, stdDev)
+	}
+}
+
+func TestMadStats(t *testing.T) {
+	data := []float64{10.0, 12.0, 11.0, 9.0, 100.0} // 100 is an outlier
+	median, mad := madStats(data)
+
+	expectedMedian := 11.0
+	if median != expectedMedian {
+		t.Errorf("expected median %f, got %f", expectedMedian, median)
+	}
+
+	// absolute deviations from 11.0: |10-11|=1, |12-11|=1, |11-11|=0, |9-11|=2, |100-11|=89
+	// sorted deviations: 0, 1, 1, 2, 89
+	// median of deviations: 1
+	expectedMad := 1.0
+	if mad != expectedMad {
+		t.Errorf("expected MAD %f, got %f", expectedMad, mad)
+	}
+}
+
+func TestDetect(t *testing.T) {
+	// Create mock AllocationSetRange
+	// We will create a time series of 10 daily points:
+	// 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 100.0 (Spike on the last day)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	step := 24 * time.Hour
+	lookback := 7 * 24 * time.Hour
+
+	var allocs []*opencost.AllocationSet
+	for i := 0; i < 10; i++ {
+		s := start.Add(time.Duration(i) * step)
+		e := s.Add(step)
+
+		cost := 10.0
+		if i == 9 {
+			cost = 100.0 // spike
+		}
+
+		alloc := &opencost.Allocation{
+			Name:    "test-namespace",
+			Start:   s,
+			End:     e,
+			CPUCost: cost,
+		}
+		as := opencost.NewAllocationSet(s, e, alloc)
+		allocs = append(allocs, as)
+	}
+	asr := opencost.NewAllocationSetRange(allocs...)
+
+	// Run detection with MAD (default threshold 3.5)
+	reports, err := Detect(asr, step, lookback, "mad", 3.5, 0.10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(reports))
+	}
+
+	report := reports[0]
+	if report.Key != "test-namespace" {
+		t.Errorf("expected key test-namespace, got %s", report.Key)
+	}
+
+	if len(report.Anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly, got %d", len(report.Anomalies))
+	}
+
+	anomaly := report.Anomalies[0]
+	if anomaly.Cost != 100.0 {
+		t.Errorf("expected anomaly cost to be 100.0, got %f", anomaly.Cost)
+	}
+
+	// Run detection with Z-Score (threshold 3.0)
+	reportsZ, err := Detect(asr, step, lookback, "zscore", 3.0, 0.10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(reportsZ) != 1 || len(reportsZ[0].Anomalies) != 1 {
+		t.Fatalf("expected 1 Z-score anomaly, got %v", reportsZ)
+	}
+
+	if reportsZ[0].Anomalies[0].Cost != 100.0 {
+		t.Errorf("expected Z-score anomaly cost to be 100.0, got %f", reportsZ[0].Anomalies[0].Cost)
+	}
+}
+
+func TestMinCostThreshold(t *testing.T) {
+	// Spiking from 0.0001 to 0.0010 (10x increase, but below minCost $0.10)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	step := 24 * time.Hour
+	lookback := 7 * 24 * time.Hour
+
+	var allocs []*opencost.AllocationSet
+	for i := 0; i < 10; i++ {
+		s := start.Add(time.Duration(i) * step)
+		e := s.Add(step)
+
+		cost := 0.0001
+		if i == 9 {
+			cost = 0.0010
+		}
+
+		alloc := &opencost.Allocation{
+			Name:    "micro-namespace",
+			Start:   s,
+			End:     e,
+			CPUCost: cost,
+		}
+		as := opencost.NewAllocationSet(s, e, alloc)
+		allocs = append(allocs, as)
+	}
+	asr := opencost.NewAllocationSetRange(allocs...)
+
+	reports, err := Detect(asr, step, lookback, "mad", 3.5, 0.10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(reports) != 0 {
+		t.Errorf("expected 0 reports due to minCost threshold, got %d", len(reports))
+	}
+}
+
+func mathAbs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/pkg/carbon/carbonassets.go
+++ b/pkg/carbon/carbonassets.go
@@ -191,10 +191,10 @@ func resolveProvider(asset opencost.Asset) string {
 		return props.Provider
 	}
 
-	return inferProviderFromProviderID(props.ProviderID)
+	return InferProviderFromProviderID(props.ProviderID)
 }
 
-// inferProviderFromProviderID is a best-effort fallback that matches the
+// InferProviderFromProviderID is a best-effort fallback that matches the
 // conventional shapes of Kubernetes Node `spec.providerID` values for the
 // cloud providers present in the embedded lookup data (AWS, GCP, Azure).
 //
@@ -202,7 +202,7 @@ func resolveProvider(asset opencost.Asset) string {
 //   - AWS:   aws:///<availability-zone>/<instance-id>  (or raw "i-…")
 //   - GCP:   gce://<project>/<zone>/<instance-name>
 //   - Azure: azure:///subscriptions/<sub>/resourceGroups/<rg>/…
-func inferProviderFromProviderID(providerID string) string {
+func InferProviderFromProviderID(providerID string) string {
 	id := strings.ToLower(strings.TrimSpace(providerID))
 	if id == "" {
 		return ""
@@ -217,4 +217,36 @@ func inferProviderFromProviderID(providerID string) string {
 		return opencost.AzureProvider
 	}
 	return ""
+}
+
+// LookupNodeCarbonCoeff resolves the carbon coefficient (tonnes CO2e per hour) for
+// the given provider, region, and instanceType, falling back to the provider-wide
+// average-region value when a specific region or instance type is not matched.
+func LookupNodeCarbonCoeff(provider, region, instanceType string) float64 {
+	switch strings.ToLower(provider) {
+	case "aws":
+		provider = opencost.AWSProvider
+	case "gcp", "gce":
+		provider = opencost.GCPProvider
+	case "azure":
+		provider = opencost.AzureProvider
+	}
+
+	if coeff, ok := carbonLookupNode[carbonLookupKeyNode{
+		provider:     provider,
+		region:       region,
+		instanceType: instanceType,
+	}]; ok {
+		return coeff
+	}
+
+	if coeff, ok := carbonLookupNode[carbonLookupKeyNode{
+		provider:     provider,
+		region:       averageRegionKey,
+		instanceType: "",
+	}]; ok {
+		return coeff
+	}
+
+	return 0
 }

--- a/pkg/carbon/carbonassets_test.go
+++ b/pkg/carbon/carbonassets_test.go
@@ -91,8 +91,8 @@ func TestInferProviderFromProviderID(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := inferProviderFromProviderID(tc.id); got != tc.want {
-				t.Fatalf("inferProviderFromProviderID(%q) = %q, want %q", tc.id, got, tc.want)
+			if got := InferProviderFromProviderID(tc.id); got != tc.want {
+				t.Fatalf("InferProviderFromProviderID(%q) = %q, want %q", tc.id, got, tc.want)
 			}
 		})
 	}

--- a/pkg/cloud/alibaba/provider.go
+++ b/pkg/cloud/alibaba/provider.go
@@ -554,7 +554,7 @@ func (alibaba *Alibaba) PVPricing(pvk models.PVKey) (*models.PV, error) {
 
 // Inter zone and Inter region network cost are defaulted based on https://www.alibabacloud.com/help/en/cloud-data-transmission/latest/cross-region-data-transfers
 // Internet cost is default based on https://www.alibabacloud.com/help/en/elastic-compute-service/latest/public-bandwidth to $0.123
-func (alibaba *Alibaba) NetworkPricing() (*models.Network, error) {
+func (alibaba *Alibaba) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := alibaba.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -591,7 +591,7 @@ func (alibaba *Alibaba) NetworkPricing() (*models.Network, error) {
 
 // Alibaba loadbalancer has three different types https://www.alibabacloud.com/product/server-load-balancer,
 // defaulted price to classic load balancer https://www.alibabacloud.com/help/en/server-load-balancer/latest/pay-as-you-go.
-func (alibaba *Alibaba) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (alibaba *Alibaba) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	cpricing, err := alibaba.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/alibaba/provider_test.go
+++ b/pkg/cloud/alibaba/provider_test.go
@@ -1225,7 +1225,7 @@ func TestPVPricing_Error(t *testing.T) {
 
 func TestNetworkPricing_Error(t *testing.T) {
 	a := &Alibaba{Config: &fakeProviderConfig{}}
-	_, err := a.NetworkPricing()
+	_, err := a.NetworkPricing(nil)
 	if err == nil {
 		t.Fatalf("NetworkPricing should return error for missing config")
 	}
@@ -1233,7 +1233,7 @@ func TestNetworkPricing_Error(t *testing.T) {
 
 func TestLoadBalancerPricing_Error(t *testing.T) {
 	a := &Alibaba{Config: &fakeProviderConfig{}}
-	_, err := a.LoadBalancerPricing()
+	_, err := a.LoadBalancerPricing(nil)
 	if err == nil {
 		t.Fatalf("LoadBalancerPricing should return error for missing config")
 	}
@@ -1614,7 +1614,7 @@ func TestNetworkPricing_WithValidConfig(t *testing.T) {
 		},
 	}
 
-	network, err := a.NetworkPricing()
+	network, err := a.NetworkPricing(nil)
 	if err != nil {
 		t.Logf("NetworkPricing failed as expected: %v", err)
 	} else {
@@ -1634,7 +1634,7 @@ func TestLoadBalancerPricing_WithValidConfig(t *testing.T) {
 		},
 	}
 
-	lb, err := a.LoadBalancerPricing()
+	lb, err := a.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Logf("LoadBalancerPricing failed as expected: %v", err)
 	} else {

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1198,25 +1198,27 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 						Sku:          product.Sku,
 						LoadBalancer: &models.LoadBalancer{},
 					}
-					key := product.Attributes.RegionCode + ",LoadBalancerUsage"
-					aws.Pricing[key] = productTerms
-					skuToPricingKeyMap[product.Sku] = key
-					aws.ValidPricingKeys[key] = true
-
-					var specKey string
+					genericKey := product.Attributes.RegionCode + ",LoadBalancerUsage"
+					pricingKey := genericKey
 					switch product.Attributes.Operation {
 					case "LoadBalancing:Network":
-						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Network"
+						pricingKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Network"
 					case "LoadBalancing:Application":
-						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Application"
+						pricingKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Application"
 					case "LoadBalancing":
-						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Classic"
+						pricingKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Classic"
 					}
+					aws.Pricing[pricingKey] = productTerms
+					skuToPricingKeyMap[product.Sku] = pricingKey
+					aws.ValidPricingKeys[pricingKey] = true
 
-					if specKey != "" {
-						aws.Pricing[specKey] = productTerms
-						skuToPricingKeyMap[product.Sku] = specKey
-						aws.ValidPricingKeys[specKey] = true
+					// Preserve a stable generic fallback key (prefer Network when available).
+					if pricingKey == genericKey || product.Attributes.Operation == "LoadBalancing:Network" {
+						aws.Pricing[genericKey] = productTerms
+						aws.ValidPricingKeys[genericKey] = true
+					} else if _, exists := aws.Pricing[genericKey]; !exists {
+						aws.Pricing[genericKey] = productTerms
+						aws.ValidPricingKeys[genericKey] = true
 					}
 				}
 			}
@@ -1478,6 +1480,7 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
+	// RLock is acquired to prevent data races with concurrent pricing downloads updating the aws.Pricing map.
 	aws.DownloadPricingDataLock.RLock()
 	defer aws.DownloadPricingDataLock.RUnlock()
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1399,8 +1399,7 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
-	// TODO: determine key based on function arguments
-	// this is something that should be changed in the Provider interface
+	// TODO: use lbKey to select a more specific pricing entry when available.
 
 	key := aws.ClusterRegion + ",LoadBalancerUsage"
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1147,10 +1147,8 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 					skusToKeys[product.Sku] = key
 					aws.ValidPricingKeys[key] = true
 					aws.ValidPricingKeys[spotKey] = true
-				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") && product.Attributes.Operation == "LoadBalancing:Network" {
-					// since the costmodel is only using services of type LoadBalancer
-					// (and not ingresses controlled by AWS load balancer controller)
-					// we can safely filter for Network load balancers only
+				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") {
+					// Parse different types of load balancers when available.
 					productTerms := &AWSProductTerms{
 						Sku:          product.Sku,
 						LoadBalancer: &models.LoadBalancer{},
@@ -1160,6 +1158,22 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 					aws.Pricing[key] = productTerms
 					skusToKeys[product.Sku] = key
 					aws.ValidPricingKeys[key] = true
+
+					var specKey string
+					switch product.Attributes.Operation {
+					case "LoadBalancing:Network":
+						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Network"
+					case "LoadBalancing:Application":
+						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Application"
+					case "LoadBalancing":
+						specKey = product.Attributes.RegionCode + ",LoadBalancerUsage:Classic"
+					}
+
+					if specKey != "" {
+						aws.Pricing[specKey] = productTerms
+						skusToKeys[product.Sku] = specKey
+						aws.ValidPricingKeys[specKey] = true
+					}
 				}
 			}
 		}
@@ -1399,13 +1413,36 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
-	// TODO: use lbKey to select a more specific pricing entry when available.
+	hourlyCost := 0.025 // set default price
 
+	if lbKey != nil {
+		features := strings.ToLower(lbKey.Features())
+		id := strings.ToLower(lbKey.ID())
+
+		var specKey string
+		if strings.Contains(features, "nlb") || strings.Contains(features, "network") ||
+			strings.Contains(id, "nlb") || strings.Contains(id, "network") {
+			specKey = aws.ClusterRegion + ",LoadBalancerUsage:Network"
+		} else if strings.Contains(features, "alb") || strings.Contains(features, "application") ||
+			strings.Contains(id, "alb") || strings.Contains(id, "application") {
+			specKey = aws.ClusterRegion + ",LoadBalancerUsage:Application"
+		} else if strings.Contains(features, "clb") || strings.Contains(features, "classic") ||
+			strings.Contains(id, "clb") || strings.Contains(id, "classic") {
+			specKey = aws.ClusterRegion + ",LoadBalancerUsage:Classic"
+		}
+
+		if specKey != "" {
+			if terms, ok := aws.Pricing[specKey]; ok {
+				hourlyCost = terms.LoadBalancer.Cost
+				return &models.LoadBalancer{
+					Cost: hourlyCost,
+				}, nil
+			}
+		}
+	}
+
+	// Fallback to standard generic LoadBalancerUsage key
 	key := aws.ClusterRegion + ",LoadBalancerUsage"
-
-	// set default price
-	hourlyCost := 0.025
-	// use price index when available
 	if terms, ok := aws.Pricing[key]; ok {
 		hourlyCost = terms.LoadBalancer.Cost
 	}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1363,7 +1363,7 @@ func (aws *AWS) spotPricingFromHistory(k models.Key) (*SpotPriceHistoryEntry, bo
 }
 
 // Stubbed NetworkPricing for AWS. Pull directly from aws.json for now
-func (aws *AWS) NetworkPricing() (*models.Network, error) {
+func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error) {
 	cpricing, err := aws.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1398,7 +1398,7 @@ func (aws *AWS) NetworkPricing() (*models.Network, error) {
 	}, nil
 }
 
-func (aws *AWS) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
 	// TODO: determine key based on function arguments
 	// this is something that should be changed in the Provider interface
 

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1194,10 +1194,6 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 					aws.ValidPricingKeys[spotKey] = true
 				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") {
 					// Parse different types of load balancers when available.
-				} else if strings.Contains(product.Attributes.UsageType, "LoadBalancerUsage") && product.Attributes.Operation == "LoadBalancing:Network" {
-					// Parse Network Load Balancer pricing
-					// Note: Only NLBs are tracked since costmodel uses LoadBalancer services,
-					// not ingresses controlled by AWS load balancer controller
 					productTerms := &AWSProductTerms{
 						Sku:          product.Sku,
 						LoadBalancer: &models.LoadBalancer{},
@@ -1219,7 +1215,7 @@ func (aws *AWS) populatePricing(resp *http.Response, inputkeys map[string]bool) 
 
 					if specKey != "" {
 						aws.Pricing[specKey] = productTerms
-						skusToKeys[product.Sku] = specKey
+						skuToPricingKeyMap[product.Sku] = specKey
 						aws.ValidPricingKeys[specKey] = true
 					}
 				}

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1413,6 +1413,9 @@ func (aws *AWS) NetworkPricing(netKey models.NetworkKey) (*models.Network, error
 }
 
 func (aws *AWS) LoadBalancerPricing(lbKey models.LBKey) (*models.LoadBalancer, error) {
+	aws.DownloadPricingDataLock.RLock()
+	defer aws.DownloadPricingDataLock.RUnlock()
+
 	hourlyCost := 0.025 // set default price
 
 	if lbKey != nil {

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -298,6 +298,7 @@ func Test_populate_pricing(t *testing.T) {
 		"us-east-2,m5.large,linux":                  expectedProdTermsInstanceOndemand,
 		"us-east-2,m5.large,linux,preemptible":      expectedProdTermsInstanceSpot,
 		"us-east-2,LoadBalancerUsage":               expectedProdTermsLoadbalancer,
+		"us-east-2,LoadBalancerUsage:Network":       expectedProdTermsLoadbalancer,
 	}
 
 	if !reflect.DeepEqual(expectedPricing, awsTest.Pricing) {
@@ -1294,4 +1295,76 @@ func TestAWS_PricingSourceStatus_spotPriceHistory(t *testing.T) {
 			t.Error("Expected Available=true when cache initialized")
 		}
 	})
+}
+
+func TestAWS_LoadBalancerPricing(t *testing.T) {
+	aws := &AWS{
+		ClusterRegion: "us-east-2",
+		Pricing: map[string]*AWSProductTerms{
+			"us-east-2,LoadBalancerUsage": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0225},
+			},
+			"us-east-2,LoadBalancerUsage:Network": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0225},
+			},
+			"us-east-2,LoadBalancerUsage:Application": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0252},
+			},
+			"us-east-2,LoadBalancerUsage:Classic": &AWSProductTerms{
+				LoadBalancer: &models.LoadBalancer{Cost: 0.0280},
+			},
+		},
+	}
+
+	cases := []struct {
+		name         string
+		key          models.LBKey
+		expectedCost float64
+	}{
+		{
+			name:         "Nil key defaults to LoadBalancerUsage fallback",
+			key:          nil,
+			expectedCost: 0.0225,
+		},
+		{
+			name: "NLB by feature name",
+			key: &models.CustomLBKey{
+				LBFeatures: "nlb-service",
+			},
+			expectedCost: 0.0225,
+		},
+		{
+			name: "ALB by ID",
+			key: &models.CustomLBKey{
+				LBID: "aws-loadbalancer-alb-1234",
+			},
+			expectedCost: 0.0252,
+		},
+		{
+			name: "Classic LB by features",
+			key: &models.CustomLBKey{
+				LBFeatures: "classic-lb",
+			},
+			expectedCost: 0.0280,
+		},
+		{
+			name: "Unknown key defaults to generic LoadBalancerUsage",
+			key: &models.CustomLBKey{
+				LBFeatures: "some-unknown-type",
+			},
+			expectedCost: 0.0225,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lb, err := aws.LoadBalancerPricing(tc.key)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if lb.Cost != tc.expectedCost {
+				t.Errorf("expected cost %f, got %f", tc.expectedCost, lb.Cost)
+			}
+		})
+	}
 }

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -304,7 +304,7 @@ func Test_populate_pricing(t *testing.T) {
 		t.Fatalf("expected parsed pricing did not match actual parsed result (us-east-2)")
 	}
 
-	lbPricing, _ := awsTest.LoadBalancerPricing()
+	lbPricing, _ := awsTest.LoadBalancerPricing(nil)
 	if lbPricing.Cost != 0.0225 {
 		t.Fatalf("expected loadbalancer pricing of 0.0225 but got %f (us-east-2)", lbPricing.Cost)
 	}

--- a/pkg/cloud/aws/provider_test.go
+++ b/pkg/cloud/aws/provider_test.go
@@ -1369,6 +1369,8 @@ func TestAWS_LoadBalancerPricing(t *testing.T) {
 			}
 		})
 	}
+}
+
 func TestAWS_findCostForDisk(t *testing.T) {
 	aws := &AWS{
 		ClusterRegion: "us-east-1",

--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -1453,7 +1453,7 @@ func (az *Azure) NodePricing(key models.Key) (*models.Node, models.PricingMetada
 }
 
 // Stubbed NetworkPricing for Azure. Pull directly from azure.json for now
-func (az *Azure) NetworkPricing() (*models.Network, error) {
+func (az *Azure) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := az.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1492,7 +1492,7 @@ func (az *Azure) NetworkPricing() (*models.Network, error) {
 // services will be that of a standard static public IP https://azure.microsoft.com/en-us/pricing/details/ip-addresses/.
 // Azure still has load balancers which follow the standard pricing scheme based on rules
 // https://azure.microsoft.com/en-us/pricing/details/load-balancer/, they are created on a per-cluster basis.
-func (azr *Azure) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (azr *Azure) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.005,
 	}, nil

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -788,14 +788,13 @@ func fallbackPV(key models.PVKey) (*models.PV, error) {
 // - Public Network Load Balancer:       ~$0.02232/hr
 // - Statically sized Load Balancers:    $0.01786–$0.10714/hr
 //
-// However, the current OpenCost provider interface does not pass information about
-// individual Load Balancer characteristics (like annotations or network mode).
+// The provider interface has been updated to accept models.LBKey.
 //
-// As a result, this implementation uses a fixed average hourly rate of $0.02,
-// which is representative of the most common DO LBs.
+// However, the current implementation still uses a fixed average hourly rate of $0.02,
+// which is representative of the most common DO LBs, because the key is not yet used for
+// pricing selection.
 //
-// TODO Once the provider interface supports more granular Load Balancer metadata,
-// this method should be updated to assign costs more precisely.
+// TODO: Update this method to use the key for assigning costs more precisely when dynamic lookup is supported.
 func (do *DOKS) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	hourlyCost := 0.02
 	return &models.LoadBalancer{

--- a/pkg/cloud/digitalocean/provider.go
+++ b/pkg/cloud/digitalocean/provider.go
@@ -796,14 +796,14 @@ func fallbackPV(key models.PVKey) (*models.PV, error) {
 //
 // TODO Once the provider interface supports more granular Load Balancer metadata,
 // this method should be updated to assign costs more precisely.
-func (do *DOKS) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (do *DOKS) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	hourlyCost := 0.02
 	return &models.LoadBalancer{
 		Cost: hourlyCost,
 	}, nil
 }
 
-func (do *DOKS) NetworkPricing() (*models.Network, error) {
+func (do *DOKS) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	// fallback
 	const (
 		defaultZoneEgress        = 0.00

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1165,7 +1165,7 @@ func (gcp *GCP) PVPricing(pvk models.PVKey) (*models.PV, error) {
 }
 
 // Stubbed NetworkPricing for GCP. Pull directly from gcp.json for now
-func (gcp *GCP) NetworkPricing() (*models.Network, error) {
+func (gcp *GCP) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := gcp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -1200,7 +1200,7 @@ func (gcp *GCP) NetworkPricing() (*models.Network, error) {
 	}, nil
 }
 
-func (gcp *GCP) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (gcp *GCP) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	fffrc := 0.025
 	afrc := 0.010
 	lbidc := 0.008

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -630,6 +630,28 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 					return nil, "", err
 				}
 
+				// Check if this is a load balancer forwarding rule
+				if strings.Contains(product.Description, "Forwarding Rule") || product.Category.ResourceGroup == "ForwardingRule" {
+					var lbType string
+					descLower := strings.ToLower(product.Description)
+					if strings.Contains(descLower, "external http") || strings.Contains(descLower, "global forwarding rule") {
+						lbType = "external-http"
+					} else if strings.Contains(descLower, "internal http") {
+						lbType = "internal-http"
+					} else if strings.Contains(descLower, "regional forwarding rule") || strings.Contains(descLower, "network") || strings.Contains(descLower, "tcp") {
+						lbType = "network-tcp"
+					} else if strings.Contains(descLower, "ssl proxy") || strings.Contains(descLower, "ssl") || strings.Contains(descLower, "proxy") {
+						lbType = "ssl-proxy"
+					}
+
+					if lbType != "" {
+						for _, region := range product.ServiceRegions {
+							candidateKey := region + ",ForwardingRule:" + lbType
+							gcpPricingList[candidateKey] = product
+						}
+					}
+				}
+
 				usageType := strings.ToLower(product.Category.UsageType)
 				instanceType := strings.ToLower(product.Category.ResourceGroup)
 
@@ -1200,7 +1222,72 @@ func (gcp *GCP) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	}, nil
 }
 
+func getGCPPricingRate(product *GCPPricing) (float64, error) {
+	if len(product.PricingInfo) == 0 || product.PricingInfo[0].PricingExpression == nil {
+		return 0.0, fmt.Errorf("no pricing expression")
+	}
+	pe := product.PricingInfo[0].PricingExpression
+	lastRateIndex := len(pe.TieredRates) - 1
+	if lastRateIndex < 0 {
+		return 0.0, fmt.Errorf("no rates found")
+	}
+	rate := pe.TieredRates[lastRateIndex]
+	nanos := float64(rate.UnitPrice.Nanos)
+	units, err := strconv.ParseFloat(rate.UnitPrice.Units, 64)
+	if err != nil {
+		units = 0
+	}
+	price := units + nanos*math.Pow10(-9)
+	// If the unit is month or similar, convert it to hourly rate
+	if strings.Contains(strings.ToLower(pe.UsageUnit), "month") || strings.Contains(strings.ToLower(pe.UsageUnitDescription), "month") {
+		price = price / 730.0
+	}
+	return price, nil
+}
+
 func (gcp *GCP) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
+	if key != nil {
+		features := strings.ToLower(key.Features())
+		id := strings.ToLower(key.ID())
+
+		var lbType string
+		if strings.Contains(features, "external-http") || strings.Contains(features, "external") || (strings.Contains(features, "http") && !strings.Contains(features, "internal")) ||
+			strings.Contains(id, "external-http") || strings.Contains(id, "external") || (strings.Contains(id, "http") && !strings.Contains(id, "internal")) {
+			lbType = "external-http"
+		} else if strings.Contains(features, "internal-http") || (strings.Contains(features, "internal") && strings.Contains(features, "http")) ||
+			strings.Contains(id, "internal-http") || (strings.Contains(id, "internal") && strings.Contains(id, "http")) {
+			lbType = "internal-http"
+		} else if strings.Contains(features, "network") || strings.Contains(features, "tcp") ||
+			strings.Contains(id, "network") || strings.Contains(id, "tcp") {
+			lbType = "network-tcp"
+		} else if strings.Contains(features, "ssl") || strings.Contains(features, "proxy") ||
+			strings.Contains(id, "ssl") || strings.Contains(id, "proxy") {
+			lbType = "ssl-proxy"
+		}
+
+		if lbType != "" {
+			region := gcp.ClusterRegion
+			if region == "" {
+				region = "us-central1"
+			}
+			cacheKey := region + ",ForwardingRule:" + lbType
+
+			gcp.DownloadPricingDataLock.RLock()
+			product, ok := gcp.Pricing[cacheKey]
+			gcp.DownloadPricingDataLock.RUnlock()
+
+			if ok {
+				price, err := getGCPPricingRate(product)
+				if err == nil {
+					return &models.LoadBalancer{
+						Cost: price,
+					}, nil
+				}
+			}
+		}
+	}
+
+	// Fallback to standard defaults
 	fffrc := 0.025
 	afrc := 0.010
 	lbidc := 0.008

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -1227,15 +1227,33 @@ func getGCPPricingRate(product *GCPPricing) (float64, error) {
 		return 0.0, fmt.Errorf("no pricing expression")
 	}
 	pe := product.PricingInfo[0].PricingExpression
-	lastRateIndex := len(pe.TieredRates) - 1
-	if lastRateIndex < 0 {
-		return 0.0, fmt.Errorf("no rates found")
+
+	var rate *TieredRates
+	for _, r := range pe.TieredRates {
+		if r != nil && r.StartUsageAmount == 0 {
+			rate = r
+			break
+		}
 	}
-	rate := pe.TieredRates[lastRateIndex]
+	if rate == nil {
+		for _, r := range pe.TieredRates {
+			if r != nil {
+				rate = r
+				break
+			}
+		}
+	}
+	if rate == nil {
+		return 0.0, fmt.Errorf("no non-nil tiered rates found")
+	}
+	if rate.UnitPrice == nil {
+		return 0.0, fmt.Errorf("tiered rate unit price is nil")
+	}
+
 	nanos := float64(rate.UnitPrice.Nanos)
 	units, err := strconv.ParseFloat(rate.UnitPrice.Units, 64)
 	if err != nil {
-		units = 0
+		return 0.0, fmt.Errorf("failed to parse rate unit price units %q: %w", rate.UnitPrice.Units, err)
 	}
 	price := units + nanos*math.Pow10(-9)
 	// If the unit is month or similar, convert it to hourly rate

--- a/pkg/cloud/gcp/provider.go
+++ b/pkg/cloud/gcp/provider.go
@@ -634,7 +634,7 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]models.Key, pvKeys m
 				if strings.Contains(product.Description, "Forwarding Rule") || product.Category.ResourceGroup == "ForwardingRule" {
 					var lbType string
 					descLower := strings.ToLower(product.Description)
-					if strings.Contains(descLower, "external http") || strings.Contains(descLower, "global forwarding rule") {
+					if strings.Contains(descLower, "external http") || (strings.Contains(descLower, "global forwarding rule") && strings.Contains(descLower, "http")) {
 						lbType = "external-http"
 					} else if strings.Contains(descLower, "internal http") {
 						lbType = "internal-http"

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -809,7 +809,7 @@ func TestGCP_NetworkPricing(t *testing.T) {
 		Config: &mockConfig{},
 	}
 
-	result, err := gcp.NetworkPricing()
+	result, err := gcp.NetworkPricing(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -817,7 +817,7 @@ func TestGCP_NetworkPricing(t *testing.T) {
 func TestGCP_LoadBalancerPricing(t *testing.T) {
 	gcp := &GCP{}
 
-	result, err := gcp.LoadBalancerPricing()
+	result, err := gcp.LoadBalancerPricing(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/pkg/cloud/gcp/provider_test.go
+++ b/pkg/cloud/gcp/provider_test.go
@@ -815,11 +815,139 @@ func TestGCP_NetworkPricing(t *testing.T) {
 }
 
 func TestGCP_LoadBalancerPricing(t *testing.T) {
-	gcp := &GCP{}
+	gcp := &GCP{
+		ClusterRegion: "us-central1",
+		Pricing: map[string]*GCPPricing{
+			"us-central1,ForwardingRule:external-http": {
+				Description: "External HTTP(S) Load Balancer Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 25000000, // 0.025
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"us-central1,ForwardingRule:internal-http": {
+				Description: "Internal HTTP(S) Load Balancer Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 18000000, // 0.018
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"us-central1,ForwardingRule:network-tcp": {
+				Description: "Regional Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 20000000, // 0.020
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"us-central1,ForwardingRule:ssl-proxy": {
+				Description: "SSL Proxy Load Balancer Forwarding Rule",
+				PricingInfo: []*PricingInfo{
+					{
+						PricingExpression: &PricingExpression{
+							UsageUnit: "h",
+							TieredRates: []*TieredRates{
+								{
+									UnitPrice: &UnitPriceInfo{
+										Units: "0",
+										Nanos: 35000000, // 0.035
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 
-	result, err := gcp.LoadBalancerPricing(nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
+	cases := []struct {
+		name         string
+		key          models.LBKey
+		expectedCost float64
+	}{
+		{
+			name:         "Nil key defaults to fallback rule cost (fffrc * 1 = 0.025)",
+			key:          nil,
+			expectedCost: 0.025,
+		},
+		{
+			name: "External HTTP(S) LB by feature name",
+			key: &models.CustomLBKey{
+				LBFeatures: "external-http",
+			},
+			expectedCost: 0.025,
+		},
+		{
+			name: "Internal HTTP(S) LB by ID",
+			key: &models.CustomLBKey{
+				LBID: "gcp-lb-internal-http",
+			},
+			expectedCost: 0.018,
+		},
+		{
+			name: "Network/TCP LB by features",
+			key: &models.CustomLBKey{
+				LBFeatures: "network-tcp-lb",
+			},
+			expectedCost: 0.020,
+		},
+		{
+			name: "SSL Proxy LB by features",
+			key: &models.CustomLBKey{
+				LBFeatures: "ssl-proxy",
+			},
+			expectedCost: 0.035,
+		},
+		{
+			name: "Unknown key defaults to fallback rule cost (0.025)",
+			key: &models.CustomLBKey{
+				LBFeatures: "unknown-lb-type",
+			},
+			expectedCost: 0.025,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := gcp.LoadBalancerPricing(tc.key)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.InDelta(t, tc.expectedCost, result.Cost, 0.0001)
+		})
+	}
 }
 
 func TestGCP_GetPVKey(t *testing.T) {

--- a/pkg/cloud/models/models.go
+++ b/pkg/cloud/models/models.go
@@ -281,8 +281,8 @@ type Provider interface {
 	NodePricing(Key) (*Node, PricingMetadata, error)
 	GpuPricing(map[string]string) (string, error)
 	PVPricing(PVKey) (*PV, error)
-	NetworkPricing() (*Network, error)           // TODO: add key interface arg for dynamic price fetching
-	LoadBalancerPricing() (*LoadBalancer, error) // TODO: add key interface arg for dynamic price fetching
+	NetworkPricing(NetworkKey) (*Network, error)
+	LoadBalancerPricing(LBKey) (*LoadBalancer, error)
 	AllNodePricing() (interface{}, error)
 	DownloadPricingData() error
 	GetKey(map[string]string, *clustercache.Node) Key

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -1,9 +1,34 @@
 package models
 
-// TODO: used for dynamic cloud provider price fetching.
-// determine what identifies a load balancer in the json returned from the cloud provider pricing API call
-// type LBKey interface {
-// }
+// LBKey represents metadata identifying a load balancer for pricing
+type LBKey interface {
+	ID() string
+	Features() string
+}
+
+// CustomLBKey is a default implementation of LBKey
+type CustomLBKey struct {
+	LBID       string
+	LBFeatures string
+}
+
+func (k *CustomLBKey) ID() string       { return k.LBID }
+func (k *CustomLBKey) Features() string { return k.LBFeatures }
+
+// NetworkKey represents metadata identifying a network resource for pricing
+type NetworkKey interface {
+	ID() string
+	Features() string
+}
+
+// CustomNetworkKey is a default implementation of NetworkKey
+type CustomNetworkKey struct {
+	NetworkID       string
+	NetworkFeatures string
+}
+
+func (k *CustomNetworkKey) ID() string       { return k.NetworkID }
+func (k *CustomNetworkKey) Features() string { return k.NetworkFeatures }
 
 // Network is the interface by which the provider and cost model communicate network egress prices.
 // The provider will best-effort try to fill out this struct.

--- a/pkg/cloud/models/network.go
+++ b/pkg/cloud/models/network.go
@@ -4,6 +4,7 @@ package models
 type LBKey interface {
 	ID() string
 	Features() string
+	IsLBKey() bool
 }
 
 // CustomLBKey is a default implementation of LBKey
@@ -14,11 +15,13 @@ type CustomLBKey struct {
 
 func (k *CustomLBKey) ID() string       { return k.LBID }
 func (k *CustomLBKey) Features() string { return k.LBFeatures }
+func (k *CustomLBKey) IsLBKey() bool    { return true }
 
 // NetworkKey represents metadata identifying a network resource for pricing
 type NetworkKey interface {
 	ID() string
 	Features() string
+	IsNetworkKey() bool
 }
 
 // CustomNetworkKey is a default implementation of NetworkKey
@@ -27,8 +30,9 @@ type CustomNetworkKey struct {
 	NetworkFeatures string
 }
 
-func (k *CustomNetworkKey) ID() string       { return k.NetworkID }
-func (k *CustomNetworkKey) Features() string { return k.NetworkFeatures }
+func (k *CustomNetworkKey) ID() string         { return k.NetworkID }
+func (k *CustomNetworkKey) Features() string   { return k.NetworkFeatures }
+func (k *CustomNetworkKey) IsNetworkKey() bool { return true }
 
 // Network is the interface by which the provider and cost model communicate network egress prices.
 // The provider will best-effort try to fill out this struct.

--- a/pkg/cloud/oracle/provider.go
+++ b/pkg/cloud/oracle/provider.go
@@ -87,7 +87,7 @@ func (o *Oracle) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	return o.RateCardStore.ForPVK(pvk, o.DefaultPricing)
 }
 
-func (o *Oracle) NetworkPricing() (*models.Network, error) {
+func (o *Oracle) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	if err := o.ensurePricingData(); err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (o *Oracle) NetworkPricing() (*models.Network, error) {
 	return o.RateCardStore.ForEgressRegion(o.ClusterRegion, o.DefaultPricing)
 }
 
-func (o *Oracle) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (o *Oracle) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	if err := o.ensurePricingData(); err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/otc/provider.go
+++ b/pkg/cloud/otc/provider.go
@@ -226,7 +226,7 @@ func (otc *OTC) DownloadPricingData() error {
 	return nil
 }
 
-func (otc *OTC) NetworkPricing() (*models.Network, error) {
+func (otc *OTC) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := otc.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -342,7 +342,7 @@ func (otc *OTC) GetConfig() (*models.CustomPricing, error) {
 
 // load balancer cost
 // taken straight up from aws
-func (otc *OTC) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (otc *OTC) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.05,
 	}, nil

--- a/pkg/cloud/ovh/provider.go
+++ b/pkg/cloud/ovh/provider.go
@@ -481,7 +481,7 @@ func (c *OVH) PVPricing(pvk models.PVKey) (*models.PV, error) {
 }
 
 // NetworkPricing returns static network pricing for OVH.
-func (c *OVH) NetworkPricing() (*models.Network, error) {
+func (c *OVH) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	return &models.Network{
 		ZoneNetworkEgressCost:     0,
 		RegionNetworkEgressCost:   0,
@@ -492,7 +492,7 @@ func (c *OVH) NetworkPricing() (*models.Network, error) {
 }
 
 // LoadBalancerPricing returns static load balancer pricing for OVH.
-func (c *OVH) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (c *OVH) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return &models.LoadBalancer{
 		Cost: 0.012,
 	}, nil

--- a/pkg/cloud/ovh/provider_test.go
+++ b/pkg/cloud/ovh/provider_test.go
@@ -387,7 +387,7 @@ func TestPVPricing(t *testing.T) {
 func TestNetworkPricing(t *testing.T) {
 	provider := &OVH{}
 
-	net, err := provider.NetworkPricing()
+	net, err := provider.NetworkPricing(nil)
 	if err != nil {
 		t.Fatalf("NetworkPricing failed: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestNetworkPricing(t *testing.T) {
 func TestLoadBalancerPricing(t *testing.T) {
 	provider := &OVH{}
 
-	lb, err := provider.LoadBalancerPricing()
+	lb, err := provider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing failed: %v", err)
 	}

--- a/pkg/cloud/provider/customprovider.go
+++ b/pkg/cloud/provider/customprovider.go
@@ -301,7 +301,7 @@ func (cp *CustomProvider) PVPricing(pvk models.PVKey) (*models.PV, error) {
 	}, nil
 }
 
-func (cp *CustomProvider) NetworkPricing() (*models.Network, error) {
+func (cp *CustomProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	cpricing, err := cp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err
@@ -347,7 +347,7 @@ func parsePriceOrZero(field, value string) (float64, error) {
 	return price, nil
 }
 
-func (cp *CustomProvider) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (cp *CustomProvider) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	cpricing, err := cp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/provider/provider_test.go
+++ b/pkg/cloud/provider/provider_test.go
@@ -228,7 +228,7 @@ func TestCustomProviderClusterInfoUsesStaticDefaultName(t *testing.T) {
 func TestCustomProviderLoadBalancerPricingEmptyConfig(t *testing.T) {
 	customProvider := newTestCustomProvider(t, nil)
 
-	lb, err := customProvider.LoadBalancerPricing()
+	lb, err := customProvider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing returned error: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestCustomProviderLoadBalancerPricingUsesDefaultLBPriceFallback(t *testing.
 		"defaultLBPrice": "0.025",
 	})
 
-	lb, err := customProvider.LoadBalancerPricing()
+	lb, err := customProvider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing returned error: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestCustomProviderLoadBalancerPricingUsesForwardingRulePrice(t *testing.T) 
 		"defaultLBPrice":               "0.025",
 	})
 
-	lb, err := customProvider.LoadBalancerPricing()
+	lb, err := customProvider.LoadBalancerPricing(nil)
 	if err != nil {
 		t.Fatalf("LoadBalancerPricing returned error: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestCustomProviderLoadBalancerPricingInvalidValue(t *testing.T) {
 		"firstFiveForwardingRulesCost": "not-a-price",
 	})
 
-	_, err := customProvider.LoadBalancerPricing()
+	_, err := customProvider.LoadBalancerPricing(nil)
 	if err == nil {
 		t.Fatal("LoadBalancerPricing returned nil error, want invalid pricing error")
 	}

--- a/pkg/cloud/scaleway/provider.go
+++ b/pkg/cloud/scaleway/provider.go
@@ -162,7 +162,7 @@ func (c *Scaleway) NodePricing(key models.Key) (*models.Node, models.PricingMeta
 	return nil, meta, fmt.Errorf("Unable to find node pricing matching thes features `%s`", key.Features())
 }
 
-func (c *Scaleway) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (c *Scaleway) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	// Different LB types, lets take the cheaper for now, we can't get the type
 	// without a service specifying the type in the annotations
 	return &models.LoadBalancer{
@@ -170,7 +170,7 @@ func (c *Scaleway) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (c *Scaleway) NetworkPricing() (*models.Network, error) {
+func (c *Scaleway) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	// it's free baby!
 	return &models.Network{
 		ZoneNetworkEgressCost:     0,

--- a/pkg/cloud/stackit/provider.go
+++ b/pkg/cloud/stackit/provider.go
@@ -122,7 +122,7 @@ func (s *STACKIT) NodePricing(key models.Key) (*models.Node, models.PricingMetad
 	}, meta, nil
 }
 
-func (s *STACKIT) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (s *STACKIT) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	config, err := s.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config: %w", err)
@@ -138,7 +138,7 @@ func (s *STACKIT) LoadBalancerPricing() (*models.LoadBalancer, error) {
 	}, nil
 }
 
-func (s *STACKIT) NetworkPricing() (*models.Network, error) {
+func (s *STACKIT) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	config, err := s.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get config: %w", err)

--- a/pkg/cmd/costmodel/costmodel.go
+++ b/pkg/cmd/costmodel/costmodel.go
@@ -69,6 +69,7 @@ func Execute(conf *Config) error {
 		router.GET("/allocation/summary", a.ComputeAllocationHandlerSummary)
 		router.GET("/assets", a.ComputeAssetsHandler)
 		if conf.CarbonEstimatesEnabled {
+			router.GET("/allocation/carbon", a.ComputeAllocationHandler)
 			router.GET("/assets/carbon", a.ComputeAssetsCarbonHandler)
 		}
 		router.GET("/kubemodel", a.KubeModelHandler)

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opencost/opencost/core/pkg/model/kubemodel"
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/core/pkg/util/timeutil"
 
+	coreenv "github.com/opencost/opencost/core/pkg/env"
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/pkg/env"
 )
@@ -549,6 +551,203 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 			// point due to it missing from queryMinutes) then insert.
 			alloc.Name = fmt.Sprintf("%s/%s/%s/%s/%s", cluster, nodeName, namespace, podName, container)
 			allocSet.Set(alloc)
+		}
+	}
+
+	// Compute and attribute ResourceQuota overhead costs
+	if cm.KubeModel != nil {
+		kms, err := cm.ComputeKubeModelSet(start, end)
+		if err == nil && kms != nil {
+			hours := end.Sub(start).Hours()
+
+			// Compute average node pricing for fallback
+			var sumCPUPrice, sumRAMPrice float64
+			var nodeCount int
+			for _, pricing := range nodeMap {
+				if pricing != nil {
+					sumCPUPrice += pricing.CostPerCPUHr
+					sumRAMPrice += pricing.CostPerRAMGiBHr
+					nodeCount++
+				}
+			}
+			avgCPUPrice := 0.0
+			avgRAMPrice := 0.0
+			if nodeCount > 0 {
+				avgCPUPrice = sumCPUPrice / float64(nodeCount)
+				avgRAMPrice = sumRAMPrice / float64(nodeCount)
+			}
+
+			// Map namespace name to nodes pricing
+			namespaceCPUPrices := make(map[string][]float64)
+			namespaceRAMPrices := make(map[string][]float64)
+			for _, pod := range podMap {
+				for _, alloc := range pod.Allocations {
+					nsName := alloc.Properties.Namespace
+					nodeName := alloc.Properties.Node
+					thisNodeKey := newNodeKey(alloc.Properties.Cluster, nodeName)
+					nodePricing := cm.getNodePricing(nodeMap, thisNodeKey)
+					if nodePricing != nil {
+						namespaceCPUPrices[nsName] = append(namespaceCPUPrices[nsName], nodePricing.CostPerCPUHr)
+						namespaceRAMPrices[nsName] = append(namespaceRAMPrices[nsName], nodePricing.CostPerRAMGiBHr)
+					}
+				}
+			}
+
+			// Map namespace name to requests and usage
+			namespaceCPURequests := make(map[string]float64)
+			namespaceCPUUsages := make(map[string]float64)
+			namespaceRAMRequests := make(map[string]float64)
+			namespaceRAMUsages := make(map[string]float64)
+			for _, pod := range podMap {
+				for _, alloc := range pod.Allocations {
+					nsName := alloc.Properties.Namespace
+					namespaceCPURequests[nsName] += alloc.CPUCoreRequestAverage
+					namespaceCPUUsages[nsName] += alloc.CPUCoreUsageAverage
+					namespaceRAMRequests[nsName] += alloc.RAMBytesRequestAverage
+					namespaceRAMUsages[nsName] += alloc.RAMBytesUsageAverage
+				}
+			}
+
+			namespaceCPURQOverhead := make(map[string]float64)
+			namespaceRAMRQOverhead := make(map[string]float64)
+
+			for _, rq := range kms.ResourceQuotas {
+				if rq == nil {
+					continue
+				}
+				var namespaceName string
+				ns, ok := kms.Namespaces[rq.NamespaceUID]
+				if ok {
+					namespaceName = ns.Name
+				} else {
+					namespaceName = rq.NamespaceUID
+				}
+				if namespaceName == "" {
+					continue
+				}
+
+				var hardCPU, hardRAM float64
+				if rq.Spec != nil && rq.Spec.Hard != nil {
+					if rqCPUReq, ok := rq.Spec.Hard.Requests[kubemodel.ResourceCPU]; ok {
+						if val, ok := rqCPUReq.Values[kubemodel.StatAvg]; ok {
+							hardCPU = val / 1000.0
+						}
+					}
+					if hardCPU == 0 {
+						if rqCPULim, ok := rq.Spec.Hard.Limits[kubemodel.ResourceCPU]; ok {
+							if val, ok := rqCPULim.Values[kubemodel.StatAvg]; ok {
+								hardCPU = val / 1000.0
+							}
+						}
+					}
+
+					if rqRAMReq, ok := rq.Spec.Hard.Requests[kubemodel.ResourceMemory]; ok {
+						if val, ok := rqRAMReq.Values[kubemodel.StatAvg]; ok {
+							hardRAM = val
+						}
+					}
+					if hardRAM == 0 {
+						if rqRAMLim, ok := rq.Spec.Hard.Limits[kubemodel.ResourceMemory]; ok {
+							if val, ok := rqRAMLim.Values[kubemodel.StatAvg]; ok {
+								hardRAM = val
+							}
+						}
+					}
+				}
+
+				if hardCPU == 0 && hardRAM == 0 {
+					continue
+				}
+
+				nsCPURequest := namespaceCPURequests[namespaceName]
+				nsCPUUsage := namespaceCPUUsages[namespaceName]
+				maxNSCPU := nsCPURequest
+				if nsCPUUsage > maxNSCPU {
+					maxNSCPU = nsCPUUsage
+				}
+
+				nsRAMRequest := namespaceRAMRequests[namespaceName]
+				nsRAMUsage := namespaceRAMUsages[namespaceName]
+				maxNSRAM := nsRAMRequest
+				if nsRAMUsage > maxNSRAM {
+					maxNSRAM = nsRAMUsage
+				}
+
+				idleCPU := hardCPU - maxNSCPU
+				if idleCPU < 0 {
+					idleCPU = 0
+				}
+				idleRAM := hardRAM - maxNSRAM
+				if idleRAM < 0 {
+					idleRAM = 0
+				}
+
+				if idleCPU > 0 {
+					nsCPUPrice := avgCPUPrice
+					if prices, ok := namespaceCPUPrices[namespaceName]; ok && len(prices) > 0 {
+						var sum float64
+						for _, p := range prices {
+							sum += p
+						}
+						nsCPUPrice = sum / float64(len(prices))
+					}
+					namespaceCPURQOverhead[namespaceName] += idleCPU * nsCPUPrice * hours
+				}
+
+				if idleRAM > 0 {
+					nsRAMPrice := avgRAMPrice
+					if prices, ok := namespaceRAMPrices[namespaceName]; ok && len(prices) > 0 {
+						var sum float64
+						for _, p := range prices {
+							sum += p
+						}
+						nsRAMPrice = sum / float64(len(prices))
+					}
+					namespaceRAMRQOverhead[namespaceName] += (idleRAM / 1024 / 1024 / 1024) * nsRAMPrice * hours
+				}
+			}
+
+			// Get all unique namespace names that have overhead
+			overheadNamespaces := make(map[string]bool)
+			for ns := range namespaceCPURQOverhead {
+				overheadNamespaces[ns] = true
+			}
+			for ns := range namespaceRAMRQOverhead {
+				overheadNamespaces[ns] = true
+			}
+
+			for namespaceName := range overheadNamespaces {
+				cpuOverhead := namespaceCPURQOverhead[namespaceName]
+				ramOverhead := namespaceRAMRQOverhead[namespaceName]
+				totalOverhead := cpuOverhead + ramOverhead
+				if totalOverhead <= 0 {
+					continue
+				}
+
+				clusterID := coreenv.GetClusterID()
+				if clusterID == "" {
+					clusterID = "default"
+				}
+
+				name := fmt.Sprintf("%s/%s/%s/%s/%s", clusterID, "__quota_overhead__", namespaceName, "__quota_overhead__", "__quota_overhead__")
+				overheadAlloc := &opencost.Allocation{
+					Name:   name,
+					Window: allocSet.Window.Clone(),
+					Properties: &opencost.AllocationProperties{
+						Cluster:   clusterID,
+						Namespace: namespaceName,
+						Pod:       "__quota_overhead__",
+						Container: "__quota_overhead__",
+						Node:      "__quota_overhead__",
+					},
+					Start:                start,
+					End:                  end,
+					QuotaOverheadCost:    totalOverhead,
+					QuotaOverheadCPUCost: cpuOverhead,
+					QuotaOverheadRAMCost: ramOverhead,
+				}
+				allocSet.Set(overheadAlloc)
+			}
 		}
 	}
 

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -534,7 +534,7 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 	applyNodeSpot(nodeMap, resNodeIsSpot)
 	applyNodeDiscount(nodeMap, cm)
 	applyExtendedNodeData(nodeMap, nodeExtendedData)
-	cm.applyNodesToPod(podMap, nodeMap)
+	cm.applyNodesToPod(podMap, nodeMap, nodeLabels)
 
 	// (3) Build out AllocationSet from Pod map
 	for _, pod := range podMap {

--- a/pkg/costmodel/allocation_helpers.go
+++ b/pkg/costmodel/allocation_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/core/pkg/util"
+	"github.com/opencost/opencost/pkg/carbon"
 	"github.com/opencost/opencost/pkg/cloud/provider"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -1915,7 +1916,39 @@ func applyNodeDiscount(nodeMap map[nodeKey]*nodePricing, cm *CostModel) {
 	}
 }
 
-func (cm *CostModel) applyNodesToPod(podMap map[podKey]*pod, nodeMap map[nodeKey]*nodePricing) {
+func (cm *CostModel) getNodeCapacity(nodeName string) (float64, float64) {
+	if cm.Cache == nil {
+		return 0, 0
+	}
+	nodes := cm.Cache.GetAllNodes()
+	for _, n := range nodes {
+		if n.Name == nodeName {
+			cores := float64(n.Status.Capacity.Cpu().Value())
+			ramBytes := float64(n.Status.Capacity.Memory().Value())
+			ramGiB := ramBytes / 1024.0 / 1024.0 / 1024.0
+			return cores, ramGiB
+		}
+	}
+	return 0, 0
+}
+
+func getRegionFromLabels(labels map[string]string) string {
+	if r, ok := labels["topology.kubernetes.io/region"]; ok {
+		return r
+	}
+	if r, ok := labels["topology_kubernetes_io_region"]; ok {
+		return r
+	}
+	if r, ok := labels["failure-domain.beta.kubernetes.io/region"]; ok {
+		return r
+	}
+	if r, ok := labels["failure_domain_beta_kubernetes_io_region"]; ok {
+		return r
+	}
+	return ""
+}
+
+func (cm *CostModel) applyNodesToPod(podMap map[podKey]*pod, nodeMap map[nodeKey]*nodePricing, nodeLabels map[nodeKey]map[string]string) {
 	for _, pod := range podMap {
 		for _, alloc := range pod.Allocations {
 			cluster := alloc.Properties.Cluster
@@ -1927,6 +1960,57 @@ func (cm *CostModel) applyNodesToPod(podMap map[podKey]*pod, nodeMap map[nodeKey
 			alloc.CPUCost = alloc.CPUCoreHours * node.CostPerCPUHr
 			alloc.RAMCost = (alloc.RAMByteHours / 1024 / 1024 / 1024) * node.CostPerRAMGiBHr
 			alloc.GPUCost = alloc.GPUHours * node.CostPerGPUHr
+
+			// Carbon footprint allocation math
+			provider := carbon.InferProviderFromProviderID(node.ProviderID)
+			var region string
+			if nodeLabels != nil {
+				if labels, ok := nodeLabels[thisNodeKey]; ok {
+					region = getRegionFromLabels(labels)
+				}
+			}
+
+			instanceType := node.NodeType
+			if instanceType == "" && nodeLabels != nil {
+				if labels, ok := nodeLabels[thisNodeKey]; ok {
+					if it, ok := labels["node.kubernetes.io/instance-type"]; ok {
+						instanceType = it
+					} else if it, ok := labels["node_kubernetes_io_instance_type"]; ok {
+						instanceType = it
+					} else if it, ok := labels["beta.kubernetes.io/instance-type"]; ok {
+						instanceType = it
+					} else if it, ok := labels["beta_kubernetes_io_instance_type"]; ok {
+						instanceType = it
+					}
+				}
+			}
+
+			nodeCoeff := carbon.LookupNodeCarbonCoeff(provider, region, instanceType)
+			nodeCarbonRateKg := nodeCoeff * 1000.0
+
+			cores, ramGiB := cm.getNodeCapacity(nodeName)
+			if cores <= 0 {
+				cores = 4.0
+			}
+			if ramGiB <= 0 {
+				ramGiB = 16.0
+			}
+			gpuCount := 0.0
+			if node.CostPerGPUHr > 0 {
+				gpuCount = 1.0
+			}
+
+			totalNodeCostRate := node.CostPerCPUHr*cores + node.CostPerRAMGiBHr*ramGiB + node.CostPerGPUHr*gpuCount
+			var carbonKilograms float64
+			if totalNodeCostRate > 0 {
+				carbonKilograms = (alloc.CPUCost + alloc.RAMCost + alloc.GPUCost) * (nodeCarbonRateKg / totalNodeCostRate)
+			} else {
+				// Fallback: allocate carbon based on resource hour shares using standard 50% CPU / 50% RAM split
+				cpuCarbonRate := nodeCarbonRateKg * 0.5
+				ramCarbonRate := nodeCarbonRateKg * 0.5
+				carbonKilograms = alloc.CPUCoreHours*(cpuCarbonRate/cores) + (alloc.RAMByteHours/1024/1024/1024)*(ramCarbonRate/ramGiB)
+			}
+			alloc.CarbonKilograms = carbonKilograms
 		}
 	}
 }

--- a/pkg/costmodel/allocation_helpers_test.go
+++ b/pkg/costmodel/allocation_helpers_test.go
@@ -2,12 +2,14 @@ package costmodel
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/core/pkg/util"
+	"github.com/opencost/opencost/pkg/cloud/models"
 )
 
 const Ki = 1024
@@ -621,4 +623,91 @@ func TestCalculateStartAndEnd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyNodesToPod_CarbonAllocation(t *testing.T) {
+	cm := &CostModel{
+		Provider: &carbonMockProvider{},
+	}
+
+	// Create pod map
+	pKey := podKey{
+		namespaceKey: namespaceKey{
+			Cluster:   "cluster1",
+			Namespace: "namespace1",
+		},
+		Pod: "pod1",
+	}
+
+	alloc := &opencost.Allocation{
+		Name: "cluster1/node1/namespace1/pod1/container1",
+		Properties: &opencost.AllocationProperties{
+			Cluster:   "cluster1",
+			Node:      "node1",
+			Namespace: "namespace1",
+			Pod:       "pod1",
+			Container: "container1",
+		},
+		CPUCoreHours: 2.0,
+		RAMByteHours: 8.0 * 1024.0 * 1024.0 * 1024.0, // 8 GiB hours
+	}
+
+	podMap := map[podKey]*pod{
+		pKey: {
+			Key: pKey,
+			Allocations: map[string]*opencost.Allocation{
+				"container1": alloc,
+			},
+		},
+	}
+
+	// Create node pricing map
+	nKey := newNodeKey("cluster1", "node1")
+	nodeMap := map[nodeKey]*nodePricing{
+		nKey: {
+			Name:            "node1",
+			NodeType:        "t4g.nano",
+			ProviderID:      "aws:///us-east-1a/i-1",
+			CostPerCPUHr:    0.01,
+			CostPerRAMGiBHr: 0.002,
+		},
+	}
+
+	// Create node labels map
+	nodeLabels := map[nodeKey]map[string]string{
+		nKey: {
+			"topology_kubernetes_io_region": "us-east-1",
+		},
+	}
+
+	cm.applyNodesToPod(podMap, nodeMap, nodeLabels)
+
+	if alloc.CarbonKilograms == 0 {
+		t.Errorf("expected non-zero CarbonKilograms")
+	}
+
+	// Math verification:
+	// nodeCoeff for AWS us-east-1 t4g.nano is 4.84769853777516e-06 tonnes/hour = 0.00484769853777516 kg/hour.
+	// default capacity fallback is 4 cores, 16 GiB RAM.
+	// totalNodeCostRate = 0.01 * 4 + 0.002 * 16 = 0.072.
+	// alloc.CPUCost = 2 * 0.01 = 0.02
+	// alloc.RAMCost = 8 * 0.002 = 0.016
+	// totalAllocCost = 0.036
+	// carbonKilograms = 0.036 * (0.00484769853777516 / 0.072) = 0.00242384926888758 kg.
+	expectedCarbon := 0.036 * (0.00484769853777516 / 0.072)
+	if math.Abs(alloc.CarbonKilograms-expectedCarbon) > 1e-9 {
+		t.Errorf("unexpected CarbonKilograms: expected %g, got %g", expectedCarbon, alloc.CarbonKilograms)
+	}
+}
+
+type carbonMockProvider struct {
+	models.Provider
+}
+
+func (mp *carbonMockProvider) GetConfig() (*models.CustomPricing, error) {
+	return &models.CustomPricing{
+		CustomPricesEnabled: "false",
+		CPU:                 "0.01",
+		RAM:                 "0.002",
+	}, nil
 }

--- a/pkg/costmodel/anomaly_handler_test.go
+++ b/pkg/costmodel/anomaly_handler_test.go
@@ -1,0 +1,70 @@
+package costmodel
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func TestGetAnomalyHandler_InvalidWindow_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	r, _ := http.NewRequest(http.MethodGet, "/anomaly?window=notawindow", nil)
+	w := httptest.NewRecorder()
+	a.GetAnomalyHandler(w, r, httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid 'window' parameter") {
+		t.Fatalf("expected invalid window error in body, got: %q", w.Body.String())
+	}
+}
+
+func TestGetAnomalyHandler_InvalidStep_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	r, _ := http.NewRequest(http.MethodGet, "/anomaly?window=30d&step=notaduration", nil)
+	w := httptest.NewRecorder()
+	a.GetAnomalyHandler(w, r, httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid 'step' parameter") {
+		t.Fatalf("expected invalid step error in body, got: %q", w.Body.String())
+	}
+}
+
+func TestGetAnomalyHandler_InvalidLookback_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	r, _ := http.NewRequest(http.MethodGet, "/anomaly?window=30d&step=1d&lookback=notaduration", nil)
+	w := httptest.NewRecorder()
+	a.GetAnomalyHandler(w, r, httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid 'lookback' parameter") {
+		t.Fatalf("expected invalid lookback error in body, got: %q", w.Body.String())
+	}
+}
+
+func TestGetAnomalyHandler_InvalidAlgorithm_Returns400(t *testing.T) {
+	a := &Accesses{}
+
+	r, _ := http.NewRequest(http.MethodGet, "/anomaly?window=30d&step=1d&lookback=7d&algorithm=invalid", nil)
+	w := httptest.NewRecorder()
+	a.GetAnomalyHandler(w, r, httprouter.Params{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid 'algorithm' parameter") {
+		t.Fatalf("expected invalid algorithm error in body, got: %q", w.Body.String())
+	}
+}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1374,7 +1374,7 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 
 		if service.Type == "LoadBalancer" {
 			lbKey := &costAnalyzerCloud.CustomLBKey{
-				LBID: service.Name,
+				LBID: fmt.Sprintf("%s/%s/%s", coreenv.GetClusterID(), service.Namespace, service.Name),
 			}
 			loadBalancer, err := cp.LoadBalancerPricing(lbKey)
 			if err != nil {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -2144,6 +2144,32 @@ func computeIdleAllocations(allocSet *opencost.AllocationSet, assetSet *opencost
 	start, end := *allocSet.Window.Start(), *allocSet.Window.End()
 	idleSet := opencost.NewAllocationSet(start, end)
 
+	// Compute raw idle costs to distribute quota overhead proportionally
+	var totalRawIdleCPU, totalRawIdleRAM float64
+	for key, assetTotal := range assetTotals {
+		allocTotal := allocTotals[key]
+		if allocTotal == nil {
+			allocTotal = &opencost.AllocationTotals{}
+		}
+		cpuRaw := assetTotal.TotalCPUCost() - allocTotal.TotalCPUCost()
+		if cpuRaw > 0 {
+			totalRawIdleCPU += cpuRaw
+		}
+		ramRaw := assetTotal.TotalRAMCost() - allocTotal.TotalRAMCost()
+		if ramRaw > 0 {
+			totalRawIdleRAM += ramRaw
+		}
+	}
+
+	// Compute total quota overhead costs from allocSet
+	var totalOverheadCPU, totalOverheadRAM float64
+	for _, alloc := range allocSet.Allocations {
+		if strings.Contains(alloc.Name, "__quota_overhead__") {
+			totalOverheadCPU += alloc.QuotaOverheadCPUCost
+			totalOverheadRAM += alloc.QuotaOverheadRAMCost
+		}
+	}
+
 	for key, assetTotal := range assetTotals {
 		allocTotal, ok := allocTotals[key]
 		if !ok {
@@ -2174,6 +2200,15 @@ func computeIdleAllocations(allocSet *opencost.AllocationSet, assetSet *opencost
 		cpuIdleCost := assetTotal.TotalCPUCost() - allocTotal.TotalCPUCost()
 		gpuIdleCost := assetTotal.TotalGPUCost() - allocTotal.TotalGPUCost()
 		ramIdleCost := assetTotal.TotalRAMCost() - allocTotal.TotalRAMCost()
+
+		if cpuIdleCost > 0 && totalRawIdleCPU > 0 && totalOverheadCPU > 0 {
+			subtraction := (cpuIdleCost / totalRawIdleCPU) * totalOverheadCPU
+			cpuIdleCost -= subtraction
+		}
+		if ramIdleCost > 0 && totalRawIdleRAM > 0 && totalOverheadRAM > 0 {
+			subtraction := (ramIdleCost / totalRawIdleRAM) * totalOverheadRAM
+			ramIdleCost -= subtraction
+		}
 
 		// Clamp idle costs to zero to prevent negative idle allocations
 		if cpuIdleCost < 0 {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1352,6 +1352,35 @@ func (cm *CostModel) GetNodeCost() (map[string]*costAnalyzerCloud.Node, error) {
 	return nodes, nil
 }
 
+func getLBFeatures(service *clustercache.Service, providerType string) string {
+	var hints []string
+
+	if service.Annotations != nil {
+		// AWS load balancer annotations
+		if class, ok := service.Annotations["service.beta.kubernetes.io/aws-load-balancer-class"]; ok {
+			hints = append(hints, strings.ToLower(class))
+		}
+		if lbType, ok := service.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"]; ok {
+			hints = append(hints, strings.ToLower(lbType))
+		}
+
+		// GCP load balancer annotations
+		if lbType, ok := service.Annotations["cloud.google.com/load-balancer-type"]; ok {
+			hints = append(hints, strings.ToLower(lbType))
+		}
+		if lbType, ok := service.Annotations["networking.gke.io/load-balancer-type"]; ok {
+			hints = append(hints, strings.ToLower(lbType))
+		}
+	}
+
+	// Add provider-specific defaults
+	if providerType == opencost.GCPProvider {
+		hints = append(hints, "network", "tcp")
+	}
+
+	return strings.Join(hints, ",")
+}
+
 // TODO: drop some logs
 func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer, error) {
 	// for fetching prices from cloud provider
@@ -1363,6 +1392,11 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 	servicesList := cm.Cache.GetAllServices()
 	loadBalancerMap := make(map[serviceKey]*costAnalyzerCloud.LoadBalancer)
 
+	var providerType string
+	if info, err := cp.ClusterInfo(); err == nil && info != nil {
+		providerType = info["provider"]
+	}
+
 	for _, service := range servicesList {
 		namespace := service.Namespace
 		name := service.Name
@@ -1373,8 +1407,10 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 		}
 
 		if service.Type == "LoadBalancer" {
+			lbFeatures := getLBFeatures(service, providerType)
 			lbKey := &costAnalyzerCloud.CustomLBKey{
-				LBID: fmt.Sprintf("%s/%s/%s", coreenv.GetClusterID(), service.Namespace, service.Name),
+				LBID:       fmt.Sprintf("%s/%s/%s", coreenv.GetClusterID(), service.Namespace, service.Name),
+				LBFeatures: lbFeatures,
 			}
 			loadBalancer, err := cp.LoadBalancerPricing(lbKey)
 			if err != nil {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1373,7 +1373,10 @@ func (cm *CostModel) GetLBCost() (map[serviceKey]*costAnalyzerCloud.LoadBalancer
 		}
 
 		if service.Type == "LoadBalancer" {
-			loadBalancer, err := cp.LoadBalancerPricing()
+			lbKey := &costAnalyzerCloud.CustomLBKey{
+				LBID: service.Name,
+			}
+			loadBalancer, err := cp.LoadBalancerPricing(lbKey)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1373,11 +1373,9 @@ func getLBFeatures(service *clustercache.Service, providerType string) string {
 		}
 	}
 
-	// Add provider-specific defaults
-	if providerType == opencost.GCPProvider {
-		hints = append(hints, "network", "tcp")
-	}
-
+	// Intentionally avoid provider-specific defaults here. Leaving hints empty (when no annotations
+	// are present) allows cloud providers to fall back to their standard default pricing.
+	// (If we later add reliable GCP LB type detection, it should be derived from Service metadata.)
 	return strings.Join(hints, ",")
 }
 

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -490,7 +490,7 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 			cmme.ClusterManagementCostRecorder.WithLabelValues(provisioner).Set(clusterManagementCost)
 
 			// Record network pricing at global scope
-			networkCosts, err := cmme.CloudProvider.NetworkPricing()
+			networkCosts, err := cmme.CloudProvider.NetworkPricing(nil)
 			if err != nil {
 				log.Debugf("Failed to retrieve network costs: %s", err.Error())
 			} else {

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -146,7 +146,13 @@ func GetNetworkUsageData(
 func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider) ([]*util.Vector, error) {
 	var results []*util.Vector
 
-	pricing, err := cloud.NetworkPricing()
+	var netKey costAnalyzerCloud.NetworkKey
+	if usage != nil {
+		netKey = &costAnalyzerCloud.CustomNetworkKey{
+			NetworkID: usage.PodName,
+		}
+	}
+	pricing, err := cloud.NetworkPricing(netKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/costmodel/networkcosts.go
+++ b/pkg/costmodel/networkcosts.go
@@ -144,13 +144,14 @@ func GetNetworkUsageData(
 
 // GetNetworkCost computes the actual cost for NetworkUsageData based on data provided by the Provider.
 func GetNetworkCost(usage *NetworkUsageData, cloud costAnalyzerCloud.Provider) ([]*util.Vector, error) {
+	if usage == nil {
+		return nil, fmt.Errorf("network usage is nil")
+	}
+
 	var results []*util.Vector
 
-	var netKey costAnalyzerCloud.NetworkKey
-	if usage != nil {
-		netKey = &costAnalyzerCloud.CustomNetworkKey{
-			NetworkID: usage.PodName,
-		}
+	netKey := &costAnalyzerCloud.CustomNetworkKey{
+		NetworkID: fmt.Sprintf("%s/%s/%s", usage.ClusterID, usage.Namespace, usage.PodName),
 	}
 	pricing, err := cloud.NetworkPricing(netKey)
 	if err != nil {

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -616,3 +616,11 @@ func TestGetNetworkCost_NATGatewayMisalignedVectors(t *testing.T) {
 		t.Errorf("expected third vector cost %f, got %f", expectedThird, result[2].Value)
 	}
 }
+
+func TestGetNetworkCost_NilUsage(t *testing.T) {
+	provider := &mockProvider{}
+	_, err := GetNetworkCost(nil, provider)
+	if err == nil {
+		t.Fatal("expected error when usage is nil, got nil")
+	}
+}

--- a/pkg/costmodel/networkcosts_test.go
+++ b/pkg/costmodel/networkcosts_test.go
@@ -16,7 +16,7 @@ type mockProvider struct {
 	err     error
 }
 
-func (m *mockProvider) NetworkPricing() (*models.Network, error) {
+func (m *mockProvider) NetworkPricing(key models.NetworkKey) (*models.Network, error) {
 	return m.network, m.err
 }
 
@@ -32,7 +32,7 @@ func (m *mockProvider) NodePricing(models.Key) (*models.Node, models.PricingMeta
 	return nil, models.PricingMetadata{}, nil
 }
 
-func (m *mockProvider) LoadBalancerPricing() (*models.LoadBalancer, error) {
+func (m *mockProvider) LoadBalancerPricing(key models.LBKey) (*models.LoadBalancer, error) {
 	return nil, nil
 }
 

--- a/pkg/costmodel/quota_overhead_test.go
+++ b/pkg/costmodel/quota_overhead_test.go
@@ -1,0 +1,217 @@
+package costmodel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opencost/opencost/core/pkg/source"
+	"github.com/opencost/opencost/core/pkg/util"
+	"github.com/opencost/opencost/pkg/cloud/models"
+)
+
+type quotaMockProvider struct {
+	models.Provider
+}
+
+func (mp *quotaMockProvider) GetConfig() (*models.CustomPricing, error) {
+	return &models.CustomPricing{
+		CustomPricesEnabled: "false",
+		CPU:                 "0.05",
+		RAM:                 "0.01",
+	}, nil
+}
+
+func (mp *quotaMockProvider) CombinedDiscountForNode(nodeName string, isPreemptible bool, defaultCPUDiscount float64, defaultRAMDiscount float64) float64 {
+	return 0
+}
+
+func TestQuotaOverheadCalculation(t *testing.T) {
+	t.Setenv("CLUSTER_ID", "test-cluster")
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	ds := source.NewMockOpenCostDataSource()
+	ds.ResolutionValue = 5 * time.Minute
+
+	// Seed cluster info and uptime
+	ds.Querier.SetOverride(source.QueryClusterInfo, []*source.ClusterInfoResult{
+		{UID: "test-cluster", Cluster: "my-cluster", Provider: "aws"},
+	})
+	ds.Querier.SetOverride(source.QueryClusterUptime, []*source.UptimeResult{
+		{UID: "test-cluster", First: start, Last: end},
+	})
+
+	// Seed namespace info and uptime
+	ds.Querier.SetOverride(source.QueryNamespaceInfo, []*source.NamespaceInfoResult{
+		{UID: "ns-1", Namespace: "tenant-a"},
+	})
+	ds.Querier.SetOverride(source.QueryNamespaceUptime, []*source.UptimeResult{
+		{UID: "ns-1", First: start, Last: end},
+	})
+
+	// Seed resource quota info, uptime, and spec limits (requests CPU = 10 cores, requests RAM = 32 GiB)
+	ds.Querier.SetOverride(source.QueryResourceQuotaInfo, []*source.ResourceQuotaInfoResult{
+		{UID: "rq-1", ResourceQuota: "quota-a", NamespaceUID: "ns-1"},
+	})
+	ds.Querier.SetOverride(source.QueryResourceQuotaUptime, []*source.UptimeResult{
+		{UID: "rq-1", First: start, Last: end},
+	})
+	// cpu hard = 10 cores
+	ds.Querier.SetOverride(source.QueryResourceQuotaSpecCPURequestAverage, []*source.ResourceResult{
+		{UID: "rq-1", Value: 10.0},
+	})
+	// memory hard = 32 GiB (34359738368 bytes)
+	ds.Querier.SetOverride(source.QueryResourceQuotaSpecRAMRequestAverage, []*source.ResourceResult{
+		{UID: "rq-1", Value: 32 * 1024 * 1024 * 1024},
+	})
+
+	// Seed QueryPods to initialize podMap
+	ds.Querier.SetOverride(source.QueryPods, []*source.PodsResult{
+		{
+			Cluster:   "test-cluster",
+			Namespace: "tenant-a",
+			Pod:       "pod-a",
+			Data: []*util.Vector{
+				{Value: 60.0, Timestamp: float64(start.Unix())},
+			},
+		},
+	})
+
+	// Seed pod request metrics (CPU cores allocated = 2, requests average = 2, RAM bytes = 8 GiB)
+	ds.Querier.SetOverride(source.QueryCPUCoresAllocated, []*source.ContainerMetricResult{
+		{
+			Cluster: "test-cluster",
+			Data: []*util.Vector{
+				{Value: 2.0, Timestamp: float64(start.Unix())},
+			},
+			Pod:       "pod-a",
+			Namespace: "tenant-a",
+			Container: "container-a",
+			Node:      "node-1",
+		},
+	})
+	ds.Querier.SetOverride(source.QueryCPURequests, []*source.ContainerMetricResult{
+		{
+			Cluster: "test-cluster",
+			Data: []*util.Vector{
+				{Value: 2.0, Timestamp: float64(start.Unix())},
+			},
+			Pod:       "pod-a",
+			Namespace: "tenant-a",
+			Container: "container-a",
+			Node:      "node-1",
+		},
+	})
+	ds.Querier.SetOverride(source.QueryCPUUsageAvg, []*source.ContainerMetricResult{
+		{
+			Cluster: "test-cluster",
+			Data: []*util.Vector{
+				{Value: 1.0, Timestamp: float64(start.Unix())},
+			},
+			Pod:       "pod-a",
+			Namespace: "tenant-a",
+			Container: "container-a",
+			Node:      "node-1",
+		},
+	})
+	ds.Querier.SetOverride(source.QueryRAMBytesAllocated, []*source.ContainerMetricResult{
+		{
+			Cluster: "test-cluster",
+			Data: []*util.Vector{
+				{Value: 8 * 1024 * 1024 * 1024, Timestamp: float64(start.Unix())},
+			},
+			Pod:       "pod-a",
+			Namespace: "tenant-a",
+			Container: "container-a",
+			Node:      "node-1",
+		},
+	})
+	ds.Querier.SetOverride(source.QueryRAMRequests, []*source.ContainerMetricResult{
+		{
+			Cluster: "test-cluster",
+			Data: []*util.Vector{
+				{Value: 8 * 1024 * 1024 * 1024, Timestamp: float64(start.Unix())},
+			},
+			Pod:       "pod-a",
+			Namespace: "tenant-a",
+			Container: "container-a",
+			Node:      "node-1",
+		},
+	})
+	ds.Querier.SetOverride(source.QueryRAMUsageAvg, []*source.ContainerMetricResult{
+		{
+			Cluster: "test-cluster",
+			Data: []*util.Vector{
+				{Value: 4 * 1024 * 1024 * 1024, Timestamp: float64(start.Unix())},
+			},
+			Pod:       "pod-a",
+			Namespace: "tenant-a",
+			Container: "container-a",
+			Node:      "node-1",
+		},
+	})
+
+	// Seed node pricing (CPU = $0.05 / hour, RAM = $0.01 / GiB hour)
+	ds.Querier.SetOverride(source.QueryNodeCPUPricePerHr, []*source.NodeCPUPricePerHrResult{
+		{
+			Cluster: "test-cluster",
+			Node:    "node-1",
+			Data: []*util.Vector{
+				{Value: 0.05, Timestamp: float64(start.Unix())},
+			},
+		},
+	})
+	ds.Querier.SetOverride(source.QueryNodeRAMPricePerGiBHr, []*source.NodeRAMPricePerGiBHrResult{
+		{
+			Cluster: "test-cluster",
+			Node:    "node-1",
+			Data: []*util.Vector{
+				{Value: 0.01, Timestamp: float64(start.Unix())},
+			},
+		},
+	})
+
+	// Instantiate CostModel
+	cm := NewCostModel("test-cluster", ds, &quotaMockProvider{}, nil, nil, time.Hour)
+	require.NotNil(t, cm)
+
+	kms, err := cm.ComputeKubeModelSet(start, end)
+	t.Logf("KMS error: %v", err)
+	if kms != nil {
+		t.Logf("KMS ResourceQuotas: %+v", kms.ResourceQuotas)
+		t.Logf("KMS Namespaces: %+v", kms.Namespaces)
+	}
+
+	// Compute allocations
+	allocSet, err := cm.ComputeAllocation(start, end)
+	require.NoError(t, err)
+	require.NotNil(t, allocSet)
+
+	// Check that we have the quota overhead allocation
+	overheadName := "test-cluster/__quota_overhead__/tenant-a/__quota_overhead__/__quota_overhead__"
+	overheadAlloc, ok := allocSet.Allocations[overheadName]
+	if !ok {
+		for k := range allocSet.Allocations {
+			t.Logf("Found allocation key: %s", k)
+		}
+	}
+	require.True(t, ok, "expected to find quota overhead allocation")
+
+	// Verify math:
+	// Unused CPU quota = 10 - 2 = 8 cores
+	// CPU unit price = $0.05 / hour
+	// Hours = 1
+	// expected CPU overhead cost = 8 * 0.05 * 1 = $0.40
+	// Unused RAM quota = 32 - 8 = 24 GiB
+	// RAM unit price = $0.01 / hour
+	// expected RAM overhead cost = 24 * 0.01 * 1 = $0.24
+	// Total expected overhead cost = $0.64
+	assert.InDelta(t, 0.40, overheadAlloc.QuotaOverheadCPUCost, 1e-9)
+	assert.InDelta(t, 0.24, overheadAlloc.QuotaOverheadRAMCost, 1e-9)
+	assert.InDelta(t, 0.64, overheadAlloc.QuotaOverheadCost, 1e-9)
+	assert.InDelta(t, 0.64, overheadAlloc.TotalCost(), 1e-9)
+}

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -16,12 +16,15 @@ import (
 	"github.com/opencost/opencost/core/pkg/external"
 	"github.com/opencost/opencost/core/pkg/kubeconfig"
 	"github.com/opencost/opencost/core/pkg/nodestats"
+	"github.com/opencost/opencost/core/pkg/opencost"
 	"github.com/opencost/opencost/core/pkg/protocol"
 	"github.com/opencost/opencost/core/pkg/source"
 	"github.com/opencost/opencost/core/pkg/storage"
+	"github.com/opencost/opencost/core/pkg/util/httputil"
 	"github.com/opencost/opencost/core/pkg/util/retry"
 	"github.com/opencost/opencost/core/pkg/util/timeutil"
 	"github.com/opencost/opencost/core/pkg/version"
+	"github.com/opencost/opencost/pkg/anomaly"
 	cloudconfig "github.com/opencost/opencost/pkg/cloud/config"
 	"github.com/opencost/opencost/pkg/cloud/provider"
 	"github.com/opencost/opencost/pkg/cloudcost"
@@ -630,6 +633,7 @@ func Initialize(router *httprouter.Router, additionalConfigWatchers ...*watcher.
 	router.GET("/installInfo", a.GetInstallInfo)
 	router.POST("/serviceKey", adminAuthMiddleware(a.AddServiceKey))
 	router.GET("/helmValues", adminAuthMiddleware(a.GetHelmValues))
+	router.GET("/anomaly", a.GetAnomalyHandler)
 
 	return a
 }
@@ -679,4 +683,80 @@ func InitializeCustomCost(router *httprouter.Router) *customcost.PipelineService
 	router.GET("/customCost/timeseries", customCostQueryService.GetCustomCostTimeseriesHandler())
 
 	return customCostPipelineService
+}
+
+func (a *Accesses) GetAnomalyHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	qp := httputil.NewQueryParams(r.URL.Query())
+
+	windowStr := qp.Get("window", "30d")
+	window, err := opencost.ParseWindowWithOffset(windowStr, env.GetParsedUTCOffset())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid 'window' parameter: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	stepStr := qp.Get("step", "1d")
+	step, err := timeutil.ParseDuration(stepStr)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid 'step' parameter: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	lookbackStr := qp.Get("lookback", "7d")
+	lookbackDur, err := timeutil.ParseDuration(lookbackStr)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid 'lookback' parameter: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	algorithm := qp.Get("algorithm", "mad")
+	if algorithm != "zscore" && algorithm != "mad" {
+		http.Error(w, "Invalid 'algorithm' parameter: must be 'zscore' or 'mad'", http.StatusBadRequest)
+		return
+	}
+
+	var defaultThreshold float64 = 3.0
+	if algorithm == "mad" {
+		defaultThreshold = 3.5
+	}
+	threshold := qp.GetFloat64("threshold", defaultThreshold)
+	minCost := qp.GetFloat64("minCost", 0.10)
+
+	aggregations := qp.GetList("aggregate", ",")
+	aggregateBy, err := ParseAggregationProperties(aggregations)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid 'aggregate' parameter: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	allocationFilter := qp.Get("filter", "")
+
+	asr, err := a.Model.QueryAllocation(
+		window,
+		step,
+		aggregateBy,
+		false,
+		false,
+		false,
+		false,
+		false,
+		opencost.AccumulateOptionNone,
+		false,
+		allocationFilter,
+	)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error querying allocation: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	reports, err := anomaly.Detect(asr, step, lookbackDur, algorithm, threshold, minCost)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error detecting anomalies: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	WriteData(w, reports, nil)
 }

--- a/pkg/costmodel/router_test.go
+++ b/pkg/costmodel/router_test.go
@@ -20,13 +20,13 @@ func TestAdminAuthMiddleware(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		setToken          string
-		authHeader        string
-		wantStatus        int
-		wantNextCalled    bool
-		wantBodySubstr    string
-		wantCacheControl  string
+		name             string
+		setToken         string
+		authHeader       string
+		wantStatus       int
+		wantNextCalled   bool
+		wantBodySubstr   string
+		wantCacheControl string
 	}{
 		{
 			name:             "no admin token configured - returns 503",

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -697,10 +697,12 @@ func (mp *mockProvider) GetOrphanedResources() ([]models.OrphanedResource, error
 func (mp *mockProvider) NodePricing(models.Key) (*models.Node, models.PricingMetadata, error) {
 	return nil, models.PricingMetadata{}, nil
 }
-func (mp *mockProvider) GpuPricing(map[string]string) (string, error)            { return "", nil }
-func (mp *mockProvider) PVPricing(models.PVKey) (*models.PV, error)              { return nil, nil }
-func (mp *mockProvider) NetworkPricing() (*models.Network, error)                { return nil, nil }
-func (mp *mockProvider) LoadBalancerPricing() (*models.LoadBalancer, error)      { return nil, nil }
+func (mp *mockProvider) GpuPricing(map[string]string) (string, error)              { return "", nil }
+func (mp *mockProvider) PVPricing(models.PVKey) (*models.PV, error)                { return nil, nil }
+func (mp *mockProvider) NetworkPricing(models.NetworkKey) (*models.Network, error) { return nil, nil }
+func (mp *mockProvider) LoadBalancerPricing(models.LBKey) (*models.LoadBalancer, error) {
+	return nil, nil
+}
 func (mp *mockProvider) DownloadPricingData() error                              { return nil }
 func (mp *mockProvider) GetKey(map[string]string, *clustercache.Node) models.Key { return nil }
 func (mp *mockProvider) GetPVKey(*clustercache.PersistentVolume, map[string]string, string) models.PVKey {

--- a/pull_request.md
+++ b/pull_request.md
@@ -15,7 +15,7 @@ Key changes:
    - `filter`: allocation filters.
 
 ## Related Issues
-Closes #4156
+Closes #3979
 
 ## User Impact
 Users/FinOps teams can query `GET /anomaly` to identify sudden unexpected spikes in cost data, grouped by namespace, pod, cluster, etc.

--- a/pull_request.md
+++ b/pull_request.md
@@ -1,0 +1,26 @@
+## Description
+This PR implements a cost anomaly detection API endpoint `GET /anomaly` in OpenCost.
+
+Key changes:
+1. Created a new package `pkg/anomaly` implementing rolling Z-score and rolling Median Absolute Deviation (MAD) anomaly detection algorithms.
+2. Added `GET /anomaly` handler in `pkg/costmodel/router.go`.
+3. Allowed query parameters:
+   - `window`: total time window (lookback + detection), e.g., `30d` (default).
+   - `step`: resolution step size, e.g., `1d` (default).
+   - `lookback`: window of historical data to build baseline, e.g., `7d` (default).
+   - `algorithm`: `mad` (default) or `zscore`.
+   - `threshold`: standard deviation/MAD multiplier (default `3.5` for MAD, `3.0` for Z-score).
+   - `minCost`: ignore micro-costs below this value to avoid noise (default `$0.10`).
+   - `aggregate`: cost grouping (default `namespace`).
+   - `filter`: allocation filters.
+
+## Related Issues
+Closes #4156
+
+## User Impact
+Users/FinOps teams can query `GET /anomaly` to identify sudden unexpected spikes in cost data, grouped by namespace, pod, cluster, etc.
+
+## Testing
+1. Added unit tests for statistical functions and anomaly detection algorithms in `pkg/anomaly/anomaly_test.go`.
+2. Added handler routing and validation tests in `pkg/costmodel/anomaly_handler_test.go`.
+3. Verified all tests passed successfully using `go test ./...`.


### PR DESCRIPTION
## Description
This PR implements a cost anomaly detection API endpoint `GET /anomaly` in OpenCost.

Key changes:
1. Created a new package `pkg/anomaly` implementing rolling Z-score and rolling Median Absolute Deviation (MAD) anomaly detection algorithms.
2. Added `GET /anomaly` handler in `pkg/costmodel/router.go`.
3. Allowed query parameters:
   - `window`: total time window (lookback + detection), e.g., `30d` (default).
   - `step`: resolution step size, e.g., `1d` (default).
   - `lookback`: window of historical data to build baseline, e.g., `7d` (default).
   - `algorithm`: `mad` (default) or `zscore`.
   - `threshold`: standard deviation/MAD multiplier (default `3.5` for MAD, `3.0` for Z-score).
   - `minCost`: ignore micro-costs below this value to avoid noise (default `$0.10`).
   - `aggregate`: cost grouping (default `namespace`).
   - `filter`: allocation filters.

## Related Issues
Closes #3979

## User Impact
Users/FinOps teams can query `GET /anomaly` to identify sudden unexpected spikes in cost data, grouped by namespace, pod, cluster, etc.

## Testing
1. Added unit tests for statistical functions and anomaly detection algorithms in `pkg/anomaly/anomaly_test.go`.
2. Added handler routing and validation tests in `pkg/costmodel/anomaly_handler_test.go`.
3. Verified all tests passed successfully using `go test ./...`.
