### PR TITLE
Reduce & dedupe "CLUSTER_ID" logs

### DIFF
--- a/core/pkg/log/log.go
+++ b/core/pkg/log/log.go
@@ -142,6 +142,17 @@ func Debugf(format string, a ...interface{}) {
 	log.Debug().Msgf(format, a...)
 }
 
+func DedupedDebugf(logTypeLimit int, format string, a ...interface{}) {
+	timesLogged := ctr.increment(format)
+
+	if timesLogged < logTypeLimit {
+		Debugf(format, a...)
+	} else if timesLogged == logTypeLimit {
+		Debugf(format, a...)
+		Debugf("%s logged %d times: suppressing future logs", fmt.Sprintf(format, a...), logTypeLimit)
+	}
+}
+
 func Trace(msg string) {
 	log.Trace().Msg(msg)
 }

--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -1784,17 +1784,13 @@ func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 	// Determine cluster name
 	clusterName := c.ClusterName
 	if clusterName == "" {
-		awsClusterID := env.GetAWSClusterID()
-		if awsClusterID != "" {
-			log.Infof("Returning \"%s\" as ClusterName", awsClusterID)
-			clusterName = awsClusterID
-			log.Warnf("Warning - %s will be deprecated in a future release. Use %s instead", env.AWSClusterIDEnvVar, coreenv.ClusterIDEnvVar)
+		if clusterName = env.GetAWSClusterID(); clusterName != "" {
+			log.DedupedWarningf(3, "%s will be deprecated in a future release. Use %s instead", env.AWSClusterIDEnvVar, coreenv.ClusterIDEnvVar)
 		} else if clusterName = coreenv.GetClusterID(); clusterName != "" {
-			log.DedupedInfof(5, "Setting cluster name to %s from %s ", clusterName, coreenv.ClusterIDEnvVar)
+			log.DedupedDebugf(3, "Setting cluster name to %s from %s", clusterName, coreenv.ClusterIDEnvVar)
 		} else {
 			clusterName = defaultClusterName
-			log.DedupedWarningf(5, "Unable to detect cluster name - using default of %s", defaultClusterName)
-			log.DedupedWarningf(5, "Please set cluster name through configmap or via %s env var", coreenv.ClusterIDEnvVar)
+			log.DedupedWarningf(3, "Unable to detect cluster name - using default of %s. Set it through the configmap or the %s env var", defaultClusterName, coreenv.ClusterIDEnvVar)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR changes. -->

Reduce & dedupe "CLUSTER_ID" logs for AWS Provider. Specifically, these logs always showed on startup.

```log
2026-09-08T22:23:35.919546067Z INF Setting cluster name to qa-eks3-thomasn-v33 from CLUSTER_ID
2026-09-08T22:23:35.989632798Z INF Setting cluster name to qa-eks3-thomasn-v33 from CLUSTER_ID
2026-09-08T22:23:35.989660897Z INF Setting cluster name to qa-eks3-thomasn-v33 from CLUSTER_ID  logged 5 times: suppressing future logs
```

## Related Issues
<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

N/A

## User Impact
<!-- Describe any user-facing changes. Is this a breaking change? Is there backwards compatibility? -->

Reduces noisy logs by deduping them. Move one set of logs from Info down to Debug. No breaking changes.

## Testing
<!-- Describe how you tested your changes: unit tests, manual tests, integration tests, etc. -->
<!-- Integration tests: https://github.com/opencost/opencost-integration-tests -->

N/A
