### PR TITLE
Reduce verbose/redundant logs during Allocation queries

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -420,8 +420,21 @@ func (cm *CostModel) computeAllocation(start, end time.Time) (*opencost.Allocati
 	resLBActiveMins, _ := resChLBActiveMins.Await()
 
 	if grp.HasErrors() {
+		// Many concurrent sub-queries can fail with the exact same underlying
+		// error (e.g. a data source rejecting the whole start/end window), which
+		// would otherwise flood the log with dozens of identical lines. Collapse
+		// duplicates and report each distinct error once with an occurrence count.
+		counts := make(map[string]int)
+		var distinct []string
 		for _, err := range grp.Errors() {
-			log.Errorf("CostModel.ComputeAllocation: query context error %s", err)
+			msg := err.String()
+			if counts[msg] == 0 {
+				distinct = append(distinct, msg)
+			}
+			counts[msg]++
+		}
+		for _, msg := range distinct {
+			log.Errorf("CostModel.ComputeAllocation: query context error (x%d) %s", counts[msg], msg)
 		}
 
 		return allocSet, nil, grp.Error()


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->
Many users see the following log repeatedly, dozens of times over.

```log
CostModel.ComputeAllocation: query context error Errors: Request Error: invalid start/end duration: 0h
```

This occurs because the function is making dozens of Allocation queries asynchronously. If they all query but pass an invalid start/end duration, we get dozens of those same exact errors back. This PR helps to dedupe those error logs.

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

Only a log change. Should not be breaking, unless users were depending on those duplicated logs (unlikely).

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

N/A