### PR TITLE
azure: use the Cost Management price sheet API for EA billing accounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/storage v1.60.0
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/Azure/go-autorest/autorest v0.11.30
@@ -69,6 +69,7 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement/v3 v3.0.0
 	github.com/google/go-cmp v0.7.0
 	github.com/opencost/bingen v0.2.0
 	github.com/oracle/oci-go-sdk/v65 v65.117.1
@@ -81,7 +82,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.22 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.6 // indirect
@@ -90,7 +91,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.2 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,12 +29,18 @@ github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 h1:fou+2+WFTib47nS+nz/ozhEBnvU96bKHy6LjRsY4E28=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0/go.mod h1:t76Ruy8AHvUAC8GfMWJMa0ElSbuIcO03NLpynfbgsPA=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 h1:aokoqcHvaGjiM3VpjKDfMMnF/8epJ+Q1HLJ7CudztqE=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0/go.mod h1:/WYEx9pcM9Y+Dd/APJaNlSvVSvzl54rrMdZT5+Oi2LM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2 h1:yz1bePFlP5Vws5+8ez6T3HWXPmwOK7Yvq8QxDBD3SKY=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.3.2/go.mod h1:Pa9ZNPuoNu/GztvBSKk9J1cDJW6vk/n0zLtV4mgd8N8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDozdmndjTm8DXdpCzPajMgA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement/v3 v3.0.0 h1:v2DszVTAXWT0bs7sgFDVRvDZJSn3pG9UK7Ua6XnNMsg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement/v3 v3.0.0/go.mod h1:Z3N8x2aFlRJvN+sFQaMvOlayWUpNb650LN7T0QLgK0s=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
@@ -68,6 +74,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 h1:4iB+IesclUXdP0ICgAabvq2FYLXrJWKx1fJQ+GxSo3Y=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=

--- a/pkg/cloud/azure/pricesheetclient.go
+++ b/pkg/cloud/azure/pricesheetclient.go
@@ -2,123 +2,171 @@ package azure
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement/v3"
+
+	"github.com/opencost/opencost/core/pkg/log"
 )
 
-const (
-	moduleName    = "armconsumption"
-	moduleVersion = "v1.0.0"
-)
+// The EA price sheet is fetched through the Cost Management price sheet API:
+//
+//	POST /providers/Microsoft.Billing/billingAccounts/{id}/billingPeriods/{yyyymm}
+//	     /providers/Microsoft.CostManagement/pricesheets/default/download
+//
+// It replaces the Microsoft.Consumption pricesheets/download API, which was
+// retired on 01 June 2026. Consumption only ever granted access via the
+// Microsoft.Consumption/pricesheets/action permission, which the EnrollmentReader
+// billing role no longer carries, so calls against it now fail with
+// AuthorizationFailed even for correctly configured service principals.
+//
+// The request is a long running operation: it returns 202 plus a Location header
+// pointing at an operationResults URL that eventually answers 200 with the
+// generated download link.
 
-// At the moment the consumption pricesheet download API is not a)
-// documented or b) supported by the SDK. This is an implementation of
-// a client in the style of the Azure go SDK - once the API is
-// supported this will be removed.
+// pollFrequency is how often we poll the operationResults URL. Generating the
+// sheet can take several minutes, and the service asks for 60s in Retry-After,
+// so there is no point polling aggressively.
+const pollFrequency = 30 * time.Second
 
-// PriceSheetClient contains the methods for the PriceSheet group.
-// Don't use this type directly, use NewPriceSheetClient() instead.
-type PriceSheetClient struct {
-	host             string
-	billingAccountID string
-	pl               runtime.Pipeline
-}
-
-// NewPriceSheetClient creates a new instance of PriceSheetClient with the specified values.
-// billingAccountId - Azure Billing Account ID.
-// credential - used to authorize requests. Usually a credential from azidentity.
-// options - pass nil to accept the default values.
-func NewPriceSheetClient(billingAccountID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PriceSheetClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
+// priceSheetDownloadURL asks Cost Management to generate the price sheet for the
+// given billing period (formatted yyyymm) and returns a URL to download it from.
+// The returned URL is time limited.
+func priceSheetDownloadURL(ctx context.Context, credential azcore.TokenCredential, options *arm.ClientOptions, billingAccountID, billingPeriodName string) (string, error) {
+	if billingAccountID == "" {
+		return "", errors.New("parameter billingAccountID cannot be empty")
 	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
+	if billingPeriodName == "" {
+		return "", errors.New("parameter billingPeriodName cannot be empty")
 	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+
+	// The generated SDK only understands "reportUrl" in the operation result,
+	// but Microsoft's own migration guide for this endpoint documents
+	// "downloadUrl". Keep a copy of the raw body so we can cope with either.
+	capture := &responseCapture{}
+	options = withResponseCapture(options, capture)
+
+	client, err := armcostmanagement.NewPriceSheetClient(credential, options)
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("creating price sheet client: %w", err)
 	}
-	client := &PriceSheetClient{
-		billingAccountID: billingAccountID,
-		host:             ep,
-		pl:               pl,
-	}
-	return client, nil
-}
 
-// BeginDownloadByBillingPeriod - requests a pricesheet for a specific billing period `yyyymm`.
-// Returns a Poller that will provide the download URL when the pricesheet is ready.
-// If the operation fails it returns an *azcore.ResponseError type.
-// Generated from API version 2022-06-01
-// billingPeriodName - Billing Period Name `yyyymm`.
-func (client *PriceSheetClient) BeginDownloadByBillingPeriod(ctx context.Context, billingPeriodName string) (*runtime.Poller[PriceSheetClientDownloadResponse], error) {
-	resp, err := client.downloadByBillingPeriodOperation(ctx, billingPeriodName)
+	poller, err := client.BeginDownloadByBillingAccount(ctx, billingAccountID, billingPeriodName, nil)
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("beginning price sheet download: %w", err)
 	}
-	return runtime.NewPoller[PriceSheetClientDownloadResponse](resp, client.pl, nil)
-}
 
-type PriceSheetClientDownloadResponse struct {
-	ID         string                             `json:"id"`
-	Name       string                             `json:"name"`
-	StartTime  time.Time                          `json:"startTime"`
-	EndTime    time.Time                          `json:"endTime"`
-	Status     string                             `json:"status"`
-	Properties PriceSheetClientDownloadProperties `json:"properties"`
-}
-
-type PriceSheetClientDownloadProperties struct {
-	DownloadURL string `json:"downloadUrl"`
-	ValidTill   string `json:"validTill"`
-}
-
-func (client *PriceSheetClient) downloadByBillingPeriodOperation(ctx context.Context, billingPeriodName string) (*http.Response, error) {
-	req, err := client.downloadByBillingPeriodCreateRequest(ctx, billingPeriodName)
+	resp, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+		Frequency: pollFrequency,
+	})
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("polling for price sheet: %w", err)
 	}
