### PR TITLE
Correct inference counter deltas per replica before aggregating

### DIFF
--- a/modules/prometheus-source/pkg/prom/inference_counter_delta_test.go
+++ b/modules/prometheus-source/pkg/prom/inference_counter_delta_test.go
@@ -1,0 +1,185 @@
+package prom
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// counterDeltaClient dispatches canned vector responses keyed by a substring of
+// the PromQL query. The end-of-window query carries the full window as its
+// lookback and the start-of-window query a fixed 2m one, so "[2m] @" selects
+// the start endpoint and "[60m] @" the end endpoint.
+type counterDeltaClient struct {
+	responses map[string]string
+	queries   []string
+}
+
+func (c *counterDeltaClient) URL(ep string, args map[string]string) *url.URL {
+	u, _ := url.Parse("http://fake-prometheus:9090" + ep)
+	return u
+}
+
+func (c *counterDeltaClient) Do(_ context.Context, req *http.Request) (*http.Response, []byte, error) {
+	query := req.URL.Query().Get("query")
+	c.queries = append(c.queries, query)
+
+	result := "[]"
+	for substr, res := range c.responses {
+		if strings.Contains(query, substr) {
+			result = res
+			break
+		}
+	}
+	body := fmt.Sprintf(`{"status":"success","data":{"resultType":"vector","result":%s}}`, result)
+	return &http.Response{StatusCode: http.StatusOK}, []byte(body), nil
+}
+
+func podSample(modelName, namespace, pod string, value float64) string {
+	return fmt.Sprintf(`{"metric":{"model_name":"%s","namespace":"%s","pod":"%s"},"value":[1712000000,"%g"]}`,
+		modelName, namespace, pod, value)
+}
+
+func podlessSample(modelName, namespace string, value float64) string {
+	return fmt.Sprintf(`{"metric":{"model_name":"%s","namespace":"%s"},"value":[1712000000,"%g"]}`,
+		modelName, namespace, value)
+}
+
+func newCounterDeltaCtx(responses map[string]string) (*Context, *counterDeltaClient) {
+	client := &counterDeltaClient{responses: responses}
+	config := &OpenCostPrometheusConfig{ClusterLabel: "cluster_id"}
+	factory := NewContextFactory(client, config)
+	return factory.NewNamedContext(ClusterContextName), client
+}
+
+// TestQueryCounterDelta_ReplicaResetIsNotMaskedByAnotherReplica is the
+// regression test for the undercount reported by @dev404ai on #3915.
+//
+// One model, one namespace, two replicas over the same window:
+//
+//	replica A: 900 -> 100 after a reset, so its reset-aware lower bound is 100
+//	replica B: 100 -> 1000, so its delta is 900
+//
+// The reset-aware model total is 1000. Summing the replicas at each endpoint
+// before subtracting reads 1000 -> 1100 and returns 100, and the reset guard
+// never fires because the aggregate delta is positive.
+func TestQueryCounterDelta_ReplicaResetIsNotMaskedByAnotherReplica(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-60 * time.Minute)
+
+	ctx, _ := newCounterDeltaCtx(map[string]string{
+		"[2m] @": "[" +
+			podSample("Qwen3-32B", "llm-d", "vllm-a", 900) + "," +
+			podSample("Qwen3-32B", "llm-d", "vllm-b", 100) + "]",
+		"[60m] @": "[" +
+			podSample("Qwen3-32B", "llm-d", "vllm-a", 100) + "," +
+			podSample("Qwen3-32B", "llm-d", "vllm-b", 1000) + "]",
+	})
+
+	got, err := queryCounterDelta(ctx, "vllm:prompt_tokens_total", start, end)
+	if err != nil {
+		t.Fatalf("queryCounterDelta: %v", err)
+	}
+
+	const want = 1000.0
+	if got["Qwen3-32B:llm-d"] != want {
+		t.Errorf("delta = %v, want %v (100 post-reset from A plus 900 from B); "+
+			"any other value means replica identity was not preserved through the subtraction",
+			got["Qwen3-32B:llm-d"], want)
+	}
+}
+
+// TestQueryCounterDelta_ReplicaResetIsNotOvercounted covers the other
+// direction of the same erasure, which the original report did not need to hit.
+//
+//	replica A: 900 -> 100 (reset), lower bound 100
+//	replica B: 100 -> 150, delta 50
+//
+// True total 150. Aggregated, the endpoints read 1000 -> 250, the delta is
+// negative, so the reset guard fires and returns the aggregate end value of
+// 250. Applying a per-series heuristic to an aggregate is unbounded in sign.
+func TestQueryCounterDelta_ReplicaResetIsNotOvercounted(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-60 * time.Minute)
+
+	ctx, _ := newCounterDeltaCtx(map[string]string{
+		"[2m] @": "[" +
+			podSample("Qwen3-32B", "llm-d", "vllm-a", 900) + "," +
+			podSample("Qwen3-32B", "llm-d", "vllm-b", 100) + "]",
+		"[60m] @": "[" +
+			podSample("Qwen3-32B", "llm-d", "vllm-a", 100) + "," +
+			podSample("Qwen3-32B", "llm-d", "vllm-b", 150) + "]",
+	})
+
+	got, err := queryCounterDelta(ctx, "vllm:prompt_tokens_total", start, end)
+	if err != nil {
+		t.Fatalf("queryCounterDelta: %v", err)
+	}
+
+	const want = 150.0
+	if got["Qwen3-32B:llm-d"] != want {
+		t.Errorf("delta = %v, want %v (100 post-reset from A plus 50 from B); "+
+			"any other value means the reset guard was applied to an aggregate rather than per replica",
+			got["Qwen3-32B:llm-d"], want)
+	}
+}
+
+// TestQueryCounterDelta_SeriesWithoutPodLabelStillCount pins the degradation
+// path. `pod` is never self-reported by the serving engine; it comes from
+// Kubernetes service discovery relabeling, so it is legitimately absent under
+// non-Kubernetes SD, under relabel rules that strip it, and under federation of
+// pre-aggregated recording rules. Those deployments must keep reporting at the
+// previous accuracy rather than losing their token totals.
+// The endpoint values here are the aggregates the two-replica scenario above
+// induces (900+100 at start, 100+1000 at end), which is exactly what Prometheus
+// returned for every deployment before this change. The resulting 100 against a
+// true 1000 is the reported undercount, preserved here as the documented
+// behaviour of the degraded path rather than as a correct answer.
+func TestQueryCounterDelta_SeriesWithoutPodLabelStillCount(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-60 * time.Minute)
+
+	ctx, _ := newCounterDeltaCtx(map[string]string{
+		"[2m] @":  "[" + podlessSample("Qwen3-32B", "llm-d", 1000) + "]",
+		"[60m] @": "[" + podlessSample("Qwen3-32B", "llm-d", 1100) + "]",
+	})
+
+	got, err := queryCounterDelta(ctx, "vllm:prompt_tokens_total", start, end)
+	if err != nil {
+		t.Fatalf("queryCounterDelta: %v", err)
+	}
+
+	const want = 100.0
+	if got["Qwen3-32B:llm-d"] != want {
+		t.Errorf("delta = %v, want %v; series without a pod label must still be counted, "+
+			"at the previous accuracy rather than dropped", got["Qwen3-32B:llm-d"], want)
+	}
+}
+
+// TestQueryCounterDelta_GroupsByPod pins the query shape, since the per-replica
+// correction is only possible if both endpoints carry pod in the by-clause.
+func TestQueryCounterDelta_GroupsByPod(t *testing.T) {
+	end := time.Now()
+	start := end.Add(-60 * time.Minute)
+
+	ctx, client := newCounterDeltaCtx(map[string]string{
+		"[2m] @":  "[" + podSample("Qwen3-32B", "llm-d", "vllm-a", 1) + "]",
+		"[60m] @": "[" + podSample("Qwen3-32B", "llm-d", "vllm-a", 2) + "]",
+	})
+
+	if _, err := queryCounterDelta(ctx, "vllm:prompt_tokens_total", start, end); err != nil {
+		t.Fatalf("queryCounterDelta: %v", err)
+	}
+	if len(client.queries) != 2 {
+		t.Fatalf("expected 2 queries, got %d", len(client.queries))
+	}
+	for _, q := range client.queries {
+		if !strings.Contains(q, "sum by (model_name, namespace, pod)") {
+			t.Errorf("endpoint query does not group by pod, so resets cannot be corrected per replica: %q", q)
+		}
+	}
+}

