### PR TITLE
Follow the allocation pattern for the network insight account field

### DIFF
--- a/core/pkg/opencost/networkinsightmatcher.go
+++ b/core/pkg/opencost/networkinsightmatcher.go
@@ -52,6 +52,9 @@ func networkInsightFieldMap(ni *NetworkInsight, identifier ast.Identifier) (stri
 		return ni.Namespace, nil
 	case nfilter.FieldPod:
 		return ni.Pod, nil
+	case nfilter.FieldAccount:
+		// Resolved against storage, not in memory. Same as allocationFieldMap.
+		return "", fmt.Errorf("account property not implemented")
 	}
 
 	return "", fmt.Errorf("Failed to find string identifier on Network Insight: %s", identifier.Field.Name)

--- a/core/pkg/opencost/networkinsightmatcher_test.go
+++ b/core/pkg/opencost/networkinsightmatcher_test.go
@@ -1,0 +1,69 @@
+package opencost
+
+import (
+	"testing"
+
+	nfilter "github.com/opencost/opencost/core/pkg/filter/networkinsight"
+)
+
+func matchNetworkInsight(t *testing.T, ni *NetworkInsight, filter string) bool {
+	t.Helper()
+
+	tree, err := nfilter.NewNetworkInsightFilterParser().Parse(filter)
+	if err != nil {
+		t.Fatalf("Parse(%q) error = %v", filter, err)
+	}
+
+	m, err := NewNetworkInsightMatchCompiler().Compile(tree)
+	if err != nil {
+		t.Fatalf("Compile(%q) error = %v", filter, err)
+	}
+
+	return m.Matches(ni)
+}
+
+// The grammar and the field map have to agree. A field the parser accepts but the map cannot reach
+// returns "Failed to find string identifier" at match time, not at parse time.
+func TestNetworkInsightMatcher_Fields(t *testing.T) {
+	ni := &NetworkInsight{
+		Cluster:   "cluster-a",
+		Namespace: "kubecost",
+		Pod:       "pod-1",
+	}
+
+	cases := []struct {
+		filter string
+		want   bool
+	}{
+		{`cluster:"cluster-a"`, true},
+		{`cluster:"cluster-b"`, false},
+		{`namespace:"kubecost"`, true},
+		{`pod:"pod-1"`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.filter, func(t *testing.T) {
+			if got := matchNetworkInsight(t, ni, tc.filter); got != tc.want {
+				t.Errorf("Matches(%q) = %v, want %v", tc.filter, got, tc.want)
+			}
+		})
+	}
+}
+
+// account is in the grammar so it parses and compiles, but the insight does not carry it. The
+// matcher must not silently treat that as a match once storage has joined the account in.
+func TestNetworkInsightMatcher_AccountIsNotResolvable(t *testing.T) {
+	ni := &NetworkInsight{Cluster: "cluster-a", Namespace: "kubecost"}
+
+	for _, filter := range []string{
+		`account:"aws-111"`,
+		`account:""`,
+		`account:"aws-111"+namespace:"kubecost"`,
+	} {
+		t.Run(filter, func(t *testing.T) {
+			if matchNetworkInsight(t, ni, filter) {
+				t.Errorf("Matches(%q) = true, want false", filter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Follow-up to #4025, which added `account` to the network insight grammar.

`networkInsightFieldMap` has no case for `account`. An in-memory filter on it falls through to the generic error:

```
Failed to find string identifier on Network Insight: account
```

and `Matches` returns `false`. So the filter matches nothing, and the error makes it look like someone forgot to add the field.

Per review on #4025, `Account` should not be a member of `NetworkInsight`. Storage joins the account in after ingestion, so the SQL compilers resolve the field and this path cannot. `allocationFieldMap` already hits the same situation and returns `"account property not implemented"`, while `AllocationProperties` carries no Account field either. This does the same, so both filters behave alike.

## Related Issues

Relates to #4025.

## User Impact

None for existing callers. No type changes, no signature changes, no new JSON fields.

An in-memory filter on `account` returns `false` before and after. Only the error changes. It now says the field is not implemented instead of looking like a lookup bug.

## Testing

There was no test for `NetworkInsightMatcher`, so this adds one.

- `TestNetworkInsightMatcher_Fields` parses a filter, compiles it, and matches it against a fixture. It covers the fields that do resolve. If the grammar and the field map drift apart, the test fails instead of the runtime.
- `TestNetworkInsightMatcher_AccountIsNotResolvable` locks the gap in on purpose, so nobody makes `account` match in memory later without the test saying so.

`go build ./...` and `go test ./...` pass on both modules.