-	resp, err := client.pl.Do(req)
-	if err != nil {
-		return nil, err
+
+	if resp.Properties != nil {
+		if resp.Properties.ReportURL != nil && *resp.Properties.ReportURL != "" {
+			logValidUntil(resp.Properties.ValidUntil)
+			return string(*resp.Properties.ReportURL), nil
+		}
+		logValidUntil(resp.Properties.ValidUntil)
 	}
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted) {
-		return nil, runtime.NewResponseError(resp)
+
+	// Fall back to reading the URL out of the raw operation result.
+	if url := extractDownloadURL(capture.Body()); url != "" {
+		return url, nil
 	}
+
+	status := ""
+	if resp.Status != nil {
+		status = string(*resp.Status)
+	}
+	return "", fmt.Errorf("price sheet operation finished with status %q but returned no download URL", status)
+}
+
+func logValidUntil(validUntil *time.Time) {
+	if validUntil != nil {
+		log.Debugf("price sheet download URL valid until %s", validUntil.Format(time.RFC3339))
+	}
+}
+
+// extractDownloadURL pulls the download link out of a raw operation result body,
+// accepting either of the two field names the service has been documented to
+// use. It returns "" if the body isn't a recognisable operation result.
+func extractDownloadURL(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var result struct {
+		Properties struct {
+			ReportURL   string `json:"reportUrl"`
+			DownloadURL string `json:"downloadUrl"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return ""
+	}
+	if result.Properties.ReportURL != "" {
+		return result.Properties.ReportURL
+	}
+	return result.Properties.DownloadURL
+}
+
+// withResponseCapture returns a copy of options with capture installed as a
+// pipeline policy, leaving the caller's options untouched.
+func withResponseCapture(options *arm.ClientOptions, capture *responseCapture) *arm.ClientOptions {
+	var updated arm.ClientOptions
+	if options != nil {
+		updated = *options
+	}
+	updated.PerRetryPolicies = append(append([]policy.Policy{}, updated.PerRetryPolicies...), capture)
+	return &updated
+}
+
+// responseCapture keeps hold of the body of the most recent successful JSON
+// response to pass through the pipeline, so we can read fields the generated
+// models don't know about. It is safe for concurrent use because the poller may
+// run on a different goroutine to the one that reads the body.
+type responseCapture struct {
+	mu   sync.Mutex
+	body []byte
+}
+
+func (c *responseCapture) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return resp, nil
+	}
+	if !strings.Contains(resp.Header.Get("Content-Type"), "json") {
+		return resp, nil
+	}
+	// runtime.Payload buffers the body and rewinds it, so the SDK can still
+	// unmarshal the response after we've looked at it.
+	body, payloadErr := runtime.Payload(resp)
+	if payloadErr != nil {
+		log.Debugf("could not buffer price sheet response body: %s", payloadErr)
+		return resp, nil
+	}
+	c.mu.Lock()
+	c.body = body
+	c.mu.Unlock()
 	return resp, nil
 }
 
-const downloadByBillingPeriodTemplate = "/providers/Microsoft.Billing/billingAccounts/%s/billingPeriods/%s/providers/Microsoft.Consumption/pricesheets/download"
-
-// downloadByBillingPeriodCreateRequest creates the DownloadByBillingPeriod request.
-func (client *PriceSheetClient) downloadByBillingPeriodCreateRequest(ctx context.Context, billingPeriodName string) (*policy.Request, error) {
-	if client.billingAccountID == "" {
-		return nil, errors.New("parameter client.billingAccountID cannot be empty")
-	}
-	if billingPeriodName == "" {
-		return nil, errors.New("parameter billingPeriodName cannot be empty")
-	}
-	urlPath := fmt.Sprintf(downloadByBillingPeriodTemplate, url.PathEscape(client.billingAccountID), url.PathEscape(billingPeriodName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "2022-06-01")
-	reqQP.Set("ln", "en")
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["Accept"] = []string{"*/*"}
-	return req, nil
+func (c *responseCapture) Body() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.body
 }

--- a/pkg/cloud/azure/pricesheetclient.go
+++ b/pkg/cloud/azure/pricesheetclient.go
@@ -34,9 +34,10 @@ import (
 // pointing at an operationResults URL that eventually answers 200 with the
 // generated download link.
 
-// pollFrequency is how often we poll the operationResults URL. Generating the
-// sheet can take several minutes, and the service asks for 60s in Retry-After,
-// so there is no point polling aggressively.
+// pollFrequency is how long to wait between polls of the operationResults URL
+// when the service doesn't tell us. Cost Management normally answers with
+// Retry-After (60s at the time of writing), which azcore honours in preference
+// to this, so it only applies if that header is ever missing.
 const pollFrequency = 30 * time.Second
 
 // priceSheetDownloadURL asks Cost Management to generate the price sheet for the

--- a/pkg/cloud/azure/pricesheetclient_test.go
+++ b/pkg/cloud/azure/pricesheetclient_test.go
@@ -2,10 +2,16 @@ package azure
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,160 +27,211 @@ func (m *mockCredential) GetToken(ctx context.Context, options policy.TokenReque
 	}, nil
 }
 
-// TestPriceSheetClient_CreateRequest tests the core HTTP method fix
-// This test directly validates the createRequest method to ensure POST is used
-func TestPriceSheetClient_CreateRequest_HTTPMethod(t *testing.T) {
-	tests := []struct {
-		name              string
-		billingAccountID  string
-		billingPeriodName string
-		expectedMethod    string
-		expectedPath      string
-	}{
-		{
-			name:              "POST method for valid billing account",
-			billingAccountID:  "test-billing-account",
-			billingPeriodName: "202308",
-			expectedMethod:    "POST",
-			expectedPath:      "/providers/Microsoft.Billing/billingAccounts/test-billing-account/billingPeriods/202308/providers/Microsoft.Consumption/pricesheets/download",
+// testClientOptions points the SDK at a local test server instead of ARM.
+func testClientOptions(endpoint string) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			// httptest serves plain HTTP, which the bearer token policy
+			// otherwise refuses to send a credential over.
+			InsecureAllowCredentialWithHTTP: true,
+			Cloud: cloud.Configuration{
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Endpoint: endpoint,
+						Audience: "https://management.azure.com",
+					},
+				},
+			},
 		},
-		{
-			name:              "POST method for different billing period",
-			billingAccountID:  "another-account",
-			billingPeriodName: "202401",
-			expectedMethod:    "POST",
-			expectedPath:      "/providers/Microsoft.Billing/billingAccounts/another-account/billingPeriods/202401/providers/Microsoft.Consumption/pricesheets/download",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cred := &mockCredential{}
-			client, err := NewPriceSheetClient(tt.billingAccountID, cred, nil)
-			require.NoError(t, err)
-
-			// Test the createRequest method directly
-			req, err := client.downloadByBillingPeriodCreateRequest(context.Background(), tt.billingPeriodName)
-			require.NoError(t, err)
-
-			// Validate HTTP method - this is the core fix validation
-			assert.Equal(t, tt.expectedMethod, req.Raw().Method, "HTTP method must be POST, not GET (fix for Azure billing API issue #3326)")
-
-			// Validate URL path construction
-			assert.Contains(t, req.Raw().URL.Path, tt.expectedPath)
-
-			// Validate query parameters
-			assert.Equal(t, "2022-06-01", req.Raw().URL.Query().Get("api-version"))
-			assert.Equal(t, "en", req.Raw().URL.Query().Get("ln"))
-
-			// Validate Accept header
-			assert.Equal(t, []string{"*/*"}, req.Raw().Header["Accept"])
-		})
 	}
 }
 
-// TestPriceSheetClient_Validation tests parameter validation
-func TestPriceSheetClient_Validation(t *testing.T) {
-	cred := &mockCredential{}
+// priceSheetServer fakes the Cost Management price sheet long running operation:
+// a POST that returns 202 with a Location header, then an operationResults URL
+// that answers 200 with the supplied body.
+type priceSheetServer struct {
+	server *httptest.Server
 
+	mu          sync.Mutex
+	downloadReq *http.Request
+	pollCount   int
+}
+
+func newPriceSheetServer(t *testing.T, resultBody string) *priceSheetServer {
+	t.Helper()
+	ps := &priceSheetServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ps.mu.Lock()
+		defer ps.mu.Unlock()
+		switch {
+		case r.Method == http.MethodPost:
+			ps.downloadReq = r.Clone(context.Background())
+			w.Header().Set("Location", ps.server.URL+"/operationResults/test-operation?api-version=2023-09-01")
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet:
+			ps.pollCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, resultBody)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	ps.server = httptest.NewServer(mux)
+	t.Cleanup(ps.server.Close)
+	return ps
+}
+
+func (ps *priceSheetServer) downloadRequest() *http.Request {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	return ps.downloadReq
+}
+
+// TestPriceSheetDownloadURL_UsesCostManagementAPI checks that we call the current
+// Cost Management endpoint. The Microsoft.Consumption pricesheets/download API
+// this replaced was retired on 01 June 2026 and had already started rejecting
+// EnrollmentReader service principals with AuthorizationFailed (issue #4003).
+func TestPriceSheetDownloadURL_UsesCostManagementAPI(t *testing.T) {
+	const downloadURL = "https://example.blob.core.windows.net/pricesheet.zip?sig=abc"
+	server := newPriceSheetServer(t, fmt.Sprintf(`{"status":"Completed","properties":{"reportUrl":%q,"validUntil":"2026-09-30T17:32:28Z"}}`, downloadURL))
+
+	url, err := priceSheetDownloadURL(context.Background(), &mockCredential{}, testClientOptions(server.server.URL), "test-billing-account", "202308")
+	require.NoError(t, err)
+	assert.Equal(t, downloadURL, url)
+
+	req := server.downloadRequest()
+	require.NotNil(t, req, "expected a download request to be made")
+
+	assert.Equal(t, http.MethodPost, req.Method, "the price sheet download is a POST")
+	assert.Equal(t,
+		"/providers/microsoft.Billing/billingAccounts/test-billing-account/billingPeriods/202308/providers/Microsoft.CostManagement/pricesheets/default/download",
+		req.URL.Path,
+		"must target Microsoft.CostManagement, not the retired Microsoft.Consumption API")
+	assert.NotContains(t, req.URL.Path, "Microsoft.Consumption")
+	assert.Equal(t, "2025-03-01", req.URL.Query().Get("api-version"))
+}
+
+// TestPriceSheetDownloadURL_AcceptsDownloadURLField covers the documentation
+// disagreement over the result field name: the 2025-03-01 spec (and so the
+// generated SDK model) says "reportUrl", while Microsoft's migration guide for
+// the same endpoint says "downloadUrl". We have to handle both.
+func TestPriceSheetDownloadURL_AcceptsDownloadURLField(t *testing.T) {
+	const downloadURL = "https://example.blob.core.windows.net/pricesheet.zip?sig=xyz"
+	server := newPriceSheetServer(t, fmt.Sprintf(`{"status":"Completed","properties":{"downloadUrl":%q,"validTill":"2026-09-30T17:32:28Z"}}`, downloadURL))
+
+	url, err := priceSheetDownloadURL(context.Background(), &mockCredential{}, testClientOptions(server.server.URL), "test-billing-account", "202308")
+	require.NoError(t, err)
+	assert.Equal(t, downloadURL, url)
+}
+
+func TestPriceSheetDownloadURL_MissingURL(t *testing.T) {
+	server := newPriceSheetServer(t, `{"status":"Completed","properties":{}}`)
+
+	_, err := priceSheetDownloadURL(context.Background(), &mockCredential{}, testClientOptions(server.server.URL), "test-billing-account", "202308")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned no download URL")
+	assert.Contains(t, err.Error(), "Completed")
+}
+
+func TestPriceSheetDownloadURL_Validation(t *testing.T) {
 	tests := []struct {
 		name              string
 		billingAccountID  string
 		billingPeriodName string
-		expectError       bool
 		expectedError     string
 	}{
 		{
 			name:              "empty billing account ID",
 			billingAccountID:  "",
 			billingPeriodName: "202308",
-			expectError:       true,
-			expectedError:     "parameter client.billingAccountID cannot be empty",
+			expectedError:     "parameter billingAccountID cannot be empty",
 		},
 		{
 			name:              "empty billing period name",
 			billingAccountID:  "test-account",
 			billingPeriodName: "",
-			expectError:       true,
 			expectedError:     "parameter billingPeriodName cannot be empty",
 		},
-		{
-			name:              "valid parameters",
-			billingAccountID:  "test-account",
-			billingPeriodName: "202308",
-			expectError:       false,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewPriceSheetClient(tt.billingAccountID, cred, nil)
-			require.NoError(t, err)
-
-			// Test the createRequest method directly for validation
-			_, err = client.downloadByBillingPeriodCreateRequest(context.Background(), tt.billingPeriodName)
-
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedError)
-			} else {
-				assert.NoError(t, err)
-			}
+			// No server: validation must fail before any request is made.
+			_, err := priceSheetDownloadURL(context.Background(), &mockCredential{}, testClientOptions("https://management.invalid"), tt.billingAccountID, tt.billingPeriodName)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
 		})
 	}
 }
 
-// TestPriceSheetClient_URLConstruction tests URL path construction
-func TestPriceSheetClient_URLConstruction(t *testing.T) {
+func TestExtractDownloadURL(t *testing.T) {
 	tests := []struct {
-		name              string
-		billingAccountID  string
-		billingPeriodName string
-		expectedPath      string
+		name     string
+		body     string
+		expected string
 	}{
 		{
-			name:              "standard billing account and period",
-			billingAccountID:  "123456789",
-			billingPeriodName: "202308",
-			expectedPath:      "/providers/Microsoft.Billing/billingAccounts/123456789/billingPeriods/202308/providers/Microsoft.Consumption/pricesheets/download",
+			name:     "reportUrl",
+			body:     `{"properties":{"reportUrl":"https://example.com/a"}}`,
+			expected: "https://example.com/a",
 		},
 		{
-			name:              "billing account with dashes",
-			billingAccountID:  "account-with-dashes",
-			billingPeriodName: "202308",
-			expectedPath:      "/providers/Microsoft.Billing/billingAccounts/account-with-dashes/billingPeriods/202308/providers/Microsoft.Consumption/pricesheets/download",
+			name:     "downloadUrl",
+			body:     `{"properties":{"downloadUrl":"https://example.com/b"}}`,
+			expected: "https://example.com/b",
+		},
+		{
+			name:     "reportUrl wins when both are set",
+			body:     `{"properties":{"reportUrl":"https://example.com/a","downloadUrl":"https://example.com/b"}}`,
+			expected: "https://example.com/a",
+		},
+		{
+			name:     "no properties",
+			body:     `{"status":"Running"}`,
+			expected: "",
+		},
+		{
+			name:     "not json",
+			body:     `<html>nope</html>`,
+			expected: "",
+		},
+		{
+			name:     "empty",
+			body:     ``,
+			expected: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cred := &mockCredential{}
-			client, err := NewPriceSheetClient(tt.billingAccountID, cred, nil)
-			require.NoError(t, err)
-
-			req, err := client.downloadByBillingPeriodCreateRequest(context.Background(), tt.billingPeriodName)
-			require.NoError(t, err)
-
-			// Verify URL path construction
-			assert.Contains(t, req.Raw().URL.Path, tt.expectedPath)
+			assert.Equal(t, tt.expected, extractDownloadURL([]byte(tt.body)))
 		})
 	}
 }
 
-// TestPriceSheetClient_MethodRegression ensures the HTTP method fix doesn't regress
-// This test would fail if someone accidentally changed POST back to GET
-func TestPriceSheetClient_MethodRegression(t *testing.T) {
-	// This test specifically prevents regression of issue #3326
-	// where Azure billing API was incorrectly using GET instead of POST
-	cred := &mockCredential{}
-	client, err := NewPriceSheetClient("test-billing-account", cred, nil)
-	require.NoError(t, err)
+// The capture policy must not consume the body it inspects, otherwise the SDK
+// can't unmarshal the response afterwards.
+func TestResponseCaptureLeavesBodyReadable(t *testing.T) {
+	const downloadURL = "https://example.blob.core.windows.net/pricesheet.zip"
+	server := newPriceSheetServer(t, fmt.Sprintf(`{"status":"Completed","properties":{"reportUrl":%q}}`, downloadURL))
 
-	req, err := client.downloadByBillingPeriodCreateRequest(context.Background(), "202308")
+	// A reportUrl response is only resolvable via the typed SDK model, so
+	// getting it back proves the body survived the capture policy.
+	url, err := priceSheetDownloadURL(context.Background(), &mockCredential{}, testClientOptions(server.server.URL), "test-billing-account", "202308")
 	require.NoError(t, err)
+	require.Equal(t, downloadURL, url)
+}
 
-	// Critical assertion: must be POST, never GET
-	// This is the core fix for Azure billing account pricing API
-	assert.Equal(t, "POST", req.Raw().Method, "REGRESSION: HTTP method changed back to GET - this will cause 404 errors with Azure billing API")
-	assert.NotEqual(t, "GET", req.Raw().Method, "HTTP method must not be GET for Azure pricesheet download endpoint")
+func TestWithResponseCaptureDoesNotMutateCallerOptions(t *testing.T) {
+	original := &arm.ClientOptions{}
+	updated := withResponseCapture(original, &responseCapture{})
+
+	assert.Empty(t, original.PerRetryPolicies, "caller's options must be left alone")
+	assert.Len(t, updated.PerRetryPolicies, 1)
+
+	// A nil input is valid too.
+	assert.Len(t, withResponseCapture(nil, &responseCapture{}).PerRetryPolicies, 1)
 }

--- a/pkg/cloud/azure/pricesheetclient_test.go
+++ b/pkg/cloud/azure/pricesheetclient_test.go
@@ -93,7 +93,7 @@ func (ps *priceSheetServer) downloadRequest() *http.Request {
 // TestPriceSheetDownloadURL_UsesCostManagementAPI checks that we call the current
 // Cost Management endpoint. The Microsoft.Consumption pricesheets/download API
 // this replaced was retired on 01 June 2026 and had already started rejecting
-// EnrollmentReader service principals with AuthorizationFailed (issue #4003).
+// EnrollmentReader service principals with AuthorizationFailed (issue #3993).
 func TestPriceSheetDownloadURL_UsesCostManagementAPI(t *testing.T) {
 	const downloadURL = "https://example.blob.core.windows.net/pricesheet.zip?sig=abc"
 	server := newPriceSheetServer(t, fmt.Sprintf(`{"status":"Completed","properties":{"reportUrl":%q,"validUntil":"2026-09-30T17:32:28Z"}}`, downloadURL))

--- a/pkg/cloud/azure/pricesheetdownloader.go
+++ b/pkg/cloud/azure/pricesheetdownloader.go
@@ -1,13 +1,17 @@
 package azure
 
 import (
+	"archive/zip"
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -42,7 +46,7 @@ func (d *PriceSheetDownloader) GetPricing(ctx context.Context) (map[string]*Azur
 	}
 	defer data.Close()
 
-	prices, err := d.readPricesheet(ctx, data)
+	prices, err := d.readPriceSheet(ctx, data.File)
 	if err != nil {
 		return nil, fmt.Errorf("reading pricesheet: %w", err)
 	}
@@ -58,7 +62,7 @@ func (d *PriceSheetDownloader) getDownloadURL(ctx context.Context) (string, erro
 	return priceSheetDownloadURL(ctx, cred, nil, d.BillingAccount, currentBillingPeriod())
 }
 
-func (d PriceSheetDownloader) saveData(ctx context.Context, url, tempName string) (io.ReadCloser, error) {
+func (d PriceSheetDownloader) saveData(ctx context.Context, url, tempName string) (*removeOnClose, error) {
 	// Download file from URL in response.
 	out, err := os.CreateTemp("", tempName)
 	if err != nil {
@@ -102,39 +106,158 @@ func (r *removeOnClose) Close() error {
 	return os.Remove(r.Name())
 }
 
+// zipMagic is the local file header signature at the start of every zip archive.
+var zipMagic = []byte{'P', 'K', 0x03, 0x04}
+
+// readPriceSheet parses a downloaded price sheet. Since January 2023 the EA
+// price sheet is delivered as a zip archive containing one or more CSV parts
+// (each capped at 75MB), but a bare CSV is still accepted so that other billing
+// account types and older sheets keep working.
+func (d *PriceSheetDownloader) readPriceSheet(ctx context.Context, file *os.File) (map[string]*AzurePricing, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat downloaded file: %w", err)
+	}
+
+	prefix := make([]byte, len(zipMagic))
+	n, err := io.ReadFull(file, prefix)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("reading downloaded file: %w", err)
+	}
+	isZip := bytes.Equal(prefix[:n], zipMagic)
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seeking to start of file: %w", err)
+	}
+
+	if isZip {
+		return d.readPricesheetZip(ctx, file, info.Size())
+	}
+	return d.readPricesheet(ctx, file)
+}
+
+// readPricesheetZip parses every CSV member of a zipped price sheet and merges
+// the results. Individual members are allowed to fail as long as at least one
+// parses, so a single malformed part can't discard the whole sheet.
+func (d *PriceSheetDownloader) readPricesheetZip(ctx context.Context, data io.ReaderAt, size int64) (map[string]*AzurePricing, error) {
+	archive, err := zip.NewReader(data, size)
+	if err != nil {
+		return nil, fmt.Errorf("opening zip: %w", err)
+	}
+
+	results := make(map[string]*AzurePricing)
+	var (
+		totals   pricesheetStats
+		parsed   int
+		csvFiles int
+		errs     []error
+	)
+	for _, entry := range archive.File {
+		if entry.FileInfo().IsDir() {
+			continue
+		}
+		if !strings.EqualFold(path.Ext(entry.Name), ".csv") {
+			log.Debugf("skipping non-CSV pricesheet entry %q", entry.Name)
+			continue
+		}
+		csvFiles++
+		entryResults, stats, err := d.readPricesheetZipEntry(ctx, entry)
+		if err != nil {
+			log.Warnf("reading pricesheet entry %q: %v", entry.Name, err)
+			errs = append(errs, fmt.Errorf("%s: %w", entry.Name, err))
+			continue
+		}
+		parsed++
+		totals.add(stats)
+		for key, pricing := range entryResults {
+			results[key] = pricing
+		}
+	}
+
+	if csvFiles == 0 {
+		return nil, errors.New("pricesheet zip contained no CSV files")
+	}
+	if parsed == 0 {
+		return nil, fmt.Errorf("no readable CSV in pricesheet zip: %w", errors.Join(errs...))
+	}
+	if len(results) == 0 {
+		return nil, d.noMatchingPricingError(totals)
+	}
+	logPricesheetUnits(totals.units)
+	return results, nil
+}
+
+func (d *PriceSheetDownloader) readPricesheetZipEntry(ctx context.Context, entry *zip.File) (map[string]*AzurePricing, pricesheetStats, error) {
+	contents, err := entry.Open()
+	if err != nil {
+		return nil, pricesheetStats{}, fmt.Errorf("opening: %w", err)
+	}
+	defer contents.Close()
+	return d.parsePricesheet(ctx, contents)
+}
+
+// readPricesheet parses a single price sheet CSV.
 func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reader) (map[string]*AzurePricing, error) {
+	results, stats, err := d.parsePricesheet(ctx, data)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, d.noMatchingPricingError(stats)
+	}
+	logPricesheetUnits(stats.units)
+	return results, nil
+}
+
+// pricesheetStats records what a pass over a CSV skipped, so that a sheet which
+// yields no usable prices can explain itself.
+type pricesheetStats struct {
+	skippedPriceType int
+	skippedOffer     int
+	// hasOfferColumn is true if any parsed CSV carried an offer ID column.
+	hasOfferColumn bool
+	// units holds every unit seen for a price we cared about.
+	units map[string]bool
+}
+
+func (s *pricesheetStats) add(other pricesheetStats) {
+	s.skippedPriceType += other.skippedPriceType
+	s.skippedOffer += other.skippedOffer
+	s.hasOfferColumn = s.hasOfferColumn || other.hasOfferColumn
+	for unit := range other.units {
+		if s.units == nil {
+			s.units = make(map[string]bool)
+		}
+		s.units[unit] = true
+	}
+}
+
+// parsePricesheet reads a price sheet CSV without judging whether the result is
+// usable, so that zipped sheets can be assessed across all their parts.
+func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, data io.Reader) (map[string]*AzurePricing, pricesheetStats, error) {
 	// Avoid double-buffering.
 	buf, ok := (data).(*bufio.Reader)
 	if !ok {
 		buf = bufio.NewReader(data)
 	}
 
-	// The CSV file starts with two lines before the header without
-	// commas (so different numbers of fields as far as the CSV parser
-	// is concerned). Skip them before making the CSV reader so we
-	// still get the benefit of the row length checks after the
-	// header.
-	for i := 0; i < 2; i++ {
-		_, err := buf.ReadBytes('\n')
-		if err != nil {
-			return nil, fmt.Errorf("skipping preamble line %d: %w", i, err)
-		}
+	cols, header, err := readPricesheetHeader(buf)
+	if err != nil {
+		return nil, pricesheetStats{}, err
 	}
+
 	reader := csv.NewReader(buf)
 	reader.ReuseRecord = true
+	// We consumed the header ourselves, so tell the reader how wide records are
+	// in order to keep its row length checks.
+	reader.FieldsPerRecord = len(header)
 
-	header, err := reader.Read()
-	if err != nil {
-		return nil, fmt.Errorf("reading header: %w", err)
+	stats := pricesheetStats{
+		hasOfferColumn: cols.offerID >= 0,
+		units:          make(map[string]bool),
 	}
-	if err := checkPricesheetHeader(header); err != nil {
-		return nil, err
-	}
-
-	units := make(map[string]bool)
-
 	results := make(map[string]*AzurePricing)
-	lines := 2
+	lines := 1
 	for {
 		row, err := reader.Read()
 		if err == io.EOF {
@@ -142,19 +265,30 @@ func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reade
 		}
 		lines++
 		if err != nil {
-			return nil, fmt.Errorf("reading line %d: %w", lines, err)
+			return nil, stats, fmt.Errorf("reading line %d: %w", lines, err)
 		}
 
-		// Skip savings plan - we should be reporting based on the
-		// consumption price because we don't know whether the user is
-		// using a savings plan or over their threshold.
-		if row[pricesheetPriceType] == "Savings Plan" || row[pricesheetOfferID] != d.OfferID {
+		// Only consumption prices are useful here. Savings plan and reserved
+		// instance rows price a commitment rather than an hour of usage - the
+		// reserved instance unit price is the whole one or three year total -
+		// and we don't know whether the user has bought either, so including
+		// them would let them overwrite the on-demand price for the same meter.
+		if !isConsumptionPriceType(row[cols.priceType]) {
+			stats.skippedPriceType++
+			continue
+		}
+
+		// The offer ID column disappeared from the current EA schema. Where it
+		// is still present a single meter can appear once per offer, so we have
+		// to pick out the one the customer is actually billed under.
+		if cols.offerID >= 0 && row[cols.offerID] != d.OfferID {
+			stats.skippedOffer++
 			continue
 		}
 
 		// TODO: Creating a meter info for each record will cause a
 		// lot of GC churn - is it worth reusing one meter info instead?
-		meterInfo, err := makeMeterInfo(row)
+		meterInfo, err := makeMeterInfo(cols, row)
 		if err != nil {
 			log.Warnf("making meter info (line %d): %v", lines, err)
 			continue
@@ -167,7 +301,7 @@ func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reade
 		}
 
 		if pricings != nil {
-			units[*meterInfo.Unit] = true
+			stats.units[*meterInfo.Unit] = true
 		}
 
 		for key, pricing := range pricings {
@@ -175,79 +309,197 @@ func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reade
 		}
 	}
 
-	if len(results) == 0 {
-		return nil, fmt.Errorf("no matching pricing from price sheet")
-	}
+	return results, stats, nil
+}
 
-	// Keep track of units seen so we can detect if there are any that
-	// need handling.
+// logPricesheetUnits records the units seen so we can detect any that still need
+// handling in the conversions table.
+func logPricesheetUnits(units map[string]bool) {
 	allUnits := make([]string, 0, len(units))
 	for unit := range units {
 		allUnits = append(allUnits, unit)
 	}
 	sort.Strings(allUnits)
 	log.Infof("all units in pricesheet: %s", strings.Join(allUnits, ", "))
-
-	return results, nil
 }
 
-func checkPricesheetHeader(header []string) error {
-	if len(header) < len(pricesheetCols) {
-		return fmt.Errorf("too few header columns: got %d, expected %d", len(header), len(pricesheetCols))
+// noMatchingPricingError explains why nothing was extracted. A mismatched offer
+// ID is the most common cause and it used to be invisible.
+func (d *PriceSheetDownloader) noMatchingPricingError(stats pricesheetStats) error {
+	const msg = "no matching pricing from price sheet"
+	var details []string
+	if stats.skippedPriceType > 0 {
+		details = append(details, fmt.Sprintf("%d rows skipped as non-consumption prices", stats.skippedPriceType))
 	}
-	for col, name := range pricesheetCols {
-		if !strings.EqualFold(header[col], name) {
-			return fmt.Errorf("unexpected header at col %d %q, expected %q", col, header[col], name)
+	if stats.skippedOffer > 0 {
+		details = append(details, fmt.Sprintf("%d rows skipped because their offer ID did not match %q (set AZURE_OFFER_ID to the offer for your enrollment)", stats.skippedOffer, d.OfferID))
+	}
+	if !stats.hasOfferColumn {
+		details = append(details, "price sheet has no offer ID column, so no offer filtering was applied")
+	}
+	if len(details) == 0 {
+		return errors.New(msg)
+	}
+	return fmt.Errorf("%s: %s", msg, strings.Join(details, "; "))
+}
+
+// isConsumptionPriceType reports whether a "Price type" / "priceType" cell
+// denotes a pay-as-you-go price. Blank counts as consumption because the legacy
+// sheet left the column empty for some meters.
+func isConsumptionPriceType(priceType string) bool {
+	switch normaliseColumnName(priceType) {
+	case "", "consumption":
+		return true
+	default:
+		return false
+	}
+}
+
+// maxPreambleLines is how far we'll look for the header row. The legacy sheet
+// began with a title line and a blank line; the current one starts with the
+// header.
+const maxPreambleLines = 4
+
+// readPricesheetHeader consumes everything up to and including the header row,
+// leaving buf positioned at the first data row.
+func readPricesheetHeader(buf *bufio.Reader) (priceSheetColumns, []string, error) {
+	var headerErr error
+	for i := 0; i < maxPreambleLines; i++ {
+		line, err := buf.ReadString('\n')
+		if line == "" {
+			if err != nil {
+				break
+			}
+			continue
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		fields, parseErr := parseCSVLine(line)
+		if parseErr != nil {
+			headerErr = fmt.Errorf("reading header: %w", parseErr)
+			continue
+		}
+
+		cols, colsErr := newPriceSheetColumns(fields)
+		if colsErr == nil {
+			return cols, fields, nil
+		}
+		headerErr = colsErr
+
+		if err != nil {
+			break
 		}
 	}
-	return nil
+	if headerErr == nil {
+		headerErr = errors.New("no header row found in price sheet")
+	}
+	return priceSheetColumns{}, nil, headerErr
 }
 
-func makeMeterInfo(row []string) (commerce.MeterInfo, error) {
-	price, err := strconv.ParseFloat(row[pricesheetUnitPrice], 64)
+func parseCSVLine(line string) ([]string, error) {
+	reader := csv.NewReader(strings.NewReader(line))
+	reader.FieldsPerRecord = -1
+	return reader.Read()
+}
+
+// priceSheetColumns records where the fields we need live in a price sheet row.
+// Columns are looked up by name rather than position because the Cost Management
+// schema renamed and reordered them relative to the Consumption one.
+type priceSheetColumns struct {
+	meterName        int
+	meterCategory    int
+	meterSubCategory int
+	meterRegion      int
+	// unit is "Unit" on the legacy sheet and "UnitOfMeasure" on the current one.
+	unit      int
+	unitPrice int
+	priceType int
+	// offerID is -1 when the sheet has no offer ID column.
+	offerID int
+}
+
+func newPriceSheetColumns(header []string) (priceSheetColumns, error) {
+	index := make(map[string]int, len(header))
+	for i, name := range header {
+		normalised := normaliseColumnName(name)
+		if normalised == "" {
+			continue
+		}
+		if _, seen := index[normalised]; !seen {
+			index[normalised] = i
+		}
+	}
+
+	cols := priceSheetColumns{offerID: -1}
+	// Each entry lists the accepted spellings for a column, most preferred
+	// first, so one table covers both schemas.
+	required := []struct {
+		name    string
+		target  *int
+		aliases []string
+	}{
+		{"MeterName", &cols.meterName, []string{"metername"}},
+		{"MeterCategory", &cols.meterCategory, []string{"metercategory"}},
+		{"MeterSubCategory", &cols.meterSubCategory, []string{"metersubcategory"}},
+		{"MeterRegion", &cols.meterRegion, []string{"meterregion"}},
+		{"UnitOfMeasure", &cols.unit, []string{"unit", "unitofmeasure"}},
+		{"UnitPrice", &cols.unitPrice, []string{"unitprice"}},
+		{"PriceType", &cols.priceType, []string{"pricetype"}},
+	}
+	for _, column := range required {
+		found := false
+		for _, alias := range column.aliases {
+			if i, ok := index[alias]; ok {
+				*column.target = i
+				found = true
+				break
+			}
+		}
+		if !found {
+			return priceSheetColumns{}, fmt.Errorf("price sheet header is missing a %q column, got %q", column.name, strings.Join(header, ","))
+		}
+	}
+
+	if i, ok := index["offerid"]; ok {
+		cols.offerID = i
+	}
+
+	return cols, nil
+}
+
+// normaliseColumnName reduces a header cell to a comparable form, so that
+// "Meter sub-category" and "MeterSubCategory" both match.
+func normaliseColumnName(name string) string {
+	name = strings.TrimPrefix(name, "\ufeff")
+	name = strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '-', '_':
+			return -1
+		}
+		return r
+	}, name)
+	return strings.ToLower(name)
+}
+
+func makeMeterInfo(cols priceSheetColumns, row []string) (commerce.MeterInfo, error) {
+	price, err := strconv.ParseFloat(strings.TrimSpace(row[cols.unitPrice]), 64)
 	if err != nil {
 		return commerce.MeterInfo{}, fmt.Errorf("parsing unit price: %w", err)
 	}
-	newPrice, unit := normalisePrice(price, row[pricesheetUnit])
+	newPrice, unit := normalisePrice(price, row[cols.unit])
 	return commerce.MeterInfo{
-		MeterName:        ptr(row[pricesheetMeterName]),
-		MeterCategory:    ptr(row[pricesheetMeterCategory]),
-		MeterSubCategory: ptr(row[pricesheetMeterSubCategory]),
+		MeterName:        ptr(row[cols.meterName]),
+		MeterCategory:    ptr(row[cols.meterCategory]),
+		MeterSubCategory: ptr(row[cols.meterSubCategory]),
 		Unit:             &unit,
-		MeterRegion:      ptr(row[pricesheetMeterRegion]),
+		MeterRegion:      ptr(row[cols.meterRegion]),
 		MeterRates:       map[string]*float64{"0": &newPrice},
 	}, nil
 }
-
-var pricesheetCols = []string{
-	"Meter ID",
-	"Meter name",
-	"Meter category",
-	"Meter sub-category",
-	"Meter region",
-	"Unit",
-	"Unit of measure",
-	"Part number",
-	"Unit price",
-	"Currency code",
-	"Included quantity",
-	"Offer Id",
-	"Term",
-	"Price type",
-}
-
-const (
-	pricesheetMeterID          = 0
-	pricesheetMeterName        = 1
-	pricesheetMeterCategory    = 2
-	pricesheetMeterSubCategory = 3
-	pricesheetMeterRegion      = 4
-	pricesheetUnit             = 5
-	pricesheetUnitPrice        = 8
-	pricesheetCurrencyCode     = 9
-	pricesheetOfferID          = 11
-	pricesheetPriceType        = 13
-)
 
 func currentBillingPeriod() string {
 	return time.Now().Format("200601")

--- a/pkg/cloud/azure/pricesheetdownloader.go
+++ b/pkg/cloud/azure/pricesheetdownloader.go
@@ -193,12 +193,12 @@ func (d *PriceSheetDownloader) readPricesheetZipEntry(ctx context.Context, entry
 		return nil, pricesheetStats{}, fmt.Errorf("opening: %w", err)
 	}
 	defer contents.Close()
-	return d.parsePricesheet(ctx, contents)
+	return d.parsePricesheet(ctx, entry.Name, contents)
 }
 
 // readPricesheet parses a single price sheet CSV.
 func (d *PriceSheetDownloader) readPricesheet(ctx context.Context, data io.Reader) (map[string]*AzurePricing, error) {
-	results, stats, err := d.parsePricesheet(ctx, data)
+	results, stats, err := d.parsePricesheet(ctx, "", data)
 	if err != nil {
 		return nil, err
 	}
@@ -234,14 +234,14 @@ func (s *pricesheetStats) add(other pricesheetStats) {
 
 // parsePricesheet reads a price sheet CSV without judging whether the result is
 // usable, so that zipped sheets can be assessed across all their parts.
-func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, data io.Reader) (map[string]*AzurePricing, pricesheetStats, error) {
+func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, source string, data io.Reader) (map[string]*AzurePricing, pricesheetStats, error) {
 	// Avoid double-buffering.
 	buf, ok := (data).(*bufio.Reader)
 	if !ok {
 		buf = bufio.NewReader(data)
 	}
 
-	cols, header, err := readPricesheetHeader(buf)
+	cols, header, headerLines, err := readPricesheetHeader(buf)
 	if err != nil {
 		return nil, pricesheetStats{}, err
 	}
@@ -257,7 +257,9 @@ func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, data io.Read
 		units:          make(map[string]bool),
 	}
 	results := make(map[string]*AzurePricing)
-	lines := 1
+	// Continue numbering from the header so these match the line numbers a
+	// reader would see opening the CSV.
+	lines := headerLines
 	for {
 		row, err := reader.Read()
 		if err == io.EOF {
@@ -265,7 +267,7 @@ func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, data io.Read
 		}
 		lines++
 		if err != nil {
-			return nil, stats, fmt.Errorf("reading line %d: %w", lines, err)
+			return nil, stats, fmt.Errorf("reading %s: %w", describeLine(source, lines), err)
 		}
 
 		// Only consumption prices are useful here. Savings plan and reserved
@@ -290,13 +292,13 @@ func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, data io.Read
 		// lot of GC churn - is it worth reusing one meter info instead?
 		meterInfo, err := makeMeterInfo(cols, row)
 		if err != nil {
-			log.Warnf("making meter info (line %d): %v", lines, err)
+			log.Warnf("making meter info (%s): %v", describeLine(source, lines), err)
 			continue
 		}
 
 		pricings, err := d.ConvertMeterInfo(meterInfo)
 		if err != nil {
-			log.Warnf("converting meter to pricings (line %d): %v", lines, err)
+			log.Warnf("converting meter to pricings (%s): %v", describeLine(source, lines), err)
 			continue
 		}
 
@@ -310,6 +312,15 @@ func (d *PriceSheetDownloader) parsePricesheet(ctx context.Context, data io.Read
 	}
 
 	return results, stats, nil
+}
+
+// describeLine names a position in the sheet. A zipped sheet is split across
+// several CSV parts, so a bare line number wouldn't say which one to look at.
+func describeLine(source string, line int) string {
+	if source == "" {
+		return fmt.Sprintf("line %d", line)
+	}
+	return fmt.Sprintf("%s line %d", source, line)
 }
 
 // logPricesheetUnits records the units seen so we can detect any that still need
@@ -361,32 +372,39 @@ func isConsumptionPriceType(priceType string) bool {
 const maxPreambleLines = 4
 
 // readPricesheetHeader consumes everything up to and including the header row,
-// leaving buf positioned at the first data row.
-func readPricesheetHeader(buf *bufio.Reader) (priceSheetColumns, []string, error) {
+// leaving buf positioned at the first data row. It also reports how many lines
+// it consumed, so that row numbers in later diagnostics line up with the file
+// whether or not the sheet had a preamble.
+func readPricesheetHeader(buf *bufio.Reader) (priceSheetColumns, []string, int, error) {
 	var headerErr error
+	consumed := 0
 	for i := 0; i < maxPreambleLines; i++ {
 		line, err := buf.ReadString('\n')
 		if line == "" {
+			break
+		}
+		consumed++
+
+		line = strings.TrimRight(line, "\r\n")
+		if strings.TrimSpace(line) == "" {
 			if err != nil {
 				break
 			}
 			continue
 		}
 
-		line = strings.TrimRight(line, "\r\n")
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-
 		fields, parseErr := parseCSVLine(line)
 		if parseErr != nil {
 			headerErr = fmt.Errorf("reading header: %w", parseErr)
+			if err != nil {
+				break
+			}
 			continue
 		}
 
 		cols, colsErr := newPriceSheetColumns(fields)
 		if colsErr == nil {
-			return cols, fields, nil
+			return cols, fields, consumed, nil
 		}
 		headerErr = colsErr
 
@@ -397,7 +415,7 @@ func readPricesheetHeader(buf *bufio.Reader) (priceSheetColumns, []string, error
 	if headerErr == nil {
 		headerErr = errors.New("no header row found in price sheet")
 	}
-	return priceSheetColumns{}, nil, headerErr
+	return priceSheetColumns{}, nil, consumed, headerErr
 }
 
 func parseCSVLine(line string) ([]string, error) {

--- a/pkg/cloud/azure/pricesheetdownloader.go
+++ b/pkg/cloud/azure/pricesheetdownloader.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/commerce/mgmt/commerce"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/opencost/opencost/core/pkg/log"
@@ -56,21 +55,7 @@ func (d *PriceSheetDownloader) getDownloadURL(ctx context.Context) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("creating credential: %w", err)
 	}
-	client, err := NewPriceSheetClient(d.BillingAccount, cred, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating pricesheet client: %w", err)
-	}
-	poller, err := client.BeginDownloadByBillingPeriod(ctx, currentBillingPeriod())
-	if err != nil {
-		return "", fmt.Errorf("beginning pricesheet download: %w", err)
-	}
-	resp, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
-		Frequency: 30 * time.Second,
-	})
-	if err != nil {
-		return "", fmt.Errorf("polling for pricesheet: %w", err)
-	}
-	return resp.Properties.DownloadURL, nil
+	return priceSheetDownloadURL(ctx, cred, nil, d.BillingAccount, currentBillingPeriod())
 }
 
 func (d PriceSheetDownloader) saveData(ctx context.Context, url, tempName string) (io.ReadCloser, error) {

--- a/pkg/cloud/azure/pricesheetdownloader_test.go
+++ b/pkg/cloud/azure/pricesheetdownloader_test.go
@@ -1,18 +1,23 @@
 package azure
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2020-09-01/commerce/mgmt/commerce"
 	"github.com/opencost/opencost/pkg/cloud/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDownloader(t *testing.T) {
-	d := PriceSheetDownloader{
+func testDownloader() PriceSheetDownloader {
+	return PriceSheetDownloader{
 		TenantID:         "test-tenant-id",
 		ClientID:         "test-client-id",
 		ClientSecret:     "test-client-secret",
@@ -20,48 +25,284 @@ func TestDownloader(t *testing.T) {
 		OfferID:          "my-offer-id",
 		ConvertMeterInfo: convertMeter,
 	}
+}
 
-	t.Run("read prices", func(t *testing.T) {
-		results, err := d.readPricesheet(context.Background(), strings.NewReader(pricesheetData))
+// expectedPrices is what both the legacy and the current price sheet schema
+// should boil down to, since the fixtures describe the same meters.
+var expectedPrices = map[string]*AzurePricing{
+	"DC96as_v4 1 Hour": {Node: &models.Node{Cost: "10.505"}},
+	"DC2as_v4 1 Hour":  {Node: &models.Node{Cost: "0.219"}},
+	"VM1 1 Hour":       {Node: &models.Node{Cost: "1.0"}},
+	"VM2 1 Hour":       {Node: &models.Node{Cost: "2.0"}},
+}
+
+func TestDownloader(t *testing.T) {
+	d := testDownloader()
+
+	// The legacy Microsoft.Consumption sheet: a title line, a blank line, then
+	// 14 fixed-position columns. Still parsed so nothing regresses for anyone
+	// reading an archived sheet.
+	t.Run("read prices from legacy schema", func(t *testing.T) {
+		results, err := d.readPricesheet(context.Background(), strings.NewReader(legacyPricesheetData))
 		require.NoError(t, err)
 
 		// Units and prices are normalised.
 		// Info for saving plans and other offers is skipped.
-		expected := map[string]*AzurePricing{
-			"DC96as_v4 1 Hour": {Node: &models.Node{Cost: "10.505"}},
-			"DC2as_v4 1 Hour":  {Node: &models.Node{Cost: "0.219"}},
-			"VM1 1 Hour":       {Node: &models.Node{Cost: "1.0"}},
-			"VM2 1 Hour":       {Node: &models.Node{Cost: "2.0"}},
+		require.Equal(t, expectedPrices, results)
+	})
+
+	// The current Microsoft.CostManagement sheet: no preamble, 21 renamed and
+	// reordered columns, no offer ID, and reserved instance rows included.
+	t.Run("read prices from current schema", func(t *testing.T) {
+		results, err := d.readPricesheet(context.Background(), strings.NewReader(currentPricesheetData))
+		require.NoError(t, err)
+		require.Equal(t, expectedPrices, results)
+	})
+
+	// A reserved instance unit price is the total cost of a one or three year
+	// commitment, so letting one through would wildly inflate an hourly rate.
+	t.Run("reserved instance rows do not overwrite consumption prices", func(t *testing.T) {
+		results, err := d.readPricesheet(context.Background(), strings.NewReader(currentPricesheetData))
+		require.NoError(t, err)
+
+		require.Contains(t, results, "DC96as_v4 1 Hour")
+		assert.Equal(t, "10.505", results["DC96as_v4 1 Hour"].Node.Cost,
+			"consumption price must win over the ReservedInstance row for the same meter")
+	})
+
+	t.Run("savings plan rows are skipped in both spellings", func(t *testing.T) {
+		for _, priceType := range []string{"Savings Plan", "SavingsPlan"} {
+			data := currentHeader + "\n" + currentRow("DC16as_v4", priceType, "10 Hours", "17.51") + "\n"
+			_, err := d.readPricesheet(context.Background(), strings.NewReader(data))
+			require.ErrorContains(t, err, "no matching pricing from price sheet", "price type %q should be skipped", priceType)
 		}
-		require.Equal(t, expected, results)
+	})
+
+	t.Run("handles CRLF line endings and a UTF-8 BOM", func(t *testing.T) {
+		data := "\ufeff" + strings.ReplaceAll(currentPricesheetData, "\n", "\r\n")
+		results, err := d.readPricesheet(context.Background(), strings.NewReader(data))
+		require.NoError(t, err)
+		require.Equal(t, expectedPrices, results)
 	})
 
 	t.Run("bad header", func(t *testing.T) {
 		data := "\n\nMeter ID,Meter name,Meter category,Something else,,,,,,,,,,,,,,\n"
 		_, err := d.readPricesheet(context.Background(), strings.NewReader(data))
-		require.ErrorContains(t, err, `unexpected header at col 3 "Something else", expected "Meter sub-category"`)
+		require.ErrorContains(t, err, `price sheet header is missing a "MeterSubCategory" column`)
 	})
 
 	t.Run("short header", func(t *testing.T) {
 		data := "\n\nMeter ID, Meter name, Meter category, Meter sub-category\n"
 		_, err := d.readPricesheet(context.Background(), strings.NewReader(data))
-		require.ErrorContains(t, err, "too few header columns: got 4, expected 14")
+		require.ErrorContains(t, err, `price sheet header is missing a "MeterRegion" column`)
+	})
+
+	t.Run("no header at all", func(t *testing.T) {
+		_, err := d.readPricesheet(context.Background(), strings.NewReader(""))
+		require.ErrorContains(t, err, "no header row found in price sheet")
 	})
 
 	t.Run("no matching prices", func(t *testing.T) {
-		d := PriceSheetDownloader{
-			TenantID:       "test-tenant-id",
-			ClientID:       "test-client-id",
-			ClientSecret:   "test-client-secret",
-			BillingAccount: "test-billing-account",
-			OfferID:        "my-offer-id",
-			ConvertMeterInfo: func(commerce.MeterInfo) (map[string]*AzurePricing, error) {
-				return nil, nil
-			},
+		d := testDownloader()
+		d.ConvertMeterInfo = func(commerce.MeterInfo) (map[string]*AzurePricing, error) {
+			return nil, nil
 		}
-		_, err := d.readPricesheet(context.Background(), strings.NewReader(pricesheetData))
+		_, err := d.readPricesheet(context.Background(), strings.NewReader(legacyPricesheetData))
 		require.ErrorContains(t, err, "no matching pricing from price sheet")
 	})
+
+	// A mismatched AZURE_OFFER_ID silently produced an empty sheet before, which
+	// was near impossible to diagnose from the logs.
+	t.Run("offer ID mismatch is explained", func(t *testing.T) {
+		d := testDownloader()
+		d.OfferID = "not-the-offer-in-the-sheet"
+		_, err := d.readPricesheet(context.Background(), strings.NewReader(legacyPricesheetData))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "offer ID did not match")
+		assert.Contains(t, err.Error(), "not-the-offer-in-the-sheet")
+		assert.Contains(t, err.Error(), "AZURE_OFFER_ID")
+	})
+
+	// The current schema has no offer ID column, so say so rather than leaving
+	// people hunting for an offer configuration problem that doesn't exist.
+	t.Run("missing offer ID column is explained", func(t *testing.T) {
+		d := testDownloader()
+		d.ConvertMeterInfo = func(commerce.MeterInfo) (map[string]*AzurePricing, error) {
+			return nil, nil
+		}
+		_, err := d.readPricesheet(context.Background(), strings.NewReader(currentPricesheetData))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no offer ID column")
+	})
+}
+
+// Since January 2023 the sheet arrives as a zip of CSV parts, each capped at
+// 75MB, rather than as a single CSV.
+func TestReadPriceSheetZip(t *testing.T) {
+	d := testDownloader()
+
+	t.Run("merges every CSV part", func(t *testing.T) {
+		archive := buildZip(t, map[string]string{
+			"pricesheet_part_1.csv": currentHeader + "\n" +
+				currentRow("DC96as_v4", "Consumption", "10 Hours", "105.05") + "\n",
+			"pricesheet_part_2.csv": currentHeader + "\n" +
+				currentRow("DC2as_v4", "Consumption", "100 Hours", "21.90") + "\n" +
+				currentRow("multiple-prices", "Consumption", "10 Hours", "105.05") + "\n",
+			// Non-CSV members must be ignored rather than fail the parse.
+			"manifest.json": `{"partCount":2}`,
+		})
+
+		results, err := d.readPriceSheet(context.Background(), tempFileWith(t, archive))
+		require.NoError(t, err)
+		require.Equal(t, expectedPrices, results)
+	})
+
+	// One unreadable part shouldn't throw away a whole sheet's pricing.
+	t.Run("tolerates one unreadable part", func(t *testing.T) {
+		archive := buildZip(t, map[string]string{
+			"part_1.csv": "totally,unrelated,columns\n1,2,3\n",
+			"part_2.csv": currentHeader + "\n" +
+				currentRow("DC96as_v4", "Consumption", "10 Hours", "105.05") + "\n",
+		})
+
+		results, err := d.readPriceSheet(context.Background(), tempFileWith(t, archive))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]*AzurePricing{
+			"DC96as_v4 1 Hour": {Node: &models.Node{Cost: "10.505"}},
+		}, results)
+	})
+
+	t.Run("fails when no part is readable", func(t *testing.T) {
+		archive := buildZip(t, map[string]string{
+			"part_1.csv": "totally,unrelated,columns\n1,2,3\n",
+		})
+
+		_, err := d.readPriceSheet(context.Background(), tempFileWith(t, archive))
+		require.ErrorContains(t, err, "no readable CSV in pricesheet zip")
+	})
+
+	t.Run("fails when the zip has no CSV", func(t *testing.T) {
+		archive := buildZip(t, map[string]string{"manifest.json": `{}`})
+
+		_, err := d.readPriceSheet(context.Background(), tempFileWith(t, archive))
+		require.ErrorContains(t, err, "pricesheet zip contained no CSV files")
+	})
+
+	t.Run("reports when parts parse but match nothing", func(t *testing.T) {
+		archive := buildZip(t, map[string]string{
+			"part_1.csv": currentHeader + "\n" +
+				currentRow("DC16as_v4", "ReservedInstance", "10 Hours", "90000") + "\n",
+		})
+
+		_, err := d.readPriceSheet(context.Background(), tempFileWith(t, archive))
+		require.ErrorContains(t, err, "no matching pricing from price sheet")
+		assert.Contains(t, err.Error(), "non-consumption prices")
+	})
+}
+
+// A bare CSV must still work, both for archived sheets and for any scope that
+// isn't handed a zip.
+func TestReadPriceSheetPlainCSV(t *testing.T) {
+	d := testDownloader()
+
+	results, err := d.readPriceSheet(context.Background(), tempFileWith(t, []byte(currentPricesheetData)))
+	require.NoError(t, err)
+	require.Equal(t, expectedPrices, results)
+}
+
+func TestReadPriceSheetEmptyFile(t *testing.T) {
+	d := testDownloader()
+
+	_, err := d.readPriceSheet(context.Background(), tempFileWith(t, nil))
+	require.ErrorContains(t, err, "no header row found in price sheet")
+}
+
+func TestNewPriceSheetColumns(t *testing.T) {
+	t.Run("legacy schema", func(t *testing.T) {
+		cols, err := newPriceSheetColumns(strings.Split(legacyHeader, ","))
+		require.NoError(t, err)
+		assert.Equal(t, 1, cols.meterName)
+		assert.Equal(t, 5, cols.unit, "legacy sheets have a Unit column distinct from Unit of measure")
+		assert.Equal(t, 8, cols.unitPrice)
+		assert.Equal(t, 11, cols.offerID)
+		assert.Equal(t, 13, cols.priceType)
+	})
+
+	t.Run("current schema", func(t *testing.T) {
+		cols, err := newPriceSheetColumns(strings.Split(currentHeader, ","))
+		require.NoError(t, err)
+		assert.Equal(t, 8, cols.meterName)
+		assert.Equal(t, 19, cols.unit, "current sheets only have UnitOfMeasure")
+		assert.Equal(t, 20, cols.unitPrice)
+		assert.Equal(t, 13, cols.priceType)
+		assert.Equal(t, -1, cols.offerID, "current schema has no offer ID column")
+	})
+
+	// Positions are resolved by name, so reordering must not matter.
+	t.Run("column order is irrelevant", func(t *testing.T) {
+		cols, err := newPriceSheetColumns([]string{
+			"UnitPrice", "priceType", "MeterRegion", "MeterSubCategory",
+			"MeterCategory", "MeterName", "UnitOfMeasure",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, cols.unitPrice)
+		assert.Equal(t, 5, cols.meterName)
+		assert.Equal(t, 6, cols.unit)
+	})
+}
+
+func TestNormaliseColumnName(t *testing.T) {
+	// Both schemas' spellings of each column must collapse to the same key.
+	pairs := [][2]string{
+		{"Meter sub-category", "MeterSubCategory"},
+		{"Meter name", "MeterName"},
+		{"Unit of measure", "UnitOfMeasure"},
+		{"Price type", "priceType"},
+		{"Offer Id", "OfferID"},
+		{"\ufeffMeter ID", "MeterId"},
+	}
+	for _, pair := range pairs {
+		assert.Equal(t, normaliseColumnName(pair[0]), normaliseColumnName(pair[1]),
+			"%q and %q should normalise the same", pair[0], pair[1])
+	}
+}
+
+func TestIsConsumptionPriceType(t *testing.T) {
+	for _, priceType := range []string{"Consumption", "consumption", "", " "} {
+		assert.True(t, isConsumptionPriceType(priceType), "%q should count as consumption", priceType)
+	}
+	for _, priceType := range []string{"Savings Plan", "SavingsPlan", "ReservedInstance", "Reserved Instance"} {
+		assert.False(t, isConsumptionPriceType(priceType), "%q should not count as consumption", priceType)
+	}
+}
+
+func buildZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	// Sort for a deterministic archive.
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	for _, name := range names {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(files[name]))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+func tempFileWith(t *testing.T, contents []byte) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pricesheet")
+	require.NoError(t, os.WriteFile(path, contents, 0o600))
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+	return f
 }
 
 func convertMeter(info commerce.MeterInfo) (map[string]*AzurePricing, error) {
@@ -84,9 +325,12 @@ func convertMeter(info commerce.MeterInfo) (map[string]*AzurePricing, error) {
 	}
 }
 
-const pricesheetData = `Price Sheet Report for billing period - 202304
+const legacyHeader = "Meter ID,Meter name,Meter category,Meter sub-category,Meter region,Unit,Unit of measure,Part number,Unit price,Currency code,Included quantity,Offer Id,Term,Price type"
 
-Meter ID,Meter name,Meter category,Meter sub-category,Meter region,Unit,Unit of measure,Part number,Unit price,Currency code,Included quantity,Offer Id,Term,Price type
+// legacyPricesheetData is a sheet in the retired Microsoft.Consumption format.
+const legacyPricesheetData = `Price Sheet Report for billing period - 202304
+
+` + legacyHeader + `
 d4236f8f-3ba6-5a9a-8c6b-14556538c44c,DC96as_v4,Virtual Machines,DCasv4 Series,US East,10 Hours,10 Hours,AAF-70822,105.050000000000000,USD,0.00,my-offer-id,,Consumption
 d4236f8f-3ba6-5a9a-8c6b-14556538c44c,DC96as_v4,Virtual Machines,DCasv4 Series,US East,10 Hours,10 Hours,AAF-70831,60.890000000000000,USD,0.00,other-offer-id,,Consumption
 e47a2c4c-4dc4-55d5-a8d7-ec5b1dcc9c08,DC2as_v4,Virtual Machines,DCasv4 Series,US East,100 Hours,100 Hours,AAF-70890,21.900000000000000,USD,0.000,my-offer-id,,Consumption
@@ -97,3 +341,52 @@ d4236f8f-3ba6-5a9a-8c6b-14556538c44c,skip-this,Virtual Machines,DCasv4 Series,US
 d4236f8f-3ba6-5a9a-8c6b-14556538c44c,multiple-prices,Virtual Machines,DCasv4 Series,US East,10 Hours,10 Hours,AAF-70822,105.050000000000000,USD,0.00,my-offer-id,,Consumption
 d4236f8f-3ba6-5a9a-8c6b-14556538c44c,error,Virtual Machines,DCasv4 Series,US East,10 Hours,10 Hours,AAF-70822,105.050000000000000,USD,0.00,my-offer-id,,Consumption
 `
+
+// currentHeader is the EA price sheet schema returned by Cost Management, in the
+// documented column order. Note there is no offer ID column, "Unit" is gone in
+// favour of "UnitOfMeasure", and the price columns moved to the end.
+const currentHeader = "BasePrice,CurrencyCode,EffectiveEndDate,EffectiveStartDate,IncludedQuantity,MarketPrice,MeterId,MeterCategory,MeterName,MeterSubCategory,MeterRegion,MeterType,PartNumber,priceType,Product,ProductID,ServiceFamily,SkuID,Term,UnitOfMeasure,UnitPrice"
+
+// currentRow builds a row in the current schema for the given meter.
+func currentRow(meterName, priceType, unitOfMeasure, unitPrice string) string {
+	return strings.Join([]string{
+		unitPrice,               // BasePrice
+		"USD",                   // CurrencyCode
+		"2026-08-31T00:00:00Z",  // EffectiveEndDate
+		"2026-08-01T00:00:00Z",  // EffectiveStartDate
+		"0",                     // IncludedQuantity
+		unitPrice,               // MarketPrice
+		"d4236f8f-3ba6-5a9a",    // MeterId
+		"Virtual Machines",      // MeterCategory
+		meterName,               // MeterName
+		"DCasv4 Series",         // MeterSubCategory
+		"US East",               // MeterRegion
+		"ComputeHours",          // MeterType
+		"AAF-70822",             // PartNumber
+		priceType,               // priceType
+		"Virtual Machines DCas", // Product
+		"DZH318Z0BQ35",          // ProductID
+		"Compute",               // ServiceFamily
+		"DZH318Z0BQ35/00GN",     // SkuID
+		"",                      // Term
+		unitOfMeasure,           // UnitOfMeasure
+		unitPrice,               // UnitPrice
+	}, ",")
+}
+
+// currentPricesheetData describes the same meters as legacyPricesheetData in the
+// current schema, plus the savings plan and reserved instance rows that the new
+// sheet adds and that we must ignore.
+var currentPricesheetData = strings.Join([]string{
+	currentHeader,
+	currentRow("DC96as_v4", "Consumption", "10 Hours", "105.05"),
+	currentRow("DC2as_v4", "Consumption", "100 Hours", "21.90"),
+	currentRow("DC16as_v4", "SavingsPlan", "10 Hours", "17.51"),
+	// Deliberately after the consumption row for the same meter: if this were
+	// not filtered out it would overwrite the hourly price with a three year
+	// commitment total.
+	currentRow("DC96as_v4", "ReservedInstance", "10 Hours", "90000.00"),
+	currentRow("skip-this", "Consumption", "10 Hours", "105.05"),
+	currentRow("multiple-prices", "Consumption", "10 Hours", "105.05"),
+	currentRow("error", "Consumption", "10 Hours", "105.05"),
+}, "\n") + "\n"

--- a/pkg/cloud/azure/pricesheetdownloader_test.go
+++ b/pkg/cloud/azure/pricesheetdownloader_test.go
@@ -2,11 +2,13 @@ package azure
 
 import (
 	"archive/zip"
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -217,6 +219,64 @@ func TestReadPriceSheetEmptyFile(t *testing.T) {
 	require.ErrorContains(t, err, "no header row found in price sheet")
 }
 
+// Diagnostics should quote the real line in the file, so a preamble must not
+// shift the numbering.
+func TestReadPricesheetHeaderReportsLinesConsumed(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		expected int
+	}{
+		{
+			name:     "current schema starts at the header",
+			data:     currentHeader + "\nrow\n",
+			expected: 1,
+		},
+		{
+			name:     "legacy schema has a title and a blank line first",
+			data:     legacyPricesheetData,
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, consumed, err := readPricesheetHeader(bufio.NewReader(strings.NewReader(tt.data)))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, consumed)
+		})
+	}
+}
+
+// A bad row in a legacy sheet sits at line 4 (title, blank, header, then data),
+// so that is what the warning has to say.
+func TestParsePricesheetLineNumbersMatchTheFile(t *testing.T) {
+	d := testDownloader()
+
+	// An unparseable unit price on the first data row.
+	data := legacyHeader + "\nid,VM,Virtual Machines,Series,US East,1 Hour,1 Hour,PN,not-a-number,USD,0,my-offer-id,,Consumption\n"
+	_, _, err := d.parsePricesheet(context.Background(), "", strings.NewReader(data))
+	require.NoError(t, err, "a bad price is skipped, not fatal")
+
+	// A malformed row (too few fields) is fatal, and reports its line.
+	broken := legacyHeader + "\nonly,three,fields\n"
+	_, _, err = d.parsePricesheet(context.Background(), "", strings.NewReader(broken))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 2", "header is line 1, so the first data row is line 2")
+
+	// The same row inside a zip part names the part it came from.
+	_, _, err = d.parsePricesheet(context.Background(), "part_2.csv", strings.NewReader(broken))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "part_2.csv line 2")
+
+	// With a legacy preamble the same row is physically on line 4: title,
+	// blank, header, data. Counting data rows instead would report 1 here.
+	withPreamble := "Price Sheet Report for billing period - 202304\n\n" + broken
+	_, _, err = d.parsePricesheet(context.Background(), "", strings.NewReader(withPreamble))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 4", "the preamble must count towards the line number")
+}
+
 func TestNewPriceSheetColumns(t *testing.T) {
 	t.Run("legacy schema", func(t *testing.T) {
 		cols, err := newPriceSheetColumns(strings.Split(legacyHeader, ","))
@@ -280,11 +340,12 @@ func buildZip(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	w := zip.NewWriter(&buf)
-	// Sort for a deterministic archive.
+	// Sort so the archive's entry order is deterministic across runs.
 	names := make([]string, 0, len(files))
 	for name := range files {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	for _, name := range names {
 		f, err := w.Create(name)
 		require.NoError(t, err)


### PR DESCRIPTION
## What

Moves the Azure EA price sheet download off the retired
`Microsoft.Consumption/pricesheets/download` API and onto
`Microsoft.CostManagement/pricesheets/default/download`, and teaches the parser
to read what that API actually returns.

Fixes #3993

## Why

`Microsoft.Consumption/pricesheets/download` retired on 1 June 2026, but it had
already stopped working before that. The endpoint authorises against
`Microsoft.Consumption/pricesheets/action`, which the `EnrollmentReader` billing
role no longer carries, so a service principal configured exactly as
[our docs describe](https://opencost.io/docs/configuration/azure#customer-specific-pricing)
gets:

```
AuthorizationFailed: The client '...' does not have authorization to perform action
'Microsoft.Consumption/pricesheets/action' over scope
'/providers/Microsoft.Billing/billingAccounts/.../providers/Microsoft.Consumption/pricesheets/download'
```

The effect is that EA customers silently fall back to Rate Card list pricing
instead of their negotiated rates.

## What changed

This is not just a URL swap, because the replacement API changes the payload as
well as the route:

| | Legacy (`Microsoft.Consumption`) | Current (`Microsoft.CostManagement`) |
|---|---|---|
| Result field | `properties.downloadUrl` | `properties.reportUrl` |
| Artifact | one `.csv`, two preamble lines | **`.zip` of multiple `.csv` parts**, 75MB each |
| Schema | 14 fixed-position columns | 21 renamed/reordered columns, no `Unit`, no `OfferID`, **`ReservedInstance` rows included** |

**1. Client.** Deleted the hand-rolled ARM client. Its comment said it only
existed because the SDK didn't support the API yet; `armcostmanagement/v3` now
does, so the URL, api-version (`2025-03-01`) and LRO polling are maintained
upstream. This bumps `azcore` to v1.22.0 and `msal` to v1.7.0. No other module
needed changing.

**2. Zip support.** The download is sniffed for the zip magic number, then every
`.csv` member is parsed and merged. One malformed part is logged and skipped
rather than discarding the whole sheet. A bare CSV still works.

**3. Columns by name.** Fixed positions can't survive a reordered schema, so
columns are now resolved by normalised name (case, spaces and dashes stripped).
One code path reads both layouts, and `"Meter sub-category"` matches
`"MeterSubCategory"`. The offer ID filter only applies when the sheet actually
has that column — the schema reference and the price sheet terms page disagree
about whether it still exists, so both cases are handled.

**4. Price type filter (behaviour change worth reviewing).** The old code only
skipped `"Savings Plan"`. The new sheet also carries `ReservedInstance` rows
whose `UnitPrice` is the *total cost of a one or three year commitment*. Those
sort after the consumption row for the same meter, so left in they would
overwrite hourly on-demand prices with a number thousands of times too large.
Only consumption rows are kept now. There's a regression test for exactly this.

**5. Diagnosability.** `no matching pricing from price sheet` now explains
itself. A mismatched `AZURE_OFFER_ID` is the most common cause and there was
previously nothing in the error or the logs pointing at it.

## Testing

- `go test ./...` on the main module, plus `go build ./...` on `core/`,
  `modules/prometheus-source` and `modules/collector-source` against the bumped
  `azcore`.
- `go fmt ./...` / `go vet ./...` clean.
- New tests: `httptest`-backed coverage of the full 202 + `Location` -> poll ->
  200 long running operation; zip merging, partial failure and no-CSV cases;
  both schemas producing identical prices; the `ReservedInstance` overwrite
  regression; BOM and CRLF handling; column mapping.
- Both commits build and pass tests independently.

## One thing I'd like a second opinion on

The 2025-03-01 spec (and therefore the generated SDK model) says the result
field is `reportUrl`. Microsoft's
[migration guide for this same endpoint](https://learn.microsoft.com/en-us/azure/cost-management-billing/automate/migrate-ea-price-sheet-api)
says `downloadUrl`. The reference page's `OperationStatus` definition is also
visibly copy-pasted from the reservation report API — it types the URL field as
the `ReservationReportSchema` *enum*.

I couldn't settle this without a live EA enrollment, so the code accepts either:
it prefers the typed SDK value and falls back to reading the raw response body
through a small pipeline policy (`runtime.Payload`, which rewinds, so the SDK
still parses the response normally). Both paths are tested.

**@yalmaty** — if you're able to share the response body from the curl
in the issue (with the SAS token redacted), I can drop whichever branch turns
out to be dead.

## Follow-ups, not in this PR

- The docs at opencost.io still describe the old permission model; the
  `EnrollmentReader` guidance is still correct but the API name should be
  updated. That lives in a different repo.
- We only request the current billing period. If Azure hasn't generated it yet
  we fall back to Rate Card, same as before. Retrying against the previous
  period would be a reasonable improvement.
- `conversions` was built from the legacy `Unit` vocabulary. If `UnitOfMeasure`
  spells anything differently those prices pass through un-normalised; the
  existing `all units in pricesheet:` log line surfaces that and is kept.
