### PR TITLE
fix: gofmt httpclient.go

### DIFF
--- a/modules/pricing/public/httpclient/httpclient.go
+++ b/modules/pricing/public/httpclient/httpclient.go
@@ -17,10 +17,10 @@ const (
 
 // retryTransport is an http.RoundTripper that retries requests on 429 and 503s
 type retryTransport struct {
-	wrapped     http.RoundTripper
-	maxRetries  int
-	baseWait    time.Duration
-	maxWait     time.Duration
+	wrapped    http.RoundTripper
+	maxRetries int
+	baseWait   time.Duration
+	maxWait    time.Duration
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Description

`format-check` fails on `develop`. `gofmt -l .` flags one file, `modules/pricing/public/httpclient/httpclient.go`, where the `retryTransport` struct fields are misaligned. This runs `gofmt -w` on it, and nothing else. Whitespace only, no behaviour change.

After this, `gofmt -l .` is empty for the whole tree.

Two things that explain why it went unnoticed:

- `modules/pricing/public` is its own Go module and is not covered by any of the `just test-*` recipes (`test-core`, `test-prometheus-source`, `test-collector-source`, `test-opencost`), so no test job touches it. `format-check` walking the tree is the only job that would catch it.
- The `Format Check` workflow last ran on `develop` on 2026-07-09, which is before this code landed.

Related but not the same as #3942: that issue is about `core/pkg/external/configmapsource_test.go`, which is already gofmt-clean on current `develop`. Its PR #3943 is still open. This is a different file, so it is not a duplicate of either.

## Related Issues

Relates to #3942

## User Impact

None. Formatting only, no exported API or behaviour touched.

The practical effect is on CI: `format-check` goes green again on `develop`, and PRs stop inheriting an unrelated red check.

## Testing

- `gofmt -l .` on the whole tree: empty after the change, flags only this file before it.
- `go build ./...`, `go vet ./...` and `go test ./...` in `modules/pricing/public`: build and vet clean, `aws`, `azure` and `gcp` packages pass, the rest have no test files.
- The touched package `httpclient` has no test files, and the diff is 4 lines of struct field alignment, so there is nothing behavioural to exercise.
