### PR TITLE
Format httpclient.go so fmt-check passes on develop

### DIFF
--- a/modules/pricing/public/httpclient/httpclient.go
+++ b/modules/pricing/public/httpclient/httpclient.go
@@ -17,10 +17,10 @@ const (
 
 // retryTransport is an http.RoundTripper that retries requests on 429 and 503s
 type retryTransport struct {
-	wrapped     http.RoundTripper
-	maxRetries  int
-	baseWait    time.Duration
-	maxWait     time.Duration
+	wrapped    http.RoundTripper
+	maxRetries int
+	baseWait   time.Duration
+	maxWait    time.Duration
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
`just fmt-check` currently fails on `develop`: gofmt aligns the `retryTransport` struct fields differently than `modules/pricing/public/httpclient/httpclient.go` has them.

Because the check runs against the whole tree, every open pull request inherits the red `format-check` regardless of its own contents. Confirmed by running `gofmt -l` against a clean `develop` checkout.

Formatting only, 4 lines, no behavior change.