### PR TITLE
fix(prom): treat null 'result' field as empty query result

### DIFF
--- a/modules/prometheus-source/pkg/prom/result.go
+++ b/modules/prometheus-source/pkg/prom/result.go
@@ -102,8 +102,13 @@ func NewQueryResults(query string, queryResult interface{}, resultKeys *source.R
 	}
 	resultsData, ok := resultData.([]interface{})
 	if !ok {
-		qrs.Error = ResultFieldFormatErr(query, resultData)
-		return qrs
+		// Google Managed Prometheus returns "result": null instead of an empty array
+		// for empty matrix results, e.g. for subqueries over ranges without samples.
+		// Treat it like an empty result instead of failing.
+		if resultData != nil {
+			qrs.Error = ResultFieldFormatErr(query, resultData)
+			return qrs
+		}
 	}
 
 	// Result vectors from the query

--- a/modules/prometheus-source/pkg/prom/result_test.go
+++ b/modules/prometheus-source/pkg/prom/result_test.go
@@ -87,3 +87,57 @@ func TestErrorFunctions(t *testing.T) {
 		})
 	}
 }
+
+func TestNewQueryResultsResultField(t *testing.T) {
+	query := "avg(kube_pod_container_status_running{} != 0) by (pod, namespace, uid, cluster_id)[1d:5m]"
+
+	testCases := []struct {
+		name      string
+		result    any
+		expectErr bool
+	}{
+		{
+			// Google Managed Prometheus returns "result": null instead of an empty
+			// array for empty matrix results.
+			name:      "null result is treated as empty",
+			result:    nil,
+			expectErr: false,
+		},
+		{
+			name:      "empty result array",
+			result:    []any{},
+			expectErr: false,
+		},
+		{
+			name:      "invalid result type",
+			result:    "invalid",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			queryResult := map[string]any{
+				"data": map[string]any{
+					"resultType": "matrix",
+					"result":     tc.result,
+				},
+			}
+
+			qrs := NewQueryResults(query, queryResult, nil)
+			if tc.expectErr {
+				if qrs.Error == nil {
+					t.Errorf("Expected error, got nil")
+				}
+				return
+			}
+
+			if qrs.Error != nil {
+				t.Errorf("Expected no error, got: %s", qrs.Error)
+			}
+			if len(qrs.Results) != 0 {
+				t.Errorf("Expected empty results, got %d", len(qrs.Results))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Google Managed Prometheus returns "result": null instead of an empty array for empty matrix results, e.g. for subqueries over ranges without samples:

    {"status":"success","data":{"resultType":"matrix","result":null}}

NewQueryResults rejected this with "'result' field improperly formatted ... Response: '<nil>'", which made CostModel.ComputeAllocation fail with "failed to build pod map" (after three retries per window) whenever a queried window contained no samples, even though an empty result is a perfectly valid answer.

Treat a null result field like an empty array instead.

## Related Issues
None.

## User Impact
No.

## Testing
Added a test.

## AI
This PR was created using Claude Code because I don't know Go. So I hope it meets your standards.