--- a/modules/prometheus-source/pkg/prom/inference_queries.go
+++ b/modules/prometheus-source/pkg/prom/inference_queries.go
@@ -233,9 +233,18 @@ func queryCounterDelta(ctx *Context, metric string, start, end time.Time) (map[s
 		windowMinutes = 2
 	}
 
-	// Query counter value at the end of the window.
-	endQuery := fmt.Sprintf(`sum by (model_name, namespace) (last_over_time(%s[%dm] @ %d))`, metric, windowMinutes, endUnix)
-	endVals, err := queryInstantMetric(ctx, endQuery, effectiveEnd)
+	// Both endpoints are grouped by pod as well as by model and namespace, so
+	// the reset correction below is applied per replica. Summing replicas
+	// before subtracting lets one replica's growth hide another's reset: with
+	// A going 900 -> 100 and B going 100 -> 1000, the aggregate reads
+	// 1000 -> 1100 and reports 100 against a true 1000, and the guard never
+	// fires because the aggregate delta is positive. The same erasure can
+	// overcount: A 900 -> 100 with B 100 -> 150 aggregates to 1000 -> 250, the
+	// guard does fire, and the aggregate end value of 250 is reported against a
+	// true 150. Applying a per-series heuristic to an aggregate is unbounded in
+	// both directions.
+	endQuery := fmt.Sprintf(`sum by (model_name, namespace, pod) (last_over_time(%s[%dm] @ %d))`, metric, windowMinutes, endUnix)
+	endVals, err := queryInstantMetricByPod(ctx, endQuery, effectiveEnd)
 	if err != nil {
 		return nil, fmt.Errorf("end-of-window query for %s: %w", metric, err)
 	}
@@ -243,22 +252,92 @@ func queryCounterDelta(ctx *Context, metric string, start, end time.Time) (map[s
 	// Query counter value at the start of the window.
 	// Use a narrow 2m lookback here: we want the value just before the window
 	// opens, not a stale value from much earlier that would undercount the delta.
-	startQuery := fmt.Sprintf(`sum by (model_name, namespace) (last_over_time(%s[2m] @ %d))`, metric, startUnix)
-	startVals, err := queryInstantMetric(ctx, startQuery, effectiveEnd)
+	startQuery := fmt.Sprintf(`sum by (model_name, namespace, pod) (last_over_time(%s[2m] @ %d))`, metric, startUnix)
+	startVals, err := queryInstantMetricByPod(ctx, startQuery, effectiveEnd)
 	if err != nil {
 		return nil, fmt.Errorf("start-of-window query for %s: %w", metric, err)
 	}
 
-	// Delta = end - start. If negative (counter reset), use endVal as a
-	// lower bound to capture post-reset activity rather than reporting 0.
+	// Delta = end - start per replica. If negative (counter reset), use the
+	// replica's end value as a lower bound to capture post-reset activity
+	// rather than reporting 0. Then fold the replicas back into the
+	// (model_name, namespace) contract the callers expect.
 	out := make(map[string]float64, len(endVals))
+	missingPod := false
 	for key, endVal := range endVals {
-		delta := endVal - startVals[key]
+		delta := endVal.value - startVals[key].value
 		if delta < 0 {
-			// Counter reset detected: use endVal to capture post-reset activity
-			delta = endVal
+			// Counter reset detected: use the end value to capture post-reset activity
+			delta = endVal.value
 		}
-		out[key] = delta
+		out[modelNamespaceKey(endVal.modelName, endVal.namespace)] += delta
+		if endVal.pod == "" {
+			missingPod = true
+		}
+	}
+
+	// A series with no pod label collapses into a single per-(model, namespace)
+	// bucket, which reproduces the previous summed behaviour exactly rather
+	// than dropping the data. That is the right degradation, because `pod` is
+	// never self-reported by the serving engine: it comes from Kubernetes
+	// service discovery relabeling, so it is legitimately absent under
+	// non-Kubernetes service discovery, under write_relabel_configs or
+	// labeldrop that strip it, and under federation of pre-aggregated
+	// recording rules. Operators should know they are on the less accurate
+	// path, so say so instead of silently reverting to it.
+	if missingPod {
+		log.Warnf("inference: %s has series with no pod label; counter resets cannot be corrected per replica "+
+			"for those series and may be masked by other replicas. Add a pod relabel rule to the model-server "+
+			"scrape job to get per-replica accuracy.", metric)
+	}
+	return out, nil
+}
+
+// podMetricValue carries one instant sample keyed by replica identity.
+type podMetricValue struct {
+	modelName string
+	namespace string
+	pod       string
+	value     float64
+}
+
+// queryInstantMetricByPod runs an instant query and returns samples keyed by
+// (model_name, namespace, pod) so counter deltas can be reset-corrected per
+// replica before being folded back to the per-model contract.
+func queryInstantMetricByPod(ctx *Context, query string, t time.Time) (map[string]podMetricValue, error) {
+	raw, _, err := ctx.query(query, t)
+	if err != nil {
+		return nil, err
+	}
+
+	results := NewQueryResults(query, raw, source.ClusterKeyWithDefaults(ctx.config.ClusterLabel))
+	if results.Error != nil {
+		return nil, results.Error
+	}
+
+	out := make(map[string]podMetricValue, len(results.Results))
+	for _, result := range results.Results {
+		modelName, err := result.GetString("model_name")
+		if err != nil || modelName == "" {
+			continue
+		}
+		namespace, err := result.GetString("namespace")
+		if err != nil || namespace == "" {
+			namespace = "unknown"
+		}
+		// An absent pod label is not a reason to drop the sample; it collapses
+		// into one bucket per (model_name, namespace), which is the previous
+		// behaviour.
+		pod, _ := result.GetString("pod")
+		if len(result.Values) == 0 {
+			continue
+		}
+		out[modelNamespaceKey(modelName, namespace)+"|"+pod] = podMetricValue{
+			modelName: modelName,
+			namespace: namespace,
+			pod:       pod,
+			value:     result.Values[0].Value,
+		}
 	}
 	return out, nil
 }


### PR DESCRIPTION
## What

`queryCounterDelta` in `modules/prometheus-source/pkg/prom/inference_queries.go` summed replicas at each window endpoint and only then subtracted. Summing before subtracting erases replica identity, and the counter-reset guard then applies a per-series heuristic to an aggregate.

Both endpoints now group by `pod` as well as `model_name` and `namespace`, the reset correction is applied per replica, and the per-replica deltas are folded back into the `map[string]float64` keyed `"model_name:namespace"` that callers and result types already expect. **No caller or result-type changes.**

## Why

Reported by @dev404ai in https://github.com/opencost/opencost/pull/3915#issuecomment-5256436968, with a reproduction that holds exactly.

One model, one namespace, two replicas over the same window:

| replica | start | end | reset-aware delta |
|---|---|---|---|
| A | 900 | 100 (reset) | 100 |
| B | 100 | 1,000 | 900 |
| **model total** | | | **1,000** |

Summed at each endpoint, Prometheus reports 1,000 to 1,100, so the delta is **100**. The reset guard never fires, because the aggregate delta is positive. A 10x undercount, silently.

The same erasure also **overcounts**. With A 900 to 100 and B 100 to 150, the aggregate reads 1,000 to 250, the delta is negative, the guard *does* fire, and it returns the aggregate end value of 250 against a true 150. The error is unbounded in sign.

This affects all five vLLM cost counters, since they share the helper: `vllm:prompt_tokens_total`, `vllm:generation_tokens_total`, `vllm:request_prefill_time_seconds_sum`, `vllm:request_time_per_output_token_seconds_sum`, `vllm:prefix_cache_hits_total`. These are the token and time denominators for inference cost, so the error moves billing-visible totals and can skew derived cost per million tokens in either direction.

## When `pod` is not available

`pod` is never self-reported by the serving engine. It comes from Kubernetes service discovery relabeling, so it is legitimately absent under:

- non-Kubernetes service discovery (`static_configs`, DNS, EC2, Consul), where `namespace` can still be a static target label
- `write_relabel_configs` or `metric_relabel_configs` `labeldrop` that strip it for cardinality
- federation of pre-aggregated recording rules such as `sum by (model_name, namespace) (...)`

Those series collapse into a single per-`(model_name, namespace)` bucket, which **reproduces the previous behaviour exactly** rather than dropping the data, and a warning names the metric so operators know they are on the less accurate path. Deployments on the standard Kubernetes scrape config get the corrected number with no configuration change.

## Testing

`modules/prometheus-source/pkg/prom/inference_counter_delta_test.go`, driving the real helper through a scripted Prometheus client:

- `TestQueryCounterDelta_ReplicaResetIsNotMaskedByAnotherReplica` (the reported undercount)
- `TestQueryCounterDelta_ReplicaResetIsNotOvercounted` (the overcount direction)
- `TestQueryCounterDelta_SeriesWithoutPodLabelStillCount` (the degraded path, pinned to the exact number every deployment returned before this change)
- `TestQueryCounterDelta_GroupsByPod` (query shape, since the correction is only possible if both endpoints carry `pod`)

All three value tests fail against the previous implementation. `go build ./...` and `go test ./...` pass on `prometheus-source`.

## Scope

Split out of #3915 deliberately. The bug is in the merged AI inference cost path from #3845 and affects `develop` users today, independent of the saturation work, so it deserves its own review and is cherry-pickable on its own.

Two adjacent items intentionally **not** included here, to keep this reviewable:

- **The start-lookback asymmetry.** The end query uses a full-window lookback while the start query uses a fixed `[2m]`. It is a no-op under normal 30s scraping, but a replica whose scrape gapped for more than two minutes around the window start contributes zero at start and its full cumulative value at end. Happy to fold in if reviewers prefer.
- **The collector source.** `newInferenceCostCounterCollector` groups the same five counters by `(model_name, namespace)` and `increaseAggregator` sums across replicas before comparing cycle totals. Bounded per scrape cycle rather than per window, so a smaller blast radius, but the same class of bug. Worth a follow-up.
