### PR TITLE
fix(clustercache): isolate node labels from cache consumers

### DIFF
--- a/pkg/clustercache/clustercache2.go
+++ b/pkg/clustercache/clustercache2.go
@@ -1,6 +1,7 @@
 package clustercache
 
 import (
+	"maps"
 	"sync"
 
 	cc "github.com/opencost/opencost/core/pkg/clustercache"
@@ -93,7 +94,18 @@ func (kcc *KubernetesClusterCacheV2) GetAllNamespaces() []*cc.Namespace {
 }
 
 func (kcc *KubernetesClusterCacheV2) GetAllNodes() []*cc.Node {
-	return kcc.nodeStore.GetAll()
+	nodes := kcc.nodeStore.GetAll()
+	isolated := make([]*cc.Node, len(nodes))
+	for i, node := range nodes {
+		if node == nil {
+			continue
+		}
+
+		clone := *node
+		clone.Labels = maps.Clone(node.Labels)
+		isolated[i] = &clone
+	}
+	return isolated
 }
 
 func (kcc *KubernetesClusterCacheV2) GetAllPods() []*cc.Pod {

--- a/pkg/clustercache/clustercache2_test.go
+++ b/pkg/clustercache/clustercache2_test.go
@@ -1,0 +1,37 @@
+package clustercache
+
+import (
+	"testing"
+
+	cc "github.com/opencost/opencost/core/pkg/clustercache"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestKubernetesClusterCacheV2GetAllNodesIsolatesLabels(t *testing.T) {
+	nodeStore := NewGenericStore(cc.TransformNode)
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID("node-1"),
+			Name: "node-1",
+			Labels: map[string]string{
+				"kubernetes.io/arch": "amd64",
+			},
+		},
+	}
+	require.NoError(t, nodeStore.Add(node))
+
+	cache := &KubernetesClusterCacheV2{nodeStore: nodeStore}
+
+	firstRead := cache.GetAllNodes()
+	require.Len(t, firstRead, 1)
+	firstRead[0].Labels["providerID"] = "aws:///us-east-1a/i-1234567890"
+
+	secondRead := cache.GetAllNodes()
+	require.Len(t, secondRead, 1)
+	require.NotSame(t, firstRead[0], secondRead[0])
+	require.Equal(t, "amd64", secondRead[0].Labels["kubernetes.io/arch"])
+	require.NotContains(t, secondRead[0].Labels, "providerID")
+}


### PR DESCRIPTION
## Description

Prevent ClusterCache V2 consumers from sharing the cached node label map.

`KubernetesClusterCacheV2.GetAllNodes()` currently returns the node pointers
stored by `GenericStore` directly. That means callers also receive the exact
cached `Labels` map.

`CostModel.GetNodeCost()` enriches those labels with `providerID`, while
`KubeNodeCollector.Collect()` can concurrently iterate the same map through
`promutil.SanitizeLabels()` during a `/metrics` scrape.

That creates a concrete read/write race on a Go map and matches the fatal
`concurrent map iteration and map write` failure reported in #3388. Because
this is a Go runtime fatal error, it terminates the OpenCost process rather
than returning a recoverable request error.

This change makes `GetAllNodes()` return a shallow node copy with an
independently cloned labels map. Callers keep the same node data and can
continue deriving/enriching labels, but those writes no longer mutate the
map held by ClusterCache V2 or race with other consumers.

A focused regression test mutates labels returned by one `GetAllNodes()` call
and verifies a subsequent read is unchanged.

## Related Issues

Fixes #3388
Relates to #3195
Relates to #2910

## User Impact

No API, configuration, or pricing behavior changes are intended.

The change prevents one class of process-level crashes when node metadata is
consumed concurrently, including the `/metrics` scrape path reported in
#3388.

The tradeoff is one shallow node copy and one label-map clone per node
returned from the V2 cache.

## Testing

- Added `TestKubernetesClusterCacheV2GetAllNodesIsolatesLabels`.
- The test verifies that mutating labels returned by one cache read cannot
  affect a later read.
- The regression test is deterministic and does not rely on race timing.
- Repository CI should run the project format, vet, and test checks.