### PR TITLE
fix(aws): include marketplace fees

### DIFF
--- a/pkg/cloud/aws/athenaintegration.go
+++ b/pkg/cloud/aws/athenaintegration.go
@@ -54,8 +54,22 @@ var AthenaNetSPPricingCoalesce = fmt.Sprintf("COALESCE(%s, %s, 0)", AthenaNetSPP
 const AthenaDateColumn = "line_item_usage_start_date"
 const AthenaDateTruncColumn = "DATE_TRUNC('day'," + AthenaDateColumn + ") as usage_date"
 
+// AthenaBillingEntityColumn distinguishes standard AWS charges ('AWS') from AWS
+// Marketplace charges ('AWS Marketplace') on a CUR line item.
+const AthenaBillingEntityColumn = "bill_billing_entity"
+const AthenaMarketplaceBillingEntity = "AWS Marketplace"
+
 const AthenaWhereDateFmt = `line_item_usage_start_date >= date '%s' AND line_item_usage_start_date < date '%s'`
-const AthenaWhereUsage = "(line_item_line_item_type = 'Usage' OR line_item_line_item_type = 'DiscountedUsage' OR line_item_line_item_type = 'SavingsPlanCoveredUsage' OR line_item_line_item_type = 'EdpDiscount' OR line_item_line_item_type = 'PrivateRateDiscount')"
+
+// AthenaWhereUsage includes usage-driving line item types plus AWS Marketplace 'Fee'
+// line items (flat-rate/subscription charges for third-party SaaS products). Marketplace
+// is scoped to bill_billing_entity = 'AWS Marketplace' so this does not also pull in
+// non-Marketplace 'Fee' rows, such as Reserved Instance upfront purchases,
+// which are outside the scope of this Marketplace-specific fix.
+var AthenaWhereUsage = fmt.Sprintf(
+	"(line_item_line_item_type = 'Usage' OR line_item_line_item_type = 'DiscountedUsage' OR line_item_line_item_type = 'SavingsPlanCoveredUsage' OR line_item_line_item_type = 'EdpDiscount' OR line_item_line_item_type = 'PrivateRateDiscount' OR (line_item_line_item_type = 'Fee' AND %s = '%s'))",
+	AthenaBillingEntityColumn, AthenaMarketplaceBillingEntity,
+)
 
 // AthenaQueryIndexes is a struct for holding the context of a query
 type AthenaQueryIndexes struct {
@@ -183,9 +197,9 @@ func (ai *AthenaIntegration) getCloudCost(start, end time.Time, limit int) (*ope
 	whereDate := fmt.Sprintf(AthenaWhereDateFmt, start.Format("2006-01-02"), end.Format("2006-01-02"))
 	wherePartitions := ai.GetPartitionWhere(start, end, isCUR20(allColumns))
 
-	// Query for all line items with a resource_id or from AWS Marketplace, which did not end before
-	// the range or start after it. This captures all costs with any amount of
-	// overlap with the range, for which we will only extract the relevant costs
+	// Query for all line items whose usage start date falls within the given range and
+	// partition, restricted to usage-driving line item types and AWS Marketplace fees
+	// (see AthenaWhereUsage).
 	whereConjuncts := []string{
 		wherePartitions,
 		whereDate,

--- a/pkg/cloud/aws/athenaintegration_coverage_test.go
+++ b/pkg/cloud/aws/athenaintegration_coverage_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/opencost/opencost/pkg/cloud"
 )
 
+func TestAthenaWhereUsage(t *testing.T) {
+	// Regression test for https://github.com/opencost/opencost/issues/4022 -
+	// AWS Marketplace subscription/fee charges (line_item_line_item_type = 'Fee')
+	// must be included, but only when billed through AWS Marketplace, so that
+	// non-Marketplace 'Fee' rows (e.g. Reserved Instance upfront purchases,
+	// already captured via 'DiscountedUsage' amortization) are not swept in and
+	// double counted.
+	expected := "(line_item_line_item_type = 'Usage' OR line_item_line_item_type = 'DiscountedUsage' OR line_item_line_item_type = 'SavingsPlanCoveredUsage' OR line_item_line_item_type = 'EdpDiscount' OR line_item_line_item_type = 'PrivateRateDiscount' OR (line_item_line_item_type = 'Fee' AND bill_billing_entity = 'AWS Marketplace'))"
+	if AthenaWhereUsage != expected {
+		t.Errorf("AthenaWhereUsage = %v, want %v", AthenaWhereUsage, expected)
+	}
+
+	if !strings.Contains(AthenaWhereUsage, "line_item_line_item_type = 'Fee' AND bill_billing_entity = 'AWS Marketplace'") {
+		t.Errorf("AthenaWhereUsage should include AWS Marketplace 'Fee' rows scoped to bill_billing_entity, got: %v", AthenaWhereUsage)
+	}
+
+	// A bare, unscoped 'Fee' disjunct would also match non-Marketplace fees like RI
+	// upfront purchases, so it must never appear on its own.
+	if strings.Contains(AthenaWhereUsage, "line_item_line_item_type = 'Fee')") {
+		t.Errorf("AthenaWhereUsage should not include an unscoped 'Fee' clause, got: %v", AthenaWhereUsage)
+	}
+}
+
 func TestAthenaIntegration_GetListCostColumn(t *testing.T) {
 	ai := &AthenaIntegration{}
 	expected := "SUM(CASE line_item_line_item_type WHEN 'EdpDiscount' THEN 0 WHEN 'PrivateRateDiscount' THEN 0 ELSE line_item_unblended_cost END) as list_cost"


### PR DESCRIPTION
## Summary

Fixes #4022 by including AWS Marketplace **Fee** charges in the Athena CUR integration.

Currently, the Athena query filters "**line_item_line_item_type**" to a fixed set of values, so **Marketplace fee charges are left out of OpenCost costs**.

## Changes

* Include **`Fee`** line items when **`bill_billing_entity = 'AWS Marketplace'**
* Keep **non-Marketplace Fee** line items excluded
* Add a **regression test** for the new filter
* Update the related comments

This keeps the change limited to **Marketplace fees** instead of including all AWS `Fee` charges.

## Testing

* `go test ./pkg/cloud/...`
* `go vet ./...`
* `gofmt`
* `git diff --check`

**Fixes #4022**