### PR TITLE
Update HTTP Handling for Public Pricing

### DIFF
--- a/.github/workflows/compare-pricing-data.yaml
+++ b/.github/workflows/compare-pricing-data.yaml
@@ -2,7 +2,7 @@ name: Compare Pricing Data
 
 on:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: '0 18 * * *'
 
 permissions:
   contents: read

--- a/modules/pricing/public/aws/pricelistapi.go
+++ b/modules/pricing/public/aws/pricelistapi.go
@@ -9,7 +9,10 @@ import (
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/util/json"
 	"github.com/opencost/opencost/modules/pricing/public/env"
+	"github.com/opencost/opencost/modules/pricing/public/httpclient"
 )
+
+var awsHTTPClient = httpclient.NewClient(0) // no timeout
 
 const (
 	awsPricingBaseURL      = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/"
@@ -62,7 +65,7 @@ func QueryEC2PriceList(
 	pricingURL := getListPriceURL("AmazonEC2", region)
 
 	log.Infof("starting download of \"%s\", which is quite large ...", pricingURL)
-	resp, err := http.Get(pricingURL)
+	resp, err := awsHTTPClient.Get(pricingURL)
 	if err != nil {
 		return fmt.Errorf("bogus fetch of \"%s\": %w", pricingURL, err)
 	}

--- a/modules/pricing/public/azure/azurepricingsource.go
+++ b/modules/pricing/public/azure/azurepricingsource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/pricing"
 	"github.com/opencost/opencost/core/pkg/unit"
+	"github.com/opencost/opencost/modules/pricing/public/httpclient"
 )
 
 const (
@@ -26,7 +27,7 @@ type AzurePricingSourceConfig struct {
 	CurrencyCode string
 }
 
-var azureHTTPClient = &http.Client{Timeout: 60 * time.Second}
+var azureHTTPClient = httpclient.NewClient(120 * time.Second)
 
 // AzurePricingSource implements the PricingSource interface using the
 // Azure Retail Prices API (no auth required).
@@ -232,11 +233,7 @@ func (a *AzurePricingSource) includeItem(item AzurePricingAttributes) bool {
 	}
 
 	skuLower := strings.ToLower(item.SkuName)
-	if strings.Contains(skuLower, "low priority") {
-		return false
-	}
-
-	return true
+	return !strings.Contains(skuLower, "low priority")
 }
 
 // includeDiskItem filters disk items to include only managed disks.

--- a/modules/pricing/public/gcp/gcppricingsource.go
+++ b/modules/pricing/public/gcp/gcppricingsource.go
@@ -15,11 +15,12 @@ import (
 	"github.com/opencost/opencost/core/pkg/log"
 	"github.com/opencost/opencost/core/pkg/pricing"
 	"github.com/opencost/opencost/core/pkg/unit"
+	"github.com/opencost/opencost/modules/pricing/public/httpclient"
 )
 
 var BillingAPIBaseURL = "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus"
 
-var gcpHTTPClient = &http.Client{Timeout: 120 * time.Second}
+var gcpHTTPClient = httpclient.NewClient(120 * time.Second)
 
 type GCPPricingSourceConfig struct {
 	APIKey       string

--- a/modules/pricing/public/httpclient/httpclient.go
+++ b/modules/pricing/public/httpclient/httpclient.go
@@ -1,0 +1,79 @@
+package httpclient
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/opencost/opencost/core/pkg/log"
+)
+
+const (
+	defaultMaxRetries    = 5
+	defaultRetryBaseWait = 2 * time.Second
+	defaultRetryMaxWait  = 60 * time.Second
+)
+
+// retryTransport is an http.RoundTripper that retries requests on 429 and 503s
+type retryTransport struct {
+	wrapped     http.RoundTripper
+	maxRetries  int
+	baseWait    time.Duration
+	maxWait     time.Duration
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	wait := t.baseWait
+	for attempt := 0; attempt <= t.maxRetries; attempt++ {
+		resp, err := t.wrapped.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusServiceUnavailable {
+			return resp, nil
+		}
+
+		if attempt == t.maxRetries {
+			// Return the final error response untouched so the caller can
+			// read the body and status code.
+			return resp, nil
+		}
+
+		// Consume and discard the error body so the connection can be reused,
+		// then close it before sleeping.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+
+		delay := wait
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil {
+				delay = time.Duration(secs) * time.Second
+			}
+		}
+		if delay > t.maxWait {
+			delay = t.maxWait
+		}
+
+		log.Warnf("pricing httpclient: HTTP %d, retrying in %s (attempt %d/%d)",
+			resp.StatusCode, delay, attempt+1, t.maxRetries)
+		time.Sleep(delay)
+		wait *= 2
+	}
+	return nil, nil
+}
+
+// NewClient returns an *http.Client whose transport automatically retries
+// on HTTP 429 / 503 with exponential backoff
+func NewClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &retryTransport{
+			wrapped:    http.DefaultTransport,
+			maxRetries: defaultMaxRetries,
+			baseWait:   defaultRetryBaseWait,
+			maxWait:    defaultRetryMaxWait,
+		},
+	}
+}


### PR DESCRIPTION
## Description
Primarily updates the http handling for public pricing by allowing retries on 429 and 503s (was seeing 429s consistently from azure because of the amount of requests required, the other ones are just like safeguards).

Also updates the time of the cronjob because I set it to 3AM PST like a crazy person.

## Related Issues
No related issue necessarily, can see the compare-pricing action recently merged just 429s 😞 

## User Impact
Shouldn't be any impact because none of this has been rolled out yet.

## Testing
Tested locally, sort of gunning for a test run on the pipeline to see if it still breaks.
