### PR TITLE
fix(clustercache): include native sidecar containers in pod cost calculations

### DIFF
--- a/core/pkg/clustercache/clustercache.go
+++ b/core/pkg/clustercache/clustercache.go
@@ -254,10 +254,28 @@ func TransformPodStatus(input v1.PodStatus) PodStatus {
 }
 
 func TransformPodSpec(input v1.PodSpec) PodSpec {
-	containers := make([]Container, len(input.Containers))
-	for i, container := range input.Containers {
-		containers[i] = TransformPodContainer(container)
+	containers := make([]Container, 0, len(input.Containers)+len(input.InitContainers))
+	for _, container := range input.Containers {
+		containers = append(containers, TransformPodContainer(container))
 	}
+
+	// Native sidecars are init containers with restartPolicy: Always. They run for the
+	// whole life of the pod, and Kubernetes sums their requests into the pod's requests
+	// exactly like a regular container, so they have to be costed like one. Ordinary init
+	// containers are deliberately left out: they are transient, and they reach the pod's
+	// requests through a max() rather than a sum.
+	//
+	// This mirrors k8s.io/component-helpers/resource.PodRequests. See KEP-753:
+	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements
+	//
+	// Sidecars are appended after the regular containers so that index 0 stays a regular
+	// container, which ComputeCostData relies on when it assigns PV claims.
+	for _, container := range input.InitContainers {
+		if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
+			containers = append(containers, TransformPodContainer(container))
+		}
+	}
+
 	return PodSpec{
 		NodeName:      input.NodeName,
 		Containers:    containers,

--- a/core/pkg/clustercache/clustercache_test.go
+++ b/core/pkg/clustercache/clustercache_test.go
@@ -1,0 +1,121 @@
+package clustercache
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func containerWithCPU(name, cpu string, restartPolicy *v1.ContainerRestartPolicy) v1.Container {
+	return v1.Container{
+		Name:          name,
+		RestartPolicy: restartPolicy,
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse(cpu),
+			},
+		},
+	}
+}
+
+// Native sidecars are init containers with restartPolicy: Always. Kubernetes sums their
+// requests into the pod's requests like a regular container, so they must be carried into
+// the cache and costed. Ordinary init containers must not be, or every pod that runs one
+// would be over-charged for the whole life of the pod.
+func TestTransformPodSpecIncludesNativeSidecars(t *testing.T) {
+	always := v1.ContainerRestartPolicyAlways
+	onFailure := v1.ContainerRestartPolicyOnFailure
+
+	tests := []struct {
+		name     string
+		spec     v1.PodSpec
+		expected []string
+	}{
+		{
+			name: "regular containers only",
+			spec: v1.PodSpec{
+				Containers: []v1.Container{containerWithCPU("app", "100m", nil)},
+			},
+			expected: []string{"app"},
+		},
+		{
+			name: "ordinary init container is excluded",
+			spec: v1.PodSpec{
+				InitContainers: []v1.Container{containerWithCPU("setup", "500m", nil)},
+				Containers:     []v1.Container{containerWithCPU("app", "100m", nil)},
+			},
+			expected: []string{"app"},
+		},
+		{
+			name: "native sidecar is included after the regular containers",
+			spec: v1.PodSpec{
+				InitContainers: []v1.Container{containerWithCPU("istio-proxy", "200m", &always)},
+				Containers:     []v1.Container{containerWithCPU("app", "100m", nil)},
+			},
+			expected: []string{"app", "istio-proxy"},
+		},
+		{
+			name: "restartPolicy OnFailure is not a sidecar",
+			spec: v1.PodSpec{
+				InitContainers: []v1.Container{containerWithCPU("setup", "500m", &onFailure)},
+				Containers:     []v1.Container{containerWithCPU("app", "100m", nil)},
+			},
+			expected: []string{"app"},
+		},
+		{
+			name: "sidecars and ordinary init containers mixed",
+			spec: v1.PodSpec{
+				InitContainers: []v1.Container{
+					containerWithCPU("setup", "500m", nil),
+					containerWithCPU("istio-proxy", "200m", &always),
+					containerWithCPU("log-shipper", "50m", &always),
+				},
+				Containers: []v1.Container{containerWithCPU("app", "100m", nil)},
+			},
+			expected: []string{"app", "istio-proxy", "log-shipper"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TransformPodSpec(tt.spec)
+			if len(got.Containers) != len(tt.expected) {
+				t.Fatalf("got %d containers %v, want %d %v", len(got.Containers), containerNames(got.Containers), len(tt.expected), tt.expected)
+			}
+			for i := range tt.expected {
+				if got.Containers[i].Name != tt.expected[i] {
+					t.Errorf("index %d: got %q, want %q", i, got.Containers[i].Name, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// The sidecar's resource requests have to survive the transform, otherwise it is carried
+// into the cache but still costed at zero.
+func TestTransformPodSpecKeepsSidecarRequests(t *testing.T) {
+	always := v1.ContainerRestartPolicyAlways
+
+	got := TransformPodSpec(v1.PodSpec{
+		InitContainers: []v1.Container{containerWithCPU("istio-proxy", "200m", &always)},
+		Containers:     []v1.Container{containerWithCPU("app", "100m", nil)},
+	})
+
+	if len(got.Containers) != 2 {
+		t.Fatalf("got %d containers, want 2", len(got.Containers))
+	}
+	sidecar := got.Containers[1]
+	want := resource.MustParse("200m")
+	if cpu := sidecar.Resources.Requests[v1.ResourceCPU]; cpu.Cmp(want) != 0 {
+		t.Errorf("sidecar cpu request: got %s, want %s", cpu.String(), want.String())
+	}
+}
+
+func containerNames(containers []Container) []string {
+	names := make([]string, len(containers))
+	for i, c := range containers {
+		names[i] = c.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Description

`TransformPodSpec` only copies `spec.containers` into the cluster cache, so native sidecars (init containers with `restartPolicy: Always`, such as an injected `istio-proxy`) never reach the cost model and are costed at zero. `InitContainer` does not appear anywhere in the codebase today.

This adds init containers with `restartPolicy: Always` to the cached container list, and deliberately leaves ordinary init containers out.

That split is the one Kubernetes itself makes. In `k8s.io/component-helpers/resource.PodRequests`, a restartable init container's requests are added to the pod's cumulative requests exactly like a regular container, while an ordinary init container only reaches the total through a `max()`. See [KEP-753](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements). Including every init container would over-charge any pod that runs a plain one for the pod's whole lifetime; including none under-charges every pod with a sidecar.

One change at the cache level covers all three readers of `pod.Spec.Containers`:

- `costmodel.ComputeCostData`, the request figures behind allocation
- `costmodel.NewContainerMetricsFromPod`, the per-container allocation keys
- `metrics.KubePodCollector`, the `kube_pod_container_resource_requests` series OpenCost emits itself. That emitter is on by default (`EmitKsmV1Metrics` defaults to `true`), so the Prometheus-sourced path picks the sidecars up too.

Sidecars are appended after the regular containers so that index 0 stays a regular container, which `ComputeCostData` relies on when it assigns PV claims to the first container only.

Not covered here: deployments that switch OpenCost's own emitter off and scrape a real kube-state-metrics instead. There a sidecar arrives as `kube_pod_init_container_resource_requests`, which carries no `restartPolicy` label, so it cannot be separated from an ordinary init container at the metric level. That needs its own design, so I left it out rather than guess.

## Related Issues

Fixes #3956

## User Impact

Pods that run native sidecars will report higher, and now correct, costs. The size of the change depends on the sidecar: for a pod whose sidecar requests are comparable to its app container, the reported pod cost roughly doubles.

Anyone who has been reading OpenCost numbers for a mesh-injected workload has been seeing the app container only, so this will look like a cost increase in dashboards even though nothing about the workload changed. Pods without native sidecars are unaffected, and pods with ordinary init containers are unaffected.

No configuration change, no API change, no new dependency.

## Testing

Added `core/pkg/clustercache/clustercache_test.go`:

- `TestTransformPodSpecIncludesNativeSidecars`, table driven over five cases: regular containers only, ordinary init container excluded, native sidecar included and ordered after the regular containers, `restartPolicy: OnFailure` not treated as a sidecar, and a mix of ordinary init containers and two sidecars.
- `TestTransformPodSpecKeepsSidecarRequests`, so a sidecar cannot be carried into the cache and then still costed at zero.

Both were confirmed to fail without the change (removing the `restartPolicy` branch makes them fail, restoring it makes them pass).

`just` is not installed here, so I ran the justfile recipes by hand as CONTRIBUTING suggests: `go test ./...` plus `go vet ./...` in `core`, `modules/prometheus-source`, `modules/collector-source` and the root module. 88 packages pass, vet is clean everywhere. `golangci-lint run ./pkg/clustercache/...` reports 0 issues.

One note: `format-check` currently fails on `develop` for `modules/pricing/public/httpclient/httpclient.go`, which is unrelated to this PR and already unformatted upstream (same area as #3942). `gofmt -l` is clean for both files touched here, and I left that file alone.
