### PR TITLE
fix(cloud/config): prevent UnmarshalJSON recursion under encoding/json v2

### DIFF
--- a/pkg/cloud/config/configurations.go
+++ b/pkg/cloud/config/configurations.go
@@ -77,10 +77,14 @@ func (c *Configurations) UnmarshalJSON(bytes []byte) error {
 	// This has been tested for backwards compatability, and it works in both config formats.
 	// It also coincidentally works if you mix-and-match both the old format and the new
 	// format.
-	// Create inline type to gain access to default Unmarshalling
-	type ConfUnmarshaller *Configurations
-	var conf ConfUnmarshaller = c
-	err := json.Unmarshal(bytes, conf)
+	// Create a distinct defined type to gain access to default Unmarshalling. This must be
+	// defined over the struct rather than over the pointer: a defined pointer type such as
+	// `type ConfUnmarshaller *Configurations` still resolves to (*Configurations).UnmarshalJSON
+	// under the encoding/json v2 backend (Go 1.25+ GOEXPERIMENT=jsonv2, default in Go 1.27),
+	// which makes this method recurse into itself until the stack overflows. Converting the
+	// pointer to *confUnmarshaller sheds the method set under both backends.
+	type confUnmarshaller Configurations
+	err := json.Unmarshal(bytes, (*confUnmarshaller)(c))
 	// If unmarshal is successful, return
 	if err == nil {
 		return nil


### PR DESCRIPTION
## What

`(*Configurations).UnmarshalJSON` recurses into itself until the stack overflows when built against the `encoding/json` v2 backend.

```
--- FAIL: TestConfigurations_UnmarshalJSON
fatal error: stack overflow
github.com/opencost/opencost/pkg/cloud/config.(*Configurations).UnmarshalJSON(0x..., {0x..., 0x7a, 0x7a})
github.com/opencost/opencost/pkg/cloud/config.(*Configurations).UnmarshalJSON(0x..., {0x..., 0x7a, 0x7a})
... repeated until the 1GB goroutine stack limit
```

The whole `pkg/cloud/config` package fails, and the crash takes the test binary with it.

## Why

The method uses the standard "shed the method set so the default decoder runs" trick, but declares the helper type over the **pointer** rather than over the struct:

```go
type ConfUnmarshaller *Configurations
var conf ConfUnmarshaller = c
err := json.Unmarshal(bytes, conf)
```

Under the v1 backend a defined pointer type has an empty method set and v1 does not look through it, so the default struct decoding runs and this works.

The v2 backend resolves through the named pointer to `*Configurations`, finds `UnmarshalJSON`, and calls it again with the same pointer and the same bytes. Infinite recursion.

`encoding/json` v2 is opt-in via `GOEXPERIMENT=jsonv2` as of Go 1.25 and is **the default in Go 1.27**.

## Why this matters now

`.github/workflows/build-test.yaml` pins `go-version: 'stable'`, and `update-go-version.yaml` opens automated Go bump PRs. CI is green today only because stable is still Go 1.26 — the build breaks the day Go 1.27 becomes stable.

## What changed

Declare the helper type over the struct and convert the pointer. A defined struct type has an empty method set, so `*confUnmarshaller` does not implement `json.Unmarshaler` under either backend:

```go
type confUnmarshaller Configurations
err := json.Unmarshal(bytes, (*confUnmarshaller)(c))
```

One line, plus a comment recording why it must not be written over the pointer. No behavior change on either backend: the fallback to the deprecated `MultiCloudConfig` format is untouched, and both config formats still round-trip.

## Testing

| Check | Result |
|---|---|
| `pkg/cloud/config` under `GOEXPERIMENT=jsonv2` | pass (was: stack overflow) |
| `pkg/cloud/config` under `GOEXPERIMENT=nojsonv2` | pass (unchanged) |
| main module `go test ./...` under jsonv2 | pass |
| `core`, `collector-source`, `prometheus-source` under jsonv2 | pass |
| `go vet`, `gofmt -l` | clean |

The existing `TestConfigurations_UnmarshalJSON` covers both config formats and is the regression test — it just needs a toolchain that exercises v2. A repo-wide sweep under jsonv2 found no other v2 incompatibility.
