### PR TITLE
fix(storage): normalize memory storage paths on write

### DIFF
--- a/core/pkg/pricing/mock.go
+++ b/core/pkg/pricing/mock.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -113,8 +114,8 @@ func (mpm *MockPricingModule) Checksum(ctx context.Context) (string, error) {
 var pricingTestFS embed.FS
 
 func (mpm *MockPricingModule) loadTestFile(filename string) error {
-	path := filepath.Join("test", filename)
-	bs, err := pricingTestFS.ReadFile(path)
+	// embedded file paths are always slash separated, so they cannot be built with filepath
+	bs, err := pricingTestFS.ReadFile(path.Join("test", filename))
 	if err != nil {
 		return fmt.Errorf("failed to read embedded pricing file: %w", err)
 	}

--- a/core/pkg/storage/memfile/util.go
+++ b/core/pkg/storage/memfile/util.go
@@ -2,26 +2,43 @@ package memfile
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 )
 
+// Separator is the separator used within memory storage paths. Memory storage paths are logical
+// keys, like the object keys used by the bucket storages, so they are separated by '/' on every
+// platform rather than by the host file system separator.
+const Separator = "/"
+
+// Normalize returns the cleaned, slash separated form of the provided path. It is the canonical
+// form used to key a file within memory storage, so every path entering memory storage must pass
+// through it.
+func Normalize(p string) string {
+	return path.Clean(filepath.ToSlash(p))
+}
+
+// Join combines the provided path elements into a single memory storage path.
+func Join(elem ...string) string {
+	return path.Join(elem...)
+}
+
 // SplitPaths splits the directory path into a slice of directory names.
-func SplitPaths(path string) []string {
-	path = filepath.Clean(path)
-	if path[len(path)-1] == filepath.Separator {
-		path = path[:len(path)-1]
-	}
-	return strings.Split(path, string(filepath.Separator))
+func SplitPaths(p string) []string {
+	p = Normalize(p)
+	p = strings.TrimSuffix(p, Separator)
+
+	return strings.Split(p, Separator)
 }
 
 // Split splits the path into a slice of directory names and the file name.
-func Split(path string) ([]string, string) {
-	path = filepath.Clean(path)
-	pDir, pFile := filepath.Split(path)
-	pDir = filepath.Dir(pDir)
+func Split(p string) ([]string, string) {
+	p = Normalize(p)
+	pDir, pFile := path.Split(p)
+	pDir = path.Dir(pDir)
 
-	return strings.Split(pDir, string(filepath.Separator)), pFile
+	return strings.Split(pDir, Separator), pFile
 }
 
 // CreateSubdirectory creates the necessary subdirectories within the provided MemoryDirectory.
@@ -48,7 +65,7 @@ func FindSubdirectory(d *MemoryDirectory, paths []string) (*MemoryDirectory, err
 	for i := 0; i < len(paths); i++ {
 		dirName := paths[i]
 		if _, ok := currentDir.dirs[dirName]; !ok {
-			return nil, fmt.Errorf("directory %s not found", filepath.Join(paths[:i+1]...))
+			return nil, fmt.Errorf("directory %s not found", Join(paths[:i+1]...))
 		}
 		currentDir = currentDir.dirs[dirName]
 	}

--- a/core/pkg/storage/memorystorage.go
+++ b/core/pkg/storage/memorystorage.go
@@ -48,7 +48,7 @@ func (ms *MemoryStorage) Stat(path string) (*StorageInfo, error) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	path = filepath.Clean(path)
+	path = memfile.Normalize(path)
 	if file, ok := ms.directPaths[path]; ok {
 		return &StorageInfo{
 			Name:    file.Name,
@@ -66,7 +66,7 @@ func (ms *MemoryStorage) Read(path string) ([]byte, error) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	path = filepath.Clean(path)
+	path = memfile.Normalize(path)
 
 	if file, ok := ms.directPaths[path]; ok {
 		return file.Contents, nil
@@ -80,7 +80,7 @@ func (ms *MemoryStorage) ReadStream(path string) (io.ReadCloser, error) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	path = filepath.Clean(path)
+	path = memfile.Normalize(path)
 
 	if file, ok := ms.directPaths[path]; ok {
 		data := append([]byte(nil), file.Contents...)
@@ -93,7 +93,7 @@ func (ms *MemoryStorage) ReadStream(path string) (io.ReadCloser, error) {
 // ReadToLocalFile writes the specified object at path to destPath on the local file system.
 func (ms *MemoryStorage) ReadToLocalFile(path, destPath string) error {
 	ms.lock.Lock()
-	path = filepath.Clean(path)
+	path = memfile.Normalize(path)
 
 	file, ok := ms.directPaths[path]
 	if !ok {
@@ -122,6 +122,14 @@ func (ms *MemoryStorage) Write(path string, data []byte) error {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
+	ms.write(path, data)
+	return nil
+}
+
+// write adds the data to the file tree and direct path lookup at the provided path. The caller
+// must hold the storage lock.
+func (ms *MemoryStorage) write(path string, data []byte) {
+	path = memfile.Normalize(path)
 	paths, pFile := memfile.Split(path)
 
 	f := memfile.NewMemoryFile(pFile, data)
@@ -129,7 +137,6 @@ func (ms *MemoryStorage) Write(path string, data []byte) error {
 
 	currentDir.AddFile(f)
 	ms.directPaths[path] = f
-	return nil
 }
 
 // WriteStream creates a new relative path and returns the io.WriteCloser that can be used to
@@ -148,13 +155,7 @@ func (ms *MemoryStorage) WriteStream(path string) (io.WriteCloser, error) {
 		ms.lock.Lock()
 		defer ms.lock.Unlock()
 
-		paths, pFile := memfile.Split(path)
-
-		f := memfile.NewMemoryFile(pFile, data)
-		currentDir := memfile.CreateSubdirectory(ms.fileTree, paths)
-
-		currentDir.AddFile(f)
-		ms.directPaths[path] = f
+		ms.write(path, data)
 	})
 
 	return &memWriteCloser{
@@ -182,7 +183,7 @@ func (ms *MemoryStorage) Remove(path string) error {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	path = filepath.Clean(path)
+	path = memfile.Normalize(path)
 	paths, pFile := memfile.Split(path)
 
 	currentDir, err := memfile.FindSubdirectory(ms.fileTree, paths)
@@ -202,7 +203,7 @@ func (ms *MemoryStorage) Exists(path string) (bool, error) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	path = filepath.Clean(path)
+	path = memfile.Normalize(path)
 
 	_, ok := ms.directPaths[path]
 	return ok, nil
@@ -254,7 +255,7 @@ func (ms *MemoryStorage) ListDirectories(path string) ([]*StorageInfo, error) {
 	storageInfos := make([]*StorageInfo, 0, currentDir.DirCount())
 	for d := range currentDir.Directories() {
 		storageInfos = append(storageInfos, &StorageInfo{
-			Name:    filepath.Join(append(paths, d.Name)...) + "/",
+			Name:    memfile.Join(append(paths, d.Name)...) + memfile.Separator,
 			Size:    d.Size(),
 			ModTime: d.ModTime,
 		})

--- a/core/pkg/storage/memorystorage_test.go
+++ b/core/pkg/storage/memorystorage_test.go
@@ -395,3 +395,78 @@ func TestMemoryStorage_WriteStream(t *testing.T) {
 	store := NewMemoryStorage()
 	TestStorageWriteStream(t, store)
 }
+
+// TestMemoryStorage_PathNormalization checks that a written file is reachable by every path that
+// refers to it. Callers build storage paths with path.Join, so on Windows the written path never
+// matched the normalized path the readers looked up, and every read of a written file failed.
+func TestMemoryStorage_PathNormalization(t *testing.T) {
+	testName := "path_normalization"
+	canonical := path.Join(testpath, testName, "dir0/file0.json")
+
+	// paths which all refer to the same file as canonical
+	equivalent := []string{
+		canonical,
+		"./" + canonical,
+		path.Join(testpath, testName) + "//dir0/file0.json",
+		path.Join(testpath, testName, "dir1/../dir0/file0.json"),
+	}
+
+	for _, written := range equivalent {
+		t.Run(written, func(t *testing.T) {
+			store := NewMemoryStorage()
+			if err := store.Write(written, []byte(written)); err != nil {
+				t.Fatalf("failed to write file '%s': %s", written, err)
+			}
+
+			for _, p := range equivalent {
+				b, err := store.Read(p)
+				if err != nil {
+					t.Errorf("failed to read '%s' after writing '%s': %s", p, written, err)
+				} else if string(b) != written {
+					t.Errorf("content of '%s' did not match written value: %s", p, string(b))
+				}
+
+				exists, err := store.Exists(p)
+				if err != nil {
+					t.Errorf("failed to check existence of '%s': %s", p, err)
+				}
+				if !exists {
+					t.Errorf("'%s' does not exist after writing '%s'", p, written)
+				}
+
+				if _, err = store.Stat(p); err != nil {
+					t.Errorf("failed to stat '%s' after writing '%s': %s", p, written, err)
+				}
+			}
+
+			files, err := store.List(path.Join(testpath, testName, "dir0"))
+			if err != nil {
+				t.Fatalf("failed to list files: %s", err)
+			}
+			if len(files) != 1 {
+				t.Fatalf("file list length does not match expected length, actual: %d, expected: %d", len(files), 1)
+			}
+
+			if err = store.Remove(canonical); err != nil {
+				t.Fatalf("failed to remove file '%s': %s", canonical, err)
+			}
+
+			// removal must clear both the file tree and the direct path lookup
+			exists, err := store.Exists(written)
+			if err != nil {
+				t.Fatalf("failed to check existence of '%s': %s", written, err)
+			}
+			if exists {
+				t.Errorf("'%s' still exists after removing '%s'", written, canonical)
+			}
+
+			files, err = store.List(path.Join(testpath, testName, "dir0"))
+			if err != nil {
+				t.Fatalf("failed to list files: %s", err)
+			}
+			if len(files) != 0 {
+				t.Errorf("file list length does not match expected length, actual: %d, expected: %d", len(files), 0)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`MemoryStorage` cannot read back a file it just wrote unless the caller's path is already in cleaned host form. On Windows that is every path, because storage paths are built with `path.Join`.

## Why

`MemoryStorage` keys files twice: in the directory tree, and in the `directPaths` map. Every reader (`Read`, `ReadStream`, `Stat`, `Exists`, `Remove`, `ReadToLocalFile`) normalized its key with `filepath.Clean`, but `Write` and `WriteStream` stored the caller's path verbatim.

```go
// Write
ms.directPaths[path] = f        // "test/test/collector/20260813120000.bingen"

// Read
path = filepath.Clean(path)     // "test\test\collector\20260813120000.bingen" on Windows
_, ok := ms.directPaths[path]   // miss -> DoesNotExistError
```

The tree half of the store normalizes on both sides, so `List` kept working while every read failed. On a clean checkout of `develop` on Windows, the collector WAL restore fails:

```
--- FAIL: TestWalinator_restore (0.00s)
    failed to load file contents for 'test/test/collector/20260813120000.bingen': file does not exist
    walinator_test.go:188: failed to get collector from repo2: failed to find MetricCollector for interval '1d' for time '2026-08-14T00:00:00Z'
```

`Walinator.restore` lists its three WAL files, fails to read all three, and the restored repository ends up empty. `TestWalinator_clean` passes only because `Remove` works through the tree, which also leaves the stale `directPaths` entry behind.

This is not Windows only. Since `Write` never normalized at all, `Write("./a/b.json")` followed by `Read("./a/b.json")` fails on any platform. CI runs on `ubuntu-latest`, where canonical paths hide the common case.

## What changed

Memory storage paths are logical keys, like bucket object keys, so they are now normalized to cleaned, slash separated form on every platform, on the write side as well as the read side.

- `memfile`: added `Normalize`, `Join` and `Separator`, and moved `Split`/`SplitPaths` from `filepath` to `path` semantics. This is a no-op on Linux, where `filepath.ToSlash` is the identity and `path.Clean` matches `filepath.Clean`.
- `MemoryStorage`: `Write` and `WriteStream` now share a `write` helper that normalizes before storing, readers use `memfile.Normalize`, and `ListDirectories` returns slash joined names instead of `opencost\storage\dir0/`.
- `core/pkg/pricing`: an embedded fixture was read through `filepath.Join`. `embed.FS` paths are always slash separated, so that read never resolved on Windows. Same class of bug, one line.

## Testing

`TestMemoryStorage_PathNormalization` covers the equivalence class of a path (canonical, `./` prefixed, doubled separator, `..` segment). Every form must read, stat and exist after a write in any other form, and `Remove` must clear both indexes. It fails on `develop` (4 of 4 subtests on Windows, 3 of 4 on Linux) and passes with this change.

On Windows, `modules/collector-source` is now fully green, `core/pkg/pricing` passes, and `core/pkg/storage` has only the pre-existing `FileStorage` failures described below.

## Known remaining Windows gaps, not addressed here

- `core/pkg/util/fileutil/locks_windows.go` stubs every locked read and write with "not implemented on Windows. Please open an issue.". `FileStorage` is built on it, so that single gap accounts for the `core/pkg/util/fileutil` failures, the `FileStorage` failures in `core/pkg/storage`, and the CSV pricing tests in `pkg/cloud/provider`. Closing it means real `LockFileEx` support, which is a feature rather than a fix.
- `TestFileStorageListDirectoriesSymlink` needs symlink privilege (elevation or developer mode).
- `TestCacheGroupMaxRollOff` in `core/pkg/util/cache` is timing sensitive and fails independently of these changes.

A `windows-latest` job on the unit test workflow would catch this class of bug, but it cannot go green until the fileutil locking gap is closed.